### PR TITLE
introduce `CloseBlockSeed` and `CloseBlockUnspentSeed`

### DIFF
--- a/crates/tachyon/src/digest/poseidon.rs
+++ b/crates/tachyon/src/digest/poseidon.rs
@@ -119,14 +119,18 @@ pub(crate) fn anchor_stamp_step(anchor_prev: Fp, tgs: Coordinates<EqAffine>) -> 
     ])
 }
 
-const ANCHOR_EMPTY_DOMAIN: &[u8; 16] = b"Tachyon-EmptyBlk";
+const ANCHOR_CLOSE_DOMAIN: &[u8; 16] = b"Tachyon-BlockEnd";
 
-/// Advances the anchor through one block that contains zero stamps.
+/// Closes a block: absorbs the block's epoch index into the running anchor.
+///
+/// Runs exactly once per block at end-of-block, after any stamp absorbs.
+/// A block with zero stamps still runs this step on its starting anchor.
 #[must_use]
-pub(crate) fn anchor_empty_step(anchor_prev: Fp) -> Fp {
-    hash::<2>([
-        Fp::from_u128(u128::from_le_bytes(*ANCHOR_EMPTY_DOMAIN)),
+pub(crate) fn anchor_close_step(anchor_prev: Fp, epoch_index: u32) -> Fp {
+    hash::<3>([
+        Fp::from_u128(u128::from_le_bytes(*ANCHOR_CLOSE_DOMAIN)),
         anchor_prev,
+        Fp::from(u64::from(epoch_index)),
     ])
 }
 

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -218,12 +218,11 @@ impl PoolSim {
     #[must_use]
     pub fn anchor_at(&self, height: BlockHeight) -> Anchor {
         let prev = self.prev_anchor_at(height);
-        let commits = self.stamp_commits_at(height);
-        if commits.is_empty() {
-            prev.next_empty()
-        } else {
-            commits.iter().fold(prev, Anchor::next_stamp)
-        }
+        let intra = self
+            .stamp_commits_at(height)
+            .iter()
+            .fold(prev, Anchor::next_stamp);
+        intra.close_block(height.epoch())
     }
 
     /// Resolve the height at which `anchor` was produced. `block.prev` already
@@ -269,9 +268,9 @@ impl PoolSim {
 /// Build an [`AnchorChain`] covering blocks `range`, rooted at the
 /// block-start anchor of `*range.start()`.
 ///
-/// Per non-empty block: one [`AnchorSeed`] per stamp, fused via
-/// [`AnchorFuse`]. Per empty block: one [`EmptyBlockSeed`].
-/// All segments fused linearly.
+/// Per block: zero or more [`AnchorSeed`]s (one per stamp) followed by
+/// one [`CloseBlockSeed`] absorbing the block's epoch. All segments fused
+/// linearly via [`AnchorFuse`].
 pub(crate) fn build_anchor_chain_pcd<'source>(
     rng: &mut (impl RngCore + CryptoRng),
     pool: &PoolSim,
@@ -287,11 +286,12 @@ pub(crate) fn build_anchor_chain_pcd<'source>(
     let mut height = start;
     loop {
         let commits = pool.stamp_commits_at(height);
-        if commits.is_empty() {
-            let next_state = state.next_empty();
+        let epoch = height.epoch();
+        for commit in commits {
+            let next_state = state.next_stamp(&commit);
             let (seed, ()) = PROOF_SYSTEM
-                .seed(rng, pool::EmptyBlockSeed, (state,))
-                .expect("EmptyBlockSeed");
+                .seed(rng, pool::AnchorSeed, (state, commit))
+                .expect("AnchorSeed");
             chain = Some(match chain.take() {
                 | None => seed,
                 | Some(left) => {
@@ -302,24 +302,21 @@ pub(crate) fn build_anchor_chain_pcd<'source>(
                 },
             });
             state = next_state;
-        } else {
-            for commit in commits {
-                let next_state = state.next_stamp(&commit);
-                let (seed, ()) = PROOF_SYSTEM
-                    .seed(rng, pool::AnchorSeed, (state, commit))
-                    .expect("AnchorSeed");
-                chain = Some(match chain.take() {
-                    | None => seed,
-                    | Some(left) => {
-                        let (fused, ()) = PROOF_SYSTEM
-                            .fuse(rng, pool::AnchorFuse, (), left, seed)
-                            .expect("AnchorFuse");
-                        fused
-                    },
-                });
-                state = next_state;
-            }
         }
+        let next_state = state.close_block(epoch);
+        let (close_seed, ()) = PROOF_SYSTEM
+            .seed(rng, pool::CloseBlockSeed, (state, epoch))
+            .expect("CloseBlockSeed");
+        chain = Some(match chain.take() {
+            | None => close_seed,
+            | Some(left) => {
+                let (fused, ()) = PROOF_SYSTEM
+                    .fuse(rng, pool::AnchorFuse, (), left, close_seed)
+                    .expect("AnchorFuse");
+                fused
+            },
+        });
+        state = next_state;
         if height >= end {
             break;
         }
@@ -342,10 +339,10 @@ pub(crate) fn build_unspent_seed_pcd<'source>(
     pcd
 }
 
-/// Build an [`Unspent`] for `nf` covering blocks `range`. Per non-empty
-/// block: one [`UnspentSeed`] per stamp. Per empty block: one
-/// [`EmptyBlockUnspentSeed`]. All segments fused linearly via
-/// [`UnspentFuse`].
+/// Build an [`Unspent`] for `nf` covering blocks `range`. Per block:
+/// zero or more [`UnspentSeed`]s (one per stamp, each proving
+/// `nf ∉ stamp`) followed by one [`CloseBlockUnspentSeed`] absorbing
+/// the block's epoch. All segments fused linearly via [`UnspentFuse`].
 pub(crate) fn build_unspent_pcd<'source>(
     rng: &mut (impl RngCore + CryptoRng),
     pool: &PoolSim,
@@ -363,11 +360,10 @@ pub(crate) fn build_unspent_pcd<'source>(
     loop {
         let stamps = pool.tachygrams_at(height);
         let stamp_commits = pool.stamp_commits_at(height);
-        if stamps.is_empty() {
-            let next_state = state.next_empty();
-            let (seed, ()) = PROOF_SYSTEM
-                .seed(rng, pool::EmptyBlockUnspentSeed, (state, nf))
-                .expect("EmptyBlockUnspentSeed");
+        let epoch = height.epoch();
+        for (tgs, commit) in stamps.iter().zip(stamp_commits.iter()) {
+            let next_state = state.next_stamp(commit);
+            let seed = build_unspent_seed_pcd(rng, state, tgs, nf);
             chain = Some(match chain.take() {
                 | None => seed,
                 | Some(left) => {
@@ -378,22 +374,21 @@ pub(crate) fn build_unspent_pcd<'source>(
                 },
             });
             state = next_state;
-        } else {
-            for (tgs, commit) in stamps.iter().zip(stamp_commits.iter()) {
-                let next_state = state.next_stamp(commit);
-                let seed = build_unspent_seed_pcd(rng, state, tgs, nf);
-                chain = Some(match chain.take() {
-                    | None => seed,
-                    | Some(left) => {
-                        let (fused, ()) = PROOF_SYSTEM
-                            .fuse(rng, pool::UnspentFuse, (), left, seed)
-                            .expect("UnspentFuse");
-                        fused
-                    },
-                });
-                state = next_state;
-            }
         }
+        let next_state = state.close_block(epoch);
+        let (close_seed, ()) = PROOF_SYSTEM
+            .seed(rng, pool::CloseBlockUnspentSeed, (state, epoch, nf))
+            .expect("CloseBlockUnspentSeed");
+        chain = Some(match chain.take() {
+            | None => close_seed,
+            | Some(left) => {
+                let (fused, ()) = PROOF_SYSTEM
+                    .fuse(rng, pool::UnspentFuse, (), left, close_seed)
+                    .expect("UnspentFuse");
+                fused
+            },
+        });
+        state = next_state;
         if height >= end {
             break;
         }
@@ -539,15 +534,11 @@ impl WalletSim {
             )
             .expect("SpendableInit");
 
-        // If cm is the last stamp, post_cm_anchor is already the
-        // block-final anchor — no rest-of-block lift needed.
-        if cm_idx + 1 == stamps.len() {
-            return spendable;
-        }
-
-        // Build an Unspent over stamps cm_idx+1..end of the cm-block,
-        // chained from post_cm_anchor, then SpendableLift.
+        // Build an Unspent over stamps cm_idx+1..end of the cm-block
+        // followed by the block's close step, chained from post_cm_anchor.
+        // Every block closes, so this is always non-empty.
         let nf = spendable.data.0;
+        let epoch = height.epoch();
         let mut state = spendable.data.1;
         let mut acc: Option<Pcd<'source, pool::Unspent>> = None;
         for (tgs, commit) in stamps[cm_idx + 1..]
@@ -567,7 +558,18 @@ impl WalletSim {
             });
             state = next_state;
         }
-        let rest = acc.expect("rest-of-block has at least one stamp");
+        let (close_seed, ()) = PROOF_SYSTEM
+            .seed(rng, pool::CloseBlockUnspentSeed, (state, epoch, nf))
+            .expect("CloseBlockUnspentSeed");
+        let rest = match acc {
+            | None => close_seed,
+            | Some(left) => {
+                let (fused, ()) = PROOF_SYSTEM
+                    .fuse(rng, pool::UnspentFuse, (), left, close_seed)
+                    .expect("UnspentFuse");
+                fused
+            },
+        };
 
         let (lifted, ()) = PROOF_SYSTEM
             .fuse(rng, spendable::SpendableLift, (), spendable, rest)

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -10,9 +10,9 @@ use crate::{digest::poseidon, serialization};
 /// A Poseidon hash sequence with three domain-separated link types:
 ///
 /// - [`Anchor::next_stamp`] (`Tachyon-StampFld`) absorbs one stamp's
-///   tachygram-set commitment.
-/// - [`Anchor::next_empty`] (`Tachyon-EmptyBlk`) advances through one block
-///   that contains zero stamps, preserving per-height anchor uniqueness.
+///   tachygram-set commitment. Runs zero or more times per block.
+/// - [`Anchor::close_block`] (`Tachyon-BlockEnd`) closes a block, absorbing the
+///   block's epoch index. Runs exactly once per block, after any stamp absorbs.
 /// - [`Anchor::next_epoch`] (`Tachyon-EpochStp`) lifts across an epoch
 ///   boundary; performed by `SpendableRollover`.
 ///
@@ -35,10 +35,15 @@ impl Anchor {
         Self(poseidon::anchor_stamp_step(self.0, coords))
     }
 
-    /// Advance the anchor through one empty block (zero stamps).
+    /// Close a block by absorbing its epoch index into the running anchor.
+    ///
+    /// Runs exactly once per block, at end of block, after any stamp absorbs.
+    /// An empty block (zero stamps) runs this step directly on the block's
+    /// starting anchor; per-height uniqueness comes from chain continuity,
+    /// per-epoch domain separation from `epoch`.
     #[must_use]
-    pub fn next_empty(self) -> Self {
-        Self(poseidon::anchor_empty_step(self.0))
+    pub fn close_block(self, epoch: EpochIndex) -> Self {
+        Self(poseidon::anchor_close_step(self.0, epoch.0))
     }
 
     /// Lift the anchor across an epoch boundary into the new epoch's
@@ -130,28 +135,49 @@ mod tests {
         assert_ne!(forward, reverse);
     }
 
-    /// An empty-block tick changes the anchor.
+    /// A close-block step changes the anchor.
     #[test]
-    fn next_empty_advances_anchor() {
+    fn close_block_advances_anchor() {
         let start = Anchor::default();
-        assert_ne!(start, start.next_empty());
+        assert_ne!(start, start.close_block(EpochIndex(0)));
     }
 
-    /// Consecutive empty-block ticks produce distinct anchors.
+    /// Closing with distinct epoch indices produces distinct anchors.
     #[test]
-    fn consecutive_empty_distinct() {
-        let first = Anchor::default().next_empty();
-        let second = first.next_empty();
-        assert_ne!(first, second);
+    fn close_block_distinct_epochs() {
+        let start = Anchor::default();
+        let e0 = start.close_block(EpochIndex(0));
+        let e1 = start.close_block(EpochIndex(1));
+        assert_ne!(e0, e1);
     }
 
-    /// Empty-block tick is domain-separated from stamp absorption.
+    /// Closing twice on the same start with the same epoch yields the same
+    /// anchor.
     #[test]
-    fn next_empty_distinct_from_next_stamp() {
+    fn close_block_is_deterministic() {
+        let start = Anchor::default();
+        assert_eq!(
+            start.close_block(EpochIndex(7)),
+            start.close_block(EpochIndex(7)),
+        );
+    }
+
+    /// Close-block step is domain-separated from stamp absorption.
+    #[test]
+    fn close_block_distinct_from_next_stamp() {
         let rng = &mut StdRng::seed_from_u64(0);
         let stamp = TachygramSetCommit::from([Tachygram::from(Fp::random(&mut *rng))].as_slice());
-        let via_empty = Anchor::default().next_empty();
+        let via_close = Anchor::default().close_block(EpochIndex(0));
         let via_stamp = Anchor::default().next_stamp(&stamp);
-        assert_ne!(via_empty, via_stamp);
+        assert_ne!(via_close, via_stamp);
+    }
+
+    /// Close-block step is domain-separated from the epoch boundary step.
+    #[test]
+    fn close_block_distinct_from_next_epoch() {
+        let start = Anchor::default();
+        let via_close = start.close_block(EpochIndex(1));
+        let via_epoch = start.next_epoch(EpochIndex(1));
+        assert_ne!(via_close, via_epoch);
     }
 }

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -28,10 +28,10 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
         .register(delegation::DelegateNfPrefixStep)?
         .register(delegation::DelegateNullifierStep)?
         .register(pool::AnchorSeed)?
-        .register(pool::EmptyBlockSeed)?
+        .register(pool::CloseBlockSeed)?
         .register(pool::AnchorFuse)?
         .register(pool::UnspentSeed)?
-        .register(pool::EmptyBlockUnspentSeed)?
+        .register(pool::CloseBlockUnspentSeed)?
         .register(pool::UnspentFuse)?
         .register(spendable::SpendableInit)?
         .register(spendable::SpendableLift)?

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -5,11 +5,13 @@
 //! multi-stamp exclusion proof ([`Unspent`]) used by
 //! [`super::spendable::SpendableLift`] to advance a spendable.
 //!
-//! Anchor advances are single-level: every link absorbs one stamp's
-//! tachygram-set commitment into the running [`Anchor`] via
-//! [`Anchor::next_stamp`]. There is no per-block hash domain — block
-//! alignment is a consensus convention (validators check that anchor
-//! endpoints belong to the published per-block anchor sequence).
+//! Anchor advances are two-kind: zero or more per-stamp absorbs
+//! ([`Anchor::next_stamp`]) followed by exactly one block-closing step
+//! ([`Anchor::close_block`]) that absorbs the block's epoch index into
+//! the running [`Anchor`]. Block alignment is therefore both a
+//! hash-domain fact (close step has its own domain) and a consensus
+//! convention (validators still check that anchor endpoints belong to the
+//! published per-block anchor sequence).
 
 #![allow(clippy::module_name_repetitions, reason = "intentional names")]
 
@@ -23,7 +25,7 @@ use pasta_curves::Fp;
 
 use crate::{
     note::Nullifier,
-    primitives::{Anchor, TachygramSetCommit, TachygramSetGadget},
+    primitives::{Anchor, EpochIndex, TachygramSetCommit, TachygramSetGadget},
 };
 
 /// Anchor segment between two endpoints. Composable via [`AnchorFuse`].
@@ -41,7 +43,7 @@ use crate::{
 /// tachygram scan that catches any tachygram already published earlier
 /// in the epoch a stamp is lifted across. See the Tachygrams book chapter.
 ///
-/// `start` at the seed steps ([`AnchorSeed`] / [`EmptyBlockSeed`]) has
+/// `start` at the seed steps ([`AnchorSeed`] / [`CloseBlockSeed`]) has
 /// PCD lineage rooted in an unbound `start: Anchor` witness, so a
 /// standalone segment proves nothing about real coverage. Final binding
 /// closes when [`super::stamp::StampLift`] consumes the segment and the
@@ -51,9 +53,9 @@ pub struct AnchorChain;
 
 impl Header for AnchorChain {
     /// `(start, end)`. `start` roots in an unbound witness at [`AnchorSeed`] or
-    /// [`EmptyBlockSeed`] and flows to [`super::stamp::StampLift`] which must
+    /// [`CloseBlockSeed`] and flows to [`super::stamp::StampLift`] which must
     /// ultimately be checked by consensus. `end` is always computed in-circuit
-    /// as `start.next_stamp(...)` or `start.next_empty()`.
+    /// as `start.next_stamp(...)` or `start.close_block(...)`.
     type Data<'source> = (Anchor, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(5);
@@ -74,9 +76,10 @@ impl Header for AnchorChain {
 /// advances are continuous.
 ///
 /// Same-epoch is structurally guaranteed by GGM-binding of `nf` to one
-/// epoch and by the intra-epoch-only `Anchor::next_stamp` advances —
-/// crossing an epoch boundary requires matching a boundary anchor that
-/// no `Unspent` builder ever emits.
+/// epoch and by the intra-epoch-only `Anchor::next_stamp` /
+/// `Anchor::close_block` advances — crossing an epoch boundary requires
+/// matching a boundary anchor (via [`Anchor::next_epoch`]) that no
+/// `Unspent` builder ever emits.
 ///
 /// At the seed steps the PCD lineage of `nf` and `start` roots in
 /// freely-chosen witnesses. `nf`'s binding closes at the consumer
@@ -94,7 +97,7 @@ impl Header for Unspent {
     /// GGM-bound upstream). `start` roots in a seed witness, bound
     /// through the spendable lineage plus consensus anchor membership.
     /// `end` is always computed in-circuit as `start.next_stamp(...)`
-    /// or `start.next_empty()`.
+    /// or `start.close_block(...)`.
     type Data<'source> = (Nullifier, Anchor, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(6);
@@ -136,32 +139,32 @@ impl Step for AnchorSeed {
     }
 }
 
-/// One-empty-block [`AnchorChain`] seed. Witness `(start,)`; emit
-/// `(start, start.next_empty())`.
+/// Block-closing [`AnchorChain`] seed. Witness `(start, epoch)`; emit
+/// `(start, start.close_block(epoch))`.
 ///
-/// Advances the anchor through one block that contains zero stamps.
-/// Used alongside [`AnchorSeed`] when an anchor segment must traverse
-/// a mix of empty and non-empty blocks.
+/// Runs exactly once per block, after the block's [`AnchorSeed`]
+/// segments (zero for an empty block). Absorbs the block's epoch index
+/// into the anchor.
 #[derive(Debug)]
-pub struct EmptyBlockSeed;
+pub struct CloseBlockSeed;
 
-impl Step for EmptyBlockSeed {
+impl Step for CloseBlockSeed {
     type Aux<'source> = ();
     type Left = ();
     type Output = AnchorChain;
     type Right = ();
-    /// `(start,)`.
-    type Witness<'source> = (Anchor,);
+    /// `(start, epoch)`.
+    type Witness<'source> = (Anchor, EpochIndex);
 
     const INDEX: Index = Index::new(8);
 
     fn witness<'source>(
         &self,
-        (start,): Self::Witness<'source>,
+        (start, epoch): Self::Witness<'source>,
         _left: <Self::Left as Header>::Data<'source>,
         _right: <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        Ok(((start, start.next_empty()), ()))
+        Ok(((start, start.close_block(epoch)), ()))
     }
 }
 
@@ -227,35 +230,40 @@ impl Step for UnspentSeed {
     }
 }
 
-/// One-empty-block [`Unspent`] seed for any `nf`. No exclusion check is
-/// needed — an empty block contains no stamps, so any nf is trivially
-/// absent.
+/// Block-closing [`Unspent`] seed for any `nf`.
 ///
-/// Witness `(start, nf)`; emit `(nf, start, start.next_empty())`. An
-/// attacker can claim any nf at an empty-block segment, but the consumer
+/// No exclusion check is performed here: the close step absorbs only
+/// the block's epoch index, not any stamp tachygram set, so any nf is
+/// trivially absent at this link.
+///
+/// Witness `(start, epoch, nf)`; emit `(nf, start,
+/// start.close_block(epoch))`. Runs exactly once per block after any
+/// per-stamp [`UnspentSeed`] segments.
+///
+/// An attacker can claim any nf at a close segment, but the consumer
 /// (`SpendableLift`) checks `unspent.nf == spendable.nf` and the
-/// spendable's nf is GGM-bound upstream — so a fake-nf empty segment can
+/// spendable's nf is GGM-bound upstream, so a fake-nf close segment can
 /// only "advance" a non-existent fake spendable.
 #[derive(Debug)]
-pub struct EmptyBlockUnspentSeed;
+pub struct CloseBlockUnspentSeed;
 
-impl Step for EmptyBlockUnspentSeed {
+impl Step for CloseBlockUnspentSeed {
     type Aux<'source> = ();
     type Left = ();
     type Output = Unspent;
     type Right = ();
-    /// `(start, nf)`.
-    type Witness<'source> = (Anchor, Nullifier);
+    /// `(start, epoch, nf)`.
+    type Witness<'source> = (Anchor, EpochIndex, Nullifier);
 
     const INDEX: Index = Index::new(11);
 
     fn witness<'source>(
         &self,
-        (start, nf): Self::Witness<'source>,
+        (start, epoch, nf): Self::Witness<'source>,
         _left: <Self::Left as Header>::Data<'source>,
         _right: <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        Ok(((nf, start, start.next_empty()), ()))
+        Ok(((nf, start, start.close_block(epoch)), ()))
     }
 }
 

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -757,14 +757,17 @@ fn empty_block_anchor_unique_per_height() {
     let h1 = BlockHeight(1);
     let h2 = BlockHeight(2);
     assert_ne!(pool.anchor_at(h1), pool.anchor_at(h2));
-    // h2's anchor is h1's anchor advanced via next_empty.
-    assert_eq!(pool.anchor_at(h2), pool.anchor_at(h1).next_empty());
+    // h2's anchor is h1's anchor advanced via close_block.
+    assert_eq!(
+        pool.anchor_at(h2),
+        pool.anchor_at(h1).close_block(h2.epoch())
+    );
 }
 
 #[test]
 fn empty_block_unspent_lifts_spendable() {
     // Build a spendable, then lift it across an empty block via an
-    // Unspent built solely from EmptyBlockUnspentSeed.
+    // Unspent built solely from CloseBlockUnspentSeed.
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
     let note = user.random_note(rng, 100);
@@ -785,7 +788,7 @@ fn empty_block_unspent_lifts_spendable() {
     pool.mine(vec![]);
     let empty_height = pool.height();
 
-    // Build an Unspent over the empty block via EmptyBlockUnspentSeed,
+    // Build an Unspent over the empty block via CloseBlockUnspentSeed,
     // then lift the spendable.
     let nf = spendable.data.0;
     let unspent = build_unspent_pcd(rng, &pool, nf, empty_height..=empty_height);
@@ -793,6 +796,9 @@ fn empty_block_unspent_lifts_spendable() {
         .fuse(rng, spendable::SpendableLift, (), spendable, unspent)
         .expect("SpendableLift across empty block");
 
-    assert_eq!(lifted.data.1, spendable_anchor_before.next_empty());
+    assert_eq!(
+        lifted.data.1,
+        spendable_anchor_before.close_block(empty_height.epoch())
+    );
     assert_eq!(lifted.data.1, pool.anchor_at(empty_height));
 }


### PR DESCRIPTION
Exploration of #84.

Adds a domain-separated block-closing step to the anchor hash chain that absorbs `(prev_anchor, epoch_index)`. Replaces the empty-block sentinel: every block, empty or not, now ends with one `close_block` after any per-stamp absorbs. Per-height uniqueness already follows from chain continuity, so the only metadata the close step needs to commit is the block's epoch.

- `digest::poseidon`: `anchor_empty_step` → `anchor_close_step(prev, epoch_index)`, domain `Tachyon-BlockEnd`.
- `primitives::anchor`: `Anchor::next_empty` → `Anchor::close_block(epoch: EpochIndex)`. `Anchor::next_epoch` is unchanged.
- `stamp::proof::pool`: `EmptyBlockSeed` → `CloseBlockSeed` (witness `(start, epoch)`); `EmptyBlockUnspentSeed` → `CloseBlockUnspentSeed` (witness `(start, epoch, nf)`). PCD INDEXes retained. Output headers (`AnchorChain`, `Unspent`) unchanged.
- `stamp::proof::spendable`: unchanged. `SpendableRollover` still applies `Anchor::next_epoch` to produce `boundary_anchor` and `SpendableEpochLift` still consumes it — `next_epoch` remains the only cross-epoch gate.
- `fixtures`: `anchor_at`, `build_anchor_chain_pcd`, `build_unspent_pcd`, and `spendable_init` emit one close seed per block. `spendable_init`'s "skip lift when cm is last stamp" early return is gone; the close step is now always part of the cm-block's lift.

The proof tree handles anchors freely so didn't change much.

`SpendableInit` still witnesses at a sub-block state. `SpendableLift`, `SpendStamp`, `MergeStamp`, `StampLift`, and `OutputStamp` all carry and equality-check anchors without inspecting kind.

The usage pattern this implies is the one wallets and aggregators already follow: a spendable starts intra-block at `SpendableInit` and should be privately lifted, just now with one more fuse and `CloseBlockUnspentSeed`.

The logic of `Unspent` ranges didn't change, but likewise a `CloseBlockUnspentSeed` is necessary per block. Same for `AnchorChain` which gains a `CloseBlockSeed` per block.

## todo

- **Book updates.** `book/src/anchor.md`, `book/src/proof-tree.md`, `book/src/domain-separators.md` still describe the empty-block sentinel.
- **Primitive type split.** Possibly bring back `SubBlock` primitive.
- **Proof headers and steps.** Possibly restore distinct sub-block header types and restrict range proofs to full-block inputs only.
- **Proof logic improvements.** Once block boundaries commit to epoch, the proof tree may wish to open these commitments at consumers to constrain epoch directly — possibly subsuming `next_epoch` and the boundary-anchor gating at `SpendableRollover`/`SpendableEpochLift`.