### PR TITLE
Mock Ragu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mock_ragu"
+version = "0.0.0"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "pasta_curves",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/mock_ragu/Cargo.toml
+++ b/crates/mock_ragu/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+categories = [
+    "cryptography::cryptocurrencies",
+]
+description = """
+BLAKE2b-based mock of the Ragu PCD proof system for testing.
+"""
+keywords = [
+    "zcash",
+    "tachyon",
+    "mock",
+]
+name = "mock_ragu"
+readme = "README.md"
+repository = "https://github.com/tachyon-zcash/tachyon"
+version = "0.0.0"
+
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+blake2b_simd = "1.0"
+ff = "0.13"
+pasta_curves = "0.5.1"
+rand = "0.8"
+
+[lib]
+bench = false

--- a/crates/mock_ragu/README.md
+++ b/crates/mock_ragu/README.md
@@ -1,0 +1,158 @@
+# Mock Ragu 
+
+This readme is primarily for coding agents.
+
+Ragu provides recursive **Proof-Carrying Data** (PCD).
+
+Proof-carrying data is simply a SNARK (proof) with information representing a specific claim (data).
+
+This guide covers a simplified API surface relevant to this mock.
+
+**All code blocks are pseudocode.** Check the actual source to identify the mock signatures and types.
+
+## Proof-Carrying Data
+
+Ragu `Pcd` is created by a series of `Steps` executed by an `Application`.
+
+The `proof` represents the correctness of every executed step.
+
+All step witnesses and step input headers are privately encoded inside `proof`, and are not available.
+
+The final step's output header is the `data`.
+
+```pseudocode
+Pcd {
+    proof, // opaque proof
+    data   // final step output header
+}
+```
+
+The `proof` and `data` together make the `Pcd`.
+
+### Verifying
+
+The `Pcd::verify` method is executed to confirm the proof's claim about the data is true.
+
+For our purposes, after proving, `Pcd` is separated.
+
+- The `proof` component is directly published by the prover.
+- The `data` component must be reconstructed by verifiers from other published data.
+
+Once reconstructed, the verifier uses `Proof::carry` to recreate `Pcd` and then `Pcd::verify` the proof.
+
+## API
+
+### `seed` — entry
+
+```pseudocode
+app.seed(step, witness) -> (step::Proof, step::Aux)
+```
+
+Executes a leaf step with no prior steps.
+Returns a `Proof` and `Aux` as defined by the step.
+
+### `fuse` — recurse
+
+```pseudocode
+app.fuse(step, witness, left_pcd, right_pcd) -> (step::Proof, step::Aux)
+```
+
+Executes a step with some prior steps.
+Returns a `Proof` and `Aux` as defined by the step.
+
+### `carry` — attach data
+
+```pseudocode
+proof.carry(data) -> Pcd
+```
+
+Attaches an output header data to a bare `Proof` to form a `Pcd`.
+The resulting `Pcd` is passed to the next `fuse()` call or to `verify()`.
+
+### `rerandomize` — blind the proof
+
+```pseudocode
+app.rerandomize(pcd) -> Pcd
+```
+
+Produces a new `Pcd` with a proof that verifies for the same data, but is cryptographically opaque.
+Only the proof changes, the data stays the same.
+
+### `verify`
+
+```pseudocode
+app.verify(pcd) -> bool
+```
+
+Verifies the PCD's proof and data are correct.
+
+## Steps
+
+In **mock_ragu**, the `Step` trait is simplified, and this description is even simpler.
+
+The `Step::witness` method describes step execution inside the application.
+
+```pseudocode
+trait Step {
+    const INDEX: Index; // unique in application
+
+    type Left;          // output header of another step
+    type Right;         // output header of another step
+    type Output;        // this step's output header
+
+    type Witness;       // private input
+    type Aux;           // arbitrary extra output
+
+    fn witness(
+        witness: Witness,
+        left: Left,
+        right: Right,
+    ) -> (Output, Aux);
+}
+```
+
+### `Aux`
+
+Arbitrary information provided by a `Step` to the prover.
+
+`Aux` is the **only way** to send information from inside the proof execution back to the caller of `fuse()`/`seed()`.
+
+It does not necessarily represent any input or output header, but the designer of an application may intend that it should be used to reconstruct the output header `data` ultimately carried by the `proof` to create the `Pcd` representation.
+
+```pseudocode
+let (proof, aux) = app.fuse(step, witness, left_pcd, right_pcd)?;
+let data = reconstruct_output_header(aux, other_stuff);
+app.verify(proof.carry(data))
+```
+
+## Example flow
+
+### On the prover 
+
+```pseudocode
+(leaf_a, aux_a) = app.seed(leaf_step, leaf_witness_b)
+data_a = reconstruct_leaf(aux_a, ...)
+pcd_a = proof_a.carry(data_a)
+pcd_a = app.rerandomize(pcd_a)
+
+(leaf_b, aux_b) = app.seed(leaf_step, leaf_witness_a)
+data_b = reconstruct_leaf(aux_b, ...)
+pcd_b = proof_b.carry(data_b)
+pcd_b = app.rerandomize(pcd_b)
+
+(merged, aux_m) = app.fuse(next_step, next_witness, pcd_a, pcd_b)
+data_m = reconstruct_merge(aux_m, ...)
+pcd_m = merged.carry(data_m)
+pcd_m = app.rerandomize(pcd_m)
+
+publish_to_verifier(pcd_m.proof)
+```
+
+### On the verifier
+
+```pseudocode
+claim_proof = receive_from_prover()
+claim_data = reconstruct_merge_from_public(public_stuff)
+pcd_claim = claim_proof.carry(claim_data)
+app.verify(pcd_claim)
+```

--- a/crates/mock_ragu/src/application.rs
+++ b/crates/mock_ragu/src/application.rs
@@ -1,0 +1,333 @@
+//! Mock PCD application — entry point for proof creation and verification.
+//!
+//! Mirrors `ragu_pcd::Application` and `ragu_pcd::ApplicationBuilder`.
+//! The builder pattern registers steps, then finalizes into an application
+//! that can seed, fuse, and verify proofs.
+
+use rand::CryptoRng;
+
+use crate::{
+    error::Result,
+    header::Header,
+    proof::{self, PROOF_SIZE, Pcd, Proof},
+    step::Step,
+};
+
+/// Builder for constructing a mock PCD [`Application`].
+///
+/// Mirrors `ragu_pcd::ApplicationBuilder`. In real Ragu, building an
+/// application compiles circuits and sets up proving parameters. In the
+/// mock, registration is a no-op.
+#[derive(Clone, Copy, Debug)]
+pub struct ApplicationBuilder;
+
+/// A mock PCD application.
+///
+/// Mirrors `ragu_pcd::Application`. Provides [`seed`](Self::seed),
+/// [`fuse`](Self::fuse), [`verify`](Self::verify), and
+/// [`rerandomize`](Self::rerandomize) operations.
+#[derive(Clone, Copy, Debug)]
+pub struct Application;
+
+impl ApplicationBuilder {
+    /// Creates a new builder.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Registers a step with this application.
+    ///
+    /// In real Ragu, this compiles the step's circuit. In the mock,
+    /// it is a no-op.
+    pub fn register<S: Step>(self, _step: S) -> Result<Self> {
+        Ok(self)
+    }
+
+    /// Finalizes the builder into an [`Application`].
+    pub fn finalize(self) -> Result<Application> {
+        Ok(Application)
+    }
+}
+
+impl Default for ApplicationBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Application {
+    /// Creates a leaf proof (no prior proofs).
+    ///
+    /// Mirrors `ragu_pcd::Application::seed`. The step's `Left` and `Right`
+    /// must both be `()` (trivial header), since there are no input proofs.
+    ///
+    /// Calls the step's [`witness`](Step::witness) to compute the output
+    /// header data, then constructs a proof binding that data.
+    pub fn seed<'source, RNG: CryptoRng, S: Step<Left = (), Right = ()>>(
+        &self,
+        _rng: &mut RNG,
+        step: &S,
+        witness: S::Witness<'source>,
+    ) -> Result<(Proof, S::Aux<'source>)> {
+        let (output_data, aux) = step.witness(witness, (), ())?;
+
+        let encoded = S::Output::encode(&output_data);
+        let header_hash = proof::compute_header_hash(&encoded);
+        let witness_hash = proof::compute_witness_hash(&encoded);
+        let merge_tag = [0u8; 32];
+
+        let proof_value = proof::assemble(&header_hash, &witness_hash, &merge_tag);
+        Ok((proof_value, aux))
+    }
+
+    /// Merges two proofs (PCD fuse).
+    ///
+    /// Mirrors `ragu_pcd::Application::fuse`. Takes two input PCDs and
+    /// a merge step, producing a combined proof.
+    pub fn fuse<'source, RNG: CryptoRng, S: Step>(
+        &self,
+        _rng: &mut RNG,
+        step: &S,
+        witness: S::Witness<'source>,
+        left: Pcd<'source, S::Left>,
+        right: Pcd<'source, S::Right>,
+    ) -> Result<(Proof, S::Aux<'source>)> {
+        let left_proof = left.proof;
+        let right_proof = right.proof;
+        let (output_data, aux) = step.witness(witness, left.data, right.data)?;
+
+        let encoded = S::Output::encode(&output_data);
+        let header_hash = proof::compute_header_hash(&encoded);
+
+        // Witness hash: hash both child proofs
+        let left_bytes: [u8; PROOF_SIZE] = left_proof.into();
+        let right_bytes: [u8; PROOF_SIZE] = right_proof.into();
+        let witness_hash_val = blake2b_simd::Params::new()
+            .hash_length(32)
+            .personal(b"MkRagu_Witness_\0")
+            .to_state()
+            .update(&left_bytes)
+            .update(&right_bytes)
+            .finalize();
+        let mut witness_hash = [0u8; 32];
+        witness_hash.copy_from_slice(witness_hash_val.as_bytes());
+
+        // Merge tag: hash of children's bindings
+        let merge_tag = proof::compute_merge_tag(&left_proof.binding(), &right_proof.binding());
+
+        let proof_value = proof::assemble(&header_hash, &witness_hash, &merge_tag);
+        Ok((proof_value, aux))
+    }
+
+    /// Verifies a proof against its carried header data.
+    ///
+    /// Mirrors `ragu_pcd::Application::verify`. Recomputes the header
+    /// hash from the PCD's data and checks the proof's binding.
+    pub fn verify<RNG: CryptoRng, H: Header>(&self, pcd: &Pcd<'_, H>, _rng: RNG) -> Result<bool> {
+        // Recompute header hash from the carried data
+        let encoded = H::encode(&pcd.data);
+        let expected_header_hash = proof::compute_header_hash(&encoded);
+
+        if expected_header_hash != pcd.proof.header_hash() {
+            return Ok(false);
+        }
+
+        // Verify binding consistency
+        let expected_binding = proof::compute_binding(
+            &pcd.proof.header_hash(),
+            &pcd.proof.witness_hash(),
+            &pcd.proof.merge_tag(),
+        );
+
+        Ok(expected_binding == pcd.proof.binding())
+    }
+
+    /// Rerandomizes a proof (no-op in mock).
+    ///
+    /// In real Ragu, this rerandomizes polynomial commitments for
+    /// unlinkability. The mock returns the same PCD unchanged.
+    pub fn rerandomize<'source, RNG: CryptoRng, H: Header>(
+        &self,
+        pcd: Pcd<'source, H>,
+        _rng: &mut RNG,
+    ) -> Result<Pcd<'source, H>> {
+        Ok(pcd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use alloc::vec::Vec;
+
+    use rand::thread_rng;
+
+    use super::*;
+    use crate::{error::Result, header::Suffix, step::Index};
+
+    // -- Test header: carries a single u64 value ----------------------------
+
+    struct TestHeader;
+
+    #[derive(Clone, Debug)]
+    struct TestHeaderData {
+        value: u64,
+    }
+
+    impl Header for TestHeader {
+        type Data<'source> = TestHeaderData;
+
+        const SUFFIX: Suffix = Suffix::new(0);
+
+        fn encode(data: &Self::Data<'_>) -> Vec<u8> {
+            #[expect(clippy::little_endian_bytes, reason = "test encoding")]
+            let bytes = data.value.to_le_bytes();
+            bytes.to_vec()
+        }
+    }
+
+    // -- Test seed step: creates a leaf from a u64 witness ------------------
+
+    struct SeedStep;
+
+    impl Step for SeedStep {
+        type Aux<'source> = ();
+        type Left = ();
+        type Output = TestHeader;
+        type Right = ();
+        type Witness<'source> = u64;
+
+        const INDEX: Index = Index::new(0);
+
+        fn witness<'source>(
+            &self,
+            witness: Self::Witness<'source>,
+            _left: <Self::Left as Header>::Data<'source>,
+            _right: <Self::Right as Header>::Data<'source>,
+        ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+            Ok((TestHeaderData { value: witness }, ()))
+        }
+    }
+
+    // -- Test merge step: sums two header values ----------------------------
+
+    struct MergeStep;
+
+    impl Step for MergeStep {
+        type Aux<'source> = ();
+        type Left = TestHeader;
+        type Output = TestHeader;
+        type Right = TestHeader;
+        type Witness<'source> = ();
+
+        const INDEX: Index = Index::new(1);
+
+        fn witness<'source>(
+            &self,
+            _witness: Self::Witness<'source>,
+            left: <Self::Left as Header>::Data<'source>,
+            right: <Self::Right as Header>::Data<'source>,
+        ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+            Ok((
+                TestHeaderData {
+                    value: left.value + right.value,
+                },
+                (),
+            ))
+        }
+    }
+
+    #[test]
+    fn seed_then_verify() {
+        let app = ApplicationBuilder::new()
+            .register(SeedStep)
+            .expect("register should succeed")
+            .finalize()
+            .expect("finalize should succeed");
+
+        let (proof, ()) = app
+            .seed(&mut thread_rng(), &SeedStep, 42u64)
+            .expect("seed should succeed");
+        let pcd = proof.carry::<TestHeader>(TestHeaderData { value: 42 });
+
+        let valid = app
+            .verify(&pcd, thread_rng())
+            .expect("verify should succeed");
+        assert!(valid, "proof should verify against matching header data");
+    }
+
+    #[test]
+    fn verify_rejects_wrong_data() {
+        let app = ApplicationBuilder::new()
+            .register(SeedStep)
+            .expect("register should succeed")
+            .finalize()
+            .expect("finalize should succeed");
+
+        let (proof, ()) = app
+            .seed(&mut thread_rng(), &SeedStep, 42u64)
+            .expect("seed should succeed");
+        // Carry wrong data
+        let pcd = proof.carry::<TestHeader>(TestHeaderData { value: 999 });
+
+        let valid = app
+            .verify(&pcd, thread_rng())
+            .expect("verify should succeed");
+        assert!(!valid, "proof should reject mismatched header data");
+    }
+
+    #[test]
+    fn fuse_then_verify() {
+        let app = ApplicationBuilder::new()
+            .register(SeedStep)
+            .expect("register should succeed")
+            .register(MergeStep)
+            .expect("register should succeed")
+            .finalize()
+            .expect("finalize should succeed");
+
+        let (proof_a, ()) = app
+            .seed(&mut thread_rng(), &SeedStep, 10u64)
+            .expect("seed a");
+        let pcd_a = proof_a.carry::<TestHeader>(TestHeaderData { value: 10 });
+
+        let (proof_b, ()) = app
+            .seed(&mut thread_rng(), &SeedStep, 20u64)
+            .expect("seed b");
+        let pcd_b = proof_b.carry::<TestHeader>(TestHeaderData { value: 20 });
+
+        let (merged_proof, ()) = app
+            .fuse(&mut thread_rng(), &MergeStep, (), pcd_a, pcd_b)
+            .expect("fuse should succeed");
+        let merged_pcd = merged_proof.carry::<TestHeader>(TestHeaderData { value: 30 });
+
+        let valid = app
+            .verify(&merged_pcd, thread_rng())
+            .expect("verify should succeed");
+        assert!(valid, "merged proof should verify");
+    }
+
+    #[test]
+    fn rerandomize_preserves_validity() {
+        let app = ApplicationBuilder::new()
+            .register(SeedStep)
+            .expect("register should succeed")
+            .finalize()
+            .expect("finalize should succeed");
+
+        let (proof, ()) = app
+            .seed(&mut thread_rng(), &SeedStep, 42u64)
+            .expect("seed should succeed");
+        let pcd = proof.carry::<TestHeader>(TestHeaderData { value: 42 });
+
+        let rerand_pcd = app
+            .rerandomize(pcd, &mut thread_rng())
+            .expect("rerandomize should succeed");
+        let valid = app
+            .verify(&rerand_pcd, thread_rng())
+            .expect("verify should succeed");
+        assert!(valid, "rerandomized proof should still verify");
+    }
+}

