### PR TITLE
Remove section: `nullifier-derivation` from `SUMMARY.md`

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,7 +10,6 @@
 - [Cryptographic Primitives]()
   - [Key Hierarchy](keys.md)
   - [Notes](notes.md)
-  - [Nullifier Derivation](nullifier-derivation.md)
 - [Protocol]()
   - [Authorization](authorization.md)
   - [Aggregation](aggregation.md)


### PR DESCRIPTION
`nullifier-derivation.md` was removed in https://github.com/tachyon-zcash/tachyon/pull/62/changes#diff-42fc5bbb57368c55d758ade6edb6d3e3860e5bc3dfc861d291d6a8dcbc9caffa.

But `SUMMARY.md` hadn't reflected the change, resulting in an untracked placeholder file `nullifier-derivation.md` always being created.

The PR removes it from `SUMMARY.md` table of contents.