### PR TITLE
Mock Ragu: serialization roundtrip tests

### DIFF
--- a/crates/mock_ragu/src/tests/application.rs
+++ b/crates/mock_ragu/src/tests/application.rs
@@ -354,8 +354,7 @@ fn serialized_proof_still_verifies() {
     let saved_data = pcd.data.clone();
 
     let bytes: [u8; PROOF_SIZE_COMPRESSED] = pcd.proof.into();
-    let recovered_proof =
-        Proof::try_from(&bytes).expect("recovered proof should deserialize");
+    let recovered_proof = Proof::try_from(&bytes).expect("recovered proof should deserialize");
 
     let recovered_pcd = recovered_proof.carry::<TestHeader>(saved_data);
     let valid = app
@@ -377,8 +376,7 @@ fn serialized_proof_rejects_mismatched_header_data() {
         .expect("seed should succeed");
 
     let bytes: [u8; PROOF_SIZE_COMPRESSED] = pcd.proof.into();
-    let recovered_proof =
-        Proof::try_from(&bytes).expect("recovered proof should deserialize");
+    let recovered_proof = Proof::try_from(&bytes).expect("recovered proof should deserialize");
 
     let bad_pcd = recovered_proof.carry::<TestHeader>(TestHeaderData { value: 999 });
     let valid = app

--- a/crates/mock_ragu/src/tests/application.rs
+++ b/crates/mock_ragu/src/tests/application.rs
@@ -6,6 +6,7 @@ use crate::{
     application::*,
     error::Result,
     header::{Header, Suffix},
+    proof::{PROOF_SIZE_COMPRESSED, Proof},
     step::{Index, Step},
 };
 
@@ -337,6 +338,56 @@ fn aux_data_flows_through_seed_and_fuse() {
     assert_eq!(reconstructed_value, 25);
     let valid = app.verify(&merged_pcd, thread_rng()).expect("verify");
     assert!(valid, "fused proof must verify");
+}
+
+#[test]
+fn serialized_proof_still_verifies() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register should succeed")
+        .finalize()
+        .expect("finalize should succeed");
+
+    let (pcd, ()) = app
+        .seed(&mut thread_rng(), SeedStep, 42u64)
+        .expect("seed should succeed");
+    let saved_data = pcd.data.clone();
+
+    let bytes: [u8; PROOF_SIZE_COMPRESSED] = pcd.proof.into();
+    let recovered_proof =
+        Proof::try_from(&bytes).expect("recovered proof should deserialize");
+
+    let recovered_pcd = recovered_proof.carry::<TestHeader>(saved_data);
+    let valid = app
+        .verify(&recovered_pcd, thread_rng())
+        .expect("verify should succeed");
+    assert!(valid, "round-tripped proof should still verify");
+}
+
+#[test]
+fn serialized_proof_rejects_mismatched_header_data() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register should succeed")
+        .finalize()
+        .expect("finalize should succeed");
+
+    let (pcd, ()) = app
+        .seed(&mut thread_rng(), SeedStep, 42u64)
+        .expect("seed should succeed");
+
+    let bytes: [u8; PROOF_SIZE_COMPRESSED] = pcd.proof.into();
+    let recovered_proof =
+        Proof::try_from(&bytes).expect("recovered proof should deserialize");
+
+    let bad_pcd = recovered_proof.carry::<TestHeader>(TestHeaderData { value: 999 });
+    let valid = app
+        .verify(&bad_pcd, thread_rng())
+        .expect("verify should succeed");
+    assert!(
+        !valid,
+        "round-tripped proof must still reject mismatched header data"
+    );
 }
 
 #[test]

--- a/crates/mock_ragu/src/tests/application.rs
+++ b/crates/mock_ragu/src/tests/application.rs
@@ -391,6 +391,24 @@ fn serialized_proof_rejects_mismatched_header_data() {
 }
 
 #[test]
+fn tampered_serialized_proof_fails_to_deserialize() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register should succeed")
+        .finalize()
+        .expect("finalize should succeed");
+
+    let (pcd, ()) = app
+        .seed(&mut thread_rng(), SeedStep, 42u64)
+        .expect("seed should succeed");
+
+    let mut bytes: [u8; PROOF_SIZE_COMPRESSED] = pcd.proof.into();
+    bytes[0] ^= 0xFFu8;
+    Proof::try_from(&bytes)
+        .expect_err("tampered proof bytes must be rejected before reaching verify");
+}
+
+#[test]
 fn rerandomize_preserves_validity() {
     let app = ApplicationBuilder::new()
         .register(SeedStep)


### PR DESCRIPTION
The existing `tests/proof.rs::round_trip` confirms that a serialized
`Proof` decodes back to a byte-identical original, and the `*_then_verify`
tests in `tests/application.rs` confirm that in-memory `Pcd`s pass
`Application::verify`. Nothing connected the two: no test confirmed that a
proof recovered from its serialized form, reattached to its header data
via `Proof::carry`, still passes `Application::verify`. That is the
operationally meaningful round-trip, since verifiers and wallets exchange
bytes, not in-memory structures.

Three tests added to [tests/application.rs](crates/mock_ragu/src/tests/application.rs):

- `serialized_proof_still_verifies`: seed a `Pcd`, push the proof through
  `Into<[u8; PROOF_SIZE_COMPRESSED]> → TryFrom`, reattach the saved header
  data via `carry`, expect `verify → true`.
- `serialized_proof_rejects_mismatched_header_data`: same round-trip, but
  reattach a different `TestHeaderData` post-recovery. Expect
  `verify → false`, confirming the header-hash check still bites after a
  round-trip.
- `tampered_serialized_proof_fails_to_deserialize`: seed a `Pcd`, flip a
  byte in the header_hash region of the serialized form, expect
  `Proof::try_from` to error. Confirms that the binding-hash guard in
  `TryFrom` ([proof.rs:118-121](crates/mock_ragu/src/proof.rs#L118-L121))
  rejects tampered bytes before they ever reach `verify`, using an
  `Application`-built proof rather than the hand-rolled one already
  covered by `tests/proof.rs::tampered_fails`.

Together the three give the full defence-in-depth coverage: clean
round-trip verifies, wrong context is caught at `verify`, byte tampering
is caught at `TryFrom`.

## Test plan

- [x] `just test`
- [x] `just lint`