--- a/crates/mock_ragu/src/application.rs
+++ b/crates/mock_ragu/src/application.rs
@@ -1,50 +1,32 @@
-//! Mock PCD application — entry point for proof creation and verification.
-//!
-//! Mirrors `ragu_pcd::Application` and `ragu_pcd::ApplicationBuilder`.
-//! The builder pattern registers steps, then finalizes into an application
-//! that can seed, fuse, and verify proofs.
+//! Mock PCD application — mirrors `ragu_pcd::Application`.
 
 use rand::CryptoRng;
 
 use crate::{
     error::Result,
     header::Header,
-    proof::{self, PROOF_SIZE, Pcd, Proof},
+    proof::{self, PROOF_SIZE_COMPRESSED, Pcd, Proof},
     step::Step,
 };
 
-/// Builder for constructing a mock PCD [`Application`].
-///
-/// Mirrors `ragu_pcd::ApplicationBuilder`. In real Ragu, building an
-/// application compiles circuits and sets up proving parameters. In the
-/// mock, registration is a no-op.
+/// Mocks `ragu_pcd::ApplicationBuilder`.
 #[derive(Clone, Copy, Debug)]
 pub struct ApplicationBuilder;
 
-/// A mock PCD application.
-///
-/// Mirrors `ragu_pcd::Application`. Provides [`seed`](Self::seed),
-/// [`fuse`](Self::fuse), [`verify`](Self::verify), and
-/// [`rerandomize`](Self::rerandomize) operations.
+/// Mocks `ragu_pcd::Application`.
 #[derive(Clone, Copy, Debug)]
 pub struct Application;
 
 impl ApplicationBuilder {
-    /// Creates a new builder.
     #[must_use]
     pub const fn new() -> Self {
         Self
     }
 
-    /// Registers a step with this application.
-    ///
-    /// In real Ragu, this compiles the step's circuit. In the mock,
-    /// it is a no-op.
     pub fn register<S: Step>(self, _step: S) -> Result<Self> {
         Ok(self)
     }
 
-    /// Finalizes the builder into an [`Application`].
     pub fn finalize(self) -> Result<Application> {
         Ok(Application)
     }
@@ -57,34 +39,18 @@ impl Default for ApplicationBuilder {
 }
 
 impl Application {
-    /// Creates a leaf proof (no prior proofs).
-    ///
-    /// Mirrors `ragu_pcd::Application::seed`. The step's `Left` and `Right`
-    /// must both be `()` (trivial header), since there are no input proofs.
-    ///
-    /// Calls the step's [`witness`](Step::witness) to compute the output
-    /// header data, then constructs a proof binding that data.
+    /// Delegates to [`fuse`](Self::fuse) with trivial PCDs.
     pub fn seed<'source, RNG: CryptoRng, S: Step<Left = (), Right = ()>>(
         &self,
-        _rng: &mut RNG,
+        rng: &mut RNG,
         step: &S,
         witness: S::Witness<'source>,
     ) -> Result<(Proof, S::Aux<'source>)> {
-        let (output_data, aux) = step.witness(witness, (), ())?;
-
-        let encoded = S::Output::encode(&output_data);
-        let header_hash = proof::compute_header_hash(&encoded);
-        let witness_hash = proof::compute_witness_hash(&encoded);
-        let merge_tag = [0u8; 32];
-
-        let proof_value = proof::assemble(&header_hash, &witness_hash, &merge_tag);
-        Ok((proof_value, aux))
+        let left = Proof::trivial().carry::<()>(());
+        let right = Proof::trivial().carry::<()>(());
+        self.fuse(rng, step, witness, left, right)
     }
 
-    /// Merges two proofs (PCD fuse).
-    ///
-    /// Mirrors `ragu_pcd::Application::fuse`. Takes two input PCDs and
-    /// a merge step, producing a combined proof.
     pub fn fuse<'source, RNG: CryptoRng, S: Step>(
         &self,
         _rng: &mut RNG,
@@ -98,236 +64,42 @@ impl Application {
         let (output_data, aux) = step.witness(witness, left.data, right.data)?;
 
         let encoded = S::Output::encode(&output_data);
-        let header_hash = proof::compute_header_hash(&encoded);
 
-        // Witness hash: hash both child proofs
-        let left_bytes: [u8; PROOF_SIZE] = left_proof.into();
-        let right_bytes: [u8; PROOF_SIZE] = right_proof.into();
-        let witness_hash_val = blake2b_simd::Params::new()
-            .hash_length(32)
-            .personal(b"MkRagu_Witness_\0")
-            .to_state()
-            .update(&left_bytes)
-            .update(&right_bytes)
-            .finalize();
-        let mut witness_hash = [0u8; 32];
-        witness_hash.copy_from_slice(witness_hash_val.as_bytes());
+        // Witness data: concatenated serialized child proofs
+        let left_bytes = left_proof.serialize();
+        let right_bytes = right_proof.serialize();
+        let mut witness_data = Vec::with_capacity(2 * PROOF_SIZE_COMPRESSED);
+        witness_data.extend_from_slice(left_bytes.as_ref());
+        witness_data.extend_from_slice(right_bytes.as_ref());
 
-        // Merge tag: hash of children's bindings
-        let merge_tag = proof::compute_merge_tag(&left_proof.binding(), &right_proof.binding());
-
-        let proof_value = proof::assemble(&header_hash, &witness_hash, &merge_tag);
+        let proof_value = Proof::new(&encoded, &witness_data);
         Ok((proof_value, aux))
     }
 
-    /// Verifies a proof against its carried header data.
-    ///
-    /// Mirrors `ragu_pcd::Application::verify`. Recomputes the header
-    /// hash from the PCD's data and checks the proof's binding.
     pub fn verify<RNG: CryptoRng, H: Header>(&self, pcd: &Pcd<'_, H>, _rng: RNG) -> Result<bool> {
         // Recompute header hash from the carried data
         let encoded = H::encode(&pcd.data);
         let expected_header_hash = proof::compute_header_hash(&encoded);
 
-        if expected_header_hash != pcd.proof.header_hash() {
+        if expected_header_hash != pcd.proof.header_hash {
             return Ok(false);
         }
 
         // Verify binding consistency
-        let expected_binding = proof::compute_binding(
-            &pcd.proof.header_hash(),
-            &pcd.proof.witness_hash(),
-            &pcd.proof.merge_tag(),
-        );
+        let expected_binding =
+            proof::compute_binding(&pcd.proof.header_hash, &pcd.proof.witness_hash);
 
-        Ok(expected_binding == pcd.proof.binding())
+        Ok(expected_binding == pcd.proof.binding)
     }
 
-    /// Rerandomizes a proof (no-op in mock).
-    ///
-    /// In real Ragu, this rerandomizes polynomial commitments for
-    /// unlinkability. The mock returns the same PCD unchanged.
     pub fn rerandomize<'source, RNG: CryptoRng, H: Header>(
         &self,
         pcd: Pcd<'source, H>,
         _rng: &mut RNG,
     ) -> Result<Pcd<'source, H>> {
-        Ok(pcd)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    extern crate alloc;
-
-    use alloc::vec::Vec;
-
-    use rand::thread_rng;
-
-    use super::*;
-    use crate::{error::Result, header::Suffix, step::Index};
-
-    // -- Test header: carries a single u64 value ----------------------------
-
-    struct TestHeader;
-
-    #[derive(Clone, Debug)]
-    struct TestHeaderData {
-        value: u64,
-    }
-
-    impl Header for TestHeader {
-        type Data<'source> = TestHeaderData;
-
-        const SUFFIX: Suffix = Suffix::new(0);
-
-        fn encode(data: &Self::Data<'_>) -> Vec<u8> {
-            #[expect(clippy::little_endian_bytes, reason = "test encoding")]
-            let bytes = data.value.to_le_bytes();
-            bytes.to_vec()
-        }
-    }
-
-    // -- Test seed step: creates a leaf from a u64 witness ------------------
-
-    struct SeedStep;
-
-    impl Step for SeedStep {
-        type Aux<'source> = ();
-        type Left = ();
-        type Output = TestHeader;
-        type Right = ();
-        type Witness<'source> = u64;
-
-        const INDEX: Index = Index::new(0);
-
-        fn witness<'source>(
-            &self,
-            witness: Self::Witness<'source>,
-            _left: <Self::Left as Header>::Data<'source>,
-            _right: <Self::Right as Header>::Data<'source>,
-        ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-            Ok((TestHeaderData { value: witness }, ()))
-        }
-    }
-
-    // -- Test merge step: sums two header values ----------------------------
-
-    struct MergeStep;
-
-    impl Step for MergeStep {
-        type Aux<'source> = ();
-        type Left = TestHeader;
-        type Output = TestHeader;
-        type Right = TestHeader;
-        type Witness<'source> = ();
-
-        const INDEX: Index = Index::new(1);
-
-        fn witness<'source>(
-            &self,
-            _witness: Self::Witness<'source>,
-            left: <Self::Left as Header>::Data<'source>,
-            right: <Self::Right as Header>::Data<'source>,
-        ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-            Ok((
-                TestHeaderData {
-                    value: left.value + right.value,
-                },
-                (),
-            ))
-        }
-    }
-
-    #[test]
-    fn seed_then_verify() {
-        let app = ApplicationBuilder::new()
-            .register(SeedStep)
-            .expect("register should succeed")
-            .finalize()
-            .expect("finalize should succeed");
-
-        let (proof, ()) = app
-            .seed(&mut thread_rng(), &SeedStep, 42u64)
-            .expect("seed should succeed");
-        let pcd = proof.carry::<TestHeader>(TestHeaderData { value: 42 });
-
-        let valid = app
-            .verify(&pcd, thread_rng())
-            .expect("verify should succeed");
-        assert!(valid, "proof should verify against matching header data");
-    }
-
-    #[test]
-    fn verify_rejects_wrong_data() {
-        let app = ApplicationBuilder::new()
-            .register(SeedStep)
-            .expect("register should succeed")
-            .finalize()
-            .expect("finalize should succeed");
-
-        let (proof, ()) = app
-            .seed(&mut thread_rng(), &SeedStep, 42u64)
-            .expect("seed should succeed");
-        // Carry wrong data
-        let pcd = proof.carry::<TestHeader>(TestHeaderData { value: 999 });
-
-        let valid = app
-            .verify(&pcd, thread_rng())
-            .expect("verify should succeed");
-        assert!(!valid, "proof should reject mismatched header data");
-    }
-
-    #[test]
-    fn fuse_then_verify() {
-        let app = ApplicationBuilder::new()
-            .register(SeedStep)
-            .expect("register should succeed")
-            .register(MergeStep)
-            .expect("register should succeed")
-            .finalize()
-            .expect("finalize should succeed");
-
-        let (proof_a, ()) = app
-            .seed(&mut thread_rng(), &SeedStep, 10u64)
-            .expect("seed a");
-        let pcd_a = proof_a.carry::<TestHeader>(TestHeaderData { value: 10 });
-
-        let (proof_b, ()) = app
-            .seed(&mut thread_rng(), &SeedStep, 20u64)
-            .expect("seed b");
-        let pcd_b = proof_b.carry::<TestHeader>(TestHeaderData { value: 20 });
-
-        let (merged_proof, ()) = app
-            .fuse(&mut thread_rng(), &MergeStep, (), pcd_a, pcd_b)
-            .expect("fuse should succeed");
-        let merged_pcd = merged_proof.carry::<TestHeader>(TestHeaderData { value: 30 });
-
-        let valid = app
-            .verify(&merged_pcd, thread_rng())
-            .expect("verify should succeed");
-        assert!(valid, "merged proof should verify");
-    }
-
-    #[test]
-    fn rerandomize_preserves_validity() {
-        let app = ApplicationBuilder::new()
-            .register(SeedStep)
-            .expect("register should succeed")
-            .finalize()
-            .expect("finalize should succeed");
-
-        let (proof, ()) = app
-            .seed(&mut thread_rng(), &SeedStep, 42u64)
-            .expect("seed should succeed");
-        let pcd = proof.carry::<TestHeader>(TestHeaderData { value: 42 });
-
-        let rerand_pcd = app
-            .rerandomize(pcd, &mut thread_rng())
-            .expect("rerandomize should succeed");
-        let valid = app
-            .verify(&rerand_pcd, thread_rng())
-            .expect("verify should succeed");
-        assert!(valid, "rerandomized proof should still verify");
+        Ok(Pcd {
+            proof: pcd.proof.rerandomize(),
+            data: pcd.data,
+        })
     }
 }

