### PR TITLE
composable transaction construction

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,9 @@
+{
+  /* MD013 */ "line-length": false,
+  /* MD029 */ "ol-prefix": { "style": "ordered" },
+  /* MD042 */ "no-empty-links": false,
+  /* MD047 */ "single-trailing-newline": true,
+  /* MD048 */ "code-fence-style": { "style": "backtick" },
+  /* MD055 */ "table-pipe-style": { "style": "leading_and_trailing" },
+  /* MD060 */ "table-column-style": { "aligned_delimiter": true, "style": "aligned" }
+}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,9 +1,0 @@
-{
-  /* MD013 */ "line-length": false,
-  /* MD029 */ "ol-prefix": { "style": "ordered" },
-  /* MD042 */ "no-empty-links": false,
-  /* MD047 */ "single-trailing-newline": true,
-  /* MD048 */ "code-fence-style": { "style": "backtick" },
-  /* MD055 */ "table-pipe-style": { "style": "leading_and_trailing" },
-  /* MD060 */ "table-column-style": { "aligned_delimiter": true, "style": "aligned" }
-}

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -94,8 +94,10 @@ impl Action {
     ///
     /// 1. Note commitment: [`Note::commitment`]
     /// 2. Value commitment: [`value::Commitment::new`]
-    /// 3. Alpha derivation: [`ActionEntropy::spend_randomizer`](private::ActionEntropy::spend_randomizer)
-    /// 4. Spend authorization: [`Custody::authorize_spend`](crate::custody::Custody::authorize_spend)
+    /// 3. Alpha derivation:
+    ///    [`ActionEntropy::spend_randomizer`](private::ActionEntropy::spend_randomizer)
+    /// 4. Spend authorization:
+    ///    [`Custody::authorize_spend`](crate::custody::Custody::authorize_spend)
     /// 5. Assembly: `Action { cv, rk, sig }` +
     ///    [`ActionPrivate`](crate::witness::ActionPrivate)
     pub fn spend<R: RngCore + CryptoRng, C: Custody>(

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -105,7 +105,7 @@ impl Action {
         rng: &mut R,
     ) -> Result<(Self, ActionPrivate), C::Error> {
         // 1. Note commitment
-        let cmx = note.commitment();
+        let cm = note.commitment();
 
         // 2. Value commitment (signer picks rcv)
         let value: i64 = note.value.into();
@@ -113,10 +113,10 @@ impl Action {
         let cv = rcv.commit(value);
 
         // 3. Alpha (user device derives for proof witness)
-        let alpha = theta.spend_randomizer(&cmx);
+        let alpha = theta.spend_randomizer(&cm);
 
         // 4. Spend authorization (custody derives alpha independently)
-        let (rk, sig) = custody.authorize_spend(cv, theta, &cmx, rng)?;
+        let (rk, sig) = custody.authorize_spend(cv, theta, &cm, rng)?;
 
         Ok((
             Self { cv, rk, sig },
@@ -140,7 +140,7 @@ impl Action {
         rng: &mut R,
     ) -> (Self, ActionPrivate) {
         // 1. Note commitment
-        let cmx = note.commitment();
+        let cm = note.commitment();
 
         // 2. Value commitment (signer picks rcv; negative for outputs)
         let value: i64 = note.value.into();
@@ -148,7 +148,7 @@ impl Action {
         let cv = rcv.commit(value.neg());
 
         // 3. Alpha (for proof witness and output signing key)
-        let alpha = theta.output_randomizer(&cmx);
+        let alpha = theta.output_randomizer(&cm);
 
         // 4. Output authorization (rsk = alpha, no custody)
         let (rk, sig) = alpha.authorize(cv, rng);

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -110,7 +110,7 @@ impl Action {
         // 2. Value commitment (signer picks rcv)
         let value: i64 = note.value.into();
         let rcv = value::CommitmentTrapdoor::random(&mut *rng);
-        let cv = value::Commitment::new(value, rcv);
+        let cv = rcv.commit(value);
 
         // 3. Alpha (user device derives for proof witness)
         let alpha = theta.spend_randomizer(&cmx);
@@ -145,7 +145,7 @@ impl Action {
         // 2. Value commitment (signer picks rcv; negative for outputs)
         let value: i64 = note.value.into();
         let rcv = value::CommitmentTrapdoor::random(&mut *rng);
-        let cv = value::Commitment::new(value.neg(), rcv);
+        let cv = rcv.commit(value.neg());
 
         // 3. Alpha (for proof witness and output signing key)
         let alpha = theta.output_randomizer(&cmx);
@@ -208,8 +208,7 @@ mod tests {
         };
         let theta = private::ActionEntropy::random(&mut rng);
 
-        let (action, _witness) =
-            Action::spend(&local, note, &theta, &mut rng).unwrap();
+        let (action, _witness) = Action::spend(&local, note, &theta, &mut rng).unwrap();
 
         action
             .rk

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -7,9 +7,9 @@ use reddsa::orchard::SpendAuth;
 
 use crate::{
     constants::SPEND_AUTH_PERSONALIZATION,
+    custody::Custody,
     keys::{private, public},
-    note::{self, Note},
-    primitives::Epoch,
+    note::Note,
     value,
     witness::ActionPrivate,
 };
@@ -86,69 +86,79 @@ impl Action {
         sighash(self.cv, self.rk)
     }
 
-    fn new<R: RngCore + CryptoRng>(
-        rsk: &private::ActionSigningKey,
-        cv: value::Commitment,
-        rng: &mut R,
-    ) -> Self {
-        let rk = rsk.derive_action_public();
-        Self {
-            cv,
-            rk,
-            sig: rsk.sign(rng, sighash(cv, rk)),
-        }
-    }
-
     /// Consume a note.
-    // TODO: Epoch-boundary transactions may require TWO nullifiers per note.
-    // The stamp's tachygram list already supports count > actions, but this API
-    // needs a variant or additional flavor parameter to produce the second
-    // nullifier.
-    pub fn spend<R: RngCore + CryptoRng>(
-        ask: &private::SpendAuthorizingKey,
+    ///
+    /// Convenience wrapper composing individual steps for the
+    /// single-device case. Each step is independently callable for
+    /// delegation (see [composable steps](crate::bundle)):
+    ///
+    /// 1. Note commitment: [`Note::commitment`]
+    /// 2. Value commitment: [`value::Commitment::new`]
+    /// 3. Alpha derivation: [`ActionEntropy::spend_randomizer`](private::ActionEntropy::spend_randomizer)
+    /// 4. Spend authorization: [`Custody::authorize_spend`](crate::custody::Custody::authorize_spend)
+    /// 5. Assembly: `Action { cv, rk, sig }` +
+    ///    [`ActionPrivate`](crate::witness::ActionPrivate)
+    pub fn spend<R: RngCore + CryptoRng, C: Custody>(
+        custody: &C,
         note: Note,
-        nf: note::Nullifier,
-        flavor: Epoch,
         theta: &private::ActionEntropy,
         rng: &mut R,
-    ) -> (Self, ActionPrivate) {
+    ) -> Result<(Self, ActionPrivate), C::Error> {
+        // 1. Note commitment
         let cmx = note.commitment();
-        let (alpha, rsk) = theta.authorize_spend(ask, &cmx);
-        let value: i64 = note.value.into();
-        let (rcv, cv) = value::Commitment::commit(value, rng);
 
-        (
-            Self::new(&rsk, cv, rng),
+        // 2. Value commitment (signer picks rcv)
+        let value: i64 = note.value.into();
+        let rcv = value::CommitmentTrapdoor::random(&mut *rng);
+        let cv = value::Commitment::new(value, rcv);
+
+        // 3. Alpha (user device derives for proof witness)
+        let alpha = theta.spend_randomizer(&cmx);
+
+        // 4. Spend authorization (custody derives alpha independently)
+        let (rk, sig) = custody.authorize_spend(cv, theta, &cmx, rng)?;
+
+        Ok((
+            Self { cv, rk, sig },
             ActionPrivate {
-                tachygram: nf.into(),
-                alpha,
-                flavor,
+                alpha: alpha.into(),
                 note,
                 rcv,
             },
-        )
+        ))
     }
 
     /// Create a note.
+    ///
+    /// Convenience wrapper composing individual steps for the
+    /// single-device case. Each step is independently callable for
+    /// delegation — see [`spend`](Self::spend) for the composable
+    /// steps.
     pub fn output<R: RngCore + CryptoRng>(
         note: Note,
-        flavor: Epoch,
         theta: &private::ActionEntropy,
         rng: &mut R,
     ) -> (Self, ActionPrivate) {
+        // 1. Note commitment
         let cmx = note.commitment();
-        let (alpha, rsk) = theta.authorize_output(&cmx);
+
+        // 2. Value commitment (signer picks rcv; negative for outputs)
         let value: i64 = note.value.into();
-        let (rcv, cv) = value::Commitment::commit(value.neg(), rng);
+        let rcv = value::CommitmentTrapdoor::random(&mut *rng);
+        let cv = value::Commitment::new(value.neg(), rcv);
+
+        // 3. Alpha (for proof witness and output signing key)
+        let alpha = theta.output_randomizer(&cmx);
+
+        // 4. Output authorization (rsk = alpha, no custody)
+        let (rk, sig) = alpha.authorize(cv, rng);
 
         (
-            Self::new(&rsk, cv, rng),
+            Self { cv, rk, sig },
             ActionPrivate {
-                tachygram: cmx.into(),
-                alpha,
-                flavor,
-                rcv,
+                alpha: alpha.into(),
                 note,
+                rcv,
             },
         )
     }
@@ -179,8 +189,9 @@ mod tests {
 
     use super::*;
     use crate::{
+        custody,
         keys::private,
-        note::{CommitmentTrapdoor, NullifierTrapdoor},
+        note::{self, CommitmentTrapdoor, NullifierTrapdoor},
     };
 
     /// A spend action's signature must verify against its own rk.
@@ -188,19 +199,17 @@ mod tests {
     fn spend_sig_round_trip() {
         let mut rng = StdRng::seed_from_u64(0);
         let sk = private::SpendingKey::from([0x42u8; 32]);
-        let ask = sk.derive_auth_private();
-        let nk = sk.derive_nullifier_key();
+        let local = custody::Local::new(sk.derive_auth_private());
         let note = Note {
             pk: sk.derive_payment_key(),
             value: note::Value::from(1000u64),
             psi: NullifierTrapdoor::from(Fp::ZERO),
             rcm: CommitmentTrapdoor::from(Fq::ZERO),
         };
-        let flavor = Epoch::from(Fp::ONE);
-        let nf = note.nullifier(&nk, flavor);
         let theta = private::ActionEntropy::random(&mut rng);
 
-        let (action, _witness) = Action::spend(&ask, note, nf, flavor, &theta, &mut rng);
+        let (action, _witness) =
+            Action::spend(&local, note, &theta, &mut rng).unwrap();
 
         action
             .rk
@@ -219,10 +228,9 @@ mod tests {
             psi: NullifierTrapdoor::from(Fp::ZERO),
             rcm: CommitmentTrapdoor::from(Fq::ZERO),
         };
-        let flavor = Epoch::from(Fp::ONE);
         let theta = private::ActionEntropy::random(&mut rng);
 
-        let (action, _witness) = Action::output(note, flavor, &theta, &mut rng);
+        let (action, _witness) = Action::output(note, &theta, &mut rng);
 
         action
             .rk

--- a/crates/tachyon/src/bundle.rs
+++ b/crates/tachyon/src/bundle.rs
@@ -73,8 +73,8 @@ pub enum BuildError {
 ///
 /// Reconstruction (same logic as consensus verification):
 /// 1. `tachygram_acc = sum[H(tg_i)] * G_acc`
-/// 2. `action_acc = sum[action_digest_i] * G_acc`  where
-///    `action_digest_i = H(cv_i, rk_i)`
+/// 2. `action_acc = sum[action_digest_i] * G_acc`  where `action_digest_i =
+///    H(cv_i, rk_i)`
 /// 3. `anchor` — already known
 /// 4. Verify Ragu proof against `(tachygram_acc, action_acc, anchor)`
 pub fn verify_stamp(stamp: &Stamp, actions: &[Action]) -> Result<(), BuildError> {

--- a/crates/tachyon/src/bundle.rs
+++ b/crates/tachyon/src/bundle.rs
@@ -415,16 +415,16 @@ mod tests {
         // === Spend action (composable steps) ===
 
         // 1. Note commitment (user device)
-        let spend_cmx = spend_note.commitment();
+        let spend_cm = spend_note.commitment();
 
         // 2. Value commitment (user device picks rcv)
         let spend_value: i64 = spend_note.value.into();
         let spend_rcv = value::CommitmentTrapdoor::random(&mut rng);
         let spend_cv = spend_rcv.commit(spend_value);
 
-        // 3. Authorization (custody device: theta + ask + cmx + cv → rk, sig)
+        // 3. Authorization (custody device: theta + ask + cm + cv → rk, sig)
         let spend_theta = private::ActionEntropy::random(&mut rng);
-        let spend_alpha = spend_theta.spend_randomizer(&spend_cmx);
+        let spend_alpha = spend_theta.spend_randomizer(&spend_cm);
         let (spend_rk, spend_sig) = spend_alpha.authorize(&ask, spend_cv, &mut rng);
 
         // 4. Assembly (user device)
@@ -441,13 +441,13 @@ mod tests {
 
         // === Output action (composable steps, no custody) ===
 
-        let output_cmx = output_note.commitment();
+        let output_cm = output_note.commitment();
         let output_value: i64 = output_note.value.into();
         let output_rcv = value::CommitmentTrapdoor::random(&mut rng);
         let output_cv = output_rcv.commit(-output_value);
 
         let output_theta = private::ActionEntropy::random(&mut rng);
-        let output_alpha = output_theta.output_randomizer(&output_cmx);
+        let output_alpha = output_theta.output_randomizer(&output_cm);
         let (output_rk, output_sig) = output_alpha.authorize(output_cv, &mut rng);
 
         let output_action = Action {

--- a/crates/tachyon/src/bundle.rs
+++ b/crates/tachyon/src/bundle.rs
@@ -6,6 +6,7 @@
 use ff::Field as _;
 use pasta_curves::Fq;
 use rand::{CryptoRng, RngCore};
+use reddsa::orchard::Binding;
 
 use crate::{
     action::Action,
@@ -277,7 +278,6 @@ impl<S> Bundle<S, i64> {
     }
 }
 
-use reddsa::orchard::Binding;
 /// A binding signature (RedPallas over the Binding group).
 ///
 /// Proves the signer knew the opening $\mathsf{bsk}$ of the Pedersen
@@ -420,7 +420,7 @@ mod tests {
         // 2. Value commitment (user device picks rcv)
         let spend_value: i64 = spend_note.value.into();
         let spend_rcv = value::CommitmentTrapdoor::random(&mut rng);
-        let spend_cv = value::Commitment::new(spend_value, spend_rcv);
+        let spend_cv = spend_rcv.commit(spend_value);
 
         // 3. Authorization (custody device: theta + ask + cmx + cv → rk, sig)
         let spend_theta = private::ActionEntropy::random(&mut rng);
@@ -444,7 +444,7 @@ mod tests {
         let output_cmx = output_note.commitment();
         let output_value: i64 = output_note.value.into();
         let output_rcv = value::CommitmentTrapdoor::random(&mut rng);
-        let output_cv = value::Commitment::new(-output_value, output_rcv);
+        let output_cv = output_rcv.commit(-output_value);
 
         let output_theta = private::ActionEntropy::random(&mut rng);
         let output_alpha = output_theta.output_randomizer(&output_cmx);

--- a/crates/tachyon/src/bundle.rs
+++ b/crates/tachyon/src/bundle.rs
@@ -8,10 +8,9 @@ use pasta_curves::Fq;
 use rand::{CryptoRng, RngCore};
 
 use crate::{
-    Proof,
     action::Action,
     constants::BINDING_SIGHASH_PERSONALIZATION,
-    keys::{ProvingKey, private::BindingSigningKey, public::BindingVerificationKey},
+    keys::{ProofAuthorizingKey, private::BindingSigningKey, public::BindingVerificationKey},
     primitives::Anchor,
     stamp::{Stamp, Stampless},
     witness::ActionPrivate,
@@ -49,6 +48,39 @@ impl Into<[u8; 64]> for SigHash {
     fn into(self) -> [u8; 64] {
         self.0
     }
+}
+
+/// Errors during bundle construction.
+///
+/// Covers both value balance failures (binding key derivation) and stamp
+/// verification failures (Ragu proof mismatch).
+#[derive(Clone, Copy, Debug)]
+pub enum BuildError {
+    /// The sum of value commitment trapdoors produced an invalid binding
+    /// signing key (e.g. the zero scalar).
+    BalanceKey,
+
+    /// Ragu proof verification failed against expected accumulators.
+    ///
+    /// The verifier reconstructed `(tachygram_acc, action_acc, anchor)`
+    /// from public data and the proof did not verify against them.
+    ProofInvalid,
+}
+
+/// Verifies the stamp by reconstructing the expected accumulators and
+/// checking the Ragu proof against them.
+///
+/// Reconstruction (same logic as consensus verification):
+/// 1. `tachygram_acc = sum[H(tg_i)] * G_acc`
+/// 2. `action_acc = sum[action_digest_i] * G_acc`  where
+///    `action_digest_i = H(cv_i, rk_i)`
+/// 3. `anchor` — already known
+/// 4. Verify Ragu proof against `(tachygram_acc, action_acc, anchor)`
+pub fn verify_stamp(stamp: &Stamp, actions: &[Action]) -> Result<(), BuildError> {
+    stamp
+        .proof
+        .verify(actions, &stamp.tachygrams, stamp.anchor)
+        .map_err(|_err| BuildError::ProofInvalid)
 }
 
 /// Compute the Tachyon binding sighash.
@@ -100,6 +132,17 @@ impl<V> Stamped<V> {
 impl Stamped<i64> {
     /// Builds a stamped bundle from action pairs.
     ///
+    /// ## Build order: stamp before binding signature
+    ///
+    /// The stamp is created and verified **before** the binding signature.
+    /// This ensures the signer withholds authorization until confirming
+    /// the stamp correctly reflects the expected tachygrams and actions.
+    /// Without the binding signature, no valid transaction can be broadcast.
+    ///
+    /// 1. Prove: `Stamp::prove` runs the ACTION STEP per action
+    /// 2. Verify: reconstruct expected accumulators, check Ragu proof
+    /// 3. Sign: create binding signature over `v_balance || sigs`
+    ///
     /// ## Binding signature scheme
     ///
     /// The binding signature enforces value balance (§4.14). The signer:
@@ -123,9 +166,9 @@ impl Stamped<i64> {
         tachyactions: Vec<(Action, ActionPrivate)>,
         value_balance: i64,
         anchor: Anchor,
-        pak: &ProvingKey,
+        pak: &ProofAuthorizingKey,
         rng: &mut R,
-    ) -> Self {
+    ) -> Result<Self, BuildError> {
         let mut actions = Vec::new();
         let mut witnesses = Vec::new();
 
@@ -138,9 +181,7 @@ impl Stamped<i64> {
             witnesses.push(witness);
         }
 
-        #[expect(clippy::expect_used, reason = "specified behavior")]
-        let bsk =
-            BindingSigningKey::try_from(rcv_sum).expect("sum of trapdoors is a valid signing key");
+        let bsk = BindingSigningKey::try_from(rcv_sum).map_err(|_err| BuildError::BalanceKey)?;
 
         // §4.14 implementation fault check:
         // DerivePublic(bsk) == bvk
@@ -154,24 +195,41 @@ impl Stamped<i64> {
             "BSK/BVK mismatch: binding key derivation is inconsistent"
         );
 
+        // 1. Create stamp FIRST (ACTION STEP per action, then merge)
+        let mut stamps: Vec<Stamp> = actions
+            .iter()
+            .zip(&witnesses)
+            .map(|(action, witness)| Stamp::prove_action(witness, action, anchor, pak))
+            .collect();
+        while stamps.len() > 1 {
+            let right = stamps.pop();
+            let left = stamps.pop();
+            // Both unwraps are safe: len > 1 guarantees two elements.
+            #[expect(clippy::expect_used, reason = "len > 1 guarantees two elements")]
+            let merged = left
+                .expect("left stamp")
+                .prove_merge(right.expect("right stamp"));
+            stamps.push(merged);
+        }
+        #[expect(clippy::expect_used, reason = "at least one action")]
+        let stamp = stamps.pop().expect("at least one action");
+
+        // 2. Verify stamp against expected accumulators
+        verify_stamp(&stamp, &actions)?;
+
+        // 3. THEN create binding signature (signer withholds until stamp verified)
         let action_sigs = actions
             .iter()
             .map(|action| <[u8; 64]>::from(action.sig))
             .collect::<Vec<[u8; 64]>>();
         let binding_sig = bsk.sign(rng, sighash(value_balance, &action_sigs));
 
-        let (proof, tachygrams) = Proof::create(&actions, &witnesses, &anchor, pak);
-
-        Self {
+        Ok(Self {
             actions,
             value_balance,
             binding_sig,
-            stamp: Stamp {
-                tachygrams,
-                anchor,
-                proof,
-            },
-        }
+            stamp,
+        })
     }
 }
 
@@ -259,17 +317,17 @@ mod tests {
 
     use super::*;
     use crate::{
+        custody,
         keys::private,
         note::{self, CommitmentTrapdoor, Note, NullifierTrapdoor},
-        primitives::Epoch,
+        value,
     };
 
     fn build_test_bundle(rng: &mut (impl RngCore + CryptoRng)) -> Stamped<i64> {
         let sk = private::SpendingKey::from([0x42u8; 32]);
         let ask = sk.derive_auth_private();
-        let pak = sk.derive_proving_key();
+        let pak = sk.derive_proof_private();
         let anchor = Anchor::from(Fp::ZERO);
-        let epoch = Epoch::from(Fp::ONE);
 
         let spend_note = Note {
             pk: sk.derive_payment_key(),
@@ -287,13 +345,12 @@ mod tests {
         let theta_spend = private::ActionEntropy::random(&mut *rng);
         let theta_output = private::ActionEntropy::random(&mut *rng);
 
-        let nk = sk.derive_nullifier_key();
-        let nf = spend_note.nullifier(&nk, epoch);
-        let spend = Action::spend(&ask, spend_note, nf, epoch, &theta_spend, rng);
-        let output = Action::output(output_note, epoch, &theta_output, rng);
+        let local = custody::Local::new(ask);
+        let spend = Action::spend(&local, spend_note, &theta_spend, rng).unwrap();
+        let output = Action::output(output_note, &theta_output, rng);
 
         // value_balance = 1000 - 700 = 300
-        Stamped::build(vec![spend, output], 300, anchor, &pak, rng)
+        Stamped::build(vec![spend, output], 300, anchor, &pak, rng).unwrap()
     }
 
     /// A correctly built bundle must pass signature verification.
@@ -322,5 +379,121 @@ mod tests {
 
         let (stripped, _stamp) = bundle.strip();
         stripped.verify_signatures().unwrap();
+    }
+
+    /// Composable flow: construct actions and bundle step-by-step,
+    /// exercising each delegation boundary independently.
+    ///
+    /// This uses no convenience wrappers (`Action::spend/output`,
+    /// `Stamped::build`). Every step is called individually, matching
+    /// the custody-delegated flow from the protocol spec.
+    #[test]
+    #[expect(
+        clippy::similar_names,
+        reason = "protocol variable names: cv/rcv, rk/rsk"
+    )]
+    fn composable_delegation_flow() {
+        let mut rng = StdRng::seed_from_u64(1);
+        let sk = private::SpendingKey::from([0x42u8; 32]);
+        let ask = sk.derive_auth_private();
+        let pak = sk.derive_proof_private();
+        let anchor = Anchor::from(Fp::ZERO);
+
+        let spend_note = Note {
+            pk: sk.derive_payment_key(),
+            value: note::Value::from(1000u64),
+            psi: NullifierTrapdoor::from(Fp::ZERO),
+            rcm: CommitmentTrapdoor::from(Fq::ZERO),
+        };
+        let output_note = Note {
+            pk: sk.derive_payment_key(),
+            value: note::Value::from(700u64),
+            psi: NullifierTrapdoor::from(Fp::ONE),
+            rcm: CommitmentTrapdoor::from(Fq::ONE),
+        };
+
+        // === Spend action (composable steps) ===
+
+        // 1. Note commitment (user device)
+        let spend_cmx = spend_note.commitment();
+
+        // 2. Value commitment (user device picks rcv)
+        let spend_value: i64 = spend_note.value.into();
+        let spend_rcv = value::CommitmentTrapdoor::random(&mut rng);
+        let spend_cv = value::Commitment::new(spend_value, spend_rcv);
+
+        // 3. Authorization (custody device: theta + ask + cmx + cv → rk, sig)
+        let spend_theta = private::ActionEntropy::random(&mut rng);
+        let spend_alpha = spend_theta.spend_randomizer(&spend_cmx);
+        let (spend_rk, spend_sig) = spend_alpha.authorize(&ask, spend_cv, &mut rng);
+
+        // 4. Assembly (user device)
+        let spend_action = Action {
+            cv: spend_cv,
+            rk: spend_rk,
+            sig: spend_sig,
+        };
+        let spend_witness = ActionPrivate {
+            alpha: spend_alpha.into(),
+            note: spend_note,
+            rcv: spend_rcv,
+        };
+
+        // === Output action (composable steps, no custody) ===
+
+        let output_cmx = output_note.commitment();
+        let output_value: i64 = output_note.value.into();
+        let output_rcv = value::CommitmentTrapdoor::random(&mut rng);
+        let output_cv = value::Commitment::new(-output_value, output_rcv);
+
+        let output_theta = private::ActionEntropy::random(&mut rng);
+        let output_alpha = output_theta.output_randomizer(&output_cmx);
+        let (output_rk, output_sig) = output_alpha.authorize(output_cv, &mut rng);
+
+        let output_action = Action {
+            cv: output_cv,
+            rk: output_rk,
+            sig: output_sig,
+        };
+        let output_witness = ActionPrivate {
+            alpha: output_alpha.into(),
+            note: output_note,
+            rcv: output_rcv,
+        };
+
+        // === Bundle assembly (composable steps) ===
+
+        let actions = vec![spend_action, output_action];
+        let value_balance: i64 = 300;
+
+        // Binding key (user device: accumulate rcv trapdoors)
+        let bsk: BindingSigningKey = [spend_witness.rcv, output_witness.rcv].into_iter().sum();
+        debug_assert_eq!(
+            bsk.derive_binding_public(),
+            BindingVerificationKey::derive(&actions, value_balance),
+        );
+
+        // Stamp (per-action proofs, then merge)
+        let spend_stamp = Stamp::prove_action(&spend_witness, &spend_action, anchor, &pak);
+        let output_stamp = Stamp::prove_action(&output_witness, &output_action, anchor, &pak);
+        let stamp = spend_stamp.prove_merge(output_stamp);
+        verify_stamp(&stamp, &actions).unwrap();
+
+        // Binding signature (user device: withheld until stamp verified)
+        let action_sigs: Vec<[u8; 64]> = actions
+            .iter()
+            .map(|action| <[u8; 64]>::from(action.sig))
+            .collect();
+        let binding_sig = bsk.sign(&mut rng, sighash(value_balance, &action_sigs));
+
+        // Assemble
+        let bundle: Stamped<i64> = Bundle {
+            actions,
+            value_balance,
+            binding_sig,
+            stamp,
+        };
+
+        bundle.verify_signatures().unwrap();
     }
 }

--- a/crates/tachyon/src/constants.rs
+++ b/crates/tachyon/src/constants.rs
@@ -24,14 +24,21 @@ pub const SPEND_AUTH_PERSONALIZATION: &[u8; 16] = b"Tachyon-SpendSig";
 /// is excluded because it is stripped during aggregation.
 pub const BINDING_SIGHASH_PERSONALIZATION: &[u8; 16] = b"Tachyon-BindHash";
 
-/// BLAKE2b-512 personalization for deterministic alpha derivation.
+/// BLAKE2b-512 personalization for spend-side alpha derivation.
 ///
-/// $\alpha = \text{ToScalar}(\text{BLAKE2b-512}(\text{"Tachyon-AlphaDrv"},\;
-/// \theta \| \mathsf{cm}))$
+/// $$\alpha_{\text{spend}} = \text{ToScalar}(\text{BLAKE2b-512}(
+/// \text{"Tachyon-Spend"},\; \theta \| \mathsf{cm}))$$
 ///
-/// Binds `alpha` to per-action randomness (`theta`) and the note commitment,
-/// enabling hardware wallet signing decoupled from proof generation.
-pub const ALPHA_PERSONALIZATION: &[u8; 16] = b"Tachyon-AlphaDrv";
+/// Domain-separated from output alpha to prevent cross-context reuse.
+pub const SPEND_ALPHA_PERSONALIZATION: &[u8; 13] = b"Tachyon-Spend";
+
+/// BLAKE2b-512 personalization for output-side alpha derivation.
+///
+/// $$\alpha_{\text{output}} = \text{ToScalar}(\text{BLAKE2b-512}(
+/// \text{"Tachyon-Output"},\; \theta \| \mathsf{cm}))$$
+///
+/// Domain-separated from spend alpha to prevent cross-context reuse.
+pub const OUTPUT_ALPHA_PERSONALIZATION: &[u8; 14] = b"Tachyon-Output";
 
 /// Domain for value commitment generators `V` and `R`.
 ///

--- a/crates/tachyon/src/constants.rs
+++ b/crates/tachyon/src/constants.rs
@@ -27,7 +27,7 @@ pub const BINDING_SIGHASH_PERSONALIZATION: &[u8; 16] = b"Tachyon-BindHash";
 /// BLAKE2b-512 personalization for deterministic alpha derivation.
 ///
 /// $\alpha = \text{ToScalar}(\text{BLAKE2b-512}(\text{"Tachyon-AlphaDrv"},\;
-/// \theta \| \mathsf{cmx}))$
+/// \theta \| \mathsf{cm}))$
 ///
 /// Binds `alpha` to per-action randomness (`theta`) and the note commitment,
 /// enabling hardware wallet signing decoupled from proof generation.

--- a/crates/tachyon/src/custody.rs
+++ b/crates/tachyon/src/custody.rs
@@ -124,7 +124,7 @@ mod tests {
         let cmx = note.commitment();
         let note_value: i64 = note.value.into();
         let rcv = value::CommitmentTrapdoor::random(&mut rng);
-        let cv = value::Commitment::new(note_value, rcv);
+        let cv = rcv.commit(note_value);
         let theta = private::ActionEntropy::random(&mut rng);
 
         let (rk, sig) = custody.authorize_spend(cv, &theta, &cmx, &mut rng).unwrap();

--- a/crates/tachyon/src/custody.rs
+++ b/crates/tachyon/src/custody.rs
@@ -1,0 +1,134 @@
+//! Custody abstraction for spend authorization.
+//!
+//! A custody device holds the spend authorizing key (`ask`) and performs
+//! per-action authorization without exposing the key. The [`Custody`] trait
+//! enables hardware wallets, software wallets, and test implementations
+//! behind a common interface.
+//!
+//! ## Protocol
+//!
+//! The user device picks $\theta$ and sends `(cv, theta, cmx)` to custody.
+//! The custody device returns `(rk, sig)`:
+//!
+//! 1. $\alpha = \text{BLAKE2b}(\text{"Tachyon-AlphaDrv"},\; \theta \|
+//!    \mathsf{cmx})$
+//! 2. $\mathsf{rsk} = \mathsf{ask} + \alpha$
+//! 3. $\mathsf{rk} = [\mathsf{rsk}]\,\mathcal{G}$
+//! 4. $\text{sig} = \mathsf{rsk}.\text{sign}(H(\mathsf{cv} \|
+//!    \mathsf{rk}))$
+//!
+//! The caller derives $\alpha$ independently via
+//! [`ActionEntropy::spend_randomizer`](crate::keys::private::ActionEntropy::spend_randomizer)
+//! from `theta` and `cmx`.
+//!
+//! Outputs do not involve custody — they use
+//! [`ActionEntropy::output_randomizer`](crate::keys::private::ActionEntropy::output_randomizer)
+//! followed by
+//! [`derive_action_private`](crate::keys::private::OutputRandomizer::derive_action_private).
+
+use core::convert::Infallible;
+
+use rand::{CryptoRng, RngCore};
+
+use crate::{action, keys::private, keys::public, note, value};
+
+/// Custody device abstraction for spend authorization.
+///
+/// A custody device holds the spend authorizing key (`ask`) and performs
+/// per-action authorization: given a value commitment, per-action entropy,
+/// and note commitment, it returns the verification key and signature.
+///
+/// ## Implementations
+///
+/// - [`Local`]: wraps [`SpendAuthorizingKey`](private::SpendAuthorizingKey)
+///   in memory
+/// - **Hardware wallet**: sends `(cv, theta, cmx)` to the device over
+///   USB/BLE
+/// - **Threshold**: distributes authorization across multiple parties
+pub trait Custody {
+    /// Error type for authorization failures.
+    type Error;
+
+    /// Authorize a spend action.
+    ///
+    /// The custody device independently derives $\alpha$ from `theta` and
+    /// `cmx`, computes $\mathsf{rsk} = \mathsf{ask} + \alpha$, and signs
+    /// the action. Returns $(\mathsf{rk}, \text{sig})$.
+    ///
+    /// `cv` is needed to compute the sighash
+    /// $H(\text{"Tachyon-SpendSig"},\; \mathsf{cv} \| \mathsf{rk})$.
+    fn authorize_spend<R: RngCore + CryptoRng>(
+        &self,
+        cv: value::Commitment,
+        theta: &private::ActionEntropy,
+        cmx: &note::Commitment,
+        rng: &mut R,
+    ) -> Result<(public::ActionVerificationKey, action::Signature), Self::Error>;
+}
+
+/// Software custody — holds the spend authorizing key in memory.
+///
+/// Suitable for single-device wallets where the spending key is
+/// available locally.
+#[derive(Clone, Copy, Debug)]
+pub struct Local {
+    /// The spend authorizing key.
+    ask: private::SpendAuthorizingKey,
+}
+
+impl Local {
+    /// Create a new software custody from a spend authorizing key.
+    #[must_use]
+    pub const fn new(ask: private::SpendAuthorizingKey) -> Self {
+        Self { ask }
+    }
+}
+
+impl Custody for Local {
+    type Error = Infallible;
+
+    fn authorize_spend<R: RngCore + CryptoRng>(
+        &self,
+        cv: value::Commitment,
+        theta: &private::ActionEntropy,
+        cmx: &note::Commitment,
+        rng: &mut R,
+    ) -> Result<(public::ActionVerificationKey, action::Signature), Self::Error> {
+        let alpha = theta.spend_randomizer(cmx);
+        Ok(alpha.authorize(&self.ask, cv, rng))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ff::Field as _;
+    use pasta_curves::{Fp, Fq};
+    use rand::{SeedableRng as _, rngs::StdRng};
+
+    use super::*;
+    use crate::note::{CommitmentTrapdoor, Note, NullifierTrapdoor};
+
+    /// Software custody authorization must produce a valid signature.
+    #[test]
+    fn software_custody_sig_round_trip() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let sk = private::SpendingKey::from([0x42u8; 32]);
+        let custody = Local::new(sk.derive_auth_private());
+
+        let note = Note {
+            pk: sk.derive_payment_key(),
+            value: note::Value::from(1000u64),
+            psi: NullifierTrapdoor::from(Fp::ZERO),
+            rcm: CommitmentTrapdoor::from(Fq::ZERO),
+        };
+        let cmx = note.commitment();
+        let note_value: i64 = note.value.into();
+        let rcv = value::CommitmentTrapdoor::random(&mut rng);
+        let cv = value::Commitment::new(note_value, rcv);
+        let theta = private::ActionEntropy::random(&mut rng);
+
+        let (rk, sig) = custody.authorize_spend(cv, &theta, &cmx, &mut rng).unwrap();
+
+        rk.verify(action::sighash(cv, rk), &sig).unwrap();
+    }
+}

--- a/crates/tachyon/src/custody.rs
+++ b/crates/tachyon/src/custody.rs
@@ -14,8 +14,7 @@
 //!    \mathsf{cm})$
 //! 2. $\mathsf{rsk} = \mathsf{ask} + \alpha$
 //! 3. $\mathsf{rk} = [\mathsf{rsk}]\,\mathcal{G}$
-//! 4. $\text{sig} = \mathsf{rsk}.\text{sign}(H(\mathsf{cv} \|
-//!    \mathsf{rk}))$
+//! 4. $\text{sig} = \mathsf{rsk}.\text{sign}(H(\mathsf{cv} \| \mathsf{rk}))$
 //!
 //! The caller derives $\alpha$ independently via
 //! [`ActionEntropy::spend_randomizer`](crate::keys::private::ActionEntropy::spend_randomizer)
@@ -30,7 +29,11 @@ use core::convert::Infallible;
 
 use rand::{CryptoRng, RngCore};
 
-use crate::{action, keys::private, keys::public, note, value};
+use crate::{
+    action,
+    keys::{private, public},
+    note, value,
+};
 
 /// Custody device abstraction for spend authorization.
 ///

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -44,8 +44,8 @@
 //!
 //! ### Proof keys ([`proof`])
 //!
-//! - `pak`: `ak` + `nk` (proof authorizing key): Authorizes proof
-//!   construction without spend authority
+//! - `pak`: `ak` + `nk` (proof authorizing key): Authorizes proof construction
+//!   without spend authority
 //!
 //! ## Nullifier Derivation
 //!

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -44,8 +44,8 @@
 //!
 //! ### Proof keys ([`proof`])
 //!
-//! - `pak`: `ak` + `nk` (proving key): Constructs proofs without spend
-//!   authority; might be delegated to a syncing service
+//! - `pak`: `ak` + `nk` (proof authorizing key): Authorizes proof
+//!   construction without spend authority
 //!
 //! ## Nullifier Derivation
 //!

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -148,9 +148,8 @@ mod tests {
             psi: NullifierTrapdoor::from(Fp::ZERO),
             rcm: CommitmentTrapdoor::from(Fq::ZERO),
         };
-        let cmx = note.commitment();
         let theta = private::ActionEntropy::random(&mut rng);
-        let alpha = theta.spend_randomizer(&cmx);
+        let alpha = theta.spend_randomizer(&note.commitment());
         let rsk = ask.derive_action_private(&alpha);
         let witness_alpha: private::ActionRandomizer = alpha.into();
 

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -41,7 +41,8 @@ impl NullifierKey {
     /// \mathsf{nk})$.
     ///
     /// `mk` is the root of the GGM tree for one note. It is used to:
-    /// - Derive nullifiers directly: $\mathsf{nf} = F_{\mathsf{mk}}(\text{flavor})$
+    /// - Derive nullifiers directly: $\mathsf{nf} =
+    ///   F_{\mathsf{mk}}(\text{flavor})$
     /// - Derive epoch-restricted prefix keys $\Psi_t$ for OSS delegation
     #[must_use]
     pub fn derive_note_private(&self, _psi: &NullifierTrapdoor) -> NoteMasterKey {

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -1,7 +1,12 @@
-//! Note-related keys: PaymentKey, NullifierKey.
+//! Note-related keys: NullifierKey, MasterRootKey, PrefixKey, PaymentKey.
 
-use ff::PrimeField as _;
+use ff::{Field as _, PrimeField as _};
 use pasta_curves::Fp;
+
+use crate::{
+    note::{Nullifier, NullifierTrapdoor},
+    primitives::Epoch,
+};
 
 /// A Tachyon nullifier deriving key.
 ///
@@ -26,20 +31,117 @@ use pasta_curves::Fp;
 ///
 /// `nk` alone does NOT confer spend authority — it only allows observing
 /// spend status and constructing proofs (when combined with `ak`).
-///
-/// ## Status
-///
-/// Currently only exposes `Into<Fp>`. Nullifier derivation is implemented
-/// externally in [`note::Nullifier`](crate::note::Nullifier). The GGM tree
-/// PRF and prefix key delegation are not yet implemented.
-// TODO: implement GGM tree PRF methods for oblivious sync delegation
-// (derive_master_key, derive_prefix_key, etc.)
 #[derive(Clone, Copy, Debug)]
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]
 pub struct NullifierKey(pub(super) Fp);
 
+impl NullifierKey {
+    /// Derive the per-note master root key: $\mathsf{mk} = \text{KDF}(\psi,
+    /// \mathsf{nk})$.
+    ///
+    /// `mk` is the root of the GGM tree for one note. It is used to:
+    /// - Derive nullifiers directly: $\mathsf{nf} = F_{\mathsf{mk}}(\text{flavor})$
+    /// - Derive epoch-restricted prefix keys $\Psi_t$ for OSS delegation
+    #[must_use]
+    pub fn derive_note_private(&self, _psi: &NullifierTrapdoor) -> NoteMasterKey {
+        todo!("Poseidon KDF");
+        NoteMasterKey(Fp::ZERO)
+    }
+}
+
 #[expect(clippy::from_over_into, reason = "restrict conversion")]
 impl Into<[u8; 32]> for NullifierKey {
+    fn into(self) -> [u8; 32] {
+        self.0.to_repr()
+    }
+}
+
+/// Per-note master root key $\mathsf{mk} = \text{KDF}(\psi, \mathsf{nk})$.
+///
+/// Root of the GGM tree PRF for a single note. Derived by the user device
+/// from [`NullifierKey`] and the note's $\psi$ trapdoor.
+///
+/// ## Delegation chain
+///
+/// ```text
+/// nk + psi → mk (per-note root, user device)
+///              ├── nf = F_mk(flavor)     nullifier for a specific epoch
+///              └── psi_t = GGM(mk, t)    prefix key for epochs e ≤ t (OSS)
+/// ```
+///
+/// `mk` is not stored or transmitted — the user device derives it
+/// ephemerally when needed. The OSS receives only the prefix keys.
+#[derive(Clone, Copy, Debug)]
+pub struct NoteMasterKey(Fp);
+
+impl NoteMasterKey {
+    /// Derive a nullifier for a specific epoch: $\mathsf{nf} =
+    /// F_{\mathsf{mk}}(\text{flavor})$.
+    ///
+    /// GGM tree walk over the bits of `flavor`. The user device calls
+    /// this directly; the OSS uses [`NoteDelegateKey::derive_nullifier`]
+    /// instead (restricted to authorized epochs).
+    #[must_use]
+    pub fn derive_nullifier(&self, _flavor: Epoch) -> Nullifier {
+        todo!("GGM tree PRF evaluation");
+        Nullifier::from(Fp::ZERO)
+    }
+
+    /// Derive an epoch-restricted prefix key $\Psi_t$ for OSS delegation.
+    ///
+    /// The prefix key allows evaluating $\mathsf{nf}_e = F_{\mathsf{mk}}(e)$
+    /// for epochs $e \leq t$ only. The OSS cannot compute nullifiers for
+    /// future epochs $e > t$.
+    ///
+    /// When the chain advances past $t$, the user device sends a delta
+    /// prefix key covering the new range $(t..t']$.
+    #[must_use]
+    pub fn derive_note_delegate(&self, _epoch: Epoch) -> NoteDelegateKey {
+        todo!("GGM tree prefix key derivation");
+        NoteDelegateKey(Fp::ZERO)
+    }
+}
+
+#[expect(clippy::from_over_into, reason = "restrict conversion")]
+impl Into<[u8; 32]> for NoteMasterKey {
+    fn into(self) -> [u8; 32] {
+        self.0.to_repr()
+    }
+}
+
+/// Epoch-restricted GGM prefix key $\Psi_t$.
+///
+/// Derived from [`NoteMasterKey`] for a specific epoch bound $t$.
+/// Held by the Oblivious Syncing Service (OSS) to evaluate nullifiers
+/// $\mathsf{nf}_e = F_{\mathsf{mk}}(e)$ for epochs $e \leq t$ without
+/// learning `mk` or `nk`.
+///
+/// ## Security boundary
+///
+/// - **Can**: derive nullifiers for epochs $e \leq t$ of one note
+/// - **Cannot**: derive nullifiers for future epochs $e > t$
+/// - **Cannot**: recover `mk` or `nk` from the prefix key
+/// - **Cannot**: derive prefix keys for other notes
+#[derive(Clone, Copy, Debug)]
+pub struct NoteDelegateKey(Fp);
+
+impl NoteDelegateKey {
+    /// Derive a nullifier for an epoch within the authorized range:
+    /// $\mathsf{nf}_e = F_{\mathsf{mk}}(e)$ for $e \leq t$.
+    ///
+    /// The OSS calls this to scan blocks for matching nullifiers.
+    /// Evaluating an epoch outside the authorized range is not possible
+    /// — the GGM prefix key only contains the subtree needed for
+    /// $e \leq t$.
+    #[must_use]
+    pub fn derive_nullifier(&self, _flavor: Epoch) -> Nullifier {
+        todo!("GGM tree PRF evaluation from prefix key");
+        Nullifier::from(Fp::ZERO)
+    }
+}
+
+#[expect(clippy::from_over_into, reason = "restrict conversion")]
+impl Into<[u8; 32]> for NoteDelegateKey {
     fn into(self) -> [u8; 32] {
         self.0.to_repr()
     }

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -29,8 +29,9 @@ use crate::{
 ///   $e \leq t$, enabling range-restricted delegation without revealing spend
 ///   capability
 ///
-/// `nk` alone does NOT confer spend authority — it only allows observing
-/// spend status and constructing proofs (when combined with `ak`).
+/// `nk` alone does NOT confer spend authority — combined with `ak` it
+/// forms the proof authorizing key `pak`, enabling proof construction
+/// and nullifier derivation without signing capability.
 #[derive(Clone, Copy, Debug)]
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]
 pub struct NullifierKey(pub(super) Fp);

--- a/crates/tachyon/src/keys/private.rs
+++ b/crates/tachyon/src/keys/private.rs
@@ -31,8 +31,8 @@ use crate::{
 /// - [`derive_nullifier_key`](Self::derive_nullifier_key) → [`NullifierKey`]
 ///   (`nk`)
 /// - [`derive_payment_key`](Self::derive_payment_key) → [`PaymentKey`] (`pk`)
-/// - [`derive_proof_authorizing_key`](Self::derive_proof_authorizing_key) → [`ProofAuthorizingKey`] (`ak` +
-///   `nk`)
+/// - [`derive_proof_authorizing_key`](Self::derive_proof_authorizing_key) →
+///   [`ProofAuthorizingKey`] (`ak` + `nk`)
 #[derive(Clone, Copy, Debug)]
 pub struct SpendingKey([u8; 32]);
 

--- a/crates/tachyon/src/keys/proof.rs
+++ b/crates/tachyon/src/keys/proof.rs
@@ -66,8 +66,8 @@ impl Into<[u8; 64]> for ProofAuthorizingKey {
 /// `ak` **cannot verify action signatures directly** — the prover uses
 /// [`derive_action_public`](Self::derive_action_public) to compute the
 /// per-action `rk` for the proof witness. Component of
-/// [`ProofAuthorizingKey`](super::ProofAuthorizingKey) for proof authorization without spend
-/// authority.
+/// [`ProofAuthorizingKey`](super::ProofAuthorizingKey) for proof authorization
+/// without spend authority.
 #[derive(Clone, Copy, Debug)]
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]
 pub struct SpendValidatingKey(pub(super) reddsa::VerificationKey<SpendAuth>);
@@ -76,8 +76,9 @@ impl SpendValidatingKey {
     /// Derive the per-action public (verification) key: $\mathsf{rk} =
     /// \mathsf{ak} + [\alpha]\,\mathcal{G}$.
     ///
-    /// Used by the prover (who has [`ProofAuthorizingKey`](super::ProofAuthorizingKey) containing
-    /// `ak`) to compute the `rk` that the Ragu circuit constrains. During
+    /// Used by the prover (who has
+    /// [`ProofAuthorizingKey`](super::ProofAuthorizingKey) containing `ak`)
+    /// to compute the `rk` that the Ragu circuit constrains. During
     /// action construction the signer derives `rk` via
     /// [`ActionSigningKey::derive_action_public`](super::ActionSigningKey::derive_action_public)
     /// instead.

--- a/crates/tachyon/src/keys/proof.rs
+++ b/crates/tachyon/src/keys/proof.rs
@@ -4,11 +4,11 @@ use reddsa::orchard::SpendAuth;
 
 use super::{note::NullifierKey, private, public};
 
-/// The proving key (`ak` + `nk`).
+/// The proof authorizing key (`ak` + `nk`).
 ///
-/// Allows constructing proofs without spend authority. This might be delegated
-/// to a service that constructs non-membership proofs for nullifiers without
-/// learning the wallet's spending key.
+/// Authorizes proof construction without spend authority. The holder can
+/// construct proofs for all notes (since `nk` is wallet-wide) but cannot
+/// sign actions.
 ///
 /// Derived from [`SpendAuthorizingKey`](super::SpendAuthorizingKey) $\to$
 /// [`SpendValidatingKey`] and [`NullifierKey`].
@@ -66,7 +66,7 @@ impl Into<[u8; 64]> for ProofAuthorizingKey {
 /// `ak` **cannot verify action signatures directly** — the prover uses
 /// [`derive_action_public`](Self::derive_action_public) to compute the
 /// per-action `rk` for the proof witness. Component of
-/// [`ProofAuthorizingKey`](super::ProofAuthorizingKey) for proof delegation without spend
+/// [`ProofAuthorizingKey`](super::ProofAuthorizingKey) for proof authorization without spend
 /// authority.
 #[derive(Clone, Copy, Debug)]
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]

--- a/crates/tachyon/src/keys/proof.rs
+++ b/crates/tachyon/src/keys/proof.rs
@@ -1,4 +1,4 @@
-//! Proof-related keys: ProvingKey.
+//! Proof-related keys: ProofAuthorizingKey.
 
 use reddsa::orchard::SpendAuth;
 
@@ -22,14 +22,14 @@ use super::{note::NullifierKey, private, public};
 // once the Ragu circuit API is available.
 #[derive(Clone, Copy, Debug)]
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]
-pub struct ProvingKey {
+pub struct ProofAuthorizingKey {
     /// The spend validating key `ak = [ask] G`.
     pub(super) ak: SpendValidatingKey,
     /// The nullifier deriving key.
     pub(super) nk: NullifierKey,
 }
 
-impl ProvingKey {
+impl ProofAuthorizingKey {
     /// The spend validating key $\mathsf{ak} = [\mathsf{ask}]\,\mathcal{G}$.
     #[must_use]
     pub const fn ak(&self) -> &SpendValidatingKey {
@@ -44,7 +44,7 @@ impl ProvingKey {
 }
 
 #[expect(clippy::from_over_into, reason = "restrict conversion")]
-impl Into<[u8; 64]> for ProvingKey {
+impl Into<[u8; 64]> for ProofAuthorizingKey {
     fn into(self) -> [u8; 64] {
         let mut bytes = [0u8; 64];
         let ak_bytes: [u8; 32] = self.ak.into();
@@ -66,7 +66,7 @@ impl Into<[u8; 64]> for ProvingKey {
 /// `ak` **cannot verify action signatures directly** — the prover uses
 /// [`derive_action_public`](Self::derive_action_public) to compute the
 /// per-action `rk` for the proof witness. Component of
-/// [`ProvingKey`](super::ProvingKey) for proof delegation without spend
+/// [`ProofAuthorizingKey`](super::ProofAuthorizingKey) for proof delegation without spend
 /// authority.
 #[derive(Clone, Copy, Debug)]
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]
@@ -76,7 +76,7 @@ impl SpendValidatingKey {
     /// Derive the per-action public (verification) key: $\mathsf{rk} =
     /// \mathsf{ak} + [\alpha]\,\mathcal{G}$.
     ///
-    /// Used by the prover (who has [`ProvingKey`](super::ProvingKey) containing
+    /// Used by the prover (who has [`ProofAuthorizingKey`](super::ProofAuthorizingKey) containing
     /// `ak`) to compute the `rk` that the Ragu circuit constrains. During
     /// action construction the signer derives `rk` via
     /// [`ActionSigningKey::derive_action_public`](super::ActionSigningKey::derive_action_public)
@@ -86,7 +86,7 @@ impl SpendValidatingKey {
         &self,
         alpha: &private::ActionRandomizer,
     ) -> public::ActionVerificationKey {
-        public::ActionVerificationKey(self.0.randomize(alpha.inner()))
+        public::ActionVerificationKey(self.0.randomize(&alpha.0))
     }
 }
 

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -44,6 +44,7 @@ macro_rules! todo {
 pub mod action;
 pub mod bundle;
 pub mod constants;
+pub mod custody;
 pub mod keys;
 pub mod note;
 pub mod proof;

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -77,8 +77,8 @@ impl CommitmentTrapdoor {
     #[must_use]
     pub fn commit(self, _v: Value, _pk: &PaymentKey, _psi: &NullifierTrapdoor) -> Commitment {
         // TODO: Implement note commitment
-        // $cm = \text{NoteCommit}_{rcm}(\text{"z.cash:Tachyon-NoteCommit"}, pk \| v \| \psi)$
-        // This stub returns Fp::ZERO for every note, making all output
+        // $cm = \text{NoteCommit}_{rcm}(\text{"z.cash:Tachyon-NoteCommit"}, pk \| v \|
+        // \psi)$ This stub returns Fp::ZERO for every note, making all output
         // tachygrams identical.
         todo!("note commitment");
         Commitment::from(Fp::ZERO)

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -70,6 +70,24 @@ impl Into<Fp> for NullifierTrapdoor {
 #[derive(Clone, Copy, Debug)]
 pub struct CommitmentTrapdoor(Fq);
 
+impl CommitmentTrapdoor {
+    /// Computes the note commitment `cmx`.
+    ///
+    /// Commits to $(pk, v, \psi)$ with randomness $rcm$
+    #[must_use]
+    pub fn commit(self, _v: Value, _pk: &PaymentKey, _psi: &NullifierTrapdoor) -> Commitment {
+        // TODO: Implement note commitment
+        // $cmx = \text{NoteCommit}_{rcm}(\text{"z.cash:Tachyon-NoteCommit"}, pk \| v \|
+        // \psi)$
+        //
+        // CORRECTNESS: the crate-local `todo!` macro prints and continues
+        // (does not panic). This stub returns Fp::ZERO for every note,
+        // making all output tachygrams identical.
+        todo!("note commitment");
+        Commitment::from(Fp::ZERO)
+    }
+}
+
 impl From<Fq> for CommitmentTrapdoor {
     fn from(fq: Fq) -> Self {
         Self(fq)
@@ -137,15 +155,7 @@ impl Note {
     /// Commits to $(pk, v, \psi)$ with randomness $rcm$
     #[must_use]
     pub fn commitment(&self) -> Commitment {
-        // TODO: Implement note commitment
-        // $cmx = \text{NoteCommit}_{rcm}(\text{"z.cash:Tachyon-NoteCommit"}, pk \| v \|
-        // \psi)$
-        //
-        // CORRECTNESS: the crate-local `todo!` macro prints and continues
-        // (does not panic). This stub returns Fp::ZERO for every note,
-        // making all output tachygrams identical.
-        todo!("note commitment");
-        Commitment::from(Fp::ZERO)
+        self.rcm.commit(self.value, &self.pk, &self.psi)
     }
 
     /// Derives a nullifier for this note at the given flavor (epoch).

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -29,7 +29,7 @@
 //!
 //! ## Note Commitment
 //!
-//! A commitment over the note fields, producing a `cmx` tachygram that
+//! A commitment over the note fields, producing a `cm` tachygram that
 //! enters the polynomial accumulator. The concrete commitment scheme
 //! (e.g. Sinsemilla, Poseidon) depends on what is efficient inside
 //! Ragu circuits and is TBD.
@@ -71,18 +71,15 @@ impl Into<Fp> for NullifierTrapdoor {
 pub struct CommitmentTrapdoor(Fq);
 
 impl CommitmentTrapdoor {
-    /// Computes the note commitment `cmx`.
+    /// Computes the note commitment `cm`.
     ///
     /// Commits to $(pk, v, \psi)$ with randomness $rcm$
     #[must_use]
     pub fn commit(self, _v: Value, _pk: &PaymentKey, _psi: &NullifierTrapdoor) -> Commitment {
         // TODO: Implement note commitment
-        // $cmx = \text{NoteCommit}_{rcm}(\text{"z.cash:Tachyon-NoteCommit"}, pk \| v \|
-        // \psi)$
-        //
-        // CORRECTNESS: the crate-local `todo!` macro prints and continues
-        // (does not panic). This stub returns Fp::ZERO for every note,
-        // making all output tachygrams identical.
+        // $cm = \text{NoteCommit}_{rcm}(\text{"z.cash:Tachyon-NoteCommit"}, pk \| v \| \psi)$
+        // This stub returns Fp::ZERO for every note, making all output
+        // tachygrams identical.
         todo!("note commitment");
         Commitment::from(Fp::ZERO)
     }
@@ -150,7 +147,7 @@ impl Into<u64> for Value {
 }
 
 impl Note {
-    /// Computes the note commitment `cmx`.
+    /// Computes the note commitment `cm`.
     ///
     /// Commits to $(pk, v, \psi)$ with randomness $rcm$
     #[must_use]
@@ -184,13 +181,12 @@ impl Note {
     }
 }
 
-/// A Tachyon note commitment (`cmx`).
+/// A Tachyon note commitment (`cm`).
 ///
 /// A field element produced by committing to the note fields. This is
 /// the value that becomes a tachygram:
-/// - For **output** operations, `cmx` IS the tachygram directly.
-/// - For **spend** operations, `cmx` is a private witness; the tachygram is the
-///   derived nullifier.
+/// - For **output** operations, `cm` IS the tachygram directly.
+/// - For **spend** operations, `cm` is a private witness.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Commitment(Fp);
 

--- a/crates/tachyon/src/proof.rs
+++ b/crates/tachyon/src/proof.rs
@@ -24,9 +24,9 @@
 
 use crate::{
     action::Action,
-    keys::ProvingKey,
+    keys::ProofAuthorizingKey,
     primitives::{Anchor, Tachygram},
-    witness::{ActionPrivate, MergePrivate},
+    witness::ActionPrivate,
 };
 
 /// Ragu proof for Tachyon transactions.
@@ -57,9 +57,9 @@ impl Proof {
     /// - **`tachygram_acc`**: $\text{VectorCommit}(\text{tachygrams})$.
     ///
     /// The circuit constrains that every $(D_i, \text{tachygram}_i)$ pair
-    /// is consistent with the witness (note fields, alpha, rcv, flavor).
+    /// is consistent with the witness (note fields, alpha, rcv).
     ///
-    /// The [`ProvingKey`] provides per-wallet key material
+    /// The [`ProofAuthorizingKey`] provides per-wallet key material
     /// shared across all actions:
     /// - $\mathsf{ak}$: constrains $\mathsf{rk} = \mathsf{ak} +
     ///   [\alpha]\,\mathcal{G}$
@@ -68,12 +68,15 @@ impl Proof {
     #[must_use]
     pub fn create(
         _actions: &[Action],
-        witnesses: &[ActionPrivate],
+        _witnesses: &[ActionPrivate],
         _anchor: &Anchor,
-        _pak: &ProvingKey,
+        _pak: &ProofAuthorizingKey,
     ) -> (Self, Vec<Tachygram>) {
         todo!("Ragu PCD");
-        (Self, witnesses.iter().map(|w| w.tachygram).collect())
+        // The circuit computes tachygrams internally from witness fields
+        // (nf = F_nk(psi, flavor) for spends, cmx = NoteCommit(...) for
+        // outputs) and returns them as public outputs.
+        (Self, Vec::new())
     }
 
     /// Merges two proofs (Ragu PCD fuse).
@@ -91,7 +94,7 @@ impl Proof {
     /// - **Accumulator combination**: the merged proof's `actions_acc` and
     ///   `tachygram_acc` are the unions of the left and right accumulators.
     #[must_use]
-    pub fn merge(left: Self, _right: Self, _witness: MergePrivate) -> Self {
+    pub fn merge(left: Self, _right: Self) -> Self {
         todo!("Ragu PCD fuse \u{2014} merge two proofs with non-overlap and anchor subset checks");
         left
     }

--- a/crates/tachyon/src/proof.rs
+++ b/crates/tachyon/src/proof.rs
@@ -73,9 +73,9 @@ impl Proof {
         _pak: &ProofAuthorizingKey,
     ) -> (Self, Vec<Tachygram>) {
         todo!("Ragu PCD");
-        // The circuit computes tachygrams internally from witness fields
-        // (nf = F_nk(psi, flavor) for spends, cmx = NoteCommit(...) for
-        // outputs) and returns them as public outputs.
+        // The circuit computes tachygrams internally from witness fields (nf =
+        // F_nk(psi, flavor) for spends, cm = NoteCommit(...) for outputs) and
+        // returns them as public outputs.
         (Self, Vec::new())
     }
 

--- a/crates/tachyon/src/value.rs
+++ b/crates/tachyon/src/value.rs
@@ -211,7 +211,6 @@ mod tests {
 
     /// The binding property: `cv_a + cv_b - balance(a+b) = [rcv_a + rcv_b]R`.
     /// The V-components cancel, leaving only the R-component.
-    /// TODO: so... a bundle with a single action would reveal an individual rcv?
     #[test]
     fn commit_homomorphic_binding_property() {
         let mut rng = StdRng::seed_from_u64(0);

--- a/crates/tachyon/src/value.rs
+++ b/crates/tachyon/src/value.rs
@@ -58,6 +58,10 @@ pub struct CommitmentTrapdoor(Fq);
 impl CommitmentTrapdoor {
     /// Generate a fresh random trapdoor.
     pub fn random(rng: &mut (impl RngCore + CryptoRng)) -> Self {
+        // TODO: the selection of `rcv` may be revised to incorporate a hash of
+        // the note commitment or other action-specific data, possibly
+        // tied to alpha/theta derivation.
+        todo!("random commitment trapdoor");
         Self(Fq::random(rng))
     }
 

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -1,51 +1,20 @@
 //! Private witnesses (prover secrets) for building Tachyon stamp proofs.
 //!
-//! - **[`MergePrivate`]** — witness for the stamp-merge step: anchor quotient
-//!   proving the left epoch anchor state is a superset of the right.
 //! - **[`ActionPrivate`]** — witness for a single action: note, spend-auth
-//!   randomizer, value commitment trapdoor, epoch (flavor), and the resulting
-//!   tachygram (nullifier or note commitment).
+//!   randomizer, and value commitment trapdoor. The circuit derives the
+//!   tachygram and flavor internally.
 
-use pasta_curves::Fp;
-
-use crate::{
-    keys::private::ActionRandomizer,
-    note::Note,
-    primitives::{Epoch, Tachygram},
-    value,
-};
-
-/// Private witness for the stamp-merge step.
-///
-/// Contains the anchor quotient proving that the left sub-proof's
-/// accumulator state is a superset of the right's. For an append-only
-/// polynomial accumulator:
-///
-/// $ \mathsf{left\_anchor} = \mathsf{right\_anchor} \times \mathsf{quotient} $
-///
-/// The quotient encodes the state diff between the two anchors.
-/// The prover can only produce a valid quotient if the subset
-/// relationship actually holds (polynomial commitment security).
-///
-/// For same-epoch merges the quotient is `Fp::one()`.
-#[derive(Clone, Copy, Debug)]
-pub struct MergePrivate {
-    /// `left_anchor / right_anchor` in the accumulator's field.
-    ///
-    /// Proves the left accumulator state is a superset of the right.
-    pub anchor_quotient: Fp,
-}
+use crate::{keys::private::ActionRandomizer, note::Note, value};
 
 /// Private witness for a single action.
 ///
-/// The `flavor` identifies the accumulator epoch. The circuit uses it
-/// for both accumulator membership ($\mathsf{cmx} \in
-/// \text{acc}(\text{flavor})$) and nullifier constraint ($\mathsf{nf} =
-/// F_{\text{KDF}(\psi, nk)}(\text{flavor})$).
+/// Contains the per-action circuit inputs. The circuit derives `flavor`
+/// from the shared `anchor` and computes the tachygram (nullifier or
+/// note commitment) internally.
 ///
 /// Per-wallet key material ($\mathsf{ak}$, $\mathsf{nk}$) is shared across
 /// all actions and passed separately via
-/// [`ProvingKey`](crate::keys::ProvingKey)
+/// [`ProofAuthorizingKey`](crate::keys::ProofAuthorizingKey)
 /// to [`Proof::create`](crate::proof::Proof::create).
 #[derive(Clone, Copy, Debug)]
 pub struct ActionPrivate {
@@ -54,20 +23,9 @@ pub struct ActionPrivate {
     /// - Output: `rsk = alpha`, `rk = [alpha]G`
     pub alpha: ActionRandomizer,
 
-    /// Accumulator epoch (doubles as nullifier flavor).
-    pub flavor: Epoch,
-
     /// The note being spent or created.
     pub note: Note, // { pk, v, psi, rcm }
 
     /// Value commitment trapdoor.
     pub rcv: value::CommitmentTrapdoor,
-
-    /// A deterministic nullifier (spend) or note commitment (output).
-    /// Computed from note fields and key material with no additional
-    /// randomness.
-    /// - Spend: $\mathsf{nf} = F_{\mathsf{mk}}(\text{flavor})$ where $mk =
-    ///   $\text{KDF}(\psi, nk)$
-    /// - Output: $\mathsf{cmx} = \text{NoteCommit}(pk, v, \psi, rcm)$
-    pub tachygram: Tachygram,
 }


### PR DESCRIPTION
Composable transaction construction with delegation-friendly boundaries. Every step in the bundle creation pipeline is independently callable, enabling hardware wallet signing, outsourced proving, and third-party stamp aggregation.

## Changes

- **Action construction**: `Action::spend()` and `Action::output()` compose note commitment, value commitment, alpha derivation, and signing into a single convenience call. Each step is also callable individually for delegation.
- **Bundle building**: `Stamped::build` enforces stamp-before-binding -- the signer withholds the binding signature until the stamp is verified.
- **Custody trait**: `Custody::authorize_spend` abstracts spend authorization behind a trait, with `Local` (in-memory) implementation. The custody device holds `ask`, receives `(cv, theta, cm)`, and returns `(rk, sig)`.
- **Binding signature**: Pedersen value commitments (`cv = [v]V + [rcv]R`) with homomorphic binding. `bsk = sum(rcv_i)` proves value balance via RedPallas over the Binding group.
- **Stamp stripping**: stamps can be removed during aggregation while action signatures remain valid.
- **Nullifier delegation**: `NoteMasterKey` and `NoteDelegateKey` stub types for GGM tree PRF delegation.

## Known issues

The per-action sighash (`H("Tachyon-SpendSig", cv || rk)`) and binding sighash (`H("Tachyon-BindHash", v_balance || sigs)`) diverge from the Zcash protocol requirement that all signatures sign a transaction-wide SigHash. The custody interface is also too narrow -- it only sees individual spend data, not the full transaction. See #11 for the tracking issue.

## Transaction creation flow

```mermaid
sequenceDiagram

box Trust Boundary
    participant Custody
    participant User
end

rect rgb(255, 0, 255, 0.1)
activate User

loop per action

    note over User: random rcv

    alt spend
      note over User: use note { pk, psi, rcm, v }
      note over User: cv = rcv.commit(v)
    else output
      note over User: create note { pk, psi, rcm, v }
      note over User: cv = rcv.commit(-v)
    end
    note over User: cm = rcm.commit(pk, psi, v)

    note over User: random theta
    alt spend
        User ->> Custody: cv, theta, cm
        note over Custody: alpha = theta.derive(cm)
        note over Custody: rsk = ask.randomize(alpha)
        note over Custody: rk = public(rsk)
        note over Custody: sig = rsk.sign(digest(cv, rk))
        destroy Custody
        Custody ->> User: rk, sig
    else output
        note over User: alpha = theta.derive(cm)
        note over User: rk = public(alpha)
        note over User: sig = alpha.sign(digest(cv, rk))
    end
    note over User: rcv, alpha, action { cv, rk, sig }
end

note over User: select anchor

loop per action
  critical anchor, rcv, alpha, action { cv, rk, sig }, pak { ak, nk }, note { pk, psi, rcm, v }
        note over User: is_spend = cv == rcv.commit(v)
        note over User: is_output = cv == rcv.commit(-v)
        User --> User: is_spend XOR is_output
        alt spend
            User --> User: rk == ak.randomize(alpha)
            note over User: flavor = epoch(anchor)
            note over User: nf = nk.derive(psi, flavor)
            note over User: tachygram_acc = nf
        else output
            User --> User: rk == public(alpha)
            note over User: cm = rcm.commit(pk, psi, v)
            note over User: tachygram_acc = cm
        end
        note over User: action_acc = digest(cv, rk)
        note over User: pcd: leaf stamp(action_acc, tachygram_acc, anchor)
    end
end

participant Stamper

User ->> Stamper: leaf stamps, actions { cv, rk, sig }, tachygrams
loop while stamps > 1
  critical left(action_acc, tachygram_acc, anchor), right(action_acc, tachygram_acc, anchor)
      note over Stamper: action_acc = union(left.action_acc, right.action_acc)
      note over Stamper: tachygram_acc = union(left.tachygram_acc, right.tachygram_acc)
      note over Stamper: anchor = intersect(left.anchor, right.anchor)
      note over Stamper: pcd: stamp(action_acc, tachygram_acc, anchor)
  end
end
destroy Stamper
Stamper ->> User: stamp(tachygram_acc, action_acc, anchor)

break
    note over User: verify stamp(tachygram_acc, action_acc, anchor)
end
note over User: bsk = sum(rcv_i)
note over User: binding_sig = bsk.sign(actions, value_balance)
deactivate User
end

participant Consensus
destroy User
User ->> Consensus: actions[], value_balance, binding_sig, tachygrams, anchor, stamp
break
    note over Consensus: check action_sigs
    note over Consensus: check binding_sig
    note over Consensus: verify stamp(tachygram_acc, action_acc, anchor)
end
```
