### PR TITLE
update core2 to corez

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,13 +67,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "core2"
-version = "0.3.3"
+name = "corez"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
-dependencies = [
- "memchr",
-]
+checksum = "4df6f98652d30167eaeea34d77b730e07c8caba6df17bd4551842b9b8da01deb"
 
 [[package]]
 name = "ff"
@@ -160,12 +157,6 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
-
-[[package]]
-name = "memchr"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mock_ragu"
@@ -386,7 +377,7 @@ name = "zcash_tachyon"
 version = "0.0.0"
 dependencies = [
  "blake2b_simd",
- "core2",
+ "corez",
  "ff",
  "group",
  "halo2_poseidon",

--- a/crates/tachyon/Cargo.toml
+++ b/crates/tachyon/Cargo.toml
@@ -29,7 +29,7 @@ std = [
     "mock_ragu/std",
     "rand_core/std",
     "reddsa/std",
-    "core2/std",
+    "corez/std",
 ]
 
 [lints]
@@ -37,7 +37,7 @@ workspace = true
 
 [dependencies]
 blake2b_simd = { version = "1.0", default-features = false }
-core2 = { version = "0.3", default-features = false, features = [
+corez = { version = "0.1.1", default-features = false, features = [
     "alloc",
 ] }
 ff = "0.13"

--- a/crates/tachyon/src/bundle.rs
+++ b/crates/tachyon/src/bundle.rs
@@ -64,7 +64,7 @@
 use alloc::vec::Vec;
 use core::{error::Error, fmt};
 
-use core2::io::{self, Read, Write};
+use corez::io::{self, Read, Write};
 use ff::{Field as _, PrimeField as _};
 use group::GroupEncoding as _;
 use lazy_static::lazy_static;
@@ -833,7 +833,8 @@ fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, i64, Sig
     let value_balance = i64::from_le_bytes(vb_bytes);
 
     let n_actions =
-        usize::try_from(serialization::read_compactsize(&mut reader)?).map_err(io::Error::other)?;
+        usize::try_from(serialization::read_compactsize(&mut reader)?)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
     let mut descriptors = Vec::with_capacity(n_actions);
     for _ in 0..n_actions {
@@ -898,7 +899,7 @@ fn write_bundle_body<W: Write>(
 
     serialization::write_compactsize(
         &mut writer,
-        u64::try_from(actions.len()).map_err(io::Error::other)?,
+        u64::try_from(actions.len()).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?,
     )?;
     for action in actions {
         serialization::write_ep_affine(&mut writer, &action.cv.0)?;

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -1,4 +1,4 @@
-use core2::io::{self, Read, Write};
+use corez::io::{self, Read, Write};
 use mock_ragu::Commitment;
 
 use super::{BlockHeight, PoolCommit};

--- a/crates/tachyon/src/serialization/compactsize.rs
+++ b/crates/tachyon/src/serialization/compactsize.rs
@@ -8,7 +8,7 @@
 
 use core::{num::TryFromIntError, ops::RangeInclusive};
 
-use core2::io::{self, Read, Write};
+use corez::io::{self, Read, Write};
 
 #[derive(Debug)]
 pub(crate) enum CompactSizeError {

--- a/crates/tachyon/src/serialization/mod.rs
+++ b/crates/tachyon/src/serialization/mod.rs
@@ -8,7 +8,7 @@
 
 use alloc::vec::Vec;
 
-use core2::io::{self, Read, Write};
+use corez::io::{self, Read, Write};
 use ff::PrimeField as _;
 use pasta_curves::{EpAffine, Fp, Fq, group::GroupEncoding as _};
 
@@ -50,7 +50,8 @@ pub(crate) fn read_fp<R: Read>(mut reader: R) -> io::Result<Fp> {
 }
 
 pub(crate) fn read_fp_list<R: Read>(mut reader: R) -> io::Result<Vec<Fp>> {
-    let n = usize::try_from(read_compactsize(&mut reader)?).map_err(io::Error::other)?;
+    let n = usize::try_from(read_compactsize(&mut reader)?)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     let mut fp_list = Vec::with_capacity(n);
     for _ in 0..n {
         let fp = read_fp(&mut reader)?;
@@ -62,7 +63,7 @@ pub(crate) fn read_fp_list<R: Read>(mut reader: R) -> io::Result<Vec<Fp>> {
 pub(crate) fn write_fp_list<W: Write>(mut writer: W, fp_list: &[Fp]) -> io::Result<()> {
     write_compactsize(
         &mut writer,
-        u64::try_from(fp_list.len()).map_err(io::Error::other)?,
+        u64::try_from(fp_list.len()).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?,
     )?;
     for fp in fp_list {
         write_fp(&mut writer, fp)?;

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -20,7 +20,7 @@ pub mod proof;
 use alloc::vec::Vec;
 use core::{error::Error, fmt};
 
-use core2::io::{self, Read, Write};
+use corez::io::{self, Read, Write};
 use ff::Field as _;
 use mock_ragu::{self, proof::PROOF_SIZE_COMPRESSED};
 use pasta_curves::Fp;


### PR DESCRIPTION
`core2` was yanked, update to the ZCash-flavored replacement, `corez`.

this builds on https://github.com/tachyon-zcash/tachyon/pull/65 which fixes no-std builds.