--- a/crates/mock_ragu/src/error.rs
+++ b/crates/mock_ragu/src/error.rs
@@ -1,0 +1,20 @@
+//! Mock error types mirroring `ragu_core`.
+
+use core::{error, fmt, result};
+
+/// Alias for [`core::result::Result<T, Error>`].
+///
+/// Mirrors `ragu_core::Result`.
+pub type Result<T> = result::Result<T, Error>;
+
+/// Mock of `ragu_core::Error`.
+#[derive(Debug)]
+pub struct Error;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("mock ragu error")
+    }
+}
+
+impl error::Error for Error {}

--- a/crates/mock_ragu/src/header.rs
+++ b/crates/mock_ragu/src/header.rs
@@ -1,0 +1,57 @@
+//! Mock PCD header — succinct representation of computation state.
+//!
+//! This is the mock equivalent of `ragu_pcd::Header`. Instead of encoding
+//! data into circuit gadgets via a `Driver`, the mock header encodes data
+//! to bytes for BLAKE2b binding verification.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+/// Unique suffix distinguishing [`Header`] types.
+///
+/// Mirrors `ragu_pcd::header::Suffix`. Each header implementation must
+/// use a distinct suffix so the proof system can distinguish them.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Suffix(usize);
+
+impl Suffix {
+    /// Creates a new application-defined header suffix.
+    #[must_use]
+    pub const fn new(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+/// A PCD header defining what data is carried by proofs.
+///
+/// Mirrors `ragu_pcd::Header`. Implementors define the data type and how
+/// to encode it to bytes. In real Ragu, headers encode data into circuit
+/// gadgets via a `Driver`; in the mock, they serialize to bytes for
+/// BLAKE2b hashing.
+///
+/// The unit type `()` implements this trait as the trivial header
+/// (carries no data), used as `Left`/`Right` for seed steps.
+pub trait Header: Send + Sync + 'static {
+    /// Unique suffix for this header type.
+    const SUFFIX: Suffix;
+
+    /// The data this header carries.
+    type Data<'source>: Send + Clone;
+
+    /// Encode header data to bytes for mock binding verification.
+    fn encode(data: &Self::Data<'_>) -> Vec<u8>;
+}
+
+/// Trivial header that encodes no data.
+///
+/// Used as `Left`/`Right` for seed steps (no prior proofs).
+impl Header for () {
+    type Data<'source> = ();
+
+    const SUFFIX: Suffix = Suffix(0);
+
+    fn encode(_data: &()) -> Vec<u8> {
+        Vec::new()
+    }
+}

--- a/crates/mock_ragu/src/header.rs
+++ b/crates/mock_ragu/src/header.rs
@@ -1,51 +1,28 @@
-//! Mock PCD header — succinct representation of computation state.
-//!
-//! This is the mock equivalent of `ragu_pcd::Header`. Instead of encoding
-//! data into circuit gadgets via a `Driver`, the mock header encodes data
-//! to bytes for BLAKE2b binding verification.
+//! Mock PCD header — mirrors `ragu_pcd::Header`.
 
 extern crate alloc;
 
 use alloc::vec::Vec;
 
-/// Unique suffix distinguishing [`Header`] types.
-///
-/// Mirrors `ragu_pcd::header::Suffix`. Each header implementation must
-/// use a distinct suffix so the proof system can distinguish them.
+/// Mirrors `ragu_pcd::header::Suffix`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Suffix(usize);
 
 impl Suffix {
-    /// Creates a new application-defined header suffix.
     #[must_use]
     pub const fn new(value: usize) -> Self {
         Self(value)
     }
 }
 
-/// A PCD header defining what data is carried by proofs.
-///
-/// Mirrors `ragu_pcd::Header`. Implementors define the data type and how
-/// to encode it to bytes. In real Ragu, headers encode data into circuit
-/// gadgets via a `Driver`; in the mock, they serialize to bytes for
-/// BLAKE2b hashing.
-///
-/// The unit type `()` implements this trait as the trivial header
-/// (carries no data), used as `Left`/`Right` for seed steps.
+/// Mirrors `ragu_pcd::Header`.
 pub trait Header: Send + Sync + 'static {
-    /// Unique suffix for this header type.
     const SUFFIX: Suffix;
-
-    /// The data this header carries.
     type Data<'source>: Send + Clone;
-
-    /// Encode header data to bytes for mock binding verification.
     fn encode(data: &Self::Data<'_>) -> Vec<u8>;
 }
 
-/// Trivial header that encodes no data.
-///
-/// Used as `Left`/`Right` for seed steps (no prior proofs).
+/// Trivial header for seed steps.
 impl Header for () {
     type Data<'source> = ();
 

--- a/crates/mock_ragu/src/lib.rs
+++ b/crates/mock_ragu/src/lib.rs
@@ -1,0 +1,35 @@
+//! Mock Ragu PCD proof system.
+//!
+//! API-level mock of the Ragu Proof-Carrying Data framework for testing
+//! the Tachyon protocol before the real Ragu implementation is available.
+//!
+//! ## Core types (mirroring `ragu_pcd`)
+//!
+//! - [`Header`] trait: defines data carried by proofs
+//! - [`Step`] trait: defines computation nodes in the PCD graph
+//! - [`ApplicationBuilder`] / [`Application`]: build and use a PCD application
+//! - [`Proof`]: the proof bytes (128 bytes)
+//! - [`Pcd`]: proof + header data bundle
+// Lints that don't apply to a mock crate mirroring an external API.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![expect(clippy::pub_use, reason = "crate public API re-exports")]
+#![expect(clippy::module_name_repetitions, reason = "names mirror real ragu API")]
+#![expect(clippy::missing_const_for_fn, reason = "mirrors non-const ragu API")]
+#![expect(
+    clippy::missing_trait_methods,
+    reason = "default impls are fine in a mock"
+)]
+
+pub use application::{Application, ApplicationBuilder};
+pub use error::{Error, Result};
+pub use header::{Header, Suffix};
+pub use polynomial::{Commitment, Polynomial, poly_with_roots};
+pub use proof::{Pcd, Proof};
+pub use step::{Index, Step};
+
+pub mod application;
+pub mod error;
+pub mod header;
+pub mod polynomial;
+pub mod proof;
+pub mod step;

--- a/crates/mock_ragu/src/lib.rs
+++ b/crates/mock_ragu/src/lib.rs
@@ -1,15 +1,4 @@
-//! Mock Ragu PCD proof system.
-//!
-//! API-level mock of the Ragu Proof-Carrying Data framework for testing
-//! the Tachyon protocol before the real Ragu implementation is available.
-//!
-//! ## Core types (mirroring `ragu_pcd`)
-//!
-//! - [`Header`] trait: defines data carried by proofs
-//! - [`Step`] trait: defines computation nodes in the PCD graph
-//! - [`ApplicationBuilder`] / [`Application`]: build and use a PCD application
-//! - [`Proof`]: the proof bytes (128 bytes)
-//! - [`Pcd`]: proof + header data bundle
+//! Mock Ragu PCD proof system — API-level mock of `ragu_pcd`.
 // Lints that don't apply to a mock crate mirroring an external API.
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![expect(clippy::pub_use, reason = "crate public API re-exports")]
@@ -33,3 +22,6 @@ pub mod header;
 pub mod polynomial;
 pub mod proof;
 pub mod step;
+
+#[cfg(test)]
+mod tests;

--- a/crates/mock_ragu/src/polynomial.rs
+++ b/crates/mock_ragu/src/polynomial.rs
@@ -1,0 +1,315 @@
+//! Polynomial and Pedersen vector commitment types.
+//!
+//! Mock equivalents of Ragu's polynomial commitment scheme. The
+//! [`Polynomial`] type mirrors
+//! `ragu_circuits::polynomials::unstructured::Polynomial`
+//! and the [`Commitment`] type represents a real Pedersen vector commitment
+//! (EC point on Vesta). Only the proof system (IPA opening, Fiat-Shamir,
+//! etc.) is mocked — the commitment itself is real crypto.
+//!
+//! These are public so that validators can recompute accumulators from
+//! public data outside the proof.
+
+extern crate alloc;
+
+use alloc::{vec, vec::Vec};
+use core::ops::Neg;
+use std::sync::LazyLock;
+
+use ff::Field;
+use pasta_curves::{Eq, EqAffine, Fp};
+
+/// Maximum number of generators to precompute.
+///
+/// Supports polynomials up to degree `MAX_GENERATORS - 1`. This is enough
+/// for stamps with up to `MAX_GENERATORS - 1` elements. If a polynomial
+/// exceeds this, `commit` will panic — increase the bound when needed.
+const MAX_GENERATORS: usize = 256;
+
+/// Lazily derived fixed generators for Pedersen vector commitments.
+///
+/// Each generator is derived via `hash_to_curve` with a domain separator
+/// and index. When real Ragu lands, these are replaced by Ragu's baked
+/// generators.
+static GENERATORS: LazyLock<Vec<EqAffine>> = LazyLock::new(|| {
+    use pasta_curves::{arithmetic::CurveExt as _, group::Curve as _};
+
+    let hasher = Eq::hash_to_curve("mock_ragu:generators");
+
+    (0..MAX_GENERATORS)
+        .map(|i| {
+            #[expect(clippy::little_endian_bytes, reason = "deterministic derivation")]
+            let point = hasher(&i.to_le_bytes());
+            point.to_affine()
+        })
+        .collect()
+});
+
+/// Computes the coefficients of the monic polynomial `∏(X - rᵢ)`.
+///
+/// Mirrors `ragu_arithmetic::poly_with_roots`. Returns coefficients in
+/// ascending degree order; the leading coefficient is always `1`.
+///
+/// Empty roots returns `[1]` (the constant polynomial `1`).
+/// Multiplicity is maintained: if a root appears `k` times, it appears
+/// `k` times in the output polynomial.
+#[must_use]
+pub fn poly_with_roots(roots: &[Fp]) -> Vec<Fp> {
+    let mut coeffs = vec![Fp::ONE];
+
+    for &root in roots {
+        // Multiply current polynomial by (X - root):
+        // new[i] = old[i-1] - root * old[i]
+        let mut new_coeffs = vec![Fp::ZERO; coeffs.len() + 1];
+        for (i, &c) in coeffs.iter().enumerate() {
+            new_coeffs[i + 1] += c;
+            new_coeffs[i] += c * root.neg();
+        }
+        coeffs = new_coeffs;
+    }
+
+    coeffs
+}
+
+/// A polynomial in monomial basis (coefficients in ascending degree order).
+///
+/// Mirrors `ragu_circuits::polynomials::unstructured::Polynomial`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Polynomial(Vec<Fp>);
+
+impl Polynomial {
+    /// Constructs a polynomial from a coefficient vector (ascending degree
+    /// order).
+    ///
+    /// Mirrors `ragu_circuits::polynomials::unstructured::Polynomial::from_coeffs`.
+    #[must_use]
+    pub fn from_coeffs(coeffs: Vec<Fp>) -> Self {
+        Self(coeffs)
+    }
+
+    /// Builds the monic polynomial whose roots are the given field elements.
+    ///
+    /// `from_roots(&[r₀, r₁, ...]) = (X - r₀)(X - r₁)...`
+    ///
+    /// Equivalent to `Polynomial::from_coeffs(poly_with_roots(roots))`.
+    /// Empty roots returns the constant polynomial `1`.
+    #[must_use]
+    pub fn from_roots(roots: &[Fp]) -> Self {
+        Self::from_coeffs(poly_with_roots(roots))
+    }
+
+    /// Polynomial multiplication (convolution).
+    ///
+    /// Used in `MergeStep` to combine `poly_left · poly_right`.
+    ///
+    /// **Mock-only** — in real Ragu, polynomial product is computed in-circuit.
+    #[must_use]
+    pub fn multiply(&self, other: &Self) -> Self {
+        let result_len = self.0.len() + other.0.len() - 1;
+        let mut result = vec![Fp::ZERO; result_len];
+
+        for (i, &a) in self.0.iter().enumerate() {
+            for (j, &b) in other.0.iter().enumerate() {
+                result[i + j] += a * b;
+            }
+        }
+
+        Self(result)
+    }
+
+    /// Returns the coefficients in ascending degree order.
+    #[must_use]
+    pub fn coefficients(&self) -> &[Fp] {
+        &self.0
+    }
+
+    /// Computes a Pedersen vector commitment to this polynomial.
+    ///
+    /// `Commit(f) = ∑ coeffᵢ · Gᵢ`
+    ///
+    /// Mirrors `ragu_circuits::polynomials::unstructured::Polynomial::commit_to_affine`.
+    /// The mock uses fixed generators derived via
+    /// `hash_to_curve("mock_ragu:generators")`.
+    ///
+    /// The `blind` parameter mirrors the real API signature. The mock does not
+    /// implement a separate blinding generator — pass `Fp::ZERO` here. Tachyon
+    /// uses zero blinding throughout: the verifier reconstructs commitments
+    /// from public data, so non-zero blinding would break verification.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial degree exceeds `MAX_GENERATORS - 1`.
+    #[must_use]
+    pub fn commit(&self, _blind: Fp) -> Commitment {
+        use pasta_curves::group::{Curve as _, Group as _};
+
+        let generators = &*GENERATORS;
+        assert!(
+            self.0.len() <= generators.len(),
+            "polynomial degree {} exceeds max generators {}",
+            self.0.len() - 1,
+            generators.len() - 1,
+        );
+
+        let mut acc = Eq::identity();
+        for (&coeff, &point) in self.0.iter().zip(generators.iter()) {
+            acc += Eq::from(point) * coeff;
+        }
+
+        Commitment(acc.to_affine())
+    }
+}
+
+/// The identity element for polynomial multiplication: the constant `1`.
+impl Default for Polynomial {
+    fn default() -> Self {
+        Self(vec![Fp::ONE])
+    }
+}
+
+/// A Pedersen vector commitment — an elliptic curve point on Vesta.
+///
+/// In real Ragu, this is the affine result of
+/// `polynomial.commit_to_affine(generators, blind)`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Commitment(EqAffine);
+
+impl Commitment {
+    /// Returns the underlying affine point.
+    #[must_use]
+    pub fn inner(&self) -> &EqAffine {
+        &self.0
+    }
+}
+
+impl From<Commitment> for [u8; 32] {
+    fn from(c: Commitment) -> Self {
+        use pasta_curves::group::GroupEncoding as _;
+        c.0.to_bytes()
+    }
+}
+
+impl TryFrom<&[u8; 32]> for Commitment {
+    type Error = &'static str;
+
+    fn try_from(bytes: &[u8; 32]) -> core::result::Result<Self, Self::Error> {
+        use pasta_curves::group::GroupEncoding as _;
+        Option::from(EqAffine::from_bytes(bytes))
+            .map(Self)
+            .ok_or("invalid curve point")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ops::Neg as _;
+
+    use ff::Field as _;
+    use pasta_curves::Fp;
+
+    use super::*;
+
+    /// `poly_with_roots([])` returns `[1]` (constant polynomial).
+    #[test]
+    fn poly_with_roots_empty() {
+        assert_eq!(poly_with_roots(&[]), &[Fp::ONE]);
+    }
+
+    /// `poly_with_roots([r])` returns `[-r, 1]` (i.e. `X - r`).
+    #[test]
+    fn poly_with_roots_single() {
+        let r = Fp::from(42u64);
+        assert_eq!(poly_with_roots(&[r]), &[r.neg(), Fp::ONE]);
+    }
+
+    /// `from_roots([])` returns the constant polynomial `[1]`.
+    #[test]
+    fn empty_roots_is_one() {
+        let poly = Polynomial::from_roots(&[]);
+        assert_eq!(poly.coefficients(), &[Fp::ONE]);
+    }
+
+    /// `from_roots([r])` returns `[-r, 1]` (i.e. `X - r`).
+    #[test]
+    fn single_root() {
+        let r = Fp::from(42u64);
+        let poly = Polynomial::from_roots(&[r]);
+        assert_eq!(poly.coefficients(), &[r.neg(), Fp::ONE]);
+    }
+
+    /// The product of two single-root polynomials equals a two-root polynomial.
+    #[test]
+    fn multiply_equals_combined_roots() {
+        let a = Fp::from(3u64);
+        let b = Fp::from(7u64);
+
+        let pa = Polynomial::from_roots(&[a]);
+        let pb = Polynomial::from_roots(&[b]);
+        let product = pa.multiply(&pb);
+
+        let combined = Polynomial::from_roots(&[a, b]);
+        assert_eq!(product, combined);
+    }
+
+    /// Polynomial evaluates to zero at each root.
+    #[test]
+    fn roots_evaluate_to_zero() {
+        let roots = [Fp::from(1u64), Fp::from(2u64), Fp::from(3u64)];
+        let poly = Polynomial::from_roots(&roots);
+
+        for &root in &roots {
+            let mut val = Fp::ZERO;
+            let mut power = Fp::ONE;
+            for &coeff in poly.coefficients() {
+                val += coeff * power;
+                power *= root;
+            }
+            assert_eq!(val, Fp::ZERO, "polynomial should be zero at its roots");
+        }
+    }
+
+    /// Commitment is deterministic: same polynomial + same blind produces same
+    /// commitment.
+    #[test]
+    fn commitment_deterministic() {
+        let poly = Polynomial::from_roots(&[Fp::from(42u64)]);
+        assert_eq!(poly.commit(Fp::ZERO), poly.commit(Fp::ZERO));
+    }
+
+    /// Different polynomials produce different commitments.
+    #[test]
+    fn distinct_polys_distinct_commitments() {
+        let c1 = Polynomial::from_roots(&[Fp::from(1u64)]).commit(Fp::ZERO);
+        let c2 = Polynomial::from_roots(&[Fp::from(2u64)]).commit(Fp::ZERO);
+        assert_ne!(c1, c2);
+    }
+
+    /// Commitment roundtrips through serialization.
+    #[test]
+    fn commitment_serialization_roundtrip() {
+        let commitment = Polynomial::from_roots(&[Fp::from(99u64)]).commit(Fp::ZERO);
+        let bytes: [u8; 32] = commitment.into();
+        let recovered = Commitment::try_from(&bytes).expect("valid point");
+        assert_eq!(commitment, recovered);
+    }
+
+    /// Multiplying by the default (identity) polynomial is a no-op.
+    #[test]
+    fn multiply_by_identity() {
+        let poly = Polynomial::from_roots(&[Fp::from(5u64), Fp::from(10u64)]);
+        let identity = Polynomial::default();
+        assert_eq!(poly.multiply(&identity), poly);
+        assert_eq!(identity.multiply(&poly), poly);
+    }
+
+    /// Blind parameter is accepted but ignored in the mock (no blinding
+    /// generator H). Tachyon always passes Fp::ZERO; the parameter exists
+    /// for API compatibility.
+    #[test]
+    fn blind_parameter_accepted() {
+        let poly = Polynomial::from_roots(&[Fp::from(1u64)]);
+        // Both calls succeed; blind is ignored in the mock.
+        let _ = poly.commit(Fp::ZERO);
+        let _ = poly.commit(Fp::ONE);
+    }
+}

--- a/crates/mock_ragu/src/polynomial.rs
+++ b/crates/mock_ragu/src/polynomial.rs
@@ -1,14 +1,6 @@
-//! Polynomial and Pedersen vector commitment types.
+//! Polynomial commitments — mirrors Ragu's polynomial commitment scheme.
 //!
-//! Mock equivalents of Ragu's polynomial commitment scheme. The
-//! [`Polynomial`] type mirrors
-//! `ragu_circuits::polynomials::unstructured::Polynomial`
-//! and the [`Commitment`] type represents a real Pedersen vector commitment
-//! (EC point on Vesta). Only the proof system (IPA opening, Fiat-Shamir,
-//! etc.) is mocked — the commitment itself is real crypto.
-//!
-//! These are public so that validators can recompute accumulators from
-//! public data outside the proof.
+//! Real Pedersen crypto on Vesta. Only the proof system is mocked.
 
 extern crate alloc;
 
@@ -19,23 +11,12 @@ use std::sync::LazyLock;
 use ff::Field;
 use pasta_curves::{Eq, EqAffine, Fp};
 
-/// Maximum number of generators to precompute.
-///
-/// Supports polynomials up to degree `MAX_GENERATORS - 1`. This is enough
-/// for stamps with up to `MAX_GENERATORS - 1` elements. If a polynomial
-/// exceeds this, `commit` will panic — increase the bound when needed.
 const MAX_GENERATORS: usize = 256;
 
-/// Lazily derived fixed generators for Pedersen vector commitments.
-///
-/// Each generator is derived via `hash_to_curve` with a domain separator
-/// and index. When real Ragu lands, these are replaced by Ragu's baked
-/// generators.
+/// Coefficient generators `g[0..n]`.
 static GENERATORS: LazyLock<Vec<EqAffine>> = LazyLock::new(|| {
     use pasta_curves::{arithmetic::CurveExt as _, group::Curve as _};
-
     let hasher = Eq::hash_to_curve("mock_ragu:generators");
-
     (0..MAX_GENERATORS)
         .map(|i| {
             #[expect(clippy::little_endian_bytes, reason = "deterministic derivation")]
@@ -45,21 +26,17 @@ static GENERATORS: LazyLock<Vec<EqAffine>> = LazyLock::new(|| {
         .collect()
 });
 
-/// Computes the coefficients of the monic polynomial `∏(X - rᵢ)`.
-///
-/// Mirrors `ragu_arithmetic::poly_with_roots`. Returns coefficients in
-/// ascending degree order; the leading coefficient is always `1`.
-///
-/// Empty roots returns `[1]` (the constant polynomial `1`).
-/// Multiplicity is maintained: if a root appears `k` times, it appears
-/// `k` times in the output polynomial.
+/// Blinding generator `h` (unknown discrete log relative to `g`).
+static BLINDING_GENERATOR: LazyLock<EqAffine> = LazyLock::new(|| {
+    use pasta_curves::{arithmetic::CurveExt as _, group::Curve as _};
+    Eq::hash_to_curve("mock_ragu:blinding")(b"h").to_affine()
+});
+
+/// Mirrors `ragu_arithmetic::poly_with_roots`.
 #[must_use]
 pub fn poly_with_roots(roots: &[Fp]) -> Vec<Fp> {
     let mut coeffs = vec![Fp::ONE];
-
     for &root in roots {
-        // Multiply current polynomial by (X - root):
-        // new[i] = old[i-1] - root * old[i]
         let mut new_coeffs = vec![Fp::ZERO; coeffs.len() + 1];
         for (i, &c) in coeffs.iter().enumerate() {
             new_coeffs[i + 1] += c;
@@ -67,80 +44,44 @@ pub fn poly_with_roots(roots: &[Fp]) -> Vec<Fp> {
         }
         coeffs = new_coeffs;
     }
-
     coeffs
 }
 
-/// A polynomial in monomial basis (coefficients in ascending degree order).
-///
 /// Mirrors `ragu_circuits::polynomials::unstructured::Polynomial`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Polynomial(Vec<Fp>);
 
 impl Polynomial {
-    /// Constructs a polynomial from a coefficient vector (ascending degree
-    /// order).
-    ///
-    /// Mirrors `ragu_circuits::polynomials::unstructured::Polynomial::from_coeffs`.
     #[must_use]
     pub fn from_coeffs(coeffs: Vec<Fp>) -> Self {
         Self(coeffs)
     }
 
-    /// Builds the monic polynomial whose roots are the given field elements.
-    ///
-    /// `from_roots(&[r₀, r₁, ...]) = (X - r₀)(X - r₁)...`
-    ///
-    /// Equivalent to `Polynomial::from_coeffs(poly_with_roots(roots))`.
-    /// Empty roots returns the constant polynomial `1`.
     #[must_use]
     pub fn from_roots(roots: &[Fp]) -> Self {
-        Self::from_coeffs(poly_with_roots(roots))
+        Self(poly_with_roots(roots))
     }
 
-    /// Polynomial multiplication (convolution).
-    ///
-    /// Used in `MergeStep` to combine `poly_left · poly_right`.
-    ///
-    /// **Mock-only** — in real Ragu, polynomial product is computed in-circuit.
     #[must_use]
     pub fn multiply(&self, other: &Self) -> Self {
         let result_len = self.0.len() + other.0.len() - 1;
         let mut result = vec![Fp::ZERO; result_len];
-
         for (i, &a) in self.0.iter().enumerate() {
             for (j, &b) in other.0.iter().enumerate() {
                 result[i + j] += a * b;
             }
         }
-
         Self(result)
     }
 
-    /// Returns the coefficients in ascending degree order.
     #[must_use]
     pub fn coefficients(&self) -> &[Fp] {
         &self.0
     }
 
-    /// Computes a Pedersen vector commitment to this polynomial.
-    ///
-    /// `Commit(f) = ∑ coeffᵢ · Gᵢ`
-    ///
-    /// Mirrors `ragu_circuits::polynomials::unstructured::Polynomial::commit_to_affine`.
-    /// The mock uses fixed generators derived via
-    /// `hash_to_curve("mock_ragu:generators")`.
-    ///
-    /// The `blind` parameter mirrors the real API signature. The mock does not
-    /// implement a separate blinding generator — pass `Fp::ZERO` here. Tachyon
-    /// uses zero blinding throughout: the verifier reconstructs commitments
-    /// from public data, so non-zero blinding would break verification.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the polynomial degree exceeds `MAX_GENERATORS - 1`.
+    /// `commit(blind) = ∑ coeffᵢ·gᵢ + blind·h`
     #[must_use]
-    pub fn commit(&self, _blind: Fp) -> Commitment {
+    pub fn commit(&self, blind: Fp) -> Commitment {
         use pasta_curves::group::{Curve as _, Group as _};
 
         let generators = &*GENERATORS;
@@ -155,27 +96,23 @@ impl Polynomial {
         for (&coeff, &point) in self.0.iter().zip(generators.iter()) {
             acc += Eq::from(point) * coeff;
         }
+        acc += Eq::from(*BLINDING_GENERATOR) * blind;
 
         Commitment(acc.to_affine())
     }
 }
 
-/// The identity element for polynomial multiplication: the constant `1`.
 impl Default for Polynomial {
     fn default() -> Self {
         Self(vec![Fp::ONE])
     }
 }
 
-/// A Pedersen vector commitment — an elliptic curve point on Vesta.
-///
-/// In real Ragu, this is the affine result of
-/// `polynomial.commit_to_affine(generators, blind)`.
+/// A Pedersen vector commitment (EC point on Vesta).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Commitment(EqAffine);
 
 impl Commitment {
-    /// Returns the underlying affine point.
     #[must_use]
     pub fn inner(&self) -> &EqAffine {
         &self.0
@@ -197,119 +134,5 @@ impl TryFrom<&[u8; 32]> for Commitment {
         Option::from(EqAffine::from_bytes(bytes))
             .map(Self)
             .ok_or("invalid curve point")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use core::ops::Neg as _;
-
-    use ff::Field as _;
-    use pasta_curves::Fp;
-
-    use super::*;
-
-    /// `poly_with_roots([])` returns `[1]` (constant polynomial).
-    #[test]
-    fn poly_with_roots_empty() {
-        assert_eq!(poly_with_roots(&[]), &[Fp::ONE]);
-    }
-
-    /// `poly_with_roots([r])` returns `[-r, 1]` (i.e. `X - r`).
-    #[test]
-    fn poly_with_roots_single() {
-        let r = Fp::from(42u64);
-        assert_eq!(poly_with_roots(&[r]), &[r.neg(), Fp::ONE]);
-    }
-
-    /// `from_roots([])` returns the constant polynomial `[1]`.
-    #[test]
-    fn empty_roots_is_one() {
-        let poly = Polynomial::from_roots(&[]);
-        assert_eq!(poly.coefficients(), &[Fp::ONE]);
-    }
-
-    /// `from_roots([r])` returns `[-r, 1]` (i.e. `X - r`).
-    #[test]
-    fn single_root() {
-        let r = Fp::from(42u64);
-        let poly = Polynomial::from_roots(&[r]);
-        assert_eq!(poly.coefficients(), &[r.neg(), Fp::ONE]);
-    }
-
-    /// The product of two single-root polynomials equals a two-root polynomial.
-    #[test]
-    fn multiply_equals_combined_roots() {
-        let a = Fp::from(3u64);
-        let b = Fp::from(7u64);
-
-        let pa = Polynomial::from_roots(&[a]);
-        let pb = Polynomial::from_roots(&[b]);
-        let product = pa.multiply(&pb);
-
-        let combined = Polynomial::from_roots(&[a, b]);
-        assert_eq!(product, combined);
-    }
-
-    /// Polynomial evaluates to zero at each root.
-    #[test]
-    fn roots_evaluate_to_zero() {
-        let roots = [Fp::from(1u64), Fp::from(2u64), Fp::from(3u64)];
-        let poly = Polynomial::from_roots(&roots);
-
-        for &root in &roots {
-            let mut val = Fp::ZERO;
-            let mut power = Fp::ONE;
-            for &coeff in poly.coefficients() {
-                val += coeff * power;
-                power *= root;
-            }
-            assert_eq!(val, Fp::ZERO, "polynomial should be zero at its roots");
-        }
-    }
-
-    /// Commitment is deterministic: same polynomial + same blind produces same
-    /// commitment.
-    #[test]
-    fn commitment_deterministic() {
-        let poly = Polynomial::from_roots(&[Fp::from(42u64)]);
-        assert_eq!(poly.commit(Fp::ZERO), poly.commit(Fp::ZERO));
-    }
-
-    /// Different polynomials produce different commitments.
-    #[test]
-    fn distinct_polys_distinct_commitments() {
-        let c1 = Polynomial::from_roots(&[Fp::from(1u64)]).commit(Fp::ZERO);
-        let c2 = Polynomial::from_roots(&[Fp::from(2u64)]).commit(Fp::ZERO);
-        assert_ne!(c1, c2);
-    }
-
-    /// Commitment roundtrips through serialization.
-    #[test]
-    fn commitment_serialization_roundtrip() {
-        let commitment = Polynomial::from_roots(&[Fp::from(99u64)]).commit(Fp::ZERO);
-        let bytes: [u8; 32] = commitment.into();
-        let recovered = Commitment::try_from(&bytes).expect("valid point");
-        assert_eq!(commitment, recovered);
-    }
-
-    /// Multiplying by the default (identity) polynomial is a no-op.
-    #[test]
-    fn multiply_by_identity() {
-        let poly = Polynomial::from_roots(&[Fp::from(5u64), Fp::from(10u64)]);
-        let identity = Polynomial::default();
-        assert_eq!(poly.multiply(&identity), poly);
-        assert_eq!(identity.multiply(&poly), poly);
-    }
-
-    /// Blind parameter is accepted but ignored in the mock (no blinding
-    /// generator H). Tachyon always passes Fp::ZERO; the parameter exists
-    /// for API compatibility.
-    #[test]
-    fn blind_parameter_accepted() {
-        let poly = Polynomial::from_roots(&[Fp::from(1u64)]);
-        // Both calls succeed; blind is ignored in the mock.
-        let _ = poly.commit(Fp::ZERO);
-        let _ = poly.commit(Fp::ONE);
     }
 }

--- a/crates/mock_ragu/src/proof.rs
+++ b/crates/mock_ragu/src/proof.rs
@@ -1,113 +1,123 @@
-//! Mock PCD proof (128 bytes) and proof-carrying data.
+//! Mock PCD proof and proof-carrying data.
 //!
-//! ## Proof layout
+//! ## Serialized layout
 //!
 //! | Offset | Size | Content |
 //! |--------|------|---------|
 //! | 0..32 | 32 | header hash |
 //! | 32..64 | 32 | witness hash |
-//! | 64..96 | 32 | merge tag (zero for leaf) |
-//! | 96..128 | 32 | binding hash |
-//!
-//! The binding hash ties the other components together:
-//! `binding = BLAKE2b("MkRagu_Binding_\0", header_hash || witness_hash ||
-//! merge_tag)`
+//! | 64..96 | 32 | binding hash |
+//! | 96..128 | 32 | rerandomization tag |
+//! | 128..23000 | 22872 | zero padding |
 
 use crate::header::Header;
 
-/// Size of the mock proof in bytes.
-pub const PROOF_SIZE: usize = 128;
+/// Compressed proof size in bytes.
+pub const PROOF_SIZE_COMPRESSED: usize = 23_000;
 
-/// A mock PCD proof.
-///
-/// Mirrors `ragu_pcd::Proof`. Not cryptographically sound — provides
-/// deterministic consistency checking for integration testing.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Mocks `ragu_pcd::Proof`.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Proof {
-    bytes: [u8; PROOF_SIZE],
+    pub(crate) header_hash: [u8; 32],
+    pub(crate) witness_hash: [u8; 32],
+    pub(crate) binding: [u8; 32],
+    pub(crate) rerand_tag: [u8; 32],
 }
 
-/// Proof-carrying data: a proof bundled with its header data.
-///
-/// Mirrors `ragu_pcd::Pcd`. Created by [`Proof::carry`].
+/// Mocks `ragu_pcd::Pcd`.
 #[derive(Clone, Debug)]
 pub struct Pcd<'source, H: Header> {
-    /// The proof bytes.
     pub proof: Proof,
-    /// The header data carried by this proof.
     pub data: H::Data<'source>,
 }
 
 impl Proof {
-    /// Attach header data to this proof, creating a [`Pcd`].
-    ///
-    /// Mirrors `ragu_pcd::Proof::carry`. Does not validate that the
-    /// header data matches the proof — that happens in
-    /// [`Application::verify`](crate::Application::verify).
+    #[must_use]
+    pub(crate) fn trivial() -> Self {
+        Self::new(&[], &[])
+    }
+
+    #[must_use]
+    pub(crate) fn new(encoded_header: &[u8], witness_data: &[u8]) -> Self {
+        let header_hash = compute_header_hash(encoded_header);
+        let witness_hash = compute_witness_hash(witness_data);
+        let binding = compute_binding(&header_hash, &witness_hash);
+        Self {
+            header_hash,
+            witness_hash,
+            binding,
+            rerand_tag: [0u8; 32],
+        }
+    }
+
+    /// Mirrors `ragu_pcd::Proof::carry`.
     #[must_use]
     pub fn carry<H: Header>(self, data: H::Data<'_>) -> Pcd<'_, H> {
         Pcd { proof: self, data }
     }
 
-    /// Extract the header hash from proof bytes.
+    /// Serialize into the full compressed proof buffer.
     #[must_use]
-    pub(crate) fn header_hash(&self) -> [u8; 32] {
-        extract_field(&self.bytes, 0)
+    pub fn serialize(&self) -> Box<[u8; PROOF_SIZE_COMPRESSED]> {
+        let mut bytes = [
+            self.header_hash,
+            self.witness_hash,
+            self.binding,
+            self.rerand_tag,
+        ]
+        .concat();
+        bytes.resize(PROOF_SIZE_COMPRESSED, 0);
+        bytes
+            .into_boxed_slice()
+            .try_into()
+            .expect("resized to PROOF_SIZE_COMPRESSED")
     }
 
-    /// Extract the witness hash from proof bytes.
     #[must_use]
-    pub(crate) fn witness_hash(&self) -> [u8; 32] {
-        extract_field(&self.bytes, 32)
-    }
-
-    /// Extract the merge tag from proof bytes.
-    #[must_use]
-    pub(crate) fn merge_tag(&self) -> [u8; 32] {
-        extract_field(&self.bytes, 64)
-    }
-
-    /// Extract the binding hash from proof bytes.
-    #[must_use]
-    pub(crate) fn binding(&self) -> [u8; 32] {
-        extract_field(&self.bytes, 96)
+    pub(crate) fn rerandomize(&self) -> Self {
+        let serialized = self.serialize();
+        Self {
+            header_hash: self.header_hash,
+            witness_hash: self.witness_hash,
+            binding: self.binding,
+            rerand_tag: compute_rerand_tag(serialized.as_ref()),
+        }
     }
 }
 
-/// Extract a 32-byte field at the given offset.
-fn extract_field(bytes: &[u8; PROOF_SIZE], offset: usize) -> [u8; 32] {
-    let mut out = [0u8; 32];
-    if let Some(slice) = bytes.get(offset..offset + 32) {
-        out.copy_from_slice(slice);
-    }
-    out
-}
-
-#[expect(clippy::from_over_into, reason = "restrict conversion")]
-impl Into<[u8; PROOF_SIZE]> for Proof {
-    fn into(self) -> [u8; PROOF_SIZE] {
-        self.bytes
+impl From<Proof> for [u8; PROOF_SIZE_COMPRESSED] {
+    fn from(proof: Proof) -> [u8; PROOF_SIZE_COMPRESSED] {
+        *proof.serialize()
     }
 }
 
-impl TryFrom<&[u8; PROOF_SIZE]> for Proof {
+impl TryFrom<&[u8; PROOF_SIZE_COMPRESSED]> for Proof {
     type Error = crate::error::Error;
 
-    fn try_from(bytes: &[u8; PROOF_SIZE]) -> Result<Self, Self::Error> {
-        let proof = Self { bytes: *bytes };
-        let expected_binding = compute_binding(
-            &proof.header_hash(),
-            &proof.witness_hash(),
-            &proof.merge_tag(),
-        );
-        if expected_binding != proof.binding() {
+    fn try_from(bytes: &[u8; PROOF_SIZE_COMPRESSED]) -> Result<Self, Self::Error> {
+        let mut fields = bytes
+            .chunks_exact(32)
+            .map(|chunk| chunk.try_into().expect("field is 32 bytes"));
+
+        let header_hash = fields.next().expect("field 0");
+        let witness_hash = fields.next().expect("field 1");
+        let binding = fields.next().expect("field 2");
+        let rerand_tag = fields.next().expect("field 3");
+
+        let expected_binding = compute_binding(&header_hash, &witness_hash);
+        if expected_binding != binding {
             return Err(crate::error::Error);
         }
-        Ok(proof)
+
+        Ok(Self {
+            header_hash,
+            witness_hash,
+            binding,
+            rerand_tag,
+        })
     }
 }
 
-/// Hash encoded header data to produce the header hash.
 pub(crate) fn compute_header_hash(encoded: &[u8]) -> [u8; 32] {
     let hash = blake2b_simd::Params::new()
         .hash_length(32)
@@ -118,7 +128,6 @@ pub(crate) fn compute_header_hash(encoded: &[u8]) -> [u8; 32] {
     out
 }
 
-/// Hash witness data (encoded header for seed, child proofs for fuse).
 pub(crate) fn compute_witness_hash(witness_bytes: &[u8]) -> [u8; 32] {
     let hash = blake2b_simd::Params::new()
         .hash_length(32)
@@ -129,90 +138,25 @@ pub(crate) fn compute_witness_hash(witness_bytes: &[u8]) -> [u8; 32] {
     out
 }
 
-/// Hash two children's bindings to produce the merge tag.
-pub(crate) fn compute_merge_tag(left_binding: &[u8; 32], right_binding: &[u8; 32]) -> [u8; 32] {
-    let hash = blake2b_simd::Params::new()
-        .hash_length(32)
-        .personal(b"MkRagu_MergeTag\0")
-        .to_state()
-        .update(left_binding)
-        .update(right_binding)
-        .finalize();
-    let mut out = [0u8; 32];
-    out.copy_from_slice(hash.as_bytes());
-    out
-}
-
-/// Compute the binding hash tying header hash, witness hash, and merge tag.
-pub(crate) fn compute_binding(
-    header_hash: &[u8; 32],
-    witness_hash: &[u8; 32],
-    merge_tag: &[u8; 32],
-) -> [u8; 32] {
+pub(crate) fn compute_binding(header_hash: &[u8; 32], witness_hash: &[u8; 32]) -> [u8; 32] {
     let hash = blake2b_simd::Params::new()
         .hash_length(32)
         .personal(b"MkRagu_Binding_\0")
         .to_state()
         .update(header_hash)
         .update(witness_hash)
-        .update(merge_tag)
         .finalize();
     let mut out = [0u8; 32];
     out.copy_from_slice(hash.as_bytes());
     out
 }
 
-/// Assemble a proof from its hash components.
-pub(crate) fn assemble(
-    header_hash: &[u8; 32],
-    witness_hash: &[u8; 32],
-    merge_tag: &[u8; 32],
-) -> Proof {
-    let binding = compute_binding(header_hash, witness_hash, merge_tag);
-    let mut bytes = [0u8; PROOF_SIZE];
-    if let Some(sl) = bytes.get_mut(..32) {
-        sl.copy_from_slice(header_hash);
-    }
-    if let Some(sl) = bytes.get_mut(32..64) {
-        sl.copy_from_slice(witness_hash);
-    }
-    if let Some(sl) = bytes.get_mut(64..96) {
-        sl.copy_from_slice(merge_tag);
-    }
-    if let Some(sl) = bytes.get_mut(96..128) {
-        sl.copy_from_slice(&binding);
-    }
-    Proof { bytes }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn proof_round_trip() {
-        let header_hash = [0x01u8; 32];
-        let witness_hash = [0x02u8; 32];
-        let merge_tag = [0u8; 32];
-
-        let proof = assemble(&header_hash, &witness_hash, &merge_tag);
-        let bytes: [u8; PROOF_SIZE] = proof.into();
-        let recovered = Proof::try_from(&bytes).expect("round trip should succeed");
-        assert_eq!(proof, recovered);
-    }
-
-    #[test]
-    fn tampered_proof_fails() {
-        let proof = assemble(&[0x01u8; 32], &[0x02u8; 32], &[0u8; 32]);
-        let mut bytes: [u8; PROOF_SIZE] = proof.into();
-        bytes[0] ^= 0xFFu8;
-        Proof::try_from(&bytes).expect_err("tampered proof should fail");
-    }
-
-    #[test]
-    fn carry_creates_pcd() {
-        let proof = assemble(&[0x01u8; 32], &[0x02u8; 32], &[0u8; 32]);
-        let pcd: Pcd<'_, ()> = proof.carry(());
-        assert_eq!(pcd.proof, proof);
-    }
+pub(crate) fn compute_rerand_tag(proof_bytes: &[u8]) -> [u8; 32] {
+    let hash = blake2b_simd::Params::new()
+        .hash_length(32)
+        .personal(b"MkRagu_Rerand_\0\0")
+        .hash(proof_bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(hash.as_bytes());
+    out
 }

--- a/crates/mock_ragu/src/proof.rs
+++ b/crates/mock_ragu/src/proof.rs
@@ -1,0 +1,218 @@
+//! Mock PCD proof (128 bytes) and proof-carrying data.
+//!
+//! ## Proof layout
+//!
+//! | Offset | Size | Content |
+//! |--------|------|---------|
+//! | 0..32 | 32 | header hash |
+//! | 32..64 | 32 | witness hash |
+//! | 64..96 | 32 | merge tag (zero for leaf) |
+//! | 96..128 | 32 | binding hash |
+//!
+//! The binding hash ties the other components together:
+//! `binding = BLAKE2b("MkRagu_Binding_\0", header_hash || witness_hash ||
+//! merge_tag)`
+
+use crate::header::Header;
+
+/// Size of the mock proof in bytes.
+pub const PROOF_SIZE: usize = 128;
+
+/// A mock PCD proof.
+///
+/// Mirrors `ragu_pcd::Proof`. Not cryptographically sound — provides
+/// deterministic consistency checking for integration testing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Proof {
+    bytes: [u8; PROOF_SIZE],
+}
+
+/// Proof-carrying data: a proof bundled with its header data.
+///
+/// Mirrors `ragu_pcd::Pcd`. Created by [`Proof::carry`].
+#[derive(Clone, Debug)]
+pub struct Pcd<'source, H: Header> {
+    /// The proof bytes.
+    pub proof: Proof,
+    /// The header data carried by this proof.
+    pub data: H::Data<'source>,
+}
+
+impl Proof {
+    /// Attach header data to this proof, creating a [`Pcd`].
+    ///
+    /// Mirrors `ragu_pcd::Proof::carry`. Does not validate that the
+    /// header data matches the proof — that happens in
+    /// [`Application::verify`](crate::Application::verify).
+    #[must_use]
+    pub fn carry<H: Header>(self, data: H::Data<'_>) -> Pcd<'_, H> {
+        Pcd { proof: self, data }
+    }
+
+    /// Extract the header hash from proof bytes.
+    #[must_use]
+    pub(crate) fn header_hash(&self) -> [u8; 32] {
+        extract_field(&self.bytes, 0)
+    }
+
+    /// Extract the witness hash from proof bytes.
+    #[must_use]
+    pub(crate) fn witness_hash(&self) -> [u8; 32] {
+        extract_field(&self.bytes, 32)
+    }
+
+    /// Extract the merge tag from proof bytes.
+    #[must_use]
+    pub(crate) fn merge_tag(&self) -> [u8; 32] {
+        extract_field(&self.bytes, 64)
+    }
+
+    /// Extract the binding hash from proof bytes.
+    #[must_use]
+    pub(crate) fn binding(&self) -> [u8; 32] {
+        extract_field(&self.bytes, 96)
+    }
+}
+
+/// Extract a 32-byte field at the given offset.
+fn extract_field(bytes: &[u8; PROOF_SIZE], offset: usize) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    if let Some(slice) = bytes.get(offset..offset + 32) {
+        out.copy_from_slice(slice);
+    }
+    out
+}
+
+#[expect(clippy::from_over_into, reason = "restrict conversion")]
+impl Into<[u8; PROOF_SIZE]> for Proof {
+    fn into(self) -> [u8; PROOF_SIZE] {
+        self.bytes
+    }
+}
+
+impl TryFrom<&[u8; PROOF_SIZE]> for Proof {
+    type Error = crate::error::Error;
+
+    fn try_from(bytes: &[u8; PROOF_SIZE]) -> Result<Self, Self::Error> {
+        let proof = Self { bytes: *bytes };
+        let expected_binding = compute_binding(
+            &proof.header_hash(),
+            &proof.witness_hash(),
+            &proof.merge_tag(),
+        );
+        if expected_binding != proof.binding() {
+            return Err(crate::error::Error);
+        }
+        Ok(proof)
+    }
+}
+
+/// Hash encoded header data to produce the header hash.
+pub(crate) fn compute_header_hash(encoded: &[u8]) -> [u8; 32] {
+    let hash = blake2b_simd::Params::new()
+        .hash_length(32)
+        .personal(b"MkRagu_HdrHash_\0")
+        .hash(encoded);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(hash.as_bytes());
+    out
+}
+
+/// Hash witness data (encoded header for seed, child proofs for fuse).
+pub(crate) fn compute_witness_hash(witness_bytes: &[u8]) -> [u8; 32] {
+    let hash = blake2b_simd::Params::new()
+        .hash_length(32)
+        .personal(b"MkRagu_Witness_\0")
+        .hash(witness_bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(hash.as_bytes());
+    out
+}
+
+/// Hash two children's bindings to produce the merge tag.
+pub(crate) fn compute_merge_tag(left_binding: &[u8; 32], right_binding: &[u8; 32]) -> [u8; 32] {
+    let hash = blake2b_simd::Params::new()
+        .hash_length(32)
+        .personal(b"MkRagu_MergeTag\0")
+        .to_state()
+        .update(left_binding)
+        .update(right_binding)
+        .finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(hash.as_bytes());
+    out
+}
+
+/// Compute the binding hash tying header hash, witness hash, and merge tag.
+pub(crate) fn compute_binding(
+    header_hash: &[u8; 32],
+    witness_hash: &[u8; 32],
+    merge_tag: &[u8; 32],
+) -> [u8; 32] {
+    let hash = blake2b_simd::Params::new()
+        .hash_length(32)
+        .personal(b"MkRagu_Binding_\0")
+        .to_state()
+        .update(header_hash)
+        .update(witness_hash)
+        .update(merge_tag)
+        .finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(hash.as_bytes());
+    out
+}
+
+/// Assemble a proof from its hash components.
+pub(crate) fn assemble(
+    header_hash: &[u8; 32],
+    witness_hash: &[u8; 32],
+    merge_tag: &[u8; 32],
+) -> Proof {
+    let binding = compute_binding(header_hash, witness_hash, merge_tag);
+    let mut bytes = [0u8; PROOF_SIZE];
+    if let Some(sl) = bytes.get_mut(..32) {
+        sl.copy_from_slice(header_hash);
+    }
+    if let Some(sl) = bytes.get_mut(32..64) {
+        sl.copy_from_slice(witness_hash);
+    }
+    if let Some(sl) = bytes.get_mut(64..96) {
+        sl.copy_from_slice(merge_tag);
+    }
+    if let Some(sl) = bytes.get_mut(96..128) {
+        sl.copy_from_slice(&binding);
+    }
+    Proof { bytes }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_round_trip() {
+        let header_hash = [0x01u8; 32];
+        let witness_hash = [0x02u8; 32];
+        let merge_tag = [0u8; 32];
+
+        let proof = assemble(&header_hash, &witness_hash, &merge_tag);
+        let bytes: [u8; PROOF_SIZE] = proof.into();
+        let recovered = Proof::try_from(&bytes).expect("round trip should succeed");
+        assert_eq!(proof, recovered);
+    }
+
+    #[test]
+    fn tampered_proof_fails() {
+        let proof = assemble(&[0x01u8; 32], &[0x02u8; 32], &[0u8; 32]);
+        let mut bytes: [u8; PROOF_SIZE] = proof.into();
+        bytes[0] ^= 0xFFu8;
+        Proof::try_from(&bytes).expect_err("tampered proof should fail");
+    }
+
+    #[test]
+    fn carry_creates_pcd() {
+        let proof = assemble(&[0x01u8; 32], &[0x02u8; 32], &[0u8; 32]);
+        let pcd: Pcd<'_, ()> = proof.carry(());
+        assert_eq!(pcd.proof, proof);
+    }
+}

--- a/crates/mock_ragu/src/step.rs
+++ b/crates/mock_ragu/src/step.rs
@@ -1,0 +1,63 @@
+//! Mock PCD step — a node in the computational graph.
+//!
+//! This is the mock equivalent of `ragu_pcd::Step`. Instead of circuit
+//! synthesis via a `Driver`, the mock step computes output header data
+//! directly from the witness and input header data.
+
+use crate::{error::Result, header::Header};
+
+/// Unique index identifying a [`Step`] within an
+/// [`Application`](crate::Application).
+///
+/// Mirrors `ragu_pcd::step::Index`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Index(usize);
+
+impl Index {
+    /// Creates a new step index.
+    #[must_use]
+    pub const fn new(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+/// A computation step in the PCD graph.
+///
+/// Mirrors `ragu_pcd::Step`. Each step defines:
+/// - Input headers (`Left`, `Right`) — what data the step consumes
+/// - Output header (`Output`) — what data the step produces
+/// - Witness and auxiliary data types
+///
+/// In real Ragu, [`witness()`](Step::witness) synthesizes constraints
+/// inside a `Driver`. In the mock, it computes the output directly.
+pub trait Step: Sized + Send + Sync {
+    /// Unique index for this step.
+    const INDEX: Index;
+
+    /// Witness data provided by the prover.
+    type Witness<'source>: Send;
+
+    /// Auxiliary data returned alongside the proof.
+    type Aux<'source>: Send;
+
+    /// Left input header type.
+    type Left: Header;
+
+    /// Right input header type.
+    type Right: Header;
+
+    /// Output header type.
+    type Output: Header;
+
+    /// Mock circuit witness generation.
+    ///
+    /// Computes the output header data from the witness and input headers.
+    /// In real Ragu, this synthesizes constraints inside a `Driver` and
+    /// returns encoded headers. The mock computes the output directly.
+    fn witness<'source>(
+        &self,
+        witness: Self::Witness<'source>,
+        left: <Self::Left as Header>::Data<'source>,
+        right: <Self::Right as Header>::Data<'source>,
+    ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)>;
+}

--- a/crates/mock_ragu/src/step.rs
+++ b/crates/mock_ragu/src/step.rs
@@ -1,59 +1,27 @@
-//! Mock PCD step — a node in the computational graph.
-//!
-//! This is the mock equivalent of `ragu_pcd::Step`. Instead of circuit
-//! synthesis via a `Driver`, the mock step computes output header data
-//! directly from the witness and input header data.
+//! Mock PCD step — mirrors `ragu_pcd::Step`.
 
 use crate::{error::Result, header::Header};
 
-/// Unique index identifying a [`Step`] within an
-/// [`Application`](crate::Application).
-///
 /// Mirrors `ragu_pcd::step::Index`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Index(usize);
 
 impl Index {
-    /// Creates a new step index.
     #[must_use]
     pub const fn new(value: usize) -> Self {
         Self(value)
     }
 }
 
-/// A computation step in the PCD graph.
-///
-/// Mirrors `ragu_pcd::Step`. Each step defines:
-/// - Input headers (`Left`, `Right`) — what data the step consumes
-/// - Output header (`Output`) — what data the step produces
-/// - Witness and auxiliary data types
-///
-/// In real Ragu, [`witness()`](Step::witness) synthesizes constraints
-/// inside a `Driver`. In the mock, it computes the output directly.
+/// Mirrors `ragu_pcd::Step`.
 pub trait Step: Sized + Send + Sync {
-    /// Unique index for this step.
     const INDEX: Index;
-
-    /// Witness data provided by the prover.
     type Witness<'source>: Send;
-
-    /// Auxiliary data returned alongside the proof.
     type Aux<'source>: Send;
-
-    /// Left input header type.
     type Left: Header;
-
-    /// Right input header type.
     type Right: Header;
-
-    /// Output header type.
     type Output: Header;
 
-    /// Mock circuit witness generation.
-    ///
-    /// Computes the output header data from the witness and input headers.
-    /// In real Ragu, this synthesizes constraints inside a `Driver` and
-    /// returns encoded headers. The mock computes the output directly.
     fn witness<'source>(
         &self,
         witness: Self::Witness<'source>,

--- a/crates/mock_ragu/src/tests.rs
+++ b/crates/mock_ragu/src/tests.rs
@@ -1,0 +1,511 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::ops::Neg as _;
+
+use ff::Field as _;
+use pasta_curves::Fp;
+use rand::thread_rng;
+
+use super::{
+    application::*,
+    error::Result,
+    header::{Header, Suffix},
+    polynomial::*,
+    proof::{Pcd, Proof, PROOF_SIZE_COMPRESSED},
+    step::{Index, Step},
+};
+
+// ---- proof ----
+
+#[test]
+fn proof_round_trip() {
+    let proof = Proof::new(b"header", b"witness");
+    let bytes: [u8; PROOF_SIZE_COMPRESSED] = proof.clone().into();
+    let recovered = Proof::try_from(&bytes).expect("round trip should succeed");
+    assert_eq!(proof, recovered);
+}
+
+#[test]
+fn tampered_proof_fails() {
+    let proof = Proof::new(b"header", b"witness");
+    let mut bytes: [u8; PROOF_SIZE_COMPRESSED] = proof.into();
+    bytes[0] ^= 0xFFu8;
+    Proof::try_from(&bytes).expect_err("tampered proof should fail");
+}
+
+#[test]
+fn carry_creates_pcd() {
+    let proof = Proof::new(b"header", b"witness");
+    let expected = proof.clone();
+    let pcd: Pcd<'_, ()> = proof.carry(());
+    assert_eq!(pcd.proof, expected);
+}
+
+#[test]
+fn rerandomize() {
+    let proof = Proof::new(b"header", b"witness");
+    assert_eq!(proof.rerand_tag, [0u8; 32]);
+
+    let once = proof.rerandomize();
+
+    assert_eq!(proof.header_hash, once.header_hash);
+    assert_eq!(proof.witness_hash, once.witness_hash);
+    assert_eq!(proof.binding, once.binding);
+    assert_ne!(proof, once);
+
+    let twice = once.rerandomize();
+    assert_eq!(proof.header_hash, twice.header_hash);
+    assert_eq!(proof.witness_hash, twice.witness_hash);
+    assert_eq!(proof.binding, twice.binding);
+    assert_ne!(once, twice);
+
+    assert_ne!(proof.rerand_tag, once.rerand_tag);
+    assert_ne!(proof.rerand_tag, twice.rerand_tag);
+    assert_ne!(once.rerand_tag, twice.rerand_tag);
+}
+
+// ---- polynomial ----
+
+#[test]
+fn from_roots_and_multiply() {
+    let a = Fp::from(3u64);
+    let b = Fp::from(7u64);
+
+    let pa = Polynomial::from_roots(&[a]);
+    assert_eq!(pa.coefficients(), &[a.neg(), Fp::ONE]);
+
+    let pb = Polynomial::from_roots(&[b]);
+    assert_eq!(pa.multiply(&pb), Polynomial::from_roots(&[a, b]));
+
+    let identity = Polynomial::default();
+    assert_eq!(pa.multiply(&identity), pa);
+}
+
+#[test]
+fn commitment_deterministic_and_distinct() {
+    let c1 = Polynomial::from_roots(&[Fp::from(1u64)]).commit(Fp::ZERO);
+    let c2 = Polynomial::from_roots(&[Fp::from(2u64)]).commit(Fp::ZERO);
+    let c1_again = Polynomial::from_roots(&[Fp::from(1u64)]).commit(Fp::ZERO);
+    assert_eq!(c1, c1_again);
+    assert_ne!(c1, c2);
+}
+
+#[test]
+fn commitment_serialization_roundtrip() {
+    let commitment = Polynomial::from_roots(&[Fp::from(99u64)]).commit(Fp::ZERO);
+    let bytes: [u8; 32] = commitment.into();
+    let recovered = Commitment::try_from(&bytes).expect("valid point");
+    assert_eq!(commitment, recovered);
+}
+
+#[test]
+fn blinding_changes_commitment() {
+    let poly = Polynomial::from_roots(&[Fp::from(42u64)]);
+    let unblinded = poly.commit(Fp::ZERO);
+    let blinded = poly.commit(Fp::ONE);
+    assert_ne!(unblinded, blinded);
+}
+
+// ---- application ----
+
+struct TestHeader;
+
+#[derive(Clone, Debug)]
+struct TestHeaderData {
+    value: u64,
+}
+
+impl Header for TestHeader {
+    type Data<'source> = TestHeaderData;
+
+    const SUFFIX: Suffix = Suffix::new(0);
+
+    fn encode(data: &Self::Data<'_>) -> Vec<u8> {
+        #[expect(clippy::little_endian_bytes, reason = "test encoding")]
+        let bytes = data.value.to_le_bytes();
+        bytes.to_vec()
+    }
+}
+
+struct SeedStep;
+
+impl Step for SeedStep {
+    type Aux<'source> = ();
+    type Left = ();
+    type Output = TestHeader;
+    type Right = ();
+    type Witness<'source> = u64;
+
+    const INDEX: Index = Index::new(0);
+
+    fn witness<'source>(
+        &self,
+        witness: Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data<'source>,
+        _right: <Self::Right as Header>::Data<'source>,
+    ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        Ok((TestHeaderData { value: witness }, ()))
+    }
+}
+
+struct MergeStep;
+
+impl Step for MergeStep {
+    type Aux<'source> = ();
+    type Left = TestHeader;
+    type Output = TestHeader;
+    type Right = TestHeader;
+    type Witness<'source> = ();
+
+    const INDEX: Index = Index::new(1);
+
+    fn witness<'source>(
+        &self,
+        _witness: Self::Witness<'source>,
+        left: <Self::Left as Header>::Data<'source>,
+        right: <Self::Right as Header>::Data<'source>,
+    ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        Ok((
+            TestHeaderData {
+                value: left.value + right.value,
+            },
+            (),
+        ))
+    }
+}
+
+#[test]
+fn seed_then_verify() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register should succeed")
+        .finalize()
+        .expect("finalize should succeed");
+
+    let (proof, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 42u64)
+        .expect("seed should succeed");
+    let pcd = proof.carry::<TestHeader>(TestHeaderData { value: 42 });
+
+    let valid = app
+        .verify(&pcd, thread_rng())
+        .expect("verify should succeed");
+    assert!(valid, "proof should verify against matching header data");
+}
+
+#[test]
+fn verify_rejects_wrong_data() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register should succeed")
+        .finalize()
+        .expect("finalize should succeed");
+
+    let (proof, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 42u64)
+        .expect("seed should succeed");
+    let pcd = proof.carry::<TestHeader>(TestHeaderData { value: 999 });
+
+    let valid = app
+        .verify(&pcd, thread_rng())
+        .expect("verify should succeed");
+    assert!(!valid, "proof should reject mismatched header data");
+}
+
+#[test]
+fn fuse_then_verify() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register should succeed")
+        .register(MergeStep)
+        .expect("register should succeed")
+        .finalize()
+        .expect("finalize should succeed");
+
+    let (proof_a, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 10u64)
+        .expect("seed a");
+    let pcd_a = proof_a.carry::<TestHeader>(TestHeaderData { value: 10 });
+
+    let (proof_b, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 20u64)
+        .expect("seed b");
+    let pcd_b = proof_b.carry::<TestHeader>(TestHeaderData { value: 20 });
+
+    let (merged_proof, ()) = app
+        .fuse(&mut thread_rng(), &MergeStep, (), pcd_a, pcd_b)
+        .expect("fuse should succeed");
+    let merged_pcd = merged_proof.carry::<TestHeader>(TestHeaderData { value: 30 });
+
+    let valid = app
+        .verify(&merged_pcd, thread_rng())
+        .expect("verify should succeed");
+    assert!(valid, "merged proof should verify");
+}
+
+#[test]
+fn fuse_rejects_wrong_sum() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register")
+        .register(MergeStep)
+        .expect("register")
+        .finalize()
+        .expect("finalize");
+
+    let (proof_a, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 10u64)
+        .expect("seed a");
+    let pcd_a = proof_a.carry::<TestHeader>(TestHeaderData { value: 10 });
+
+    let (proof_b, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 20u64)
+        .expect("seed b");
+    let pcd_b = proof_b.carry::<TestHeader>(TestHeaderData { value: 20 });
+
+    let (merged_proof, ()) = app
+        .fuse(&mut thread_rng(), &MergeStep, (), pcd_a, pcd_b)
+        .expect("fuse");
+    let bad_pcd = merged_proof.carry::<TestHeader>(TestHeaderData { value: 31 });
+
+    let valid = app.verify(&bad_pcd, thread_rng()).expect("verify");
+    assert!(!valid, "fused proof must reject wrong header data");
+}
+
+#[test]
+fn deep_fuse_chain() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register")
+        .register(MergeStep)
+        .expect("register")
+        .finalize()
+        .expect("finalize");
+
+    let mut proofs = Vec::new();
+    for val in 1u64..=4 {
+        let (proof, ()) = app.seed(&mut thread_rng(), &SeedStep, val).expect("seed");
+        proofs.push((proof, val));
+    }
+
+    let (p1, v1) = proofs.remove(0);
+    let (p2, v2) = proofs.remove(0);
+    let pcd1 = p1.carry::<TestHeader>(TestHeaderData { value: v1 });
+    let pcd2 = p2.carry::<TestHeader>(TestHeaderData { value: v2 });
+    let (merged_left, ()) = app
+        .fuse(&mut thread_rng(), &MergeStep, (), pcd1, pcd2)
+        .expect("fuse left");
+
+    let (p3, v3) = proofs.remove(0);
+    let (p4, v4) = proofs.remove(0);
+    let pcd3 = p3.carry::<TestHeader>(TestHeaderData { value: v3 });
+    let pcd4 = p4.carry::<TestHeader>(TestHeaderData { value: v4 });
+    let (merged_right, ()) = app
+        .fuse(&mut thread_rng(), &MergeStep, (), pcd3, pcd4)
+        .expect("fuse right");
+
+    let pcd_left = merged_left.carry::<TestHeader>(TestHeaderData { value: v1 + v2 });
+    let pcd_right = merged_right.carry::<TestHeader>(TestHeaderData { value: v3 + v4 });
+    let (final_proof, ()) = app
+        .fuse(&mut thread_rng(), &MergeStep, (), pcd_left, pcd_right)
+        .expect("fuse final");
+
+    let final_pcd = final_proof.carry::<TestHeader>(TestHeaderData { value: 10 });
+    assert!(
+        app.verify(&final_pcd, thread_rng()).expect("verify"),
+        "depth-2 fuse tree must verify"
+    );
+
+    let bad_pcd = final_pcd
+        .proof
+        .carry::<TestHeader>(TestHeaderData { value: 11 });
+    assert!(
+        !app.verify(&bad_pcd, thread_rng()).expect("verify"),
+        "wrong total must fail"
+    );
+}
+
+#[test]
+fn different_merge_trees_same_header() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register")
+        .register(MergeStep)
+        .expect("register")
+        .finalize()
+        .expect("finalize");
+
+    let (pa, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 1u64)
+        .expect("seed a");
+    let (pb, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 2u64)
+        .expect("seed b");
+    let (pc, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 3u64)
+        .expect("seed c");
+
+    // Tree shape 1: fuse(fuse(a, b), c)
+    let pcd_a1 = pa.clone().carry::<TestHeader>(TestHeaderData { value: 1 });
+    let pcd_b1 = pb.clone().carry::<TestHeader>(TestHeaderData { value: 2 });
+    let (ab, ()) = app
+        .fuse(&mut thread_rng(), &MergeStep, (), pcd_a1, pcd_b1)
+        .expect("fuse ab");
+    let pcd_ab = ab.carry::<TestHeader>(TestHeaderData { value: 3 });
+    let pcd_c1 = pc.clone().carry::<TestHeader>(TestHeaderData { value: 3 });
+    let (left_leaning, ()) = app
+        .fuse(&mut thread_rng(), &MergeStep, (), pcd_ab, pcd_c1)
+        .expect("fuse (ab)c");
+
+    // Tree shape 2: fuse(a, fuse(b, c))
+    let pcd_b2 = pb.carry::<TestHeader>(TestHeaderData { value: 2 });
+    let pcd_c2 = pc.carry::<TestHeader>(TestHeaderData { value: 3 });
+    let (bc, ()) = app
+        .fuse(&mut thread_rng(), &MergeStep, (), pcd_b2, pcd_c2)
+        .expect("fuse bc");
+    let pcd_a2 = pa.carry::<TestHeader>(TestHeaderData { value: 1 });
+    let pcd_bc = bc.carry::<TestHeader>(TestHeaderData { value: 5 });
+    let (right_leaning, ()) = app
+        .fuse(&mut thread_rng(), &MergeStep, (), pcd_a2, pcd_bc)
+        .expect("fuse a(bc)");
+
+    let final_header = TestHeaderData { value: 6 };
+
+    let pcd_left = left_leaning.carry::<TestHeader>(final_header.clone());
+    let pcd_right = right_leaning.carry::<TestHeader>(final_header);
+
+    assert!(app.verify(&pcd_left, thread_rng()).expect("verify"));
+    assert!(app.verify(&pcd_right, thread_rng()).expect("verify"));
+    assert_ne!(
+        pcd_left.proof, pcd_right.proof,
+        "different tree shapes must produce different proofs"
+    );
+}
+
+// -- Steps with aux --
+
+/// Header value is `witness²`, aux is `vec![witness²]`.
+struct AuxSeedStep;
+
+impl Step for AuxSeedStep {
+    type Aux<'source> = Vec<u64>;
+    type Left = ();
+    type Output = TestHeader;
+    type Right = ();
+    type Witness<'source> = u64;
+
+    const INDEX: Index = Index::new(2);
+
+    fn witness<'source>(
+        &self,
+        witness: Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data<'source>,
+        _right: <Self::Right as Header>::Data<'source>,
+    ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        let squared = witness * witness;
+        Ok((TestHeaderData { value: squared }, vec![squared]))
+    }
+}
+
+struct AuxMergeStep;
+
+impl Step for AuxMergeStep {
+    type Aux<'source> = Vec<u64>;
+    type Left = TestHeader;
+    type Output = TestHeader;
+    type Right = TestHeader;
+    type Witness<'source> = (Vec<u64>, Vec<u64>);
+
+    const INDEX: Index = Index::new(3);
+
+    fn witness<'source>(
+        &self,
+        witness: Self::Witness<'source>,
+        left: <Self::Left as Header>::Data<'source>,
+        right: <Self::Right as Header>::Data<'source>,
+    ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        let (left_aux, right_aux) = witness;
+        let mut combined = left_aux;
+        combined.extend(right_aux);
+        Ok((
+            TestHeaderData {
+                value: left.value + right.value,
+            },
+            combined,
+        ))
+    }
+}
+
+#[test]
+fn aux_data_flows_through_seed_and_fuse() {
+    let app = ApplicationBuilder::new()
+        .register(AuxSeedStep)
+        .expect("register")
+        .register(AuxMergeStep)
+        .expect("register")
+        .finalize()
+        .expect("finalize");
+
+    let (proof_a, aux_a) = app
+        .seed(&mut thread_rng(), &AuxSeedStep, 3u64)
+        .expect("seed a");
+    assert_eq!(aux_a, vec![9]);
+
+    let (proof_b, aux_b) = app
+        .seed(&mut thread_rng(), &AuxSeedStep, 4u64)
+        .expect("seed b");
+    assert_eq!(aux_b, vec![16]);
+
+    let pcd_a = proof_a.carry::<TestHeader>(TestHeaderData { value: 9 });
+    let pcd_b = proof_b.carry::<TestHeader>(TestHeaderData { value: 16 });
+    let (merged_proof, merged_aux) = app
+        .fuse(
+            &mut thread_rng(),
+            &AuxMergeStep,
+            (aux_a, aux_b),
+            pcd_a,
+            pcd_b,
+        )
+        .expect("fuse");
+
+    assert_eq!(merged_aux, vec![9, 16]);
+
+    let reconstructed_value: u64 = merged_aux.iter().sum();
+    assert_eq!(reconstructed_value, 25);
+    let pcd = merged_proof.carry::<TestHeader>(TestHeaderData {
+        value: reconstructed_value,
+    });
+    let valid = app.verify(&pcd, thread_rng()).expect("verify");
+    assert!(
+        valid,
+        "proof must verify with header reconstructed from aux"
+    );
+}
+
+#[test]
+fn rerandomize_preserves_validity() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register should succeed")
+        .finalize()
+        .expect("finalize should succeed");
+
+    let (proof, ()) = app
+        .seed(&mut thread_rng(), &SeedStep, 42u64)
+        .expect("seed should succeed");
+    let original_proof = proof.clone();
+    let pcd = proof.carry::<TestHeader>(TestHeaderData { value: 42 });
+
+    let rerand_pcd = app
+        .rerandomize(pcd, &mut thread_rng())
+        .expect("rerandomize should succeed");
+    let valid = app
+        .verify(&rerand_pcd, thread_rng())
+        .expect("verify should succeed");
+    assert!(valid, "rerandomized proof should still verify");
+    assert_ne!(
+        rerand_pcd.proof, original_proof,
+        "rerandomization must change the proof"
+    );
+}


### PR DESCRIPTION
Before #27

Ragu can't be integrated yet due to `rand` and `ff` dependency conflicts. This PR adds a standalone mock crate.
