### PR TITLE
Mock Ragu: add index enforcement

### DIFF
--- a/crates/mock_ragu/src/application.rs
+++ b/crates/mock_ragu/src/application.rs
@@ -1,42 +1,74 @@
 //! Mock PCD application — mirrors `ragu_pcd::Application`.
 
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, vec::Vec};
+use core::any::TypeId;
 
 use rand_core::CryptoRng;
 
 use crate::{
-    error::Result,
-    header::Header,
+    error::{Error, Result},
+    header::{Header, Suffix},
     proof::{self, PROOF_SIZE_COMPRESSED, Pcd, Proof},
     step::Step,
 };
 
 /// Mocks `ragu_pcd::ApplicationBuilder`.
-#[derive(Clone, Copy, Debug)]
-pub struct ApplicationBuilder;
+#[derive(Clone, Debug, Default)]
+pub struct ApplicationBuilder {
+    num_application_steps: usize,
+    header_map: BTreeMap<Suffix, TypeId>,
+}
 
 /// Mocks `ragu_pcd::Application`.
 #[derive(Clone, Copy, Debug)]
-pub struct Application;
+pub struct Application {
+    num_application_steps: usize,
+}
 
 impl ApplicationBuilder {
     #[must_use]
-    pub const fn new() -> Self {
-        Self
+    pub fn new() -> Self {
+        Self {
+            num_application_steps: 0,
+            header_map: BTreeMap::new(),
+        }
     }
 
-    pub fn register<S: Step>(self, _step: S) -> Result<Self> {
+    pub fn register<S: Step>(mut self, _step: S) -> Result<Self> {
+        S::INDEX.assert_sequential(self.num_application_steps)?;
+
+        self.prevent_duplicate_suffix::<S::Output>()?;
+        self.prevent_duplicate_suffix::<S::Left>()?;
+        self.prevent_duplicate_suffix::<S::Right>()?;
+
+        self.num_application_steps = self
+            .num_application_steps
+            .checked_add(1)
+            .ok_or(Error("registered step count overflow"))?;
         Ok(self)
     }
 
     pub fn finalize(self) -> Result<Application> {
-        Ok(Application)
+        Ok(Application {
+            num_application_steps: self.num_application_steps,
+        })
     }
-}
 
-impl Default for ApplicationBuilder {
-    fn default() -> Self {
-        Self::new()
+    fn prevent_duplicate_suffix<H: Header>(&mut self) -> Result<()> {
+        let suffix = H::SUFFIX;
+        let type_id = TypeId::of::<H>();
+        match self.header_map.get(&suffix) {
+            | Some(registered) if *registered != type_id => {
+                Err(Error(
+                    "two distinct Header implementations declared the same suffix",
+                ))
+            },
+            | Some(_) => Ok(()),
+            | None => {
+                self.header_map.insert(suffix, type_id);
+                Ok(())
+            },
+        }
     }
 }
 
@@ -67,30 +99,33 @@ impl Application {
 
         let encoded = S::Output::encode(&output_data);
 
-        // Witness data: concatenated serialized child proofs
         let left_bytes = left_proof.serialize();
         let right_bytes = right_proof.serialize();
         let mut witness_data = Vec::with_capacity(2 * PROOF_SIZE_COMPRESSED);
         witness_data.extend_from_slice(left_bytes.as_ref());
         witness_data.extend_from_slice(right_bytes.as_ref());
 
-        let proof_value = Proof::new(&encoded, &witness_data);
+        let proof_value = Proof::new(S::Output::SUFFIX, S::INDEX, &encoded, &witness_data);
         Ok((proof_value.carry::<S::Output>(output_data), aux))
     }
 
     pub fn verify<RNG: CryptoRng, H: Header>(&self, pcd: &Pcd<'_, H>, _rng: RNG) -> Result<bool> {
-        // Recompute header hash from the carried data
-        let encoded = H::encode(&pcd.data);
-        let expected_header_hash = proof::compute_header_hash(&encoded);
+        match pcd.proof.step_index.application() {
+            | Some(application_index) if application_index < self.num_application_steps => {},
+            | _ => return Ok(false),
+        }
 
+        let encoded = H::encode(&pcd.data);
+        let expected_header_hash = proof::compute_header_hash(H::SUFFIX, &encoded);
         if expected_header_hash != pcd.proof.header_hash {
             return Ok(false);
         }
 
-        // Verify binding consistency
-        let expected_binding =
-            proof::compute_binding(&pcd.proof.header_hash, &pcd.proof.witness_hash);
-
+        let expected_binding = proof::compute_binding(
+            pcd.proof.step_index,
+            &pcd.proof.header_hash,
+            &pcd.proof.witness_hash,
+        );
         Ok(expected_binding == pcd.proof.binding)
     }
 

--- a/crates/mock_ragu/src/header.rs
+++ b/crates/mock_ragu/src/header.rs
@@ -4,10 +4,11 @@ use alloc::vec::Vec;
 
 /// Number of internal header suffixes reserved by mock_ragu.
 ///
-/// Only the trivial header [`()`] uses an internal suffix; reserving a small
-/// range mirrors real ragu's value-space partition between internal and
-/// application suffixes.
-pub(crate) const NUM_INTERNAL_SUFFIXES: usize = 1;
+/// Mirrors real ragu's `InternalStepIndex` layout:
+/// - Slot 0: `Rerandomize` (reserved; mock rerandomize is a transformation,
+///   not a Step, but the slot stays reserved for migration parity).
+/// - Slot 1: trivial header [`()`].
+pub(crate) const NUM_INTERNAL_SUFFIXES: usize = 2;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 enum HeaderSuffix {
@@ -69,7 +70,7 @@ pub trait Header: Send + Sync + 'static {
 impl Header for () {
     type Data<'source> = ();
 
-    const SUFFIX: Suffix = Suffix::internal(0);
+    const SUFFIX: Suffix = Suffix::internal(1);
 
     fn encode(_data: &()) -> Vec<u8> {
         Vec::new()

--- a/crates/mock_ragu/src/header.rs
+++ b/crates/mock_ragu/src/header.rs
@@ -2,14 +2,59 @@
 
 use alloc::vec::Vec;
 
-/// Mirrors `ragu_pcd::header::Suffix`.
+/// Number of internal header suffixes reserved by mock_ragu.
+///
+/// Only the trivial header [`()`] uses an internal suffix; reserving a small
+/// range mirrors real ragu's value-space partition between internal and
+/// application suffixes.
+pub(crate) const NUM_INTERNAL_SUFFIXES: usize = 1;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Suffix(usize);
+enum HeaderSuffix {
+    Internal(usize),
+    Application(usize),
+}
+
+/// Mirrors `ragu_pcd::header::Suffix`.
+///
+/// Variants are crate-private. Construct via [`Suffix::new`] for application
+/// headers; only mock_ragu itself constructs internal-header suffixes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Suffix {
+    suffix: HeaderSuffix,
+}
 
 impl Suffix {
     #[must_use]
     pub const fn new(value: usize) -> Self {
-        Self(value)
+        Self {
+            suffix: HeaderSuffix::Application(value),
+        }
+    }
+
+    pub(crate) const fn internal(value: usize) -> Self {
+        assert!(
+            value < NUM_INTERNAL_SUFFIXES,
+            "invalid internal header suffix index"
+        );
+        Self {
+            suffix: HeaderSuffix::Internal(value),
+        }
+    }
+
+    /// Returns the encoded value mapping internal vs application into a
+    /// single `u64` namespace. Internal values occupy
+    /// `0..NUM_INTERNAL_SUFFIXES` and application values follow.
+    #[expect(
+        clippy::expect_used,
+        reason = "usize fits in u64 on all supported targets"
+    )]
+    pub(crate) fn get(self) -> u64 {
+        let value_usize = match self.suffix {
+            | HeaderSuffix::Internal(value) => value,
+            | HeaderSuffix::Application(value) => value + NUM_INTERNAL_SUFFIXES,
+        };
+        u64::try_from(value_usize).expect("suffix value fits in u64")
     }
 }
 
@@ -24,7 +69,7 @@ pub trait Header: Send + Sync + 'static {
 impl Header for () {
     type Data<'source> = ();
 
-    const SUFFIX: Suffix = Suffix(0);
+    const SUFFIX: Suffix = Suffix::internal(0);
 
     fn encode(_data: &()) -> Vec<u8> {
         Vec::new()

--- a/crates/mock_ragu/src/header.rs
+++ b/crates/mock_ragu/src/header.rs
@@ -5,8 +5,8 @@ use alloc::vec::Vec;
 /// Number of internal header suffixes reserved by mock_ragu.
 ///
 /// Mirrors real ragu's `InternalStepIndex` layout:
-/// - Slot 0: `Rerandomize` (reserved; mock rerandomize is a transformation,
-///   not a Step, but the slot stays reserved for migration parity).
+/// - Slot 0: `Rerandomize` (reserved; mock rerandomize is a transformation, not
+///   a Step, but the slot stays reserved for migration parity).
 /// - Slot 1: trivial header [`()`].
 pub(crate) const NUM_INTERNAL_SUFFIXES: usize = 2;
 

--- a/crates/mock_ragu/src/proof.rs
+++ b/crates/mock_ragu/src/proof.rs
@@ -2,28 +2,36 @@
 //!
 //! ## Serialized layout
 //!
-//! | Offset | Size | Content |
-//! |--------|------|---------|
-//! | 0..32 | 32 | header hash |
-//! | 32..64 | 32 | witness hash |
-//! | 64..96 | 32 | binding hash |
-//! | 96..128 | 32 | rerandomization tag |
-//! | 128..23000 | 22872 | zero padding |
+//! | Offset      | Size | Content                                            |
+//! |-------------|------|----------------------------------------------------|
+//! | 0..8        | 8    | step_index (u64 LE, value-space partitioned)       |
+//! | 8..40       | 32   | header hash                                        |
+//! | 40..72      | 32   | witness hash                                       |
+//! | 72..104     | 32   | binding hash                                       |
+//! | 104..136    | 32   | rerandomization tag                                |
+//! | 136..23000  | …    | zero padding                                       |
 
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec};
 
-use crate::header::Header;
+use crate::{
+    header::{Header, Suffix},
+    step::Index,
+};
 
 /// Compressed proof size in bytes.
 pub const PROOF_SIZE_COMPRESSED: usize = 23_000;
 
+const STEP_INDEX_SIZE: usize = 8;
+const HASH_SIZE: usize = 32;
+
 /// Mocks `ragu_pcd::Proof`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Proof {
-    pub(crate) header_hash: [u8; 32],
-    pub(crate) witness_hash: [u8; 32],
-    pub(crate) binding: [u8; 32],
-    pub(crate) rerand_tag: [u8; 32],
+    pub(crate) step_index: Index,
+    pub(crate) header_hash: [u8; HASH_SIZE],
+    pub(crate) witness_hash: [u8; HASH_SIZE],
+    pub(crate) binding: [u8; HASH_SIZE],
+    pub(crate) rerand_tag: [u8; HASH_SIZE],
 }
 
 /// Mocks `ragu_pcd::Pcd`.
@@ -45,19 +53,25 @@ impl<'source, H: Header> Clone for Pcd<'source, H> {
 impl Proof {
     #[must_use]
     pub fn trivial() -> Self {
-        Self::new(&[], &[])
+        Self::new(<() as Header>::SUFFIX, Index::internal(0), &[], &[])
     }
 
     #[must_use]
-    pub(crate) fn new(encoded_header: &[u8], witness_data: &[u8]) -> Self {
-        let header_hash = compute_header_hash(encoded_header);
+    pub(crate) fn new(
+        suffix: Suffix,
+        step_index: Index,
+        encoded_header: &[u8],
+        witness_data: &[u8],
+    ) -> Self {
+        let header_hash = compute_header_hash(suffix, encoded_header);
         let witness_hash = compute_witness_hash(witness_data);
-        let binding = compute_binding(&header_hash, &witness_hash);
+        let binding = compute_binding(step_index, &header_hash, &witness_hash);
         Self {
+            step_index,
             header_hash,
             witness_hash,
             binding,
-            rerand_tag: [0u8; 32],
+            rerand_tag: [0u8; HASH_SIZE],
         }
     }
 
@@ -69,25 +83,29 @@ impl Proof {
 
     /// Serialize into the full compressed proof buffer.
     #[must_use]
+    #[expect(
+        clippy::expect_used,
+        reason = "buffer is sized to PROOF_SIZE_COMPRESSED by construction"
+    )]
     pub fn serialize(&self) -> Box<[u8; PROOF_SIZE_COMPRESSED]> {
-        let mut bytes = [
-            self.header_hash,
-            self.witness_hash,
-            self.binding,
-            self.rerand_tag,
-        ]
-        .concat();
+        let mut bytes = vec::Vec::with_capacity(PROOF_SIZE_COMPRESSED);
+        bytes.extend_from_slice(&self.step_index.get().to_le_bytes());
+        bytes.extend_from_slice(&self.header_hash);
+        bytes.extend_from_slice(&self.witness_hash);
+        bytes.extend_from_slice(&self.binding);
+        bytes.extend_from_slice(&self.rerand_tag);
         bytes.resize(PROOF_SIZE_COMPRESSED, 0);
         bytes
             .into_boxed_slice()
             .try_into()
-            .expect("resized to PROOF_SIZE_COMPRESSED")
+            .expect("buffer sized to PROOF_SIZE_COMPRESSED")
     }
 
     #[must_use]
     pub(crate) fn rerandomize(&self) -> Self {
         let serialized = self.serialize();
         Self {
+            step_index: self.step_index,
             header_hash: self.header_hash,
             witness_hash: self.witness_hash,
             binding: self.binding,
@@ -106,68 +124,88 @@ impl TryFrom<&[u8; PROOF_SIZE_COMPRESSED]> for Proof {
     type Error = crate::error::Error;
 
     fn try_from(bytes: &[u8; PROOF_SIZE_COMPRESSED]) -> Result<Self, Self::Error> {
-        let mut fields = bytes
-            .chunks_exact(32)
-            .map(|chunk| chunk.try_into().expect("field is 32 bytes"));
+        let slice: &[u8] = bytes.as_slice();
+        let (step_index_bytes, rest) = slice
+            .split_first_chunk::<STEP_INDEX_SIZE>()
+            .ok_or(crate::error::Error("step_index slot missing"))?;
+        let (header_hash, rest) = rest
+            .split_first_chunk::<HASH_SIZE>()
+            .ok_or(crate::error::Error("header_hash slot missing"))?;
+        let (witness_hash, rest) = rest
+            .split_first_chunk::<HASH_SIZE>()
+            .ok_or(crate::error::Error("witness_hash slot missing"))?;
+        let (binding, rest) = rest
+            .split_first_chunk::<HASH_SIZE>()
+            .ok_or(crate::error::Error("binding slot missing"))?;
+        let (rerand_tag, _padding) = rest
+            .split_first_chunk::<HASH_SIZE>()
+            .ok_or(crate::error::Error("rerand_tag slot missing"))?;
 
-        let header_hash = fields.next().expect("field 0");
-        let witness_hash = fields.next().expect("field 1");
-        let binding = fields.next().expect("field 2");
-        let rerand_tag = fields.next().expect("field 3");
+        let step_index_value = u64::from_le_bytes(*step_index_bytes);
+        let step_index = Index::from_value(step_index_value)?;
 
-        let expected_binding = compute_binding(&header_hash, &witness_hash);
-        if expected_binding != binding {
+        let expected_binding = compute_binding(step_index, header_hash, witness_hash);
+        if expected_binding != *binding {
             return Err(crate::error::Error("mock_ragu internal binding mismatch"));
         }
 
         Ok(Self {
-            header_hash,
-            witness_hash,
-            binding,
-            rerand_tag,
+            step_index,
+            header_hash: *header_hash,
+            witness_hash: *witness_hash,
+            binding: *binding,
+            rerand_tag: *rerand_tag,
         })
     }
 }
 
-pub(crate) fn compute_header_hash(encoded: &[u8]) -> [u8; 32] {
+pub(crate) fn compute_header_hash(suffix: Suffix, encoded: &[u8]) -> [u8; HASH_SIZE] {
     let hash = blake2b_simd::Params::new()
-        .hash_length(32)
+        .hash_length(HASH_SIZE)
         .personal(b"MkRagu_HdrHash_\0")
-        .hash(encoded);
-    let mut out = [0u8; 32];
+        .to_state()
+        .update(&suffix.get().to_le_bytes())
+        .update(encoded)
+        .finalize();
+    let mut out = [0u8; HASH_SIZE];
     out.copy_from_slice(hash.as_bytes());
     out
 }
 
-pub(crate) fn compute_witness_hash(witness_bytes: &[u8]) -> [u8; 32] {
+pub(crate) fn compute_witness_hash(witness_bytes: &[u8]) -> [u8; HASH_SIZE] {
     let hash = blake2b_simd::Params::new()
-        .hash_length(32)
+        .hash_length(HASH_SIZE)
         .personal(b"MkRagu_Witness_\0")
         .hash(witness_bytes);
-    let mut out = [0u8; 32];
+    let mut out = [0u8; HASH_SIZE];
     out.copy_from_slice(hash.as_bytes());
     out
 }
 
-pub(crate) fn compute_binding(header_hash: &[u8; 32], witness_hash: &[u8; 32]) -> [u8; 32] {
+pub(crate) fn compute_binding(
+    step_index: Index,
+    header_hash: &[u8; HASH_SIZE],
+    witness_hash: &[u8; HASH_SIZE],
+) -> [u8; HASH_SIZE] {
     let hash = blake2b_simd::Params::new()
-        .hash_length(32)
+        .hash_length(HASH_SIZE)
         .personal(b"MkRagu_Binding_\0")
         .to_state()
+        .update(&step_index.get().to_le_bytes())
         .update(header_hash)
         .update(witness_hash)
         .finalize();
-    let mut out = [0u8; 32];
+    let mut out = [0u8; HASH_SIZE];
     out.copy_from_slice(hash.as_bytes());
     out
 }
 
-pub(crate) fn compute_rerand_tag(proof_bytes: &[u8]) -> [u8; 32] {
+pub(crate) fn compute_rerand_tag(proof_bytes: &[u8]) -> [u8; HASH_SIZE] {
     let hash = blake2b_simd::Params::new()
-        .hash_length(32)
+        .hash_length(HASH_SIZE)
         .personal(b"MkRagu_Rerand_\0\0")
         .hash(proof_bytes);
-    let mut out = [0u8; 32];
+    let mut out = [0u8; HASH_SIZE];
     out.copy_from_slice(hash.as_bytes());
     out
 }

--- a/crates/mock_ragu/src/proof.rs
+++ b/crates/mock_ragu/src/proof.rs
@@ -53,7 +53,7 @@ impl<'source, H: Header> Clone for Pcd<'source, H> {
 impl Proof {
     #[must_use]
     pub fn trivial() -> Self {
-        Self::new(<() as Header>::SUFFIX, Index::internal(0), &[], &[])
+        Self::new(<() as Header>::SUFFIX, Index::internal(1), &[], &[])
     }
 
     #[must_use]

--- a/crates/mock_ragu/src/step.rs
+++ b/crates/mock_ragu/src/step.rs
@@ -7,10 +7,11 @@ use crate::{
 
 /// Number of internal step indexes reserved by mock_ragu.
 ///
-/// Only the trivial step (used to seed [`crate::proof::Proof::trivial`]) is
-/// allocated; reserving a small range mirrors real ragu's value-space
-/// partition between internal and application steps.
-pub(crate) const NUM_INTERNAL_STEPS: usize = 1;
+/// Mirrors real ragu's `InternalStepIndex` layout:
+/// - Slot 0: `Rerandomize` (reserved; mock rerandomize is a transformation,
+///   not a Step, but the slot stays reserved for migration parity).
+/// - Slot 1: trivial step (used to seed [`crate::proof::Proof::trivial`]).
+pub(crate) const NUM_INTERNAL_STEPS: usize = 2;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 enum StepIndex {

--- a/crates/mock_ragu/src/step.rs
+++ b/crates/mock_ragu/src/step.rs
@@ -1,15 +1,98 @@
 //! Mock PCD step — mirrors `ragu_pcd::Step`.
 
-use crate::{error::Result, header::Header};
+use crate::{
+    error::{Error, Result},
+    header::Header,
+};
+
+/// Number of internal step indexes reserved by mock_ragu.
+///
+/// Only the trivial step (used to seed [`crate::proof::Proof::trivial`]) is
+/// allocated; reserving a small range mirrors real ragu's value-space
+/// partition between internal and application steps.
+pub(crate) const NUM_INTERNAL_STEPS: usize = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+enum StepIndex {
+    Internal(usize),
+    Application(usize),
+}
 
 /// Mirrors `ragu_pcd::step::Index`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct Index(usize);
+///
+/// Variants are crate-private. Construct via [`Index::new`] for application
+/// steps; only mock_ragu itself constructs internal-step indexes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Index {
+    index: StepIndex,
+}
 
 impl Index {
     #[must_use]
     pub const fn new(value: usize) -> Self {
-        Self(value)
+        Self {
+            index: StepIndex::Application(value),
+        }
+    }
+
+    pub(crate) const fn internal(value: usize) -> Self {
+        assert!(value < NUM_INTERNAL_STEPS, "invalid internal step index");
+        Self {
+            index: StepIndex::Internal(value),
+        }
+    }
+
+    /// Returns the encoded value mapping internal vs application into a
+    /// single `u64` namespace. Internal values occupy `0..NUM_INTERNAL_STEPS`
+    /// and application values follow.
+    #[expect(
+        clippy::expect_used,
+        reason = "usize fits in u64 on all supported targets"
+    )]
+    pub(crate) fn get(self) -> u64 {
+        let value_usize = match self.index {
+            | StepIndex::Internal(value) => value,
+            | StepIndex::Application(value) => value + NUM_INTERNAL_STEPS,
+        };
+        u64::try_from(value_usize).expect("step index fits in u64")
+    }
+
+    /// Returns the application offset (0-based) if this is an application
+    /// step, or `None` if it is internal.
+    pub(crate) fn application(self) -> Option<usize> {
+        match self.index {
+            | StepIndex::Application(value) => Some(value),
+            | StepIndex::Internal(_) => None,
+        }
+    }
+
+    /// Parses an [`Index`] from its `get()` value.
+    pub(crate) fn from_value(value: u64) -> Result<Self> {
+        let value_usize =
+            usize::try_from(value).map_err(|_err| Error("step index value exceeds usize"))?;
+        if value_usize < NUM_INTERNAL_STEPS {
+            return Ok(Self {
+                index: StepIndex::Internal(value_usize),
+            });
+        }
+        let application = value_usize
+            .checked_sub(NUM_INTERNAL_STEPS)
+            .ok_or(Error("step index value underflow"))?;
+        Ok(Self {
+            index: StepIndex::Application(application),
+        })
+    }
+
+    /// Mirrors `ragu_pcd::step::Index::assert_index`. Used during
+    /// registration to require sequential application indexes.
+    pub(crate) fn assert_sequential(self, expected: usize) -> Result<()> {
+        match self.index {
+            | StepIndex::Application(value) if value == expected => Ok(()),
+            | StepIndex::Application(_) => {
+                Err(Error("steps must be registered in sequential order"))
+            },
+            | StepIndex::Internal(_) => Err(Error("step INDEX must be application-defined")),
+        }
     }
 }
 

--- a/crates/mock_ragu/src/step.rs
+++ b/crates/mock_ragu/src/step.rs
@@ -8,8 +8,8 @@ use crate::{
 /// Number of internal step indexes reserved by mock_ragu.
 ///
 /// Mirrors real ragu's `InternalStepIndex` layout:
-/// - Slot 0: `Rerandomize` (reserved; mock rerandomize is a transformation,
-///   not a Step, but the slot stays reserved for migration parity).
+/// - Slot 0: `Rerandomize` (reserved; mock rerandomize is a transformation, not
+///   a Step, but the slot stays reserved for migration parity).
 /// - Slot 1: trivial step (used to seed [`crate::proof::Proof::trivial`]).
 pub(crate) const NUM_INTERNAL_STEPS: usize = 2;
 

--- a/crates/mock_ragu/src/tests/application.rs
+++ b/crates/mock_ragu/src/tests/application.rs
@@ -6,7 +6,7 @@ use crate::{
     application::*,
     error::Result,
     header::{Header, Suffix},
-    proof::{PROOF_SIZE_COMPRESSED, Proof},
+    proof::{PROOF_SIZE_COMPRESSED, Pcd, Proof},
     step::{Index, Step},
 };
 
@@ -261,7 +261,7 @@ impl Step for AuxSeedStep {
     type Right = ();
     type Witness<'source> = u64;
 
-    const INDEX: Index = Index::new(2);
+    const INDEX: Index = Index::new(0);
 
     fn witness<'source>(
         &self,
@@ -283,7 +283,7 @@ impl Step for AuxMergeStep {
     type Right = TestHeader;
     type Witness<'source> = (Vec<u64>, Vec<u64>);
 
-    const INDEX: Index = Index::new(3);
+    const INDEX: Index = Index::new(1);
 
     fn witness<'source>(
         &self,
@@ -429,5 +429,197 @@ fn rerandomize_preserves_validity() {
     assert_ne!(
         rerand_pcd.proof, original_proof,
         "rerandomization must change the proof"
+    );
+}
+
+/// Distinct Header type that declares the same `SUFFIX` value as `TestHeader`.
+struct ConflictingHeader;
+
+impl Header for ConflictingHeader {
+    type Data<'source> = TestHeaderData;
+
+    const SUFFIX: Suffix = Suffix::new(0);
+
+    fn encode(data: &Self::Data<'_>) -> Vec<u8> {
+        data.value.to_le_bytes().to_vec()
+    }
+}
+
+/// Second seed step claiming `Index::new(0)` for the duplicate-index test.
+struct DuplicateIndexStep;
+
+impl Step for DuplicateIndexStep {
+    type Aux<'source> = ();
+    type Left = ();
+    type Output = TestHeader;
+    type Right = ();
+    type Witness<'source> = ();
+
+    const INDEX: Index = Index::new(0);
+
+    fn witness<'source>(
+        &self,
+        _witness: Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data<'source>,
+        _right: <Self::Right as Header>::Data<'source>,
+    ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        Ok((TestHeaderData { value: 0 }, ()))
+    }
+}
+
+/// Seed step whose output is `ConflictingHeader` (which collides with
+/// `TestHeader::SUFFIX`).
+struct SuffixCollisionStep;
+
+impl Step for SuffixCollisionStep {
+    type Aux<'source> = ();
+    type Left = ();
+    type Output = ConflictingHeader;
+    type Right = ();
+    type Witness<'source> = ();
+
+    const INDEX: Index = Index::new(1);
+
+    fn witness<'source>(
+        &self,
+        _witness: Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data<'source>,
+        _right: <Self::Right as Header>::Data<'source>,
+    ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        Ok((TestHeaderData { value: 0 }, ()))
+    }
+}
+
+#[test]
+fn duplicate_index_rejects_registration() {
+    let result = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register first step should succeed")
+        .register(DuplicateIndexStep);
+    assert!(result.is_err(), "duplicate INDEX must be rejected");
+}
+
+#[test]
+fn non_sequential_index_rejects_registration() {
+    let result = ApplicationBuilder::new().register(MergeStep);
+    assert!(
+        result.is_err(),
+        "non-sequential INDEX (1 before 0) must be rejected"
+    );
+}
+
+#[test]
+fn duplicate_suffix_distinct_types_rejects_registration() {
+    let result = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register first step should succeed")
+        .register(SuffixCollisionStep);
+    assert!(
+        result.is_err(),
+        "distinct Header types sharing a SUFFIX must be rejected"
+    );
+}
+
+#[test]
+fn same_suffix_same_type_succeeds_registration() {
+    let result = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register SeedStep should succeed")
+        .register(MergeStep);
+    assert!(
+        result.is_ok(),
+        "reusing the same Header type across steps is allowed"
+    );
+}
+
+#[test]
+fn internal_step_index_rejects_registration() {
+    struct InternalIndexStep;
+    impl Step for InternalIndexStep {
+        type Aux<'source> = ();
+        type Left = ();
+        type Output = TestHeader;
+        type Right = ();
+        type Witness<'source> = ();
+
+        const INDEX: Index = Index::internal(0);
+
+        fn witness<'source>(
+            &self,
+            _witness: Self::Witness<'source>,
+            _left: <Self::Left as Header>::Data<'source>,
+            _right: <Self::Right as Header>::Data<'source>,
+        ) -> Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+            Ok((TestHeaderData { value: 0 }, ()))
+        }
+    }
+
+    let result = ApplicationBuilder::new().register(InternalIndexStep);
+    assert!(
+        result.is_err(),
+        "application-defined steps must not use Index::Internal"
+    );
+}
+
+#[test]
+fn verify_rejects_unregistered_step_index() {
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register should succeed")
+        .finalize()
+        .expect("finalize should succeed");
+
+    let encoded = TestHeader::encode(&TestHeaderData { value: 42 });
+    let forged_proof = Proof::new(
+        TestHeader::SUFFIX,
+        Index::new(999),
+        &encoded,
+        b"unused-witness",
+    );
+    let forged_pcd: Pcd<'_, TestHeader> =
+        forged_proof.carry::<TestHeader>(TestHeaderData { value: 42 });
+
+    let valid = app
+        .verify(&forged_pcd, thread_rng())
+        .expect("verify should succeed");
+    assert!(
+        !valid,
+        "proof whose step_index is outside the registered range must fail verify"
+    );
+}
+
+#[test]
+fn verify_rejects_swapped_header_type() {
+    struct SwappedHeader;
+    impl Header for SwappedHeader {
+        type Data<'source> = TestHeaderData;
+
+        const SUFFIX: Suffix = Suffix::new(99);
+
+        fn encode(data: &Self::Data<'_>) -> Vec<u8> {
+            data.value.to_le_bytes().to_vec()
+        }
+    }
+
+    let app = ApplicationBuilder::new()
+        .register(SeedStep)
+        .expect("register should succeed")
+        .finalize()
+        .expect("finalize should succeed");
+
+    let (pcd, ()) = app
+        .seed(&mut thread_rng(), SeedStep, 42u64)
+        .expect("seed should succeed");
+
+    let swapped_pcd: Pcd<'_, SwappedHeader> = pcd
+        .proof
+        .carry::<SwappedHeader>(TestHeaderData { value: 42 });
+
+    let valid = app
+        .verify(&swapped_pcd, thread_rng())
+        .expect("verify should succeed");
+    assert!(
+        !valid,
+        "proof bound to a different Header SUFFIX must fail verify"
     );
 }

--- a/crates/mock_ragu/src/tests/proof.rs
+++ b/crates/mock_ragu/src/tests/proof.rs
@@ -1,8 +1,15 @@
-use crate::proof::{PROOF_SIZE_COMPRESSED, Pcd, Proof};
+use crate::{
+    header::Suffix,
+    proof::{PROOF_SIZE_COMPRESSED, Pcd, Proof},
+    step::Index,
+};
+
+const TEST_SUFFIX: Suffix = Suffix::new(0);
+const TEST_INDEX: Index = Index::new(0);
 
 #[test]
 fn round_trip() {
-    let proof = Proof::new(b"header", b"witness");
+    let proof = Proof::new(TEST_SUFFIX, TEST_INDEX, b"header", b"witness");
     let bytes: [u8; PROOF_SIZE_COMPRESSED] = proof.clone().into();
     let recovered = Proof::try_from(&bytes).expect("round trip should succeed");
     assert_eq!(proof, recovered);
@@ -10,7 +17,7 @@ fn round_trip() {
 
 #[test]
 fn tampered_fails() {
-    let proof = Proof::new(b"header", b"witness");
+    let proof = Proof::new(TEST_SUFFIX, TEST_INDEX, b"header", b"witness");
     let mut bytes: [u8; PROOF_SIZE_COMPRESSED] = proof.into();
     bytes[0] ^= 0xFFu8;
     Proof::try_from(&bytes).expect_err("tampered proof should fail");
@@ -18,7 +25,7 @@ fn tampered_fails() {
 
 #[test]
 fn carry_creates_pcd() {
-    let proof = Proof::new(b"header", b"witness");
+    let proof = Proof::new(TEST_SUFFIX, TEST_INDEX, b"header", b"witness");
     let expected = proof.clone();
     let pcd: Pcd<'_, ()> = proof.carry(());
     assert_eq!(pcd.proof, expected);
@@ -26,7 +33,7 @@ fn carry_creates_pcd() {
 
 #[test]
 fn rerandomize() {
-    let proof = Proof::new(b"header", b"witness");
+    let proof = Proof::new(TEST_SUFFIX, TEST_INDEX, b"header", b"witness");
     assert_eq!(proof.rerand_tag, [0u8; 32]);
 
     let once = proof.rerandomize();

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -49,7 +49,10 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
 
 lazy_static! {
     pub(crate) static ref PROOF_SYSTEM: Application = {
-        #[expect(clippy::expect_used, reason = "mock registration is infallible")]
-        make_app().expect("should work")
+        #[expect(
+            clippy::expect_used,
+            reason = "hardcoded step ordering must register cleanly"
+        )]
+        make_app().expect("registration of fixed step list must succeed")
     };
 }


### PR DESCRIPTION
Brings real ragu's three-layer step/header enforcement to the mock,
which previously did none of it.

- **Register-time**: `ApplicationBuilder::register` requires sequential `Index::new(0..)` and rejects two distinct `Header` types declaring the same `SUFFIX` (deduped by `TypeId`).
- **Header hash**: `compute_header_hash` mixes in `SUFFIX`, so a proof bound to Header A can't be verified as Header B.
- **Verify**: `Proof` now carries `step_index`; verify rejects any step_index outside the registered application range.

`Application::rerandomize` intentionally stays a transformation (not a fusion via an internal Rerandomize step) since the mock has no recursion; the API surface is unchanged.

Tests cover both register-time and verify-time enforcement.

Tachyon's 24-step registration is already sequential with no SUFFIX collisions, so it passes through unchanged.