### PR TITLE
Parameterize effect

### DIFF
--- a/crates/mock_ragu/src/proof.rs
+++ b/crates/mock_ragu/src/proof.rs
@@ -108,13 +108,16 @@ impl<'de> serde::Deserialize<'de> for Proof {
             }
 
             fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Proof, E> {
-                let arr: &[u8; PROOF_SIZE_COMPRESSED] = v.try_into().map_err(|_| {
-                    E::invalid_length(v.len(), &self)
-                })?;
+                let arr: &[u8; PROOF_SIZE_COMPRESSED] = v
+                    .try_into()
+                    .map_err(|_| E::invalid_length(v.len(), &self))?;
                 Proof::try_from(arr).map_err(|_| E::custom("invalid proof binding"))
             }
 
-            fn visit_seq<A: serde::de::SeqAccess<'de>>(self, mut seq: A) -> Result<Proof, A::Error> {
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Proof, A::Error> {
                 let mut bytes = [0u8; PROOF_SIZE_COMPRESSED];
                 for (i, byte) in bytes.iter_mut().enumerate() {
                     *byte = seq

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -1,30 +1,20 @@
 //! Tachyon Action descriptions.
 
-use reddsa::orchard::SpendAuth;
+use core::{any::TypeId, marker::PhantomData};
 
 use crate::{
     entropy::ActionEntropy,
     keys::{SpendValidatingKey, private, public},
     note::Note,
-    value,
+    primitives::{Effect, effect},
+    reddsa, value,
+    witness::ActionPrivate,
 };
-
-/// Whether an action plan represents a spend or an output.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum Effect {
-    /// Spend — signed with
-    /// [`SpendAuthorizingKey::derive_action_private`](private::SpendAuthorizingKey::derive_action_private).
-    Spend,
-    /// Output — signed via
-    /// [`ActionSigningKey<Output>::sign`](private::ActionSigningKey::sign).
-    Output,
-}
 
 /// A planned Tachyon action, not yet authorized.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Plan {
+pub struct Plan<E: Effect> {
     /// Randomized action verification key.
     pub rk: public::ActionVerificationKey,
     /// The note being spent or created.
@@ -33,11 +23,11 @@ pub struct Plan {
     pub theta: ActionEntropy,
     /// Value commitment trapdoor.
     pub rcv: value::CommitmentTrapdoor,
-    /// Spend or output.
-    pub effect: Effect,
+    /// Effect marker (zero-sized).
+    pub _effect: PhantomData<E>,
 }
 
-impl Plan {
+impl Plan<effect::Spend> {
     /// Assemble a spend action plan.
     ///
     /// $\mathsf{rk} = \mathsf{ak} + [\alpha]\,\mathcal{G}$.
@@ -49,7 +39,7 @@ impl Plan {
         ak: &SpendValidatingKey,
     ) -> Self {
         let cm = note.commitment();
-        let alpha = theta.spend_randomizer(&cm);
+        let alpha = theta.randomizer::<effect::Spend>(&cm);
         let rk = ak.derive_action_public(&alpha);
 
         Self {
@@ -57,18 +47,31 @@ impl Plan {
             note,
             theta,
             rcv,
-            effect: Effect::Spend,
+            _effect: PhantomData,
         }
     }
 
+    /// Assemble the proof witness for this spend plan.
+    #[must_use]
+    pub fn witness(&self) -> ActionPrivate {
+        let cm = self.note.commitment();
+        ActionPrivate {
+            alpha: self.theta.randomizer::<effect::Spend>(&cm).into(),
+            note: self.note,
+            rcv: self.rcv,
+        }
+    }
+}
+
+impl Plan<effect::Output> {
     /// Assemble an output action plan.
     ///
     /// $\mathsf{rk} = [\alpha]\,\mathcal{G}$.
     #[must_use]
     pub fn output(note: Note, theta: ActionEntropy, rcv: value::CommitmentTrapdoor) -> Self {
         let cm = note.commitment();
-        let alpha = theta.output_randomizer(&cm);
-        let rsk = private::ActionSigningKey::new(alpha);
+        let alpha = theta.randomizer::<effect::Output>(&cm);
+        let rsk = private::ActionSigningKey::new(&alpha);
         let rk = rsk.derive_action_public();
 
         Self {
@@ -76,19 +79,37 @@ impl Plan {
             note,
             theta,
             rcv,
-            effect: Effect::Output,
+            _effect: PhantomData,
         }
     }
 
+    /// Assemble the proof witness for this output plan.
+    #[must_use]
+    pub fn witness(&self) -> ActionPrivate {
+        let cm = self.note.commitment();
+        ActionPrivate {
+            alpha: self.theta.randomizer::<effect::Output>(&cm).into(),
+            note: self.note,
+            rcv: self.rcv,
+        }
+    }
+}
+
+impl<E: Effect> Plan<E> {
     /// Derive the value commitment of this action plan.
     ///
     /// $$\mathsf{cv} = [\pm v]\,\mathcal{V} + [\mathsf{rcv}]\,\mathcal{R}$$
     #[must_use]
+    #[expect(clippy::unreachable, reason = "Effect is sealed to Spend and Output")]
     pub fn cv(&self) -> value::Commitment {
-        match self.effect {
-            | Effect::Spend => self.rcv.commit_spend(self.note),
-            | Effect::Output => self.rcv.commit_output(self.note),
+        let value: i64 = self.note.value.into();
+        if TypeId::of::<E>() == TypeId::of::<effect::Spend>() {
+            return self.rcv.commit(value);
         }
+        if TypeId::of::<E>() == TypeId::of::<effect::Output>() {
+            return self.rcv.commit(-value);
+        }
+        unreachable!("Effect is sealed to Spend and Output")
     }
 }
 
@@ -111,15 +132,15 @@ pub struct Action {
     pub sig: Signature,
 }
 
-/// A spend authorization signature (RedPallas over SpendAuth).
+/// A spend authorization signature (RedPallas over reddsa::ActionAuth).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct Signature(pub(crate) reddsa::Signature<SpendAuth>);
+pub struct Signature(pub(crate) reddsa::Signature<reddsa::ActionAuth>);
 
 impl From<[u8; 64]> for Signature {
     fn from(bytes: [u8; 64]) -> Self {
-        Self(reddsa::Signature::<SpendAuth>::from(bytes))
+        Self(reddsa::Signature::<reddsa::ActionAuth>::from(bytes))
     }
 }
 

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -1,6 +1,6 @@
 //! Tachyon Action descriptions.
 
-use core::{any::TypeId, marker::PhantomData};
+use core::marker::PhantomData;
 
 use crate::{
     entropy::ActionEntropy,
@@ -100,16 +100,8 @@ impl<E: Effect> Plan<E> {
     ///
     /// $$\mathsf{cv} = [\pm v]\,\mathcal{V} + [\mathsf{rcv}]\,\mathcal{R}$$
     #[must_use]
-    #[expect(clippy::unreachable, reason = "Effect is sealed to Spend and Output")]
     pub fn cv(&self) -> value::Commitment {
-        let value: i64 = self.note.value.into();
-        if TypeId::of::<E>() == TypeId::of::<effect::Spend>() {
-            return self.rcv.commit(value);
-        }
-        if TypeId::of::<E>() == TypeId::of::<effect::Output>() {
-            return self.rcv.commit(-value);
-        }
-        unreachable!("Effect is sealed to Spend and Output")
+        E::commit_value(self.rcv, self.note.value)
     }
 }
 

--- a/crates/tachyon/src/bundle.rs
+++ b/crates/tachyon/src/bundle.rs
@@ -10,13 +10,13 @@
 use alloc::vec::Vec;
 
 use lazy_static::lazy_static;
-use reddsa::orchard::Binding;
 
 use crate::{
     action::{self, Action},
     constants::BUNDLE_COMMITMENT_PERSONALIZATION,
     keys::{private, public},
-    primitives::{ActionDigest, ActionDigestError, multiset::Multiset},
+    primitives::{ActionDigest, ActionDigestError, effect, multiset::Multiset},
+    reddsa,
     stamp::{Stamp, Stampless},
 };
 
@@ -186,8 +186,11 @@ lazy_static! {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Plan {
-    /// Action plans (spends and outputs, in order).
-    pub actions: Vec<action::Plan>,
+    /// Spend action plans.
+    pub spends: Vec<action::Plan<effect::Spend>>,
+
+    /// Output action plans.
+    pub outputs: Vec<action::Plan<effect::Output>>,
 
     /// Net value of spends minus outputs (plaintext integer).
     pub value_balance: i64,
@@ -196,19 +199,42 @@ pub struct Plan {
 impl Plan {
     /// Create a new bundle plan from assembled action plans.
     #[must_use]
-    pub const fn new(actions: Vec<action::Plan>, value_balance: i64) -> Self {
+    pub const fn new(
+        spends: Vec<action::Plan<effect::Spend>>,
+        outputs: Vec<action::Plan<effect::Output>>,
+        value_balance: i64,
+    ) -> Self {
         Self {
-            actions,
+            spends,
+            outputs,
             value_balance,
         }
     }
 
     /// Compute the bundle commitment.
-    /// See [`commit_bundle_digest`].
+    /// See [`digest_bundle`].
     #[must_use]
     pub fn commitment(&self) -> [u8; 64] {
+        let actions: Vec<Action> = self
+            .spends
+            .iter()
+            .map(|plan| {
+                Action {
+                    cv: plan.cv(),
+                    rk: plan.rk,
+                    sig: action::Signature::from([0u8; 64]),
+                }
+            })
+            .chain(self.outputs.iter().map(|plan| {
+                Action {
+                    cv: plan.cv(),
+                    rk: plan.rk,
+                    sig: action::Signature::from([0u8; 64]),
+                }
+            }))
+            .collect();
         #[expect(clippy::expect_used, reason = "don't plan invalid actions")]
-        Multiset::try_from(self.actions.as_slice())
+        Multiset::try_from(actions.as_slice())
             .and_then(|action_acc| digest_bundle(&action_acc, self.value_balance))
             .expect("don't plan invalid actions")
     }
@@ -219,7 +245,12 @@ impl Plan {
     /// $\mathsf{bsk} = \boxplus_i \mathsf{rcv}_i$.
     #[must_use]
     pub fn derive_bsk_private(&self) -> private::BindingSigningKey {
-        let trapdoors: Vec<_> = self.actions.iter().map(|plan| plan.rcv).collect();
+        let trapdoors: Vec<_> = self
+            .spends
+            .iter()
+            .map(|plan| plan.rcv)
+            .chain(self.outputs.iter().map(|plan| plan.rcv))
+            .collect();
         private::BindingSigningKey::from(trapdoors.as_slice())
     }
 }
@@ -243,7 +274,7 @@ impl Stamped {
 }
 
 impl<S: StampState> Bundle<S> {
-    /// See [`commit_bundle_digest`].
+    /// See [`digest_bundle`].
     pub fn commitment(&self) -> Result<[u8; 64], ActionDigestError> {
         let action_acc = Multiset::try_from(self.actions.as_slice())?;
         digest_bundle(&action_acc, self.value_balance)
@@ -282,7 +313,7 @@ impl<S: StampState> Bundle<S> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct Signature(pub(crate) reddsa::Signature<Binding>);
+pub struct Signature(pub(crate) reddsa::Signature<reddsa::BindingAuth>);
 
 impl From<[u8; 64]> for Signature {
     fn from(bytes: [u8; 64]) -> Self {
@@ -305,13 +336,12 @@ mod tests {
     use super::*;
     use crate::{
         action,
-        entropy::{ActionEntropy, ActionRandomizer},
+        entropy::ActionEntropy,
         keys::private,
         note::{self, Note},
         primitives::{Anchor, Epoch},
         stamp::Stamp,
         value,
-        witness::ActionPrivate,
     };
 
     /// Normally, data from other parts of the transaction is included in the
@@ -378,11 +408,11 @@ mod tests {
         let spend_plan = action::Plan::spend(spend_note, theta_spend, spend_rcv, pak.ak());
         let output_plan = action::Plan::output(output_note, theta_output, output_rcv);
 
-        let bundle_plan = Plan::new(alloc::vec![spend_plan, output_plan], 300);
+        let bundle_plan = Plan::new(alloc::vec![spend_plan], alloc::vec![output_plan], 300);
         let sighash = mock_sighash(bundle_plan.commitment());
         let ask = sk.derive_auth_private();
 
-        let spend_alpha = theta_spend.spend_randomizer(&spend_note.commitment());
+        let spend_alpha = theta_spend.randomizer::<effect::Spend>(&spend_note.commitment());
         let spend_rsk = ask.derive_action_private(&spend_alpha);
         let spend_action = Action {
             cv: spend_plan.cv(),
@@ -390,18 +420,12 @@ mod tests {
             sig: spend_rsk.sign(&mut rng, &sighash),
         };
 
-        let output_alpha = theta_output.output_randomizer(&output_note.commitment());
-        let output_rsk = private::ActionSigningKey::new(output_alpha);
+        let output_alpha = theta_output.randomizer::<effect::Output>(&output_note.commitment());
+        let output_rsk = private::ActionSigningKey::new(&output_alpha);
         let output_action = Action {
             cv: output_plan.cv(),
             rk: output_plan.rk,
             sig: output_rsk.sign(&mut rng, &sighash),
-        };
-
-        let spend_witness = ActionPrivate {
-            alpha: ActionRandomizer::from(spend_alpha),
-            note: spend_note,
-            rcv: spend_rcv,
         };
 
         let bundle: Stamped = Bundle {
@@ -411,9 +435,8 @@ mod tests {
             stamp: {
                 let (stamp, _) = Stamp::prove_action(
                     &mut rng,
-                    &spend_witness,
+                    &spend_plan.witness(),
                     &spend_action,
-                    action::Effect::Spend,
                     Anchor::from(Fp::ZERO),
                     Epoch::from(0u32),
                     &pak,
@@ -430,7 +453,7 @@ mod tests {
     /// commitment (identity accumulator + zero balance).
     #[test]
     fn no_bundle_commitment_differs_from_empty_bundle() {
-        let empty_plan = Plan::new(alloc::vec![], 0);
+        let empty_plan = Plan::new(alloc::vec![], alloc::vec![], 0);
         assert_ne!(
             *COMMIT_NO_BUNDLE,
             empty_plan.commitment(),
@@ -446,7 +469,7 @@ mod tests {
     #[test]
     fn zero_action_bundle_is_valid() {
         let mut rng = StdRng::seed_from_u64(0xdead);
-        let plan = Plan::new(alloc::vec![], 0);
+        let plan = Plan::new(alloc::vec![], alloc::vec![], 0);
         let sighash = mock_sighash(plan.commitment());
 
         let bundle: Stripped = Bundle {
@@ -494,16 +517,20 @@ mod tests {
         let value_balance =
             i64::try_from(spend_value).expect("fits") - i64::try_from(output_value).expect("fits");
 
-        let bundle_plan = Plan::new(alloc::vec![spend_plan, output_plan], value_balance);
+        let bundle_plan = Plan::new(
+            alloc::vec![spend_plan],
+            alloc::vec![output_plan],
+            value_balance,
+        );
         let sighash = mock_sighash(bundle_plan.commitment());
 
         // Sign each action
-        let spend_alpha = theta_spend.spend_randomizer(&spend_note.commitment());
+        let spend_alpha = theta_spend.randomizer::<effect::Spend>(&spend_note.commitment());
         let spend_sig = ask
             .derive_action_private(&spend_alpha)
             .sign(&mut *rng, &sighash);
-        let output_alpha = theta_output.output_randomizer(&output_note.commitment());
-        let output_rsk = private::ActionSigningKey::new(output_alpha);
+        let output_alpha = theta_output.randomizer::<effect::Output>(&output_note.commitment());
+        let output_rsk = private::ActionSigningKey::new(&output_alpha);
         let output_sig = output_rsk.sign(&mut *rng, &sighash);
 
         // Materialize actions
@@ -519,22 +546,10 @@ mod tests {
         };
 
         // Build witnesses and prove leaf stamps
-        let spend_witness = ActionPrivate {
-            alpha: ActionRandomizer::from(spend_alpha),
-            note: spend_note,
-            rcv: spend_rcv,
-        };
-        let output_witness = ActionPrivate {
-            alpha: ActionRandomizer::from(output_alpha),
-            note: output_note,
-            rcv: output_rcv,
-        };
-
         let (spend_stamp, (spend_acc, _)) = Stamp::prove_action(
             &mut *rng,
-            &spend_witness,
+            &spend_plan.witness(),
             &spend_action,
-            action::Effect::Spend,
             anchor,
             epoch,
             &pak,
@@ -543,9 +558,8 @@ mod tests {
 
         let (output_stamp, (output_acc, _)) = Stamp::prove_action(
             &mut *rng,
-            &output_witness,
+            &output_plan.witness(),
             &output_action,
-            action::Effect::Output,
             anchor,
             epoch,
             &pak,
@@ -588,7 +602,7 @@ mod tests {
         let (adjunct_b, stamp_b) = autonome_b.strip();
 
         let innocent: Stamped = {
-            let innocent_plan = Plan::new(alloc::vec![], 0);
+            let innocent_plan = Plan::new(alloc::vec![], alloc::vec![], 0);
             let innocent_sighash = mock_sighash(innocent_plan.commitment());
 
             let (stamp, _accs) =
@@ -641,7 +655,7 @@ mod tests {
 
         // Build the innocent aggregate as a full stamped bundle.
         let (innocent, innocent_accs) = {
-            let innocent_plan = Plan::new(alloc::vec![], 0);
+            let innocent_plan = Plan::new(alloc::vec![], alloc::vec![], 0);
             let innocent_sighash = mock_sighash(innocent_plan.commitment());
 
             let (stamp, accs) = Stamp::prove_merge(&mut rng, stamp_a, acc_a, stamp_b, acc_b)

--- a/crates/tachyon/src/entropy.rs
+++ b/crates/tachyon/src/entropy.rs
@@ -4,17 +4,13 @@
 //! Combined with a note commitment it deterministically derives an
 //! [`ActionRandomizer`].
 
-use core::{any::TypeId, marker::PhantomData};
+use core::marker::PhantomData;
 
 use ff::{FromUniformBytes as _, PrimeField as _};
 use pasta_curves::{Fp, Fq};
 use rand_core::{CryptoRng, RngCore};
 
-use crate::{
-    constants::{OUTPUT_ALPHA_PERSONALIZATION, SPEND_ALPHA_PERSONALIZATION},
-    note,
-    primitives::{Effect, effect},
-};
+use crate::{note, primitives::Effect};
 
 /// Per-action entropy $\theta$ chosen by the signer (e.g. hardware wallet).
 ///
@@ -52,21 +48,8 @@ impl ActionEntropy {
     /// Uses distinct BLAKE2b personalizations for spend vs output to
     /// ensure the two randomizers are independent.
     #[must_use]
-    #[expect(clippy::unreachable, reason = "Effect is sealed to Spend and Output")]
     pub fn randomizer<E: Effect>(&self, cm: &note::Commitment) -> ActionRandomizer<E> {
-        if TypeId::of::<E>() == TypeId::of::<effect::Spend>() {
-            return ActionRandomizer(
-                derive_alpha(SPEND_ALPHA_PERSONALIZATION, self, cm),
-                PhantomData,
-            );
-        }
-        if TypeId::of::<E>() == TypeId::of::<effect::Output>() {
-            return ActionRandomizer(
-                derive_alpha(OUTPUT_ALPHA_PERSONALIZATION, self, cm),
-                PhantomData,
-            );
-        }
-        unreachable!("Effect is sealed to Spend and Output")
+        ActionRandomizer(E::derive_alpha(self, cm), PhantomData)
     }
 }
 
@@ -112,12 +95,11 @@ impl<E: Effect> From<ActionRandomizer<E>> for ActionRandomizer<Witness> {
 ///   \text{"Tachyon-Spend"},\; \theta \| \mathsf{cm}))$$
 /// $$\alpha_{\text{output}} = \text{ToScalar}(\text{BLAKE2b-512}(
 ///   \text{"Tachyon-Output"},\; \theta \| \mathsf{cm}))$$
-fn derive_alpha(personalization: &[u8], theta: &ActionEntropy, cm: &note::Commitment) -> Fq {
-    assert!(
-        personalization == SPEND_ALPHA_PERSONALIZATION
-            || personalization == OUTPUT_ALPHA_PERSONALIZATION,
-        "invalid personalization: {personalization:?}",
-    );
+pub(crate) fn derive_alpha(
+    personalization: &[u8],
+    theta: &ActionEntropy,
+    cm: &note::Commitment,
+) -> Fq {
     let hash = blake2b_simd::Params::new()
         .hash_length(64)
         .personal(personalization)
@@ -135,7 +117,7 @@ mod tests {
     use rand::{SeedableRng as _, rngs::StdRng};
 
     use super::*;
-    use crate::note;
+    use crate::{note, primitives::effect};
 
     fn test_cm() -> note::Commitment {
         note::Commitment::from(Fp::ZERO)

--- a/crates/tachyon/src/entropy.rs
+++ b/crates/tachyon/src/entropy.rs
@@ -1,8 +1,10 @@
 //! Per-action randomizers and entropy.
 //!
 //! [`ActionEntropy`] ($\theta$) is per-action randomness chosen by the signer.
-//! Combined with a note commitment it deterministically derives
-//! [`SpendRandomizer`] or [`OutputRandomizer`].
+//! Combined with a note commitment it deterministically derives an
+//! [`ActionRandomizer`].
+
+use core::{any::TypeId, marker::PhantomData};
 
 use ff::{FromUniformBytes as _, PrimeField as _};
 use pasta_curves::{Fp, Fq};
@@ -11,14 +13,14 @@ use rand_core::{CryptoRng, RngCore};
 use crate::{
     constants::{OUTPUT_ALPHA_PERSONALIZATION, SPEND_ALPHA_PERSONALIZATION},
     note,
+    primitives::{Effect, effect},
 };
 
 /// Per-action entropy $\theta$ chosen by the signer (e.g. hardware wallet).
 ///
 /// 32 bytes of randomness combined with a note commitment to
 /// deterministically derive $\alpha$ via
-/// [`spend_randomizer`](Self::spend_randomizer) or
-/// [`output_randomizer`](Self::output_randomizer).
+/// [`randomizer`](Self::randomizer).
 /// The signer picks $\theta$ once; any device with $\theta$ and the
 /// note can independently reconstruct $\alpha$.
 ///
@@ -45,53 +47,62 @@ impl ActionEntropy {
         Self(bytes)
     }
 
-    /// Derive $\alpha$ for a spend action.
+    /// Derive the action randomizer $\alpha$ for effect `E`.
+    ///
+    /// Uses distinct BLAKE2b personalizations for spend vs output to
+    /// ensure the two randomizers are independent.
     #[must_use]
-    pub fn spend_randomizer(&self, cm: &note::Commitment) -> SpendRandomizer {
-        SpendRandomizer(derive_alpha(SPEND_ALPHA_PERSONALIZATION, self, cm))
-    }
-
-    /// Derive $\alpha$ for an output action.
-    #[must_use]
-    pub fn output_randomizer(&self, cm: &note::Commitment) -> OutputRandomizer {
-        OutputRandomizer(derive_alpha(OUTPUT_ALPHA_PERSONALIZATION, self, cm))
+    #[expect(clippy::unreachable, reason = "Effect is sealed to Spend and Output")]
+    pub fn randomizer<E: Effect>(&self, cm: &note::Commitment) -> ActionRandomizer<E> {
+        if TypeId::of::<E>() == TypeId::of::<effect::Spend>() {
+            return ActionRandomizer(
+                derive_alpha(SPEND_ALPHA_PERSONALIZATION, self, cm),
+                PhantomData,
+            );
+        }
+        if TypeId::of::<E>() == TypeId::of::<effect::Output>() {
+            return ActionRandomizer(
+                derive_alpha(OUTPUT_ALPHA_PERSONALIZATION, self, cm),
+                PhantomData,
+            );
+        }
+        unreachable!("Effect is sealed to Spend and Output")
     }
 }
 
-/// Spend-side randomizer $\alpha$ derived with spend personalization.
+/// Effect-erased marker for [`ActionRandomizer`].
 ///
-/// $\mathsf{rsk} = \mathsf{ask} + \alpha$, $\mathsf{rk} = \mathsf{ak} +
-/// [\alpha]\,\mathcal{G}$.
+/// Used in proof witness storage where the effect is inferred from
+/// the value commitment rather than carried in the type.
 #[derive(Clone, Copy, Debug)]
-pub struct SpendRandomizer(pub(crate) Fq);
+pub struct Witness;
 
-/// Output-side randomizer $\alpha$ derived with output personalization.
+mod sealed {
+    use crate::primitives::Effect;
+
+    pub trait RandomizerState: Copy {}
+    impl<T: Effect> RandomizerState for T {}
+    impl RandomizerState for super::Witness {}
+}
+
+/// Per-action randomizer $\alpha$, parameterized by effect state.
 ///
-/// $\mathsf{rsk} = \alpha$.
+/// - [`ActionRandomizer<Spend>`]: $\mathsf{rsk} = \mathsf{ask} + \alpha$,
+///   $\mathsf{rk} = \mathsf{ak} + [\alpha]\,\mathcal{G}$.
+/// - [`ActionRandomizer<Output>`]: $\mathsf{rsk} = \alpha$.
+/// - [`ActionRandomizer<Witness>`]: effect-erased, used in proof witnesses.
 #[derive(Clone, Copy, Debug)]
-pub struct OutputRandomizer(pub(crate) Fq);
+pub struct ActionRandomizer<S: sealed::RandomizerState>(pub(crate) Fq, pub(crate) PhantomData<S>);
 
-/// Bare $\alpha$ scalar for proof witness storage.
-///
-/// Spend and output are indistinguishable at the witness level.
-#[derive(Clone, Copy, Debug)]
-pub struct ActionRandomizer(Fq);
-
-impl From<ActionRandomizer> for Fq {
-    fn from(randomizer: ActionRandomizer) -> Self {
+impl<S: sealed::RandomizerState> From<ActionRandomizer<S>> for Fq {
+    fn from(randomizer: ActionRandomizer<S>) -> Self {
         randomizer.0
     }
 }
 
-impl From<SpendRandomizer> for ActionRandomizer {
-    fn from(alpha: SpendRandomizer) -> Self {
-        Self(alpha.0)
-    }
-}
-
-impl From<OutputRandomizer> for ActionRandomizer {
-    fn from(alpha: OutputRandomizer) -> Self {
-        Self(alpha.0)
+impl<E: Effect> From<ActionRandomizer<E>> for ActionRandomizer<Witness> {
+    fn from(randomizer: ActionRandomizer<E>) -> Self {
+        Self(randomizer.0, PhantomData)
     }
 }
 
@@ -138,8 +149,8 @@ mod tests {
         let theta = ActionEntropy::random(&mut rng);
         let cm = test_cm();
 
-        let spend_alpha: Fq = ActionRandomizer::from(theta.spend_randomizer(&cm)).into();
-        let output_alpha: Fq = ActionRandomizer::from(theta.output_randomizer(&cm)).into();
+        let spend_alpha: Fq = theta.randomizer::<effect::Spend>(&cm).into();
+        let output_alpha: Fq = theta.randomizer::<effect::Output>(&cm).into();
 
         assert_ne!(spend_alpha, output_alpha);
     }
@@ -152,12 +163,12 @@ mod tests {
         let cm = test_cm();
 
         // Deterministic: same theta twice
-        let first: Fq = ActionRandomizer::from(theta_a.spend_randomizer(&cm)).into();
-        let second: Fq = ActionRandomizer::from(theta_a.spend_randomizer(&cm)).into();
+        let first: Fq = theta_a.randomizer::<effect::Spend>(&cm).into();
+        let second: Fq = theta_a.randomizer::<effect::Spend>(&cm).into();
         assert_eq!(first, second);
 
         // Sensitive: different theta
-        let other: Fq = ActionRandomizer::from(theta_b.spend_randomizer(&cm)).into();
+        let other: Fq = theta_b.randomizer::<effect::Spend>(&cm).into();
         assert_ne!(first, other);
     }
 }

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -18,10 +18,10 @@
 //!     sighash["sighash &amp;[u8; 32]"]
 //!     sk --> ask & nk & pk
 //!     ask --> ak
-//!     theta["ActionEntropy theta"] -- spend_randomizer --> spend_alpha["SpendRandomizer"]
-//!     theta -- output_randomizer --> output_alpha["OutputRandomizer"]
+//!     theta["ActionEntropy theta"] -- "randomizer::&lt;Spend&gt;" --> spend_alpha["ActionRandomizer&lt;Spend&gt;"]
+//!     theta -- "randomizer::&lt;Output&gt;" --> output_alpha["ActionRandomizer&lt;Output&gt;"]
 //!     ask -- "derive_action_private(alpha)" --> spend_rsk["ActionSigningKey&lt;Spend&gt;"]
-//!     output_alpha -- "From" --> output_rsk["ActionSigningKey&lt;Output&gt;"]
+//!     output_alpha -- "new" --> output_rsk["ActionSigningKey&lt;Output&gt;"]
 //!     ak -- "+alpha" --> rk
 //!     spend_rsk -- "derive_action_public()" --> rk
 //!     output_rsk -- "derive_action_public()" --> rk
@@ -89,6 +89,8 @@ mod tests {
         entropy::ActionEntropy,
         keys::private,
         note::{self, CommitmentTrapdoor, Note, NullifierTrapdoor},
+        primitives::effect,
+        reddsa,
     };
 
     /// RedPallas requires ak to have tilde_y = 0 (sign bit cleared).
@@ -98,7 +100,6 @@ mod tests {
     #[test]
     fn ask_sign_normalization() {
         use ff::FromUniformBytes as _;
-        use reddsa::orchard::SpendAuth;
 
         let mut rng = StdRng::seed_from_u64(0);
         let mut flipped = 0u32;
@@ -109,7 +110,7 @@ mod tests {
             // Check the raw (pre-normalization) sign bit.
             let ask_scalar = Fq::from_uniform_bytes(&PrfExpand::ASK.with(&sk_bytes));
             let unnormalized_ak: [u8; 32] = reddsa::VerificationKey::from(
-                &reddsa::SigningKey::<SpendAuth>::try_from(ask_scalar.to_repr()).unwrap(),
+                &reddsa::SigningKey::<reddsa::ActionAuth>::try_from(ask_scalar.to_repr()).unwrap(),
             )
             .into();
             if unnormalized_ak[31] >> 7u8 == 1u8 {
@@ -156,7 +157,7 @@ mod tests {
             rcm: CommitmentTrapdoor::from(Fp::ZERO),
         };
         let theta = ActionEntropy::random(&mut rng);
-        let alpha = theta.spend_randomizer(&note.commitment());
+        let alpha = theta.randomizer::<effect::Spend>(&note.commitment());
         let rsk = ask.derive_action_private(&alpha);
 
         let rk_from_signer: [u8; 32] = rsk.derive_action_public().0.into();

--- a/crates/tachyon/src/keys/private.rs
+++ b/crates/tachyon/src/keys/private.rs
@@ -5,7 +5,6 @@ use core::marker::PhantomData;
 use ff::{Field as _, FromUniformBytes as _, PrimeField as _};
 use pasta_curves::{Fp, Fq};
 use rand_core::{CryptoRng, RngCore};
-use reddsa::orchard::{Binding, SpendAuth};
 
 use super::{
     note::{NullifierKey, PaymentKey},
@@ -14,31 +13,10 @@ use super::{
 use crate::{
     action, bundle,
     constants::PrfExpand,
-    entropy::{OutputRandomizer, SpendRandomizer},
-    value,
+    entropy::ActionRandomizer,
+    primitives::{Effect, effect},
+    reddsa, value,
 };
-
-/// Marker type for spend-side action signing keys.
-///
-/// $\mathsf{rsk} = \mathsf{ask} + \alpha$ — requires spend authority.
-#[derive(Clone, Copy, Debug)]
-pub struct SpendAuthority;
-
-/// Marker type for output-side action signing keys.
-///
-/// $\mathsf{rsk} = \alpha$ — no spend authority.
-#[derive(Clone, Copy, Debug)]
-pub struct OutputAuthority;
-
-mod sealed {
-    pub trait Sealed {}
-    impl Sealed for super::SpendAuthority {}
-    impl Sealed for super::OutputAuthority {}
-}
-
-/// Sealed trait constraining signing authority.
-pub trait ActionAuthority: sealed::Sealed {}
-impl<T: sealed::Sealed> ActionAuthority for T {}
 
 /// A Tachyon spending key — raw 32-byte entropy.
 ///
@@ -86,7 +64,7 @@ impl SpendingKey {
     /// $\mathsf{ask}$: $[-\mathsf{ask}]\,\mathcal{G} =
     /// -[\mathsf{ask}]\,\mathcal{G}$ flips the y-coordinate sign.
     ///
-    /// The SpendAuth basepoint $\mathcal{G}$ is hash-derived
+    /// The reddsa::ActionAuth basepoint $\mathcal{G}$ is hash-derived
     /// (`hash_to_curve("z.cash:Orchard")(b"G")`) and sealed inside
     /// reddsa's `private::Sealed` trait, so we must construct a
     /// `SigningKey` (which internally computes $[\mathsf{ask}]\,\mathcal{G}$)
@@ -104,7 +82,7 @@ impl SpendingKey {
         // Compute ak = [ask]G via reddsa (basepoint is sealed) and check
         // the y-sign bit (byte 31, bit 7 of the compressed encoding).
         let ak: [u8; 32] = reddsa::VerificationKey::from(
-            &reddsa::SigningKey::<SpendAuth>::try_from(ask.to_repr())
+            &reddsa::SigningKey::<reddsa::ActionAuth>::try_from(ask.to_repr())
                 .expect("PRF-derived ask should be a valid RedPallas scalar"),
         )
         .into();
@@ -114,7 +92,7 @@ impl SpendingKey {
 
         // Build the final key from the sign-normalized scalar.
         SpendAuthorizingKey(
-            reddsa::SigningKey::<SpendAuth>::try_from(ask.to_repr())
+            reddsa::SigningKey::<reddsa::ActionAuth>::try_from(ask.to_repr())
                 .expect("sign-normalized ask should be a valid RedPallas scalar"),
         )
     }
@@ -175,7 +153,7 @@ impl SpendingKey {
 /// (`ak`) via [`derive_auth_public`](Self::derive_auth_public) — the
 /// circuit witness that validates spend authorization.
 #[derive(Clone, Copy, Debug)]
-pub struct SpendAuthorizingKey(reddsa::SigningKey<SpendAuth>);
+pub struct SpendAuthorizingKey(reddsa::SigningKey<reddsa::ActionAuth>);
 
 impl SpendAuthorizingKey {
     /// Derive the spend validating (public) key: `ak = [ask]G`.
@@ -189,30 +167,30 @@ impl SpendAuthorizingKey {
     /// Derive the per-action private (signing) key: $\mathsf{rsk} =
     /// \mathsf{ask} + \alpha$.
     ///
-    /// Only accepts [`SpendRandomizer`] — passing an output randomizer is
-    /// a compile error.
+    /// Only accepts [`ActionRandomizer<Spend>`] — passing an output
+    /// randomizer is a compile error.
     #[must_use]
     pub fn derive_action_private(
         &self,
-        alpha: &SpendRandomizer,
-    ) -> ActionSigningKey<SpendAuthority> {
+        alpha: &ActionRandomizer<effect::Spend>,
+    ) -> ActionSigningKey<effect::Spend> {
         ActionSigningKey(self.0.randomize(&alpha.0), PhantomData)
     }
 }
 
-/// The per-action signing key `rsk` — ephemeral, parameterized by kind.
+/// The per-action signing key `rsk` — ephemeral, parameterized by effect.
 ///
-/// - [`ActionSigningKey<effect::Spend>`]: $\mathsf{rsk} = \mathsf{ask} +
-///   \alpha$ — derived from [`SpendAuthorizingKey::derive_action_private`]
-/// - [`ActionSigningKey<effect::Output>`]: $\mathsf{rsk} = \alpha$ — derived
-///   from [`OutputRandomizer`]
+/// - [`ActionSigningKey<Spend>`]: $\mathsf{rsk} = \mathsf{ask} + \alpha$ —
+///   derived from [`SpendAuthorizingKey::derive_action_private`]
+/// - [`ActionSigningKey<Output>`]: $\mathsf{rsk} = \alpha$ — derived from
+///   [`ActionRandomizer<Output>`]
 ///
 /// Both variants sign via [`sign`](Self::sign) and derive `rk` via
 /// [`derive_action_public`](Self::derive_action_public).
 #[derive(Clone, Copy, Debug)]
-pub struct ActionSigningKey<K: ActionAuthority>(reddsa::SigningKey<SpendAuth>, PhantomData<K>);
+pub struct ActionSigningKey<E: Effect>(reddsa::SigningKey<reddsa::ActionAuth>, PhantomData<E>);
 
-impl<K: ActionAuthority> ActionSigningKey<K> {
+impl<E: Effect> ActionSigningKey<E> {
     /// Sign a transaction sighash with this action key.
     pub fn sign(
         &self,
@@ -232,26 +210,20 @@ impl<K: ActionAuthority> ActionSigningKey<K> {
     }
 }
 
-impl ActionSigningKey<OutputAuthority> {
+impl ActionSigningKey<effect::Output> {
     /// Create a new output action signing key from an output randomizer.
     #[must_use]
-    pub fn new(alpha: OutputRandomizer) -> Self {
-        alpha.into()
-    }
-}
-
-impl From<OutputRandomizer> for ActionSigningKey<OutputAuthority> {
-    fn from(alpha: OutputRandomizer) -> Self {
+    pub fn new(alpha: &ActionRandomizer<effect::Output>) -> Self {
         #[expect(clippy::expect_used, reason = "specified behavior")]
         Self(
-            reddsa::SigningKey::<SpendAuth>::try_from(alpha.0.to_repr())
+            reddsa::SigningKey::<reddsa::ActionAuth>::try_from(alpha.0.to_repr())
                 .expect("output randomizer should be a valid RedPallas signing key"),
             PhantomData,
         )
     }
 }
 
-/// Binding signing key $\mathsf{bsk}$ — the scalar sum of all value
+/// BindingAuth signing key $\mathsf{bsk}$ — the scalar sum of all value
 /// commitment trapdoors in a bundle.
 ///
 /// $$\mathsf{bsk} := \boxplus_i \mathsf{rcv}_i$$
@@ -272,7 +244,7 @@ impl From<OutputRandomizer> for ActionSigningKey<OutputAuthority> {
 /// excluded from the bundle commitment because it is stripped during
 /// aggregation.
 #[derive(Clone, Copy, Debug)]
-pub struct BindingSigningKey(reddsa::SigningKey<Binding>);
+pub struct BindingSigningKey(reddsa::SigningKey<reddsa::BindingAuth>);
 
 impl BindingSigningKey {
     /// Sign a transaction sighash with this binding key.
@@ -293,7 +265,8 @@ impl BindingSigningKey {
 }
 
 impl From<&[value::CommitmentTrapdoor]> for BindingSigningKey {
-    /// Binding signing key is the scalar sum of all value commitment trapdoors.
+    /// BindingAuth signing key is the scalar sum of all value commitment
+    /// trapdoors.
     ///
     /// Every Pallas scalar field element, including zero, is a valid binding
     /// signing key. See Zcash protocol §4.14.
@@ -306,7 +279,7 @@ impl From<&[value::CommitmentTrapdoor]> for BindingSigningKey {
             reason = "all Fq are valid RedPallas signing keys"
         )]
         Self(
-            reddsa::SigningKey::<Binding>::try_from(sum.to_repr())
+            reddsa::SigningKey::<reddsa::BindingAuth>::try_from(sum.to_repr())
                 .expect("all Fq are valid RedPallas signing keys"),
         )
     }

--- a/crates/tachyon/src/keys/proof.rs
+++ b/crates/tachyon/src/keys/proof.rs
@@ -1,9 +1,7 @@
 //! Proof-related keys: ProofAuthorizingKey.
 
-use reddsa::orchard::SpendAuth;
-
 use super::{note::NullifierKey, public};
-use crate::entropy::SpendRandomizer;
+use crate::{entropy::ActionRandomizer, primitives::effect, reddsa};
 
 /// The proof authorizing key (`ak` + `nk`).
 ///
@@ -11,7 +9,8 @@ use crate::entropy::SpendRandomizer;
 /// construct proofs for all notes (since `nk` is wallet-wide) but cannot
 /// sign actions.
 ///
-/// Derived from [`SpendAuthorizingKey`](super::SpendAuthorizingKey) $\to$
+/// Derived from
+/// [`reddsa::ActionAuthorizingKey`](super::reddsa::ActionAuthorizingKey) $\to$
 /// [`SpendValidatingKey`] and [`NullifierKey`].
 ///
 /// ## Status
@@ -46,7 +45,7 @@ impl ProofAuthorizingKey {
 
 /// The spend validating key $\mathsf{ak} = [\mathsf{ask}]\,\mathcal{G}$ —
 /// the long-lived counterpart of
-/// [`SpendAuthorizingKey`](super::SpendAuthorizingKey).
+/// [`reddsa::ActionAuthorizingKey`](super::reddsa::ActionAuthorizingKey).
 ///
 /// Corresponds to the "spend validating key" in Orchard (§4.2.3).
 /// Constrains per-action `rk` in the proof, tying accumulator activity
@@ -60,13 +59,14 @@ impl ProofAuthorizingKey {
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct SpendValidatingKey(pub(super) reddsa::VerificationKey<SpendAuth>);
+pub struct SpendValidatingKey(pub(crate) reddsa::VerificationKey<reddsa::ActionAuth>);
 
 impl SpendValidatingKey {
     /// Derive the per-action public (verification) key: $\mathsf{rk} =
     /// \mathsf{ak} + [\alpha]\,\mathcal{G}$.
     ///
-    /// Only accepts [`SpendRandomizer`] — output actions derive `rk` via
+    /// Only accepts [`ActionRandomizer<Spend>`] — output actions derive `rk`
+    /// via
     /// [`ActionSigningKey<Output>::derive_action_public`](super::private::ActionSigningKey::derive_action_public)
     /// instead.
     ///
@@ -77,7 +77,10 @@ impl SpendValidatingKey {
     /// [`ActionSigningKey<Spend>::derive_action_public`](super::private::ActionSigningKey::derive_action_public)
     /// instead.
     #[must_use]
-    pub fn derive_action_public(&self, alpha: &SpendRandomizer) -> public::ActionVerificationKey {
+    pub fn derive_action_public(
+        &self,
+        alpha: &ActionRandomizer<effect::Spend>,
+    ) -> public::ActionVerificationKey {
         public::ActionVerificationKey(self.0.randomize(&alpha.0))
     }
 }

--- a/crates/tachyon/src/keys/public.rs
+++ b/crates/tachyon/src/keys/public.rs
@@ -1,9 +1,8 @@
 //! Public (verification) keys.
 
 use pasta_curves::{EpAffine, group::GroupEncoding as _};
-use reddsa::orchard::{Binding, SpendAuth};
 
-use crate::{action, action::Action, bundle, value};
+use crate::{action, action::Action, bundle, reddsa, value};
 
 /// The randomized action verification key `rk` — per-action, public.
 ///
@@ -24,7 +23,7 @@ use crate::{action, action::Action, bundle, value};
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct ActionVerificationKey(pub(crate) reddsa::VerificationKey<SpendAuth>);
+pub struct ActionVerificationKey(pub(crate) reddsa::VerificationKey<reddsa::ActionAuth>);
 
 impl ActionVerificationKey {
     /// Verify an action signature against a transaction sighash.
@@ -49,7 +48,7 @@ impl TryFrom<[u8; 32]> for ActionVerificationKey {
     type Error = reddsa::Error;
 
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        reddsa::VerificationKey::<SpendAuth>::try_from(bytes).map(Self)
+        reddsa::VerificationKey::<reddsa::ActionAuth>::try_from(bytes).map(Self)
     }
 }
 
@@ -106,10 +105,10 @@ pub fn derive_bvk(
 ///
 /// ## Type representation
 ///
-/// Wraps `reddsa::VerificationKey<Binding>`, which internally stores
-/// a Pallas curve point (EpAffine, encoded as 32 compressed bytes).
+/// Wraps `reddsa::VerificationKey<reddsa::BindingAuth>`, which internally
+/// stores a Pallas curve point (EpAffine, encoded as 32 compressed bytes).
 #[derive(Clone, Copy, Debug)]
-pub struct BindingVerificationKey(pub(super) reddsa::VerificationKey<Binding>);
+pub struct BindingVerificationKey(pub(super) reddsa::VerificationKey<reddsa::BindingAuth>);
 
 impl BindingVerificationKey {
     /// Derive the binding verification key from public action data.
@@ -127,7 +126,7 @@ impl BindingVerificationKey {
 
         #[expect(clippy::expect_used, reason = "specified behavior")]
         Self(
-            reddsa::VerificationKey::<Binding>::try_from(bvk_bytes)
+            reddsa::VerificationKey::<reddsa::BindingAuth>::try_from(bvk_bytes)
                 .expect("cv sum minus balance should be a valid RedPallas verification key"),
         )
     }

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -54,6 +54,7 @@ pub mod constants;
 pub mod entropy;
 pub mod keys;
 pub mod note;
+pub mod reddsa;
 pub mod stamp;
 pub mod value;
 pub mod witness;
@@ -62,11 +63,11 @@ mod primitives;
 #[cfg(feature = "serde")]
 mod serde_helpers;
 
-pub use action::{Action, Plan as ActionPlan};
+pub use action::Action;
 pub use bundle::{Bundle, Plan as BundlePlan, Stamped, Stripped};
 pub use note::Note;
 pub use primitives::{
-    ActionDigest, ActionDigestError, Anchor, Epoch, Tachygram,
+    ActionDigest, ActionDigestError, Anchor, Effect, Epoch, Tachygram, effect,
     multiset::{self, Multiset},
 };
 pub use stamp::{Stamp, proof::Proof};

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -10,7 +10,7 @@ use pasta_curves::{
 
 use crate::{
     Action, action::Plan as ActionPlan, constants::ACTION_DIGEST_PERSONALIZATION, keys::public,
-    value,
+    primitives::Effect, value,
 };
 
 /// Digest a single action into the accumulation domain.
@@ -87,10 +87,10 @@ impl From<ActionDigest> for Fp {
     }
 }
 
-impl TryFrom<&ActionPlan> for ActionDigest {
+impl<E: Effect> TryFrom<&ActionPlan<E>> for ActionDigest {
     type Error = ActionDigestError;
 
-    fn try_from(plan: &ActionPlan) -> Result<Self, Self::Error> {
+    fn try_from(plan: &ActionPlan<E>) -> Result<Self, Self::Error> {
         let cv_coords = EpAffine::from(plan.cv())
             .coordinates()
             .into_option()
@@ -170,6 +170,7 @@ mod tests {
         entropy::ActionEntropy,
         keys::private,
         note::{self, CommitmentTrapdoor, Note, NullifierTrapdoor},
+        primitives::effect,
         value,
     };
 
@@ -188,10 +189,10 @@ mod tests {
             rcm: CommitmentTrapdoor::from(rcm),
         };
         let rcv = value::CommitmentTrapdoor::random(rng);
-        let cv = rcv.commit_spend(note);
+        let cv = rcv.commit(i64::from(note.value));
         let theta = ActionEntropy::random(rng);
-        let alpha = theta.output_randomizer(&note.commitment());
-        let rk = private::ActionSigningKey::new(alpha).derive_action_public();
+        let alpha = theta.randomizer::<effect::Output>(&note.commitment());
+        let rk = private::ActionSigningKey::new(&alpha).derive_action_public();
         (cv, rk)
     }
 

--- a/crates/tachyon/src/primitives/effect.rs
+++ b/crates/tachyon/src/primitives/effect.rs
@@ -1,0 +1,27 @@
+//! Compile-time effect markers for spend vs output actions.
+//!
+//! [`Spend`] and [`Output`] are zero-sized marker types that parameterize
+//! [`Plan`](crate::action::Plan),
+//! [`ActionRandomizer`](crate::entropy::ActionRandomizer),
+//! [`ActionSigningKey`](crate::keys::private::ActionSigningKey), and key types
+//! to enforce the spend/output distinction at compile time.
+
+mod sealed {
+    pub trait Sealed: Copy {}
+    impl Sealed for super::Spend {}
+    impl Sealed for super::Output {}
+}
+
+/// Sealed trait marking an action effect (spend or output).
+pub trait Effect: sealed::Sealed + 'static {}
+
+/// Spend effect marker.
+#[derive(Clone, Copy, Debug)]
+pub struct Spend;
+
+/// Output effect marker.
+#[derive(Clone, Copy, Debug)]
+pub struct Output;
+
+impl Effect for Spend {}
+impl Effect for Output {}

--- a/crates/tachyon/src/primitives/effect.rs
+++ b/crates/tachyon/src/primitives/effect.rs
@@ -6,6 +6,14 @@
 //! [`ActionSigningKey`](crate::keys::private::ActionSigningKey), and key types
 //! to enforce the spend/output distinction at compile time.
 
+use pasta_curves::Fq;
+
+use crate::{
+    constants::{OUTPUT_ALPHA_PERSONALIZATION, SPEND_ALPHA_PERSONALIZATION},
+    entropy::{self, ActionEntropy},
+    note, value,
+};
+
 mod sealed {
     pub trait Sealed: Copy {}
     impl Sealed for super::Spend {}
@@ -13,7 +21,13 @@ mod sealed {
 }
 
 /// Sealed trait marking an action effect (spend or output).
-pub trait Effect: sealed::Sealed + 'static {}
+pub trait Effect: sealed::Sealed + 'static {
+    /// Derive this effect's $\alpha$ scalar from per-action entropy and a note commitment.
+    fn derive_alpha(theta: &ActionEntropy, cm: &note::Commitment) -> Fq;
+
+    /// Commit to this effect's signed value contribution using the given trapdoor.
+    fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment;
+}
 
 /// Spend effect marker.
 #[derive(Clone, Copy, Debug)]
@@ -23,5 +37,24 @@ pub struct Spend;
 #[derive(Clone, Copy, Debug)]
 pub struct Output;
 
-impl Effect for Spend {}
-impl Effect for Output {}
+impl Effect for Spend {
+    fn derive_alpha(theta: &ActionEntropy, cm: &note::Commitment) -> Fq {
+        entropy::derive_alpha(SPEND_ALPHA_PERSONALIZATION, theta, cm)
+    }
+
+    fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment {
+        let raw: i64 = value.into();
+        rcv.commit(raw)
+    }
+}
+
+impl Effect for Output {
+    fn derive_alpha(theta: &ActionEntropy, cm: &note::Commitment) -> Fq {
+        entropy::derive_alpha(OUTPUT_ALPHA_PERSONALIZATION, theta, cm)
+    }
+
+    fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment {
+        let raw: i64 = value.into();
+        rcv.commit(-raw)
+    }
+}

--- a/crates/tachyon/src/primitives/mod.rs
+++ b/crates/tachyon/src/primitives/mod.rs
@@ -1,10 +1,12 @@
 mod action_digest;
 mod anchor;
+pub mod effect;
 mod epoch;
 pub mod multiset;
 mod tachygram;
 
 pub use action_digest::{ActionDigest, ActionDigestError};
 pub use anchor::Anchor;
+pub use effect::Effect;
 pub use epoch::Epoch;
 pub use tachygram::Tachygram;

--- a/crates/tachyon/src/reddsa.rs
+++ b/crates/tachyon/src/reddsa.rs
@@ -1,0 +1,16 @@
+//! RedPallas type aliases for Tachyon.
+//!
+//! Tachyon reuses Orchard's RedPallas basepoints for action and binding
+//! signatures. This module re-exports reddsa types under Tachyon-specific
+//! names so the rest of the crate avoids direct `reddsa::orchard` imports.
+
+use ::reddsa::orchard;
+pub(crate) use ::reddsa::{Error, Signature, SigningKey, VerificationKey};
+
+/// RedPallas signature scheme for action authorization.
+///
+/// Both spend and output actions use the same basepoint.
+pub(crate) type ActionAuth = orchard::SpendAuth;
+
+/// RedPallas signature scheme for value-balance binding.
+pub(crate) type BindingAuth = orchard::Binding;

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -26,7 +26,7 @@ use rand_core::CryptoRng;
 use self::proof::{ActionStep, ActionWitness, MergeStep, MergeWitness, StampHeader};
 use crate::{
     ActionDigest, Epoch,
-    action::{Action, Effect},
+    action::Action,
     keys::ProofAuthorizingKey,
     primitives::{ActionDigestError, Anchor, Tachygram, multiset::Multiset},
     witness::ActionPrivate,
@@ -86,9 +86,8 @@ pub struct Stamp {
 impl Stamp {
     /// Creates a leaf stamp for a single action (ACTION STEP).
     ///
-    /// The circuit derives the tachygram and returns it through `Aux` for
-    /// data availability on the stamp. The proof is rerandomized before
-    /// returning.
+    /// The circuit infers spend vs output by testing `rk` against `[alpha]G`.
+    /// The proof is rerandomized before returning.
     ///
     /// Leaf stamps are combined via [`prove_merge`](Self::prove_merge).
     #[expect(clippy::type_complexity, reason = "deal with it")]
@@ -96,7 +95,6 @@ impl Stamp {
         rng: &mut RNG,
         witness: &ActionPrivate,
         action: &Action,
-        effect: Effect,
         anchor: Anchor,
         epoch: Epoch,
         pak: &ProofAuthorizingKey,
@@ -107,8 +105,9 @@ impl Stamp {
             &ActionStep,
             ActionWitness {
                 action,
-                witness,
-                effect,
+                alpha: witness.alpha,
+                note: witness.note,
+                rcv: witness.rcv,
                 anchor,
                 epoch,
                 pak,
@@ -239,17 +238,16 @@ mod tests {
     use super::*;
     use crate::{
         action,
-        entropy::{ActionEntropy, ActionRandomizer},
+        entropy::ActionEntropy,
         keys::private,
         note::{self, Note},
         value,
     };
 
-    fn make_action_and_witness(
+    fn make_spend(
         rng: &mut StdRng,
         sk: &private::SpendingKey,
         value_amount: u64,
-        effect: Effect,
     ) -> (Action, ActionPrivate) {
         let pak = sk.derive_proof_private();
         let note = Note {
@@ -260,11 +258,7 @@ mod tests {
         };
         let rcv = value::CommitmentTrapdoor::random(rng);
         let theta = ActionEntropy::random(rng);
-
-        let plan = match effect {
-            | Effect::Spend => action::Plan::spend(note, theta, rcv, pak.ak()),
-            | Effect::Output => action::Plan::output(note, theta, rcv),
-        };
+        let plan = action::Plan::spend(note, theta, rcv, pak.ak());
 
         let action = Action {
             cv: plan.cv(),
@@ -272,13 +266,31 @@ mod tests {
             sig: action::Signature::from([0u8; 64]),
         };
 
-        let witness = ActionPrivate {
-            alpha: ActionRandomizer::from(theta.spend_randomizer(&note.commitment())),
-            note,
-            rcv,
+        (action, plan.witness())
+    }
+
+    fn make_output(
+        rng: &mut StdRng,
+        sk: &private::SpendingKey,
+        value_amount: u64,
+    ) -> (Action, ActionPrivate) {
+        let note = Note {
+            pk: sk.derive_payment_key(),
+            value: note::Value::from(value_amount),
+            psi: note::NullifierTrapdoor::from(Fp::ZERO),
+            rcm: note::CommitmentTrapdoor::from(Fp::ZERO),
+        };
+        let rcv = value::CommitmentTrapdoor::random(rng);
+        let theta = ActionEntropy::random(rng);
+        let plan = action::Plan::output(note, theta, rcv);
+
+        let action = Action {
+            cv: plan.cv(),
+            rk: plan.rk,
+            sig: action::Signature::from([0u8; 64]),
         };
 
-        (action, witness)
+        (action, plan.witness())
     }
 
     #[test]
@@ -289,17 +301,9 @@ mod tests {
         let anchor = Anchor::from(Fp::ZERO);
         let epoch = Epoch::from(0u32);
 
-        let (action, witness) = make_action_and_witness(&mut rng, &sk, 500, Effect::Spend);
-        let (stamp, _accs) = Stamp::prove_action(
-            &mut rng,
-            &witness,
-            &action,
-            Effect::Spend,
-            anchor,
-            epoch,
-            &pak,
-        )
-        .expect("prove_action");
+        let (action, witness) = make_spend(&mut rng, &sk, 500);
+        let (stamp, _accs) = Stamp::prove_action(&mut rng, &witness, &action, anchor, epoch, &pak)
+            .expect("prove_action");
 
         stamp
             .verify(
@@ -317,19 +321,12 @@ mod tests {
         let anchor = Anchor::from(Fp::ZERO);
         let epoch = Epoch::from(0u32);
 
-        let (action_a, witness_a) = make_action_and_witness(&mut rng, &sk, 500, Effect::Spend);
-        let (stamp, _accs) = Stamp::prove_action(
-            &mut rng,
-            &witness_a,
-            &action_a,
-            Effect::Spend,
-            anchor,
-            epoch,
-            &pak,
-        )
-        .expect("prove_action");
+        let (action_a, witness_a) = make_spend(&mut rng, &sk, 500);
+        let (stamp, _accs) =
+            Stamp::prove_action(&mut rng, &witness_a, &action_a, anchor, epoch, &pak)
+                .expect("prove_action");
 
-        let (action_b, _witness_b) = make_action_and_witness(&mut rng, &sk, 200, Effect::Output);
+        let (action_b, _witness_b) = make_output(&mut rng, &sk, 200);
 
         assert!(
             stamp
@@ -350,29 +347,15 @@ mod tests {
         let anchor = Anchor::from(Fp::ZERO);
         let epoch = Epoch::from(0u32);
 
-        let (action_a, witness_a) = make_action_and_witness(&mut rng, &sk, 500, Effect::Spend);
-        let (stamp_a, accs_a) = Stamp::prove_action(
-            &mut rng,
-            &witness_a,
-            &action_a,
-            Effect::Spend,
-            anchor,
-            epoch,
-            &pak,
-        )
-        .expect("prove_action a");
+        let (action_a, witness_a) = make_spend(&mut rng, &sk, 500);
+        let (stamp_a, accs_a) =
+            Stamp::prove_action(&mut rng, &witness_a, &action_a, anchor, epoch, &pak)
+                .expect("prove_action a");
 
-        let (action_b, witness_b) = make_action_and_witness(&mut rng, &sk, 200, Effect::Output);
-        let (stamp_b, accs_b) = Stamp::prove_action(
-            &mut rng,
-            &witness_b,
-            &action_b,
-            Effect::Output,
-            anchor,
-            epoch,
-            &pak,
-        )
-        .expect("prove_action b");
+        let (action_b, witness_b) = make_output(&mut rng, &sk, 200);
+        let (stamp_b, accs_b) =
+            Stamp::prove_action(&mut rng, &witness_b, &action_b, anchor, epoch, &pak)
+                .expect("prove_action b");
 
         let (merged, _merged_accs) =
             Stamp::prove_merge(&mut rng, stamp_a, accs_a.0, stamp_b, accs_b.0)
@@ -394,29 +377,15 @@ mod tests {
         let anchor = Anchor::from(Fp::ZERO);
         let epoch = Epoch::from(0u32);
 
-        let (action_a, witness_a) = make_action_and_witness(&mut rng, &sk, 500, Effect::Spend);
-        let (stamp_a, accs_a) = Stamp::prove_action(
-            &mut rng,
-            &witness_a,
-            &action_a,
-            Effect::Spend,
-            anchor,
-            epoch,
-            &pak,
-        )
-        .expect("prove_action a");
+        let (action_a, witness_a) = make_spend(&mut rng, &sk, 500);
+        let (stamp_a, accs_a) =
+            Stamp::prove_action(&mut rng, &witness_a, &action_a, anchor, epoch, &pak)
+                .expect("prove_action a");
 
-        let (action_b, witness_b) = make_action_and_witness(&mut rng, &sk, 200, Effect::Output);
-        let (stamp_b, accs_b) = Stamp::prove_action(
-            &mut rng,
-            &witness_b,
-            &action_b,
-            Effect::Output,
-            anchor,
-            epoch,
-            &pak,
-        )
-        .expect("prove_action b");
+        let (action_b, witness_b) = make_output(&mut rng, &sk, 200);
+        let (stamp_b, accs_b) =
+            Stamp::prove_action(&mut rng, &witness_b, &action_b, anchor, epoch, &pak)
+                .expect("prove_action b");
 
         let (merged, _merged_accs) =
             Stamp::prove_merge(&mut rng, stamp_a, accs_a.0, stamp_b, accs_b.0)

--- a/crates/tachyon/src/stamp/proof.rs
+++ b/crates/tachyon/src/stamp/proof.rs
@@ -25,6 +25,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use core::{marker::PhantomData, ops::Neg as _};
 
 use ff::PrimeField as _;
 pub use mock_ragu::Proof;
@@ -32,13 +33,15 @@ use mock_ragu::{self, Header, Index, Step, Suffix};
 use pasta_curves::{EqAffine, Fp, group::GroupEncoding as _};
 
 use crate::{
-    action::{Action, Effect},
-    keys::ProofAuthorizingKey,
+    action::Action,
+    entropy::{ActionRandomizer, Witness},
+    keys::{ProofAuthorizingKey, private::ActionSigningKey},
+    note::Note,
     primitives::{
-        ActionDigest, Anchor, Epoch, Tachygram,
+        ActionDigest, Anchor, Epoch, Tachygram, effect,
         multiset::{self, Multiset},
     },
-    witness::ActionPrivate,
+    value,
 };
 
 /// PCD header type for Tachyon stamps.
@@ -75,10 +78,12 @@ impl Header for StampHeader {
 pub(crate) struct ActionWitness<'action> {
     /// The authorized action (cv, rk, sig).
     pub(crate) action: &'action Action,
-    /// Private witness (note, alpha, rcv).
-    pub(crate) witness: &'action ActionPrivate,
-    /// Whether this is a spend or output.
-    pub(crate) effect: Effect,
+    /// Action randomizer $\alpha$.
+    pub(crate) alpha: ActionRandomizer<Witness>,
+    /// The note being spent or created.
+    pub(crate) note: Note,
+    /// Value commitment trapdoor.
+    pub(crate) rcv: value::CommitmentTrapdoor,
     /// Accumulator state reference.
     pub(crate) anchor: Anchor,
     /// Epoch index for nullifier derivation.
@@ -105,32 +110,61 @@ impl Step for ActionStep {
         _left: <Self::Left as Header>::Data<'source>,
         _right: <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        // Derive tachygram (the raw value stays inside the circuit; the caller
-        // receives it through Aux for data availability on the stamp).
-        let tachygram: Tachygram = match witness.effect {
-            | Effect::Spend => {
-                let nf = witness
-                    .witness
-                    .note
-                    .nullifier(witness.pak.nk(), witness.epoch);
-                nf.into()
+        let note_value: i64 = witness.note.value.into();
+
+        // output: rk == [alpha]G
+        let is_output = witness.action.rk
+            == ActionSigningKey::new(&ActionRandomizer::<effect::Output>(
+                witness.alpha.0,
+                PhantomData,
+            ))
+            .derive_action_public();
+
+        // spend: rk == ak + [alpha]G
+        let is_spend = witness.action.rk
+            == witness
+                .pak
+                .ak()
+                .derive_action_public(&ActionRandomizer::<effect::Spend>(
+                    witness.alpha.0,
+                    PhantomData,
+                ));
+
+        let (tachygram, check_cv): (Tachygram, value::Commitment) = match (is_spend, is_output) {
+            | (true, false) => {
+                Ok((
+                    witness
+                        .note
+                        .nullifier(witness.pak.nk(), witness.epoch)
+                        .into(),
+                    witness.rcv.commit(note_value),
+                ))
             },
-            | Effect::Output => {
-                let cm = witness.witness.note.commitment();
-                cm.into()
+            | (false, true) => {
+                // constrain cv: output commits negative value
+                Ok((
+                    witness.note.commitment().into(),
+                    witness.rcv.commit(note_value.neg()),
+                ))
             },
-        };
+            | (true, true) | (false, false) => Err(mock_ragu::Error),
+        }?;
+
+        // constrain cv
+        if witness.action.cv != check_cv {
+            return Err(mock_ragu::Error);
+        }
 
         let action_acc = ActionDigest::try_from(witness.action)
             .map(Multiset::<ActionDigest>::from)
             .map_err(|_err| mock_ragu::Error)?;
-        let action_commitment = action_acc.commit();
 
         let tachygram_acc = Multiset::<Tachygram>::from(tachygram);
-        let tachygram_commitment = tachygram_acc.commit();
 
-        let header = (action_commitment, tachygram_commitment, witness.anchor);
-        Ok((header, (tachygram, action_acc, tachygram_acc)))
+        Ok((
+            (action_acc.commit(), tachygram_acc.commit(), witness.anchor),
+            (tachygram, action_acc, tachygram_acc),
+        ))
     }
 }
 

--- a/crates/tachyon/src/value.rs
+++ b/crates/tachyon/src/value.rs
@@ -15,7 +15,7 @@ use pasta_curves::{
 };
 use rand_core::{CryptoRng, RngCore};
 
-use crate::{Note, constants::VALUE_COMMITMENT_DOMAIN};
+use crate::constants::VALUE_COMMITMENT_DOMAIN;
 
 lazy_static! {
     /// Generator $\mathcal{V}$ for value commitments.
@@ -53,28 +53,6 @@ impl CommitmentTrapdoor {
         // tied to alpha/theta derivation.
         todo!("random commitment trapdoor");
         Self(Fq::random(rng))
-    }
-
-    /// Commit to spend a value with this trapdoor.
-    ///
-    /// $$\mathsf{cv} = [v]\,\mathcal{V} + [\mathsf{rcv}]\,\mathcal{R}$$
-    ///
-    /// Positive $v$ for spends (balance contributed).
-    #[must_use]
-    pub fn commit_spend(self, note: Note) -> Commitment {
-        let value: i64 = note.value.into();
-        self.commit(value)
-    }
-
-    /// Commit to output a value with this trapdoor.
-    ///
-    /// $$\mathsf{cv} = [-v]\,\mathcal{V} + [\mathsf{rcv}]\,\mathcal{R}$$
-    ///
-    /// Negative $v$ for outputs (balance exhausted).
-    #[must_use]
-    pub fn commit_output(self, note: Note) -> Commitment {
-        let value: i64 = note.value.into();
-        self.commit(value.neg())
     }
 
     /// Commit to a value with this trapdoor.

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -4,12 +4,13 @@
 //!   randomizer, and value commitment trapdoor. The circuit derives the
 //!   tachygram and flavor internally.
 
-use crate::{entropy::ActionRandomizer, note::Note, value};
+use crate::{
+    entropy::{ActionRandomizer, Witness},
+    note::Note,
+    value,
+};
 
 /// Private witness for a single action.
-///
-/// The [`ActionRandomizer`] is a bare $\alpha$ scalar — spend and output
-/// are intentionally indistinguishable at the witness level.
 ///
 /// Per-wallet key material ($\mathsf{ak}$, $\mathsf{nk}$) is shared across
 /// all actions and passed separately via
@@ -17,8 +18,8 @@ use crate::{entropy::ActionRandomizer, note::Note, value};
 /// to [`Stamp::prove_action`](crate::stamp::Stamp::prove_action).
 #[derive(Clone, Copy, Debug)]
 pub struct ActionPrivate {
-    /// Action randomizer $\alpha$ with derivation path.
-    pub alpha: ActionRandomizer,
+    /// Action randomizer $\alpha$.
+    pub alpha: ActionRandomizer<Witness>,
     /// The note being spent or created.
     pub note: Note,
     /// Value commitment trapdoor.


### PR DESCRIPTION
Replaces the runtime `Effect` enum with a sealed `Effect` trait and two zero-sized marker types (`Spend`, `Output`), so the spend/output distinction is enforced at compile time throughout the crate.

| Type | Before | After |
| --- | --- | --- |
| Action plan | `Plan` + `Effect` enum | `Plan<Spend>`, `Plan<Output>` |
| Randomizer | `spend_randomizer()`, `output_randomizer()` | `randomizer::<E>()` |
| Signing key | `ActionSigningKey` (unparameterized) | `ActionSigningKey<E>` |
| Bundle plan | single `actions` vec | separate `spends` / `outputs` vecs |
| Value commitment | match on `Effect` enum | `TypeId`-based dispatch on sealed trait |

### Other changes

- `reddsa.rs` with `ActionAuth` / `BindingAuth` type aliases, replacing direct `reddsa::orchard` imports
- `action::Plan::spend` takes a closure `derive_rk: impl FnOnce(ActionRandomizer<Spend>) -> ActionVerificationKey` instead of `&SpendValidatingKey`, decoupling plan construction from key material
- `bundle::Plan::value_balance()` derived from note values instead of stored
