### PR TITLE
GGM refactor and `NoteId`

### DIFF
--- a/crates/tachyon/src/constants.rs
+++ b/crates/tachyon/src/constants.rs
@@ -51,6 +51,9 @@ pub const NOTE_NULLIFIER_DOMAIN: &[u8; 16] = b"Tachyon-NfDerive";
 /// Poseidon domain tag for note commitments.
 pub const NOTE_COMMITMENT_DOMAIN: &[u8; 16] = b"Tachyon-NoteCmmt";
 
+/// Poseidon domain tag for note identity binding: `H(domain, mk, cm)`.
+pub const NOTE_ID_DOMAIN: &[u8; 16] = b"Tachyon-NoteMkCm";
+
 /// Poseidon domain tag for action digests.
 pub const ACTION_DIGEST_PERSONALIZATION: &[u8; 16] = b"Tachyon-ActnDgst";
 

--- a/crates/tachyon/src/keys/ggm.rs
+++ b/crates/tachyon/src/keys/ggm.rs
@@ -57,23 +57,17 @@ impl NoteMasterKey {
     /// only hashing children that overlap the range.
     #[must_use]
     pub fn derive_note_delegates(&self, range: RangeInclusive<u32>) -> Vec<NotePrefixedKey> {
-        let (low, high) = {
-            #[expect(clippy::expect_used, reason = "guaranteed valid shift")]
-            let root_split = u32::MAX
-                .checked_shr(1u32)
-                .expect("shifting u32::MAX by 1 will never overflow");
-            (
-                *range.start()..=root_split.min(*range.end()),
-                (*range.start()).max(root_split + 1)..=*range.end(),
-            )
-        };
+        // Children at depth 1 each own half of the u32 epoch space.
+        let split: u32 = u32::MAX >> 1;
 
         let mut result = Vec::new();
-        if !low.is_empty() {
-            result.extend(self.step(false).derive_note_delegates(low));
+        if *range.start() <= split {
+            let lo = *range.start()..=(*range.end()).min(split);
+            result.extend(self.step(false).derive_note_delegates(lo));
         }
-        if !high.is_empty() {
-            result.extend(self.step(true).derive_note_delegates(high));
+        if *range.end() > split {
+            let hi = (*range.start()).max(split + 1)..=*range.end();
+            result.extend(self.step(true).derive_note_delegates(hi));
         }
         result
     }
@@ -150,32 +144,36 @@ impl NotePrefixedKey {
     ///
     /// Recursively descends the tree, emitting fully-covered nodes and
     /// only hashing children that overlap the range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `range` is not a subset of [`Self::range`].
     #[must_use]
     pub fn derive_note_delegates(&self, range: RangeInclusive<u32>) -> Vec<Self> {
+        assert!(
+            self.range().contains(range.start()) && self.range().contains(range.end()),
+            "prefix key for {:?} does not cover requested range {:?}",
+            self.range(),
+            range,
+        );
+
         if range == self.range() {
             // This node exactly covers the requested range.
             alloc::vec![*self]
         } else {
             // This node is larger than the requested range.
-            let (low, high) = {
-                let next_depth = u32::from(self.depth.get() + 1);
-                let next_dyad_size = u32::MAX.checked_shr(next_depth).unwrap_or(0);
-
-                // a key's range is dyadic-aligned. select next smallest dyad.
-                let next_split = *self.range().start() | next_dyad_size;
-
-                (
-                    *range.start()..=next_split.min(*range.end()),
-                    (*range.start()).max(next_split + 1)..=*range.end(),
-                )
-            };
+            let next_depth = u32::from(self.depth.get() + 1);
+            let next_dyad_size = u32::MAX.checked_shr(next_depth).unwrap_or(0);
+            let split = *self.range().start() | next_dyad_size;
 
             let mut result = Vec::new();
-            if !low.is_empty() {
-                result.extend(self.step(false).derive_note_delegates(low));
+            if *range.start() <= split {
+                let lo = *range.start()..=(*range.end()).min(split);
+                result.extend(self.step(false).derive_note_delegates(lo));
             }
-            if !high.is_empty() {
-                result.extend(self.step(true).derive_note_delegates(high));
+            if *range.end() > split {
+                let hi = (*range.start()).max(split + 1)..=*range.end();
+                result.extend(self.step(true).derive_note_delegates(hi));
             }
             result
         }
@@ -341,5 +339,41 @@ mod tests {
         }
         // Now at depth 32 (leaf) — one more step should panic.
         let _boom = key.step(false);
+    }
+
+    #[test]
+    fn full_range_from_master() {
+        let root = NoteMasterKey(Fp::from(1u64));
+        let delegates = root.derive_note_delegates(0..=u32::MAX);
+        assert_eq!(delegates.len(), 2);
+        assert_eq!(delegates[0].range(), 0..=(u32::MAX >> 1u32));
+        assert_eq!(delegates[1].range(), (u32::MAX >> 1u32) + 1..=u32::MAX);
+    }
+
+    #[test]
+    fn last_epoch_delegate() {
+        let root = NoteMasterKey(Fp::from(1u64));
+        let delegates = root.derive_note_delegates(u32::MAX..=u32::MAX);
+        assert_eq!(delegates.len(), 1);
+        assert_eq!(delegates[0].range(), u32::MAX..=u32::MAX);
+        assert_eq!(delegates[0].depth.get(), GGM_TREE_DEPTH);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not cover requested range")]
+    fn disjoint_range_panics() {
+        let root = NoteMasterKey(Fp::from(1u64));
+        // depth-2 prefix covering [0..=0x3FFF_FFFF].
+        let prefix = root.step(false).step(false);
+        let _delegates = prefix.derive_note_delegates(0x8000_0000..=0x8000_0010);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not cover requested range")]
+    fn partial_overlap_panics() {
+        let root = NoteMasterKey(Fp::from(1u64));
+        // depth-2 prefix covering [0..=0x3FFF_FFFF].
+        let prefix = root.step(false).step(false);
+        let _delegates = prefix.derive_note_delegates(0..=0x4000_0000);
     }
 }

--- a/crates/tachyon/src/keys/ggm.rs
+++ b/crates/tachyon/src/keys/ggm.rs
@@ -6,197 +6,268 @@
 //! leaves, enabling contiguous-range prefix delegation.
 
 use alloc::vec::Vec;
-use core::num::NonZeroU8;
+use core::{num::NonZeroU8, ops::RangeInclusive};
 
 use ff::PrimeField as _;
 // TODO(#39): replace halo2_poseidon with Ragu Poseidon params
 use halo2_poseidon::{ConstantLength, Hash, P128Pow5T3};
 use pasta_curves::Fp;
 
-use super::note::NoteKey;
 use crate::{constants::NOTE_NULLIFIER_DOMAIN, note::Nullifier, primitives::Epoch};
 
-/// GGM tree depth — 32-bit epochs cover ~4 billion values.
-pub(super) const MAX_TREE_DEPTH: u8 = 32;
+/// GGM tree depth — 32-bit epochs, leaves at depth 32.
+pub const GGM_TREE_DEPTH: u8 = 32;
 
-/// Marker for a master (root, depth 0) note key.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Master;
-
-/// A GGM subtree identified by its depth and node index.
+/// Per-note master root key.
 ///
-/// At depth `d` there are `2^d` nodes. Node `i` covers the contiguous epoch
-/// range `[i * 2^(32-d) ..= (i+1) * 2^(32-d) - 1]`. The index encodes the
-/// `d`-bit path from root (MSB-first).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct Prefixed {
-    depth: NonZeroU8,
-    index: u32,
-}
+/// Root of the GGM tree PRF for a single note. Derived by the user device
+/// from [`NullifierKey`](super::NullifierKey) and the note's psi trapdoor.
+///
+/// ## Delegation chain
+///
+/// ```text
+/// nk + psi → mk (per-note root, user device)
+///              ├── nf = F_mk(flavor)     nullifier for a specific epoch
+///              └── psi_t = GGM(mk, t)    prefix key for epochs e ≤ t (OSS)
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NoteMasterKey(pub Fp);
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum PrefixedError {
-    DepthOutOfRange,
-    IndexOutOfRange,
-}
-
-impl Prefixed {
-    /// Create a new prefix identifying the specified node.
-    pub const fn new(depth: NonZeroU8, index: u32) -> Result<Self, PrefixedError> {
-        if depth.get() >= MAX_TREE_DEPTH {
-            return Err(PrefixedError::DepthOutOfRange);
+impl NoteMasterKey {
+    /// Descend one level from the root of the GGM tree.
+    #[must_use]
+    pub fn step(&self, direction: bool) -> NotePrefixedKey {
+        #[expect(clippy::expect_used, reason = "depth 1 is always valid")]
+        NotePrefixedKey {
+            inner: ggm_step(self.0, direction),
+            depth: NonZeroU8::new(1).expect("1 != 0"),
+            index: u32::from(direction),
         }
-
-        let height = MAX_TREE_DEPTH - depth.get();
-        if index > (u32::MAX >> height) {
-            return Err(PrefixedError::IndexOutOfRange);
-        }
-
-        Ok(Self { depth, index })
     }
 
-    /// The node index at this depth.
-    pub const fn index(self) -> u32 {
-        self.index
+    /// Derive a nullifier for the given epoch.
+    #[must_use]
+    pub fn derive_nullifier(&self, flavor: Epoch) -> Nullifier {
+        Nullifier::from(ggm_walk(self.0, flavor.0, GGM_TREE_DEPTH))
     }
 
-    /// First leaf index in the covered range.
-    pub const fn first(self) -> u32 {
-        let height = MAX_TREE_DEPTH - self.depth.get();
-        self.index << height
-    }
+    /// Derive epoch-restricted prefix keys covering the specified range.
+    ///
+    /// Recursively descends the tree, emitting fully-covered nodes and
+    /// only hashing children that overlap the range.
+    #[must_use]
+    pub fn derive_note_delegates(&self, range: RangeInclusive<u32>) -> Vec<NotePrefixedKey> {
+        let (low, high) = {
+            #[expect(clippy::expect_used, reason = "guaranteed valid shift")]
+            let root_split = u32::MAX
+                .checked_shr(1u32)
+                .expect("shifting u32::MAX by 1 will never overflow");
+            (
+                *range.start()..=root_split.min(*range.end()),
+                (*range.start()).max(root_split + 1)..=*range.end(),
+            )
+        };
 
-    /// Last leaf index in the covered range (inclusive).
-    pub const fn last(self) -> u32 {
-        self.first() | (u32::MAX >> self.depth.get())
-    }
-
-    /// Decompose the epoch range `[start..end)` into the minimal set of dyadic
-    /// intervals.
-    pub fn tight(start: u32, end: u32) -> Vec<Self> {
-        let mut pos = start;
         let mut result = Vec::new();
-        while pos < end {
-            let sub_height = {
-                let fits = (end - pos).ilog2();
-                let aligned = pos.trailing_zeros();
-                #[expect(clippy::expect_used, reason = "betwen 1 and 31")]
-                u8::try_from(aligned.min(fits)).expect("small number")
-            };
-
-            #[expect(clippy::expect_used, reason = "valid depth")]
-            let sub_depth = NonZeroU8::new(MAX_TREE_DEPTH - sub_height).expect("valid depth");
-
-            #[expect(clippy::expect_used, reason = "index calculation")]
-            result
-                .push(Self::new(sub_depth, pos >> sub_height).expect("valid index at valid depth"));
-
-            let span_width = 1u32 << sub_height;
-            pos += span_width;
+        if !low.is_empty() {
+            result.extend(self.step(false).derive_note_delegates(low));
+        }
+        if !high.is_empty() {
+            result.extend(self.step(true).derive_note_delegates(high));
         }
         result
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl Sealed for super::Master {}
-    impl Sealed for super::Prefixed {}
-}
+impl TryFrom<[u8; 32]> for NoteMasterKey {
+    type Error = NoteKeyError;
 
-pub trait GGMTreeDepth: Copy + sealed::Sealed {
-    fn depth(self) -> u8;
-}
-
-impl GGMTreeDepth for Master {
-    fn depth(self) -> u8 {
-        u8::MIN
+    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
+        Ok(Self(
+            Fp::from_repr(bytes)
+                .into_option()
+                .ok_or(NoteKeyError::InvalidRepr)?,
+        ))
     }
 }
 
-impl GGMTreeDepth for Prefixed {
-    fn depth(self) -> u8 {
-        self.depth.get()
+impl From<NoteMasterKey> for [u8; 32] {
+    fn from(key: NoteMasterKey) -> [u8; 32] {
+        key.0.to_repr()
     }
 }
 
-impl<D: GGMTreeDepth> NoteKey<D> {
+/// A Tachyon prefix key for range-restricted nullifier delegation.
+///
+/// At depth `d` there are `2^d` nodes. Node `i` covers the contiguous epoch
+/// range `[i * 2^(32-d) ..= (i+1) * 2^(32-d) - 1]`. At depth 32, a key
+/// is a leaf whose `index` equals the epoch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NotePrefixedKey {
+    /// GGM tree node value.
+    pub inner: Fp,
     /// The number of levels already descended.
-    pub fn depth(self) -> u8 {
-        self.prefix.depth()
-    }
-
-    /// Evaluate the GGM PRF at the given epoch, walking the remaining bits
-    /// MSB-first.
-    pub(in crate::keys) fn evaluate(&self, leaf: u32) -> Fp {
-        walk(self.inner, leaf, MAX_TREE_DEPTH - self.prefix.depth())
-    }
+    pub depth: NonZeroU8,
+    /// Node index at this depth.
+    pub index: u32,
 }
 
-impl NoteKey<Master> {
-    /// Derive a nullifier for epoch `flavor`: $\mathsf{nf} =
-    /// F_{\mathsf{mk}}(\text{flavor})$.
+impl NotePrefixedKey {
+    /// The epoch range covered by this key.
+    #[must_use]
+    pub const fn range(self) -> RangeInclusive<u32> {
+        match self.depth.get() {
+            | GGM_TREE_DEPTH => self.index..=self.index,
+            | depth => {
+                let first = self.index << (GGM_TREE_DEPTH - depth);
+                let last = first | (u32::MAX >> depth);
+                first..=last
+            },
+        }
+    }
+
+    /// Descend one level in the GGM tree.
+    ///
+    /// # Panics
+    ///
+    /// Panics if already at a leaf (depth == `GGM_TREE_DEPTH`).
+    #[must_use]
+    pub fn step(&self, direction: bool) -> Self {
+        assert!(
+            self.depth.get() < GGM_TREE_DEPTH,
+            "must not step beyond leaf"
+        );
+        Self {
+            inner: ggm_step(self.inner, direction),
+            #[expect(clippy::expect_used, reason = "nonzero plus one is not zero")]
+            depth: NonZeroU8::new(self.depth.get() + 1).expect("not zero"),
+            index: self.index * 2 + u32::from(direction),
+        }
+    }
+
+    /// Derive epoch-restricted prefix keys covering the specified range
+    /// within this key's range.
+    ///
+    /// Recursively descends the tree, emitting fully-covered nodes and
+    /// only hashing children that overlap the range.
+    #[must_use]
+    pub fn derive_note_delegates(&self, range: RangeInclusive<u32>) -> Vec<Self> {
+        if range == self.range() {
+            // This node exactly covers the requested range.
+            alloc::vec![*self]
+        } else {
+            // This node is larger than the requested range.
+            let (low, high) = {
+                let next_depth = u32::from(self.depth.get() + 1);
+                let next_dyad_size = u32::MAX.checked_shr(next_depth).unwrap_or(0);
+
+                // a key's range is dyadic-aligned. select next smallest dyad.
+                let next_split = *self.range().start() | next_dyad_size;
+
+                (
+                    *range.start()..=next_split.min(*range.end()),
+                    (*range.start()).max(next_split + 1)..=*range.end(),
+                )
+            };
+
+            let mut result = Vec::new();
+            if !low.is_empty() {
+                result.extend(self.step(false).derive_note_delegates(low));
+            }
+            if !high.is_empty() {
+                result.extend(self.step(true).derive_note_delegates(high));
+            }
+            result
+        }
+    }
+
+    /// Derive a nullifier for the given epoch.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the epoch is outside this key's authorized range.
     #[must_use]
     pub fn derive_nullifier(&self, flavor: Epoch) -> Nullifier {
-        Nullifier::from(self.evaluate(u32::from(flavor)))
-    }
-
-    /// Derive epoch-restricted prefix keys for OSS delegation.
-    ///
-    /// Each returned key can evaluate the PRF only for epochs within
-    /// the subtree identified by its prefix.
-    pub fn derive_note_delegates(
-        &self,
-        prefixes: impl IntoIterator<Item = Prefixed>,
-    ) -> Vec<NoteKey<Prefixed>> {
-        prefixes
-            .into_iter()
-            .map(|prefix| {
-                NoteKey {
-                    inner: walk(self.inner, prefix.index, prefix.depth()),
-                    prefix,
-                }
-            })
-            .collect()
+        assert!(self.range().contains(&flavor.0), "epoch out of range");
+        let remaining = GGM_TREE_DEPTH - self.depth.get();
+        Nullifier::from(ggm_walk(self.inner, flavor.0, remaining))
     }
 }
 
-impl NoteKey<Prefixed> {
-    /// Derive a nullifier for epoch `flavor`, returning `None` if the
-    /// epoch is outside this prefix's authorized range.
-    #[must_use]
-    pub fn derive_nullifier(&self, flavor: Epoch) -> Option<Nullifier> {
-        let epoch = u32::from(flavor);
-        if epoch < self.prefix.first() || epoch > self.prefix.last() {
-            return None;
+impl TryFrom<[u8; 37]> for NotePrefixedKey {
+    type Error = NoteKeyError;
+
+    fn try_from(bytes: [u8; 37]) -> Result<Self, Self::Error> {
+        // [repr(32) | depth(1) | index_le(4)]
+        let fp_bytes: &[u8; 32] = bytes.first_chunk().ok_or(NoteKeyError::InvalidRepr)?;
+        let inner = Fp::from_repr(*fp_bytes)
+            .into_option()
+            .ok_or(NoteKeyError::InvalidRepr)?;
+        let tail: &[u8; 5] = bytes.last_chunk().ok_or(NoteKeyError::InvalidPrefix)?;
+        let (&depth_byte, index_slice) = tail.split_first().ok_or(NoteKeyError::InvalidPrefix)?;
+        let depth = NonZeroU8::new(depth_byte).ok_or(NoteKeyError::InvalidPrefix)?;
+        if depth.get() > GGM_TREE_DEPTH {
+            return Err(NoteKeyError::InvalidPrefix);
         }
-        Some(Nullifier::from(self.evaluate(epoch)))
+        let index_bytes: &[u8; 4] = index_slice
+            .first_chunk()
+            .ok_or(NoteKeyError::InvalidPrefix)?;
+        #[expect(clippy::little_endian_bytes, reason = "deserialization")]
+        let index = u32::from_le_bytes(*index_bytes);
+        if index > u32::MAX >> (GGM_TREE_DEPTH - depth.get()) {
+            return Err(NoteKeyError::InvalidPrefix);
+        }
+        Ok(Self {
+            inner,
+            depth,
+            index,
+        })
     }
+}
+
+impl From<NotePrefixedKey> for [u8; 37] {
+    fn from(key: NotePrefixedKey) -> [u8; 37] {
+        // [repr(32) | depth(1) | index_le(4)]
+        #[expect(clippy::expect_used, reason = "length is statically known")]
+        [
+            key.inner.to_repr().as_slice(),
+            &[key.depth.get()],
+            #[expect(clippy::little_endian_bytes, reason = "serialization")]
+            &key.index.to_le_bytes(),
+        ]
+        .concat()
+        .try_into()
+        .expect("32 + 1 + 4 = 37")
+    }
+}
+
+#[derive(Debug)]
+pub enum NoteKeyError {
+    InvalidRepr,
+    InvalidPrefix,
 }
 
 /// One GGM tree step: `Poseidon(tag, node, bit)`.
-pub(super) fn step(node: Fp, bit: Fp) -> Fp {
+fn ggm_step(node: Fp, bit: bool) -> Fp {
     #[expect(clippy::little_endian_bytes, reason = "specified behavior")]
-    let personalization = Fp::from_u128(u128::from_le_bytes(*NOTE_NULLIFIER_DOMAIN));
-    Hash::<_, P128Pow5T3, ConstantLength<3>, 3, 2>::init().hash([personalization, node, bit])
+    let domain = Fp::from_u128(u128::from_le_bytes(*NOTE_NULLIFIER_DOMAIN));
+    Hash::<_, P128Pow5T3, ConstantLength<3>, 3, 2>::init().hash([domain, node, Fp::from(bit)])
 }
 
 /// Recursive GGM walk: consume the top bit of `leaf` at each level,
 /// MSB-first, for `remaining` levels.
-pub(super) fn walk(node: Fp, leaf: u32, remaining: u8) -> Fp {
+fn ggm_walk(node: Fp, leaf: u32, remaining: u8) -> Fp {
     match remaining.checked_sub(1) {
         | None => node,
         | Some(next) => {
-            let bit = (leaf >> next) & 0b0001;
-            walk(step(node, Fp::from(u64::from(bit))), leaf, next)
+            let bit = (leaf >> next) & 1 != 0;
+            ggm_walk(ggm_step(node, bit), leaf, next)
         },
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use core::num::NonZeroU8;
-
     use ff::Field as _;
     use rand::{SeedableRng as _, rngs::StdRng};
 
@@ -204,119 +275,71 @@ mod tests {
 
     #[test]
     fn distinct_leaves() {
-        let mut rng = StdRng::seed_from_u64(0);
-        let key = NoteKey::<Master>::try_from(Fp::random(&mut rng).to_repr()).unwrap();
+        let key =
+            NoteMasterKey::try_from(Fp::random(&mut StdRng::seed_from_u64(0)).to_repr()).unwrap();
 
-        assert_ne!(key.evaluate(0), key.evaluate(1));
+        assert_ne!(
+            key.derive_nullifier(Epoch(0)),
+            key.derive_nullifier(Epoch(1)),
+        );
     }
 
     #[test]
     fn distinct_keys() {
         let mut rng = StdRng::seed_from_u64(0);
-        let key1 = NoteKey::<Master>::try_from(Fp::random(&mut rng).to_repr()).unwrap();
-        let key2 = NoteKey::<Master>::try_from(Fp::random(&mut rng).to_repr()).unwrap();
+        let key1 = NoteMasterKey::try_from(Fp::random(&mut rng).to_repr()).unwrap();
+        let key2 = NoteMasterKey::try_from(Fp::random(&mut rng).to_repr()).unwrap();
 
-        assert_ne!(key1.evaluate(42), key2.evaluate(42));
+        assert_ne!(
+            key1.derive_nullifier(Epoch(42)),
+            key2.derive_nullifier(Epoch(42)),
+        );
     }
 
-    /// Prefix key at each depth (index 0) produces the same nullifier
-    /// as the root key for leaf 0.
+    /// Delegate covering epoch 0 produces the same nullifier as the root.
     #[test]
-    fn prefix_index_zero_matches_root() {
-        let mut rng = StdRng::seed_from_u64(0);
-        let root = NoteKey::<Master>::try_from(Fp::random(&mut rng).to_repr()).unwrap();
-        let prefixes: Vec<_> = [6u8, 14, 20, 26]
-            .into_iter()
-            .map(|depth| Prefixed::new(NonZeroU8::new(depth).unwrap(), 0).unwrap())
-            .collect();
-        for delegate in root.derive_note_delegates(prefixes) {
+    fn delegate_matches_root() {
+        let root =
+            NoteMasterKey::try_from(Fp::random(&mut StdRng::seed_from_u64(0)).to_repr()).unwrap();
+        // Single delegate covering [0..=63]
+        for delegate in root.derive_note_delegates(0..=63) {
             assert_eq!(
-                delegate.evaluate(0),
-                root.evaluate(0),
+                delegate.derive_nullifier(Epoch(0)),
+                root.derive_nullifier(Epoch(0)),
                 "mismatch at depth {:?}",
-                delegate.depth()
+                delegate.depth.get()
             );
         }
     }
 
     #[test]
-    fn prefixed_new_rejects_invalid() {
-        // depth=0 is prevented by NonZeroU8 parameter type
-        // depth > TREE_DEPTH is invalid
-        assert_eq!(
-            Prefixed::new(NonZeroU8::new(33u8).unwrap(), 0).unwrap_err(),
-            PrefixedError::DepthOutOfRange
-        );
-        // index >= 2^depth is invalid
-        assert_eq!(
-            Prefixed::new(NonZeroU8::new(1u8).unwrap(), 2).unwrap_err(),
-            PrefixedError::IndexOutOfRange
-        );
-        assert_eq!(
-            Prefixed::new(NonZeroU8::new(2u8).unwrap(), 4).unwrap_err(),
-            PrefixedError::IndexOutOfRange
-        );
-        // depth == MAX_TREE_DEPTH (single leaf) is not delegable.
-        assert_eq!(
-            Prefixed::new(NonZeroU8::new(32u8).unwrap(), 0).unwrap_err(),
-            PrefixedError::DepthOutOfRange
-        );
-        // Rightmost valid nodes at each depth.
-        assert_eq!(
-            Prefixed::new(NonZeroU8::new(1u8).unwrap(), 1).unwrap(),
-            Prefixed {
-                depth: NonZeroU8::new(1u8).unwrap(),
-                index: 1
-            }
-        );
-        assert_eq!(
-            Prefixed::new(NonZeroU8::new(2u8).unwrap(), 3).unwrap(),
-            Prefixed {
-                depth: NonZeroU8::new(2u8).unwrap(),
-                index: 3
-            }
-        );
-        assert_eq!(
-            Prefixed::new(NonZeroU8::new(31u8).unwrap(), u32::MAX >> 1).unwrap(),
-            Prefixed {
-                depth: NonZeroU8::new(31u8).unwrap(),
-                index: u32::MAX >> 1
-            }
-        );
+    fn tight_cover() {
+        let root = NoteMasterKey(Fp::from(1u64));
+        let delegates = root.derive_note_delegates(0..=5);
+        // [0..=3] and [4..=5]
+        assert_eq!(delegates.len(), 2);
+        assert_eq!(delegates[0].range(), 0..=3);
+        assert_eq!(delegates[1].range(), 4..=5);
     }
 
     #[test]
-    fn prefixed_epoch_range() {
-        let minute = Prefixed::new(NonZeroU8::new(26u8).unwrap(), 1).unwrap();
-        assert_eq!(minute.first(), 64);
-        assert_eq!(minute.last(), 127);
-
-        let half = Prefixed::new(NonZeroU8::new(1u8).unwrap(), 0).unwrap();
-        assert_eq!(half.first(), 0);
-        assert_eq!(half.last(), 0b0111_1111_1111_1111_1111_1111_1111_1111);
-
-        // Rightmost subtree at depth 1 covers [2^31 ..= u32::MAX].
-        let upper_half = Prefixed::new(NonZeroU8::new(1u8).unwrap(), 1).unwrap();
-        assert_eq!(
-            upper_half.first(),
-            0b1000_0000_0000_0000_0000_0000_0000_0000
-        );
-        assert_eq!(upper_half.last(), u32::MAX);
+    fn single_epoch_delegate() {
+        let root = NoteMasterKey(Fp::from(1u64));
+        let delegates = root.derive_note_delegates(42..=42);
+        assert_eq!(delegates.len(), 1);
+        assert_eq!(delegates[0].range(), 42..=42);
+        assert_eq!(delegates[0].depth.get(), GGM_TREE_DEPTH);
     }
 
     #[test]
-    fn cover_simple() {
-        let cover = Prefixed::tight(0, 6);
-        // [0..=3] at depth 30, [4..=5] at depth 31.
-        assert_eq!(cover.len(), 2);
-        assert_eq!(cover[0].first(), 0);
-        assert_eq!(cover[0].last(), 3);
-        assert_eq!(cover[1].first(), 4);
-        assert_eq!(cover[1].last(), 5);
-
-        let single = Prefixed::tight(0, 4);
-        assert_eq!(single.len(), 1);
-        assert_eq!(single[0].first(), 0);
-        assert_eq!(single[0].last(), 3);
+    #[should_panic(expected = "must not step beyond leaf")]
+    fn step_beyond_leaf_panics() {
+        let root = NoteMasterKey(Fp::from(1u64));
+        let mut key = root.step(false);
+        for _ in 1..GGM_TREE_DEPTH {
+            key = key.step(false);
+        }
+        // Now at depth 32 (leaf) — one more step should panic.
+        let _boom = key.step(false);
     }
 }

--- a/crates/tachyon/src/keys/ggm.rs
+++ b/crates/tachyon/src/keys/ggm.rs
@@ -31,7 +31,7 @@ pub const GGM_TREE_DEPTH: u8 = 32;
 ///              └── psi_t = GGM(mk, t)    prefix key for epochs e ≤ t (OSS)
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct NoteMasterKey(pub Fp);
+pub struct NoteMasterKey(pub(crate) Fp);
 
 impl NoteMasterKey {
     /// Descend one level from the root of the GGM tree.
@@ -105,11 +105,11 @@ impl From<NoteMasterKey> for [u8; 32] {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NotePrefixedKey {
     /// GGM tree node value.
-    pub inner: Fp,
+    pub(crate) inner: Fp,
     /// The number of levels already descended.
-    pub depth: NonZeroU8,
+    pub(crate) depth: NonZeroU8,
     /// Node index at this depth.
-    pub index: u32,
+    pub(crate) index: u32,
 }
 
 impl NotePrefixedKey {

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -75,7 +75,8 @@ mod note;
 mod proof;
 
 // Re-exports: public API surface.
-pub use note::{NoteMasterKey, NullifierKey, PaymentKey};
+pub use ggm::{GGM_TREE_DEPTH, NoteMasterKey, NotePrefixedKey};
+pub use note::{NullifierKey, PaymentKey};
 pub use proof::{ProofAuthorizingKey, SpendValidatingKey};
 
 #[cfg(test)]

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -1,89 +1,12 @@
-//! Note-related keys: NullifierKey, NoteKey, PaymentKey.
-
-use core::num::NonZeroU8;
+//! Note-related keys: NullifierKey, PaymentKey.
 
 use ff::PrimeField as _;
 // TODO(#39): replace halo2_poseidon with Ragu Poseidon params
 use halo2_poseidon::{ConstantLength, Hash, P128Pow5T3};
 use pasta_curves::Fp;
 
-use super::ggm::{GGMTreeDepth as _, Master, Prefixed};
-use crate::{constants::NOTE_MASTER_DOMAIN, note::NullifierTrapdoor};
-
-/// A GGM tree node parameterized by its depth type.
-///
-/// - `NoteKey<Master>` is a root node (depth 0, ZST overhead).
-/// - `NoteKey<Prefixed>` is a delegate node covering a specific subtree.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct NoteKey<D> {
-    pub inner: Fp,
-    pub prefix: D,
-}
-
-#[derive(Debug)]
-pub enum NoteKeyError {
-    InvalidRepr,
-    InvalidPrefix,
-}
-
-impl TryFrom<[u8; 32]> for NoteKey<Master> {
-    type Error = NoteKeyError;
-
-    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        let inner = Fp::from_repr(bytes)
-            .into_option()
-            .ok_or(NoteKeyError::InvalidRepr)?;
-        Ok(Self {
-            inner,
-            prefix: Master,
-        })
-    }
-}
-
-impl From<NoteKey<Master>> for [u8; 32] {
-    fn from(key: NoteKey<Master>) -> [u8; 32] {
-        key.inner.to_repr()
-    }
-}
-
-impl TryFrom<[u8; 37]> for NoteKey<Prefixed> {
-    type Error = NoteKeyError;
-
-    fn try_from(bytes: [u8; 37]) -> Result<Self, Self::Error> {
-        // [repr(32) | depth(1) | index_le(4)]
-        let fp_bytes: &[u8; 32] = bytes.first_chunk().ok_or(NoteKeyError::InvalidRepr)?;
-        let inner = Fp::from_repr(*fp_bytes)
-            .into_option()
-            .ok_or(NoteKeyError::InvalidRepr)?;
-        let tail: &[u8; 5] = bytes.last_chunk().ok_or(NoteKeyError::InvalidPrefix)?;
-        let (&depth_byte, index_slice) = tail.split_first().ok_or(NoteKeyError::InvalidPrefix)?;
-        let depth = NonZeroU8::new(depth_byte).ok_or(NoteKeyError::InvalidPrefix)?;
-        let index_bytes: &[u8; 4] = index_slice
-            .first_chunk()
-            .ok_or(NoteKeyError::InvalidPrefix)?;
-        #[expect(clippy::little_endian_bytes, reason = "deserialization")]
-        let index = u32::from_le_bytes(*index_bytes);
-        let prefix =
-            Prefixed::new(depth, index).map_err(|_prefix_err| NoteKeyError::InvalidPrefix)?;
-        Ok(Self { inner, prefix })
-    }
-}
-
-impl From<NoteKey<Prefixed>> for [u8; 37] {
-    fn from(key: NoteKey<Prefixed>) -> [u8; 37] {
-        // [repr(32) | depth(1) | index_le(4)]
-        #[expect(clippy::expect_used, reason = "length is statically known")]
-        [
-            key.inner.to_repr().as_slice(),
-            &[key.prefix.depth()],
-            #[expect(clippy::little_endian_bytes, reason = "serialization")]
-            &key.prefix.index().to_le_bytes(),
-        ]
-        .concat()
-        .try_into()
-        .expect("32 + 1 + 4 = 37")
-    }
-}
+use super::ggm::NoteMasterKey;
+use crate::{constants::NOTE_MASTER_DOMAIN, note, primitives::NoteId};
 
 /// A Tachyon nullifier deriving key.
 ///
@@ -121,17 +44,27 @@ impl NullifierKey {
     ///   F_{\mathsf{mk}}(\text{flavor})$
     /// - Derive epoch-restricted prefix keys $\Psi_t$ for OSS delegation
     #[must_use]
-    pub fn derive_note_private(&self, psi: &NullifierTrapdoor) -> NoteMasterKey {
+    pub fn derive_note_private(&self, psi: &note::NullifierTrapdoor) -> NoteMasterKey {
         #[expect(clippy::little_endian_bytes, reason = "specified behavior")]
         let personalization = Fp::from_u128(u128::from_le_bytes(*NOTE_MASTER_DOMAIN));
-        NoteKey {
-            inner: Hash::<_, P128Pow5T3, ConstantLength<3>, 3, 2>::init().hash([
+        NoteMasterKey(
+            Hash::<_, P128Pow5T3, ConstantLength<3>, 3, 2>::init().hash([
                 personalization,
                 psi.0,
                 self.0,
             ]),
-            prefix: Master,
-        }
+        )
+    }
+
+    /// Provides the note identity binding: `H(domain, mk, cm)`.
+    ///
+    /// Computes the master key and note commitment internally.
+    ///
+    /// This method is located here and not on `NoteMasterKey` to encourage the
+    /// correct relationship between master key and note commitment.
+    #[must_use]
+    pub fn note_id(&self, note: &note::Note) -> NoteId {
+        NoteId::derive(self, note)
     }
 }
 
@@ -163,34 +96,15 @@ impl NullifierKey {
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]
 pub struct PaymentKey(pub(crate) Fp);
 
-/// Per-note master root key $\mathsf{mk} = \text{KDF}(\psi, \mathsf{nk})$.
-///
-/// Root of the GGM tree PRF for a single note. Derived by the user device
-/// from [`NullifierKey`] and the note's $\psi$ trapdoor.
-///
-/// ## Delegation chain
-///
-/// ```text
-/// nk + psi → mk (per-note root, user device)
-///              ├── nf = F_mk(flavor)     nullifier for a specific epoch
-///              └── psi_t = GGM(mk, t)    prefix key for epochs e ≤ t (OSS)
-/// ```
-///
-/// `mk` is not stored or transmitted — the user device derives it
-/// ephemerally when needed. The OSS receives only the prefix keys.
-pub type NoteMasterKey = NoteKey<Master>;
-
 #[cfg(test)]
 mod tests {
-    use core::num::NonZeroU8;
-
     use super::*;
-    use crate::{keys::ggm::Prefixed, primitives::Epoch};
+    use crate::primitives::Epoch;
 
     #[test]
     fn derive_note_private_deterministic() {
         let nk = NullifierKey(Fp::from(42u64));
-        let psi = NullifierTrapdoor::from(Fp::from(99u64));
+        let psi = note::NullifierTrapdoor::from(Fp::from(99u64));
         let mk1 = nk.derive_note_private(&psi);
         let mk2 = nk.derive_note_private(&psi);
         assert_eq!(mk1, mk2);
@@ -199,15 +113,15 @@ mod tests {
     #[test]
     fn different_psi_different_mk() {
         let nk = NullifierKey(Fp::from(42u64));
-        let mk1 = nk.derive_note_private(&NullifierTrapdoor::from(Fp::from(1u64)));
-        let mk2 = nk.derive_note_private(&NullifierTrapdoor::from(Fp::from(2u64)));
+        let mk1 = nk.derive_note_private(&note::NullifierTrapdoor::from(Fp::from(1u64)));
+        let mk2 = nk.derive_note_private(&note::NullifierTrapdoor::from(Fp::from(2u64)));
         assert_ne!(mk1, mk2);
     }
 
     #[test]
     fn different_epochs_different_nullifiers() {
         let nk = NullifierKey(Fp::from(42u64));
-        let psi = NullifierTrapdoor::from(Fp::from(99u64));
+        let psi = note::NullifierTrapdoor::from(Fp::from(99u64));
         let mk = nk.derive_note_private(&psi);
         assert_ne!(
             mk.derive_nullifier(Epoch::from(0u32)),
@@ -215,80 +129,35 @@ mod tests {
         );
     }
 
-    /// Prefix key (index 0) produces same nullifier as master key for
-    /// epochs within the authorized range.
+    /// Delegate key produces same nullifiers as master for epochs in range.
     #[test]
-    fn prefix_matches_master_at_index_zero() {
+    fn delegate_matches_master() {
         let nk = NullifierKey(Fp::from(42u64));
-        let psi = NullifierTrapdoor::from(Fp::from(99u64));
+        let psi = note::NullifierTrapdoor::from(Fp::from(99u64));
         let mk = nk.derive_note_private(&psi);
 
-        // depth=26 → window of 64 epochs at index 0 → epochs [0..=63]
-        let prefix = Prefixed::new(NonZeroU8::new(26u8).unwrap(), 0).unwrap();
-        let dk = &mk.derive_note_delegates([prefix])[0];
-
-        for epoch in 0..64u32 {
-            assert_eq!(
-                mk.derive_nullifier(Epoch::from(epoch)),
-                dk.derive_nullifier(Epoch::from(epoch)).unwrap(),
-                "mismatch at epoch {epoch}"
-            );
-        }
-    }
-
-    /// Prefix key at a non-zero index produces same nullifiers as
-    /// master key for epochs within its range.
-    #[test]
-    fn prefix_matches_master_at_nonzero_index() {
-        let nk = NullifierKey(Fp::from(42u64));
-        let psi = NullifierTrapdoor::from(Fp::from(99u64));
-        let mk = nk.derive_note_private(&psi);
-
-        // depth=26 → window of 64 epochs at index 1 → epochs [64..=127]
-        let prefix = Prefixed::new(NonZeroU8::new(26u8).unwrap(), 1).unwrap();
-        let dk = &mk.derive_note_delegates([prefix])[0];
-
-        for epoch in 64..128u32 {
-            assert_eq!(
-                mk.derive_nullifier(Epoch::from(epoch)),
-                dk.derive_nullifier(Epoch::from(epoch)).unwrap(),
-                "mismatch at epoch {epoch}"
-            );
-        }
-    }
-
-    /// Prefix cover produces same nullifiers as master for all
-    /// epochs in the covered range.
-    #[test]
-    fn cover_matches_master() {
-        let nk = NullifierKey(Fp::from(42u64));
-        let psi = NullifierTrapdoor::from(Fp::from(99u64));
-        let mk = nk.derive_note_private(&psi);
-
-        let prefixes = Prefixed::tight(0, 100);
-        for dk in &mk.derive_note_delegates(prefixes) {
-            for epoch in dk.prefix.first()..=dk.prefix.last() {
+        for dk in &mk.derive_note_delegates(0..=99) {
+            for epoch in dk.range() {
                 assert_eq!(
                     mk.derive_nullifier(Epoch::from(epoch)),
-                    dk.derive_nullifier(Epoch::from(epoch)).unwrap(),
+                    dk.derive_nullifier(Epoch::from(epoch)),
                     "mismatch at epoch {epoch} with delegate {dk:?}"
                 );
             }
         }
     }
 
-    /// A prefix key returns `None` for epochs outside its authorized range.
+    /// A delegate key panics for epochs outside its authorized range.
     #[test]
-    fn prefix_rejects_outside_range() {
+    #[should_panic(expected = "epoch out of range")]
+    fn delegate_rejects_outside_range() {
         let nk = NullifierKey(Fp::from(42u64));
-        let psi = NullifierTrapdoor::from(Fp::from(99u64));
+        let psi = note::NullifierTrapdoor::from(Fp::from(99u64));
         let mk = nk.derive_note_private(&psi);
 
-        // depth=26 index=0 → epochs [0..=63]
-        let prefix = Prefixed::new(NonZeroU8::new(26u8).unwrap(), 0).unwrap();
-        let dk = &mk.derive_note_delegates([prefix])[0];
-
+        // Delegate covering [0..=63]
+        let dk = &mk.derive_note_delegates(0..=63)[0];
         // epoch 64 is outside the authorized range
-        assert!(dk.derive_nullifier(Epoch::from(64u32)).is_none());
+        let _compute = dk.derive_nullifier(Epoch::from(64u32));
     }
 }

--- a/crates/tachyon/src/primitives/effect.rs
+++ b/crates/tachyon/src/primitives/effect.rs
@@ -22,10 +22,12 @@ mod sealed {
 
 /// Sealed trait marking an action effect (spend or output).
 pub trait Effect: sealed::Sealed + 'static {
-    /// Derive this effect's $\alpha$ scalar from per-action entropy and a note commitment.
+    /// Derive this effect's $\alpha$ scalar from per-action entropy and a note
+    /// commitment.
     fn derive_alpha(theta: &ActionEntropy, cm: &note::Commitment) -> Fq;
 
-    /// Commit to this effect's signed value contribution using the given trapdoor.
+    /// Commit to this effect's signed value contribution using the given
+    /// trapdoor.
     fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment;
 }
 

--- a/crates/tachyon/src/primitives/epoch.rs
+++ b/crates/tachyon/src/primitives/epoch.rs
@@ -8,7 +8,7 @@
 /// Different epochs produce different nullifiers for the same note,
 /// enabling range-restricted delegation via the GGM tree PRF.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Epoch(u32);
+pub struct Epoch(pub u32);
 
 impl From<u32> for Epoch {
     fn from(val: u32) -> Self {

--- a/crates/tachyon/src/primitives/mod.rs
+++ b/crates/tachyon/src/primitives/mod.rs
@@ -3,10 +3,12 @@ mod anchor;
 pub mod effect;
 mod epoch;
 pub mod multiset;
+mod note_id;
 mod tachygram;
 
 pub use action_digest::{ActionDigest, ActionDigestError};
 pub use anchor::Anchor;
 pub use effect::Effect;
 pub use epoch::Epoch;
+pub(crate) use note_id::NoteId;
 pub use tachygram::Tachygram;

--- a/crates/tachyon/src/primitives/note_id.rs
+++ b/crates/tachyon/src/primitives/note_id.rs
@@ -1,0 +1,43 @@
+use ff::PrimeField as _;
+use halo2_poseidon::{ConstantLength, Hash, P128Pow5T3};
+use pasta_curves::Fp;
+
+use crate::{constants::NOTE_ID_DOMAIN, keys, note};
+
+/// Identity binding: `H(domain, mk, cm)`.
+///
+/// Binds the note's identity (via master key) to its value commitment,
+/// threading through the proof pipeline. Fuse steps verify that left
+/// and right inputs agree on note id.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NoteId(Fp);
+
+impl NoteId {
+    pub(crate) fn derive(nk: &keys::NullifierKey, note: &note::Note) -> Self {
+        #[expect(clippy::little_endian_bytes, reason = "specified behavior")]
+        let domain = Fp::from_u128(u128::from_le_bytes(*NOTE_ID_DOMAIN));
+
+        let mk = &nk.derive_note_private(&note.psi);
+        let cm = note.commitment();
+
+        Self(
+            Hash::<_, P128Pow5T3, ConstantLength<3>, 3, 2>::init().hash([
+                domain,
+                mk.0,
+                Fp::from(cm),
+            ]),
+        )
+    }
+}
+
+impl From<Fp> for NoteId {
+    fn from(fp: Fp) -> Self {
+        Self(fp)
+    }
+}
+
+impl From<NoteId> for Fp {
+    fn from(id: NoteId) -> Self {
+        id.0
+    }
+}

--- a/crates/tachyon/src/primitives/note_id.rs
+++ b/crates/tachyon/src/primitives/note_id.rs
@@ -13,6 +13,7 @@ use crate::{constants::NOTE_ID_DOMAIN, keys, note};
 pub struct NoteId(Fp);
 
 impl NoteId {
+    /// TODO: consider adding trapdoor so note_id may be opaque
     pub(crate) fn derive(nk: &keys::NullifierKey, note: &note::Note) -> Self {
         #[expect(clippy::little_endian_bytes, reason = "specified behavior")]
         let domain = Fp::from_u128(u128::from_le_bytes(*NOTE_ID_DOMAIN));


### PR DESCRIPTION
## Summary

Rewrite the GGM tree PRF module around concrete key types and lazy recursive delegation, and introduce `NoteId` identity binding. No changes to the cryptographic tree structure or domain separators.

This is preliminary work for #46 

### Concrete key types

Replace the generic `NoteKey<D>` (parameterized over sealed `Master`/`Prefixed` depth markers) with concrete `NoteMasterKey` and `NotePrefixedKey` structs. This removes the `GGMTreeDepth` sealed trait, `PrefixedError` enum, and all depth-type machinery from `keys/note.rs`. Serialization moves onto the concrete types in `ggm.rs`.

### Lazy recursive delegation

Replace eager dyadic decomposition (`Prefixed::tight(start, end)`) with `derive_note_delegates(RangeInclusive<u32>)` on both key types. Only tree nodes overlapping the requested range are hashed — no up-front interval arithmetic.

### Fluent tree traversal

Add `step(bool)` on both `NoteMasterKey` and `NotePrefixedKey` for single-level descent, and `range()` on `NotePrefixedKey` to recover the covered epoch interval.

### NoteId

New `NoteId` primitive: `H(domain, mk, cm)` binds a note's identity (via its master key) to its commitment. `NullifierKey::note_id(&Note)` derives both `mk` and `cm` internally so callers can't misassociate them. Domain tag: `Tachyon-NoteMkCm`.

### Behavioural changes

- `NotePrefixedKey::derive_nullifier` panics on out-of-range epochs (previously returned `Option`). Callers already know their range.
- `GGM_TREE_DEPTH` is now `pub` (was `pub(super)`).

## Files changed

| File | Change |
|---|---|
| `keys/ggm.rs` | Full rewrite: concrete types, recursive delegation, `step`/`range` API, serialization |
| `keys/note.rs` | Remove `NoteKey<D>` and depth-type machinery; add `note_id()` accessor |
| `keys/mod.rs` | Re-export `GGM_TREE_DEPTH`, `NoteMasterKey`, `NotePrefixedKey` from `ggm` |
| `primitives/note_id.rs` | New `NoteId` type with `derive(nk, note)` |
| `primitives/mod.rs` | Wire `NoteId` |
| `primitives/effect.rs` | Docstring rewrap (no logic change) |
| `constants.rs` | Add `NOTE_ID_DOMAIN` |
