### PR TITLE
use no-std friendly io::Error constructor

### DIFF
--- a/crates/mock_ragu/src/tests/application.rs
+++ b/crates/mock_ragu/src/tests/application.rs
@@ -235,15 +235,9 @@ fn different_merge_trees_same_header() {
         .finalize()
         .expect("finalize");
 
-    let (pa, ()) = app
-        .seed(&mut thread_rng(), SeedStep, 1u64)
-        .expect("seed a");
-    let (pb, ()) = app
-        .seed(&mut thread_rng(), SeedStep, 2u64)
-        .expect("seed b");
-    let (pc, ()) = app
-        .seed(&mut thread_rng(), SeedStep, 3u64)
-        .expect("seed c");
+    let (pa, ()) = app.seed(&mut thread_rng(), SeedStep, 1u64).expect("seed a");
+    let (pb, ()) = app.seed(&mut thread_rng(), SeedStep, 2u64).expect("seed b");
+    let (pc, ()) = app.seed(&mut thread_rng(), SeedStep, 3u64).expect("seed c");
 
     // Tree shape 1: fuse(fuse(a, b), c)
     let pcd_a1 = pa.clone().carry::<TestHeader>(TestHeaderData { value: 1 });

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -91,19 +91,6 @@ enum BundleState {
     Stripped = 0b0000_0010,
 }
 
-impl TryFrom<u8> for BundleState {
-    type Error = ();
-
-    fn try_from(byte: u8) -> Result<Self, Self::Error> {
-        match byte {
-            | 0b0000_0000 => Ok(Self::NoBundle),
-            | 0b0000_0001 => Ok(Self::Stamped),
-            | 0b0000_0010 => Ok(Self::Stripped),
-            | _other => Err(()),
-        }
-    }
-}
-
 impl From<BundleState> for u8 {
     fn from(state: BundleState) -> Self {
         match state {
@@ -731,8 +718,17 @@ impl From<Signature> for [u8; 64] {
 fn read_bundle_head<R: Read>(mut reader: R) -> io::Result<BundleState> {
     let mut byte = [0u8; 1];
     reader.read_exact(&mut byte)?;
-    BundleState::try_from(byte[0])
-        .map_err(|_err| io::Error::new(io::ErrorKind::InvalidData, "invalid bundle state"))
+    match byte[0] {
+        | 0b0000_0000 => Ok(BundleState::NoBundle),
+        | 0b0000_0001 => Ok(BundleState::Stamped),
+        | 0b0000_0010 => Ok(BundleState::Stripped),
+        | _other => {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid bundle state",
+            ))
+        },
+    }
 }
 
 /// Read bundle fields: value balance, action descriptors, action sigs,
@@ -743,7 +739,12 @@ fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, i64, Sig
     let value_balance = i64::from_le_bytes(vb_bytes);
 
     let n_actions =
-        usize::try_from(serialization::read_compactsize(&mut reader)?).map_err(io::Error::other)?;
+        usize::try_from(serialization::read_compactsize(&mut reader)?).map_err(|_err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "actions vector length exceeds usize",
+            )
+        })?;
 
     let mut descriptors = Vec::with_capacity(n_actions);
     for _ in 0..n_actions {
@@ -808,7 +809,12 @@ fn write_bundle_body<W: Write>(
 
     serialization::write_compactsize(
         &mut writer,
-        u64::try_from(actions.len()).map_err(io::Error::other)?,
+        u64::try_from(actions.len()).map_err(|_err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "actions vector length exceeds u64",
+            )
+        })?,
     )?;
     for action in actions {
         serialization::write_ep_affine(&mut writer, &action.cv.0)?;

--- a/crates/tachyon/src/serialization/mod.rs
+++ b/crates/tachyon/src/serialization/mod.rs
@@ -50,7 +50,9 @@ pub(crate) fn read_fp<R: Read>(mut reader: R) -> io::Result<Fp> {
 }
 
 pub(crate) fn read_fp_list<R: Read>(mut reader: R) -> io::Result<Vec<Fp>> {
-    let n = usize::try_from(read_compactsize(&mut reader)?).map_err(io::Error::other)?;
+    let n = usize::try_from(read_compactsize(&mut reader)?).map_err(|_err| {
+        io::Error::new(io::ErrorKind::InvalidData, "vector length exceeds usize")
+    })?;
     let mut fp_list = Vec::with_capacity(n);
     for _ in 0..n {
         let fp = read_fp(&mut reader)?;
@@ -62,7 +64,9 @@ pub(crate) fn read_fp_list<R: Read>(mut reader: R) -> io::Result<Vec<Fp>> {
 pub(crate) fn write_fp_list<W: Write>(mut writer: W, fp_list: &[Fp]) -> io::Result<()> {
     write_compactsize(
         &mut writer,
-        u64::try_from(fp_list.len()).map_err(io::Error::other)?,
+        u64::try_from(fp_list.len()).map_err(|_err| {
+            io::Error::new(io::ErrorKind::InvalidData, "vector length exceeds u64")
+        })?,
     )?;
     for fp in fp_list {
         write_fp(&mut writer, fp)?;

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -106,16 +106,16 @@ impl Step for SpendableInit {
         }
 
         if pool.0.commit() != anchor.1.0 {
-            return Err(mock_ragu::Error("SpendableInit: pool must commit to anchor"));
+            return Err(mock_ragu::Error(
+                "SpendableInit: pool must commit to anchor",
+            ));
         }
 
         if pool.0.query(Fp::from(cm_tg)) != Fp::ZERO {
             return Err(mock_ragu::Error("SpendableInit: cm not in pool"));
         }
         if pool.0.query(Fp::from(nf)) == Fp::ZERO {
-            return Err(mock_ragu::Error(
-                "SpendableInit: nullifier already in pool",
-            ));
+            return Err(mock_ragu::Error("SpendableInit: nullifier already in pool"));
         }
 
         Ok(((nf, anchor), ()))


### PR DESCRIPTION
The current method of constructing `io::Error`s is not no_std friendly, here's a fix for that.