### PR TITLE
Correct payment key derivation

### DIFF
--- a/book/src/keys.md
+++ b/book/src/keys.md
@@ -14,8 +14,8 @@ flowchart TB
 
     sk -->|"PRF 0x09"| ask
     sk -->|"PRF 0x0a"| nk
-    sk -->|"PRF 0x0b"| pk
     ask -->|"[ask]G"| ak
+    ak & nk -->|"Poseidon"| pk
 
     subgraph pak["pak (ProofAuthorizingKey)"]
         ak["ak (SpendValidatingKey)"]
@@ -23,21 +23,21 @@ flowchart TB
     end
 ```
 
-All child keys are derived from the spending key $\mathsf{sk}$ via domain-separated PRF expansion:
+The spending key $\mathsf{sk}$ derives $\mathsf{ask}$ and $\mathsf{nk}$ via domain-separated PRF expansion:
 
 $$ \text{PRF}^{\text{expand}}_{\mathsf{sk}}(t) = \text{BLAKE2b-512}(\text{"Zcash\_ExpandSeed"},\; \mathsf{sk} \| t) $$
 
-The domain bytes ($\texttt{0x09}$, $\texttt{0x0a}$, $\texttt{0x0b}$) are allocated to avoid collisions with Sapling and Orchard.
+The domain bytes ($\texttt{0x09}$, $\texttt{0x0a}$) are allocated to avoid collisions with Sapling and Orchard. The payment key $\mathsf{pk}$ is then derived from both $\mathsf{ak}$ and $\mathsf{nk}$ via Poseidon, binding it to the full proof authorizing key.
 
 ### Comparison with Orchard
 
 | Layer | Orchard | Tachyon | Rationale |
 | ----- | ------- | ------- | --------- |
 | Root | Spending key ($\mathsf{sk}$) | Spending key ($\mathsf{sk}$) | Identical |
-| Auth | $\mathsf{ask} \to \mathsf{ak}$ | $\mathsf{ask} \to \mathsf{ak}$ | Identical |
+| Auth | $\mathsf{ask} \to \mathsf{ak}$ | $\mathsf{ask} \to \mathsf{ak}$ | Identical (RedPallas) |
 | Viewing | Full viewing key ($\mathsf{ak}, \mathsf{nk}, \mathsf{rivk}$) | **Removed** | Out-of-band |
 | Incoming | $\mathsf{dk}, \mathsf{ivk}, \mathsf{ovk}$ | **Removed** | Out-of-band |
-| Address | Diversifier $d$, transmission key $\mathsf{pk_d}$ | Payment key $\mathsf{pk}$ | No diversification |
+| Address | Diversifier $d$, transmission key $\mathsf{pk_d}$ | $\mathsf{pk} = \text{Poseidon}(\mathsf{ak}_x, \mathsf{nk})$ | No diversification; binds to pak |
 | Proof authorization | Not separated | $\mathsf{pak} = (\mathsf{ak}, \mathsf{nk})$ | Authorize proofs for all notes |
 | Per-note delegation | Not separated | $(\mathsf{ak}, \mathsf{mk})$ | Delegate proofs for one note |
 | Epoch delegation | Not separated | $(\mathsf{ak}, \Psi_t)$ | Delegate non-inclusion proving for epochs $e \leq t$ |
@@ -98,12 +98,14 @@ $\mathsf{nk}$ alone does NOT confer spend authority — combined with $\mathsf{a
 
 ### Payment key ($\mathsf{pk}$)
 
-$$\mathsf{pk} = \text{ToBase}\bigl(\text{PRF}^{\text{expand}}_{\mathsf{sk}}([\texttt{0x0b}])\bigr)$$
+$$\mathsf{pk} = \text{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x, \mathsf{nk})$$
 
-Replaces Orchard's diversified transmission key $\mathsf{pk_d}$ and the entire diversified address system:
+where $\mathsf{ak}_x$ is the x-coordinate of the spend validating key. Replaces Orchard's diversified transmission key $\mathsf{pk_d}$ and the entire diversified address system:
 
 > "Tachyon removes the diversifier $d$ because payment addresses are removed. The transmission key $\mathsf{pk_d}$ is substituted with a payment key $\mathsf{pk}$."
 > — "Tachyaction at a Distance" (Bowe 2025)
+
+Deriving $\mathsf{pk}$ from $(\mathsf{ak}, \mathsf{nk})$ binds the payment key to the full proof authorizing key. Since $\mathsf{pk}$ is committed in the note commitment $\mathsf{cm}$, the accumulator membership check transitively pins both $\mathsf{ak}$ and $\mathsf{nk}$. A wrong $\mathsf{nk}$ produces a wrong $\mathsf{pk}$, a wrong $\mathsf{cm}$, and accumulator inclusion fails.
 
 $\mathsf{pk}$ is **deterministic per spending key** — every note from the same $\mathsf{sk}$ shares the same $\mathsf{pk}$. There is no per-note diversification. Unlinkability is the wallet layer's responsibility, handled via out-of-band payment protocols (ZIP 321 payment requests, ZIP 324 URI encapsulated payments).
 

--- a/crates/tachyon/src/constants.rs
+++ b/crates/tachyon/src/constants.rs
@@ -57,7 +57,8 @@ pub const NOTE_ID_DOMAIN: &[u8; 16] = b"Tachyon-NoteMkCm";
 /// Poseidon domain tag for action digests.
 pub const ACTION_DIGEST_PERSONALIZATION: &[u8; 16] = b"Tachyon-ActnDgst";
 
-/// Poseidon domain tag for payment key derivation: $pk = \text{Poseidon}(\text{domain}, ak_x, nk)$.
+/// Poseidon domain tag for payment key derivation: $pk =
+/// \text{Poseidon}(\text{domain}, ak_x, nk)$.
 pub const PAYMENT_KEY_DOMAIN: &[u8; 16] = b"Tachyon-PkDerive";
 
 /// Maximum note value in zatoshis (§5.3 of the protocol spec)

--- a/crates/tachyon/src/constants.rs
+++ b/crates/tachyon/src/constants.rs
@@ -5,7 +5,7 @@
 //! variable-length strings under the `z.cash:` namespace.
 
 /// BLAKE2b-512 personalization for `PRF^expand`: key expansion from
-/// a spending key to child keys (`ask`, `nk`, `pk`).
+/// a spending key to child keys (`ask`, `nk`).
 ///
 /// Matches Zcash's `PRF^expand` pattern (§5.4.2 of the protocol spec).
 pub const PRF_EXPAND_PERSONALIZATION: &[u8; 16] = b"Zcash_ExpandSeed";
@@ -57,6 +57,9 @@ pub const NOTE_ID_DOMAIN: &[u8; 16] = b"Tachyon-NoteMkCm";
 /// Poseidon domain tag for action digests.
 pub const ACTION_DIGEST_PERSONALIZATION: &[u8; 16] = b"Tachyon-ActnDgst";
 
+/// Poseidon domain tag for payment key derivation: $pk = \text{Poseidon}(\text{domain}, ak_x, nk)$.
+pub const PAYMENT_KEY_DOMAIN: &[u8; 16] = b"Tachyon-PkDerive";
+
 /// Maximum note value in zatoshis (§5.3 of the protocol spec)
 pub const NOTE_VALUE_MAX: u64 = 2_100_000_000_000_000;
 
@@ -82,10 +85,6 @@ impl PrfExpand {
     /// `[0x0a]` -> `nk` (nullifier key, base field)
     pub(crate) const NK: Self = Self {
         domain_separator: 0x0a,
-    };
-    /// `[0x0b]` -> `pk` (payment key, base field)
-    pub(crate) const PK: Self = Self {
-        domain_separator: 0x0b,
     };
 
     /// Evaluate the PRF: `BLAKE2b-512("Zcash_ExpandSeed", sk || domain_sep)`.
@@ -115,9 +114,6 @@ mod tests {
         let sk = [0x42u8; 32];
         let ask = PrfExpand::ASK.with(&sk);
         let nk = PrfExpand::NK.with(&sk);
-        let pk = PrfExpand::PK.with(&sk);
         assert_ne!(ask, nk);
-        assert_ne!(ask, pk);
-        assert_ne!(nk, pk);
     }
 }

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -90,7 +90,7 @@ mod tests {
     use crate::{
         constants::PrfExpand,
         entropy::ActionEntropy,
-        keys::private,
+        keys::{NullifierKey, PaymentKey, private},
         note::{self, CommitmentTrapdoor, Note, NullifierTrapdoor},
         primitives::effect,
         reddsa,
@@ -146,6 +146,21 @@ mod tests {
 
         let pak = sk.derive_proof_private();
         assert_eq!(pak.derive_payment_key().0, pk.0);
+    }
+
+    /// pk must bind to nk: varying nk (with ak fixed) must produce a
+    /// different pk. This is what makes the note commitment transitively
+    /// pin the full proof authorizing key.
+    #[test]
+    fn payment_key_binds_nk() {
+        let sk = private::SpendingKey::from([0x42u8; 32]);
+        let ak = sk.derive_auth_private().derive_auth_public();
+        let nk = sk.derive_nullifier_private();
+        let pk = PaymentKey::derive(&ak, &nk);
+
+        let nk_other = NullifierKey(nk.0 + Fp::ONE);
+        let pk_other = PaymentKey::derive(&ak, &nk_other);
+        assert_ne!(pk.0, pk_other.0);
     }
 
     /// rsk.derive_action_public() must equal ak.derive_action_public(alpha) for

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -16,7 +16,7 @@
 //!     sig["sig (action::Signature)"]
 //!     pak[ProofAuthorizingKey]
 //!     sighash["sighash &amp;[u8; 32]"]
-//!     sk --> ask & nk & pk
+//!     sk --> ask & nk
 //!     ask --> ak
 //!     theta["ActionEntropy theta"] -- "randomizer::&lt;Spend&gt;" --> spend_alpha["ActionRandomizer&lt;Spend&gt;"]
 //!     theta -- "randomizer::&lt;Output&gt;" --> output_alpha["ActionRandomizer&lt;Output&gt;"]
@@ -28,6 +28,7 @@
 //!     spend_rsk -- "sign(sighash)" --> sig
 //!     output_rsk -- "sign(sighash)" --> sig
 //!     ak & nk --> pak
+//!     ak & nk -->|"Poseidon"| pk
 //! ```
 //!
 //! ### Private keys ([`private`])
@@ -45,7 +46,8 @@
 //! ### Note keys ([`note`])
 //!
 //! - `nk`: Observes when funds are spent (nullifier derivation)
-//! - `pk`: Used in note construction and out-of-band payment protocols
+//! - `pk = Poseidon(domain, ak_x, nk)`: Derived from `pak`, binds spending
+//!   authority and nullifier key to the note commitment
 //!
 //! ### Proof keys ([`proof`])
 //!
@@ -129,17 +131,21 @@ mod tests {
         assert_eq!(flipped, 16u32);
     }
 
-    /// ask, nk, pk derived from the same sk must all be different
-    /// (different domain separators produce independent keys).
+    /// ask, nk, pk derived from the same sk must all be different.
+    /// pk derives from (ak, nk) via Poseidon, not directly from sk.
     #[test]
     fn child_keys_independent() {
         let sk = private::SpendingKey::from([0x42u8; 32]);
-        let ask_bytes: [u8; 32] = sk.derive_auth_private().derive_auth_public().0.into();
-        let nk: Fp = sk.derive_nullifier_private().0;
-        let pk: Fp = sk.derive_payment_key().0;
+        let ak = sk.derive_auth_private().derive_auth_public();
+        let nk = sk.derive_nullifier_private();
+        let pk = sk.derive_payment_key();
 
-        assert_ne!(ask_bytes, nk.to_repr());
-        assert_ne!(nk.to_repr(), pk.to_repr());
+        let ak_bytes: [u8; 32] = ak.0.into();
+        assert_ne!(ak_bytes, nk.0.to_repr());
+        assert_ne!(nk.0.to_repr(), pk.0.to_repr());
+
+        let pak = sk.derive_proof_private();
+        assert_eq!(pak.derive_payment_key().0, pk.0);
     }
 
     /// rsk.derive_action_public() must equal ak.derive_action_public(alpha) for

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -86,7 +86,8 @@ impl NullifierKey {
 ///
 /// Derived from the proof authorizing key components:
 ///
-/// $$\mathsf{pk} = \text{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x, \mathsf{nk})$$
+/// $$\mathsf{pk} = \text{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x,
+/// \mathsf{nk})$$
 ///
 /// where $\mathsf{ak}_x$ is the x-coordinate of the spend validating key.
 /// This binds `pk` to both `ak` and `nk`, so the note commitment `cm`
@@ -110,7 +111,8 @@ pub struct PaymentKey(pub(crate) Fp);
 
 impl PaymentKey {
     /// Derive the payment key from `ak` and `nk`:
-    /// $\mathsf{pk} = \text{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x, \mathsf{nk})$.
+    /// $\mathsf{pk} = \text{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x,
+    /// \mathsf{nk})$.
     #[must_use]
     #[expect(
         clippy::expect_used,
@@ -121,8 +123,8 @@ impl PaymentKey {
         let domain = Fp::from_u128(u128::from_le_bytes(*PAYMENT_KEY_DOMAIN));
 
         let ak_bytes: [u8; 32] = ak.0.into();
-        let ak_x = Option::from(Fp::from_repr(ak_bytes))
-            .expect("sign-normalized ak should be a valid Fp");
+        let ak_x =
+            Option::from(Fp::from_repr(ak_bytes)).expect("sign-normalized ak should be a valid Fp");
 
         Self(Hash::<_, P128Pow5T3, ConstantLength<3>, 3, 2>::init().hash([domain, ak_x, nk.0]))
     }

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -5,8 +5,12 @@ use ff::PrimeField as _;
 use halo2_poseidon::{ConstantLength, Hash, P128Pow5T3};
 use pasta_curves::Fp;
 
-use super::ggm::NoteMasterKey;
-use crate::{constants::NOTE_MASTER_DOMAIN, note, primitives::NoteId};
+use super::{ggm::NoteMasterKey, proof::SpendValidatingKey};
+use crate::{
+    constants::{NOTE_MASTER_DOMAIN, PAYMENT_KEY_DOMAIN},
+    note,
+    primitives::NoteId,
+};
 
 /// A Tachyon nullifier deriving key.
 ///
@@ -80,8 +84,16 @@ impl NullifierKey {
 ///
 /// ## Derivation
 ///
-/// Deterministic per-`sk`: $\mathsf{pk} =
-/// \text{ToBase}(\text{PRF}^{\text{expand}}_{\mathsf{sk}}([0\text{x}0b]))$.
+/// Derived from the proof authorizing key components:
+///
+/// $$\mathsf{pk} = \text{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x, \mathsf{nk})$$
+///
+/// where $\mathsf{ak}_x$ is the x-coordinate of the spend validating key.
+/// This binds `pk` to both `ak` and `nk`, so the note commitment `cm`
+/// (which contains `pk`) transitively pins the full proof authorizing key.
+/// Wrong `nk` produces wrong `pk`, wrong `cm`, and accumulator inclusion
+/// fails.
+///
 /// Every note from the same spending key shares the same `pk`. There is
 /// no per-note diversification — unlinkability is the wallet layer's
 /// responsibility, not the core protocol's.
@@ -95,6 +107,26 @@ impl NullifierKey {
 #[derive(Clone, Copy, Debug)]
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]
 pub struct PaymentKey(pub(crate) Fp);
+
+impl PaymentKey {
+    /// Derive the payment key from `ak` and `nk`:
+    /// $\mathsf{pk} = \text{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x, \mathsf{nk})$.
+    #[must_use]
+    #[expect(
+        clippy::expect_used,
+        reason = "sign-normalized ak (tilde_y=0) is always a valid Fp repr"
+    )]
+    pub fn derive(ak: &SpendValidatingKey, nk: &NullifierKey) -> Self {
+        #[expect(clippy::little_endian_bytes, reason = "specified behavior")]
+        let domain = Fp::from_u128(u128::from_le_bytes(*PAYMENT_KEY_DOMAIN));
+
+        let ak_bytes: [u8; 32] = ak.0.into();
+        let ak_x = Option::from(Fp::from_repr(ak_bytes))
+            .expect("sign-normalized ak should be a valid Fp");
+
+        Self(Hash::<_, P128Pow5T3, ConstantLength<3>, 3, 2>::init().hash([domain, ak_x, nk.0]))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/tachyon/src/keys/private.rs
+++ b/crates/tachyon/src/keys/private.rs
@@ -107,19 +107,18 @@ impl SpendingKey {
 
     /// Derive the payment key $\mathsf{pk}$ from $\mathsf{sk}$.
     ///
-    /// $$\mathsf{pk} = \text{ToBase}\bigl(\text{PRF}^{\text{expand}}_
-    /// {\mathsf{sk}}([0\text{x}0b])\bigr)$$
+    /// $$\mathsf{pk} = \text{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x,
+    /// \mathsf{nk})$$
     ///
-    /// BLAKE2b-512 of $(\mathsf{sk} \| \texttt{0x0b})$, reduced to
-    /// $\mathbb{F}_p$ via `from_uniform_bytes`.
-    ///
-    /// This is deterministic: every note from the same `sk` shares the
-    /// same `pk`. Tachyon removes per-note diversification from the core
-    /// protocol; the wallet layer handles unlinkability via out-of-band
-    /// payment protocols ("Tachyaction at a Distance", Bowe 2025).
+    /// Derives `ak` and `nk` from `sk`, then computes `pk` via Poseidon.
+    /// This binds `pk` to both spending authority and nullifier derivation,
+    /// so `cm` (which contains `pk`) transitively pins the full proof
+    /// authorizing key to the accumulator.
     #[must_use]
     pub fn derive_payment_key(&self) -> PaymentKey {
-        PaymentKey(Fp::from_uniform_bytes(&PrfExpand::PK.with(&self.0)))
+        let ak = self.derive_auth_private().derive_auth_public();
+        let nk = self.derive_nullifier_private();
+        PaymentKey::derive(&ak, &nk)
     }
 
     /// Derive the proof authorizing key (`ak` + `nk`) for delegated proof

--- a/crates/tachyon/src/keys/proof.rs
+++ b/crates/tachyon/src/keys/proof.rs
@@ -1,6 +1,9 @@
 //! Proof-related keys: ProofAuthorizingKey.
 
-use super::{note::NullifierKey, public};
+use super::{
+    note::{NullifierKey, PaymentKey},
+    public,
+};
 use crate::{entropy::ActionRandomizer, primitives::effect, reddsa};
 
 /// The proof authorizing key (`ak` + `nk`).
@@ -39,6 +42,14 @@ impl ProofAuthorizingKey {
     #[must_use]
     pub const fn nk(&self) -> &NullifierKey {
         &self.nk
+    }
+
+    /// Derive the payment key $\mathsf{pk}$ from `ak` and `nk`.
+    ///
+    /// Allows the pak holder to compute `pk` without access to `sk`.
+    #[must_use]
+    pub fn derive_payment_key(&self) -> PaymentKey {
+        PaymentKey::derive(&self.ak, &self.nk)
     }
 }
 


### PR DESCRIPTION
Base https://github.com/tachyon-zcash/tachyon/pull/56

## Summary

- Derive `pk` from `(ak, nk)` via Poseidon instead of directly from `sk` via PRF, matching original intent
- Add `PaymentKey::derive(ak, nk)` and `ProofAuthorizingKey::derive_payment_key()`
- Remove `PrfExpand::PK`

## Motivation

The previous derivation (`pk = ToBase(PRF(sk, 0x0b))`) made `pk` independent of both `ak` and `nk`. This breaks the cryptographic binding between the payment key committed in notes and the proof authorizing key used for nullifier derivation.

Then, because `cm = Poseidon(pk, v, psi, rcm)` didn't relate to an `nk`, an arbitrary `nk` might 'prove' derivation of unrelated nullifiers for any given `cm`.

## Solution

Derive `pk = Poseidon(PK_DOMAIN, ak_x, nk)`. Since `pk` is already committed in `cm`, note commitments now transitively bind to both `ak` and `nk`, and proof steps may properly constrain note data.