### PR TITLE
accumulator

### DIFF
--- a/crates/tachyon/src/accumulator.rs
+++ b/crates/tachyon/src/accumulator.rs
@@ -1,0 +1,63 @@
+//! Running accumulator that folds batches of `Fp` elements into an `Fq` state.
+//!
+//! Each batch is Pedersen-committed as the coefficients of a polynomial with
+//! the batch elements as roots, and the resulting Vesta point is absorbed
+//! into the state via a Poseidon hash over `Fq`.
+
+use ff::{Field, PrimeField};
+use halo2_poseidon::{ConstantLength, Hash, P128Pow5T3};
+use pasta_curves::{EqAffine, Fp, Fq, arithmetic::CurveAffine as _};
+
+use crate::{Multiset, constants::ACCUMULATOR_DOMAIN};
+
+/// A running accumulator whose state is an `Fq` element at a given height.
+///
+/// Height is the number of batches that have been absorbed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Accumulator {
+    state: Fq,
+    height: u64,
+}
+
+impl Accumulator {
+    /// Initial accumulator (state `Fq::ZERO`, height `0`).
+    pub fn new() -> Self {
+        Self {
+            state: Fq::ZERO,
+            height: 0,
+        }
+    }
+
+    /// Absorb a batch of `Fp` elements, incrementing the height by one.
+    pub fn accumulate(self, elements: &[Fp]) -> Self {
+        let point = EqAffine::from(Multiset::<Fp>::from(elements).commit());
+        let coords = point
+            .coordinates()
+            .into_option()
+            .expect("pedersen commitment is the identity point");
+        #[expect(clippy::little_endian_bytes, reason = "specified behavior")]
+        let domain = Fq::from_u128(u128::from_le_bytes(*ACCUMULATOR_DOMAIN));
+        let next = Hash::<Fq, P128Pow5T3, ConstantLength<4>, 3, 2>::init()
+            .hash([domain, self.state, *coords.x(), *coords.y()]);
+        Self {
+            state: next,
+            height: self.height + 1,
+        }
+    }
+
+    /// Return the current `Fq` state of the accumulator.
+    pub fn state(&self) -> Fq {
+        self.state
+    }
+
+    /// Return the number of batches that have been absorbed.
+    pub fn height(&self) -> u64 {
+        self.height
+    }
+}
+
+impl Default for Accumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/tachyon/src/constants.rs
+++ b/crates/tachyon/src/constants.rs
@@ -61,6 +61,9 @@ pub const ACTION_DIGEST_PERSONALIZATION: &[u8; 16] = b"Tachyon-ActnDgst";
 /// \text{Poseidon}(\text{domain}, ak_x, nk)$.
 pub const PAYMENT_KEY_DOMAIN: &[u8; 16] = b"Tachyon-PkDerive";
 
+/// Poseidon domain tag for the Fq accumulator state transition.
+pub const ACCUMULATOR_DOMAIN: &[u8; 16] = b"Tachyon-AccState";
+
 /// Maximum note value in zatoshis (§5.3 of the protocol spec)
 pub const NOTE_VALUE_MAX: u64 = 2_100_000_000_000_000;
 

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -49,6 +49,7 @@ macro_rules! todo {
     };
 }
 
+pub mod accumulator;
 pub mod action;
 pub mod bundle;
 pub mod constants;


### PR DESCRIPTION
Stores the height and state of the accumulator as a `u64` and `Fq` element, obtained from the Poseidon hash of the concatenation of the previous accumulator state and a pedersen commitment to the coefficients of a polynomial with roots at the accumulated Fp values.