### PR TITLE
Relocate action digest from `SpendBind` to `SpendStamp`

### DIFF
--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -27,8 +27,8 @@ Crossing an epoch boundary requires a new-epoch nullifier and the cross-epoch an
 `SpendableEpochLift` consumes that header and a new-epoch `Unspent` whose start equals the boundary anchor, producing a fresh spendable in the new epoch.
 
 To spend, the wallet derives two `NullifierHeader`s (for the present epoch and the next) by running the GGM walk[^nullifiers] twice on the same note.
-`SpendBind` fuses these two leaves, checks that the witnessed note's commitment[^notes] matches the commitment carried on each, and emits a `SpendHeader` containing the action digest and both nullifiers.
-`SpendStamp` then fuses that `SpendHeader` with a current-epoch `SpendableHeader`, checks that the present-epoch nullifier matches the spendable's, and emits a `StampHeader` whose tachygram set contains both nullifiers and whose anchor is the spendable's.
+`SpendBind` fuses these two leaves, checks that the witnessed note's commitment[^notes] matches the commitment carried on each, and emits a `SpendHeader` containing the value commitment, action verification key, and both nullifiers.
+`SpendStamp` then fuses that `SpendHeader` with a current-epoch `SpendableHeader`, checks that the present-epoch nullifier matches the spendable's, derives the action digest from the SpendHeader's value commitment and verification key, and emits a `StampHeader` whose tachygram set contains both nullifiers and whose anchor is the spendable's.
 
 An output operation runs `OutputStamp` directly.
 The step witnesses the new note, value-randomness, action-randomness, and an anchor; the wallet typically anchors each output at the same height as the transaction's spends so the merge can proceed without an intervening lift.
@@ -128,14 +128,14 @@ The cross-epoch anchor advance is the only such transition in the proof tree; sa
 
 Spending a note publishes two nullifiers, one for the current epoch and one for the next.
 Both leaves come from the same note's GGM tree[^nullifiers], and `SpendBind` ties them together by checking that the witnessed note's commitment[^notes] equals the commitment carried on each input.
-The action digest is computed from the value commitment and the action verification key derived from the same witnessed note and key material[^keys].
+The value commitment and action verification key are derived at `SpendBind` from the witnessed note and key material[^keys]; the action digest is derived downstream at `SpendStamp` from those two values, so that `SpendBind` stays within its per-step gate budget.
 Publishing both nullifiers lets consensus apply the spend across an epoch transition that may occur between proof construction and inclusion.
 
 ### Stamp construction
 
 A stamp commits to two multisets, an action-digest set and a tachygram set[^tachygrams].
 `OutputStamp` derives a value commitment, action verification key, and action digest from a witnessed note, value-randomness, and action-randomness; constraints reject zero or over-range note values and require the note's payment key to match the witnessed key material[^keys].
-`SpendStamp` consumes a `SpendHeader` (already action-bound) and a `SpendableHeader` (already anchor-bound), checks the spend's present-epoch nullifier equals the spendable's, and emits a stamp whose action digest, two-nullifier tachygram set, and threaded anchor follow from that constraint.
+`SpendStamp` consumes a `SpendHeader` (carrying value commitment, action verification key, and two nullifiers) and a `SpendableHeader` (already anchor-bound), checks the spend's present-epoch nullifier equals the spendable's, derives the action digest from the SpendHeader's value commitment and verification key, and emits a stamp whose action digest, two-nullifier tachygram set, and threaded anchor follow from that constraint.
 `MergeStamp` fuses two stamps by checking anchor equality and unioning their commitments through witnessed multiset gadgets.
 
 ### Stamp anchor
@@ -335,7 +335,7 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | NullifierRolloverHeader | (old_nf, new_nf, new_epoch) |
 | SpendableHeader | (nf, anchor) |
 | SpendableRolloverHeader | (new_nf, epoch_anchor) |
-| SpendHeader | (action_digest, present_nf, future_nf) |
+| SpendHeader | (cv, rk, present_nf, future_nf) |
 | StampHeader | (action_acc, tachygram_acc, anchor) |
 
 ## Steps

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -193,7 +193,7 @@ impl Plan {
         }
 
         for (((cv, rk), (alpha, note, rcv)), (nf_now_pcd, nf_next_pcd, spendable_pcd)) in
-            self.spends.into_iter().zip(spend_pcds.into_iter())
+            self.spends.into_iter().zip(spend_pcds)
         {
             let action_digest = ActionDigest::new(cv, rk).map_err(ProveError::ActionDigest)?;
 

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -1,8 +1,4 @@
 //! Spend action-binding header and step.
-//!
-//! TODO: eliminate SpendBind and SpendStep? possibly NullifierRolloverHeader
-//! would replace SpendHeader as input to SpendStamp, and SpendStamp would be
-//! responsible for witnessing the action fields presently handled by SpendBind.
 
 extern crate alloc;
 
@@ -16,9 +12,9 @@ use super::delegation::NullifierHeader;
 use crate::{
     constants::NOTE_VALUE_MAX,
     entropy::ActionRandomizer,
-    keys::ProofAuthorizingKey,
+    keys::{ProofAuthorizingKey, public},
     note::{Note, Nullifier},
-    primitives::{ActionDigest, effect},
+    primitives::effect,
     value,
 };
 
@@ -32,33 +28,60 @@ use crate::{
 pub struct SpendHeader;
 
 impl Header for SpendHeader {
-    /// `(action_digest, (now_nf, next_nf))`. `action_digest` is
-    /// computed at [`SpendBind`] as the Poseidon digest of the
-    /// witnessed `(cv, rk)`. `now_nf` and `next_nf` are computed
-    /// upstream by [`NullifierStep`](super::delegation::NullifierStep)
-    /// on two [`NullifierHeader`](super::delegation::NullifierHeader)s
-    /// that [`SpendBind`] constrains to share a `cm` lineage and to
-    /// live on consecutive epochs.
-    type Data<'source> = (ActionDigest, (Nullifier, Nullifier));
+    /// `(cv, rk, (now_nf, next_nf))`. `cv` and `rk` are derived at
+    /// [`SpendBind`] from the witnessed `(rcv, alpha, pak, note)`.
+    /// [`SpendStamp`](super::stamp::SpendStamp) hashes `(cv, rk)`
+    /// into the per-action `ActionDigest` when committing the
+    /// action set. `now_nf` and `next_nf` are computed upstream by
+    /// [`NullifierStep`](super::delegation::NullifierStep) on two
+    /// [`NullifierHeader`](super::delegation::NullifierHeader)s
+    /// that [`SpendBind`] constrains to share a `cm` lineage and
+    /// to live on consecutive epochs.
+    type Data<'source> = (
+        value::Commitment,
+        public::ActionVerificationKey,
+        (Nullifier, Nullifier),
+    );
 
     const SUFFIX: Suffix = Suffix::new(10);
 
     fn encode(data: &Self::Data<'_>) -> Vec<u8> {
-        let mut out = Vec::with_capacity(32 + 32 + 32);
-        out.extend_from_slice(&Fp::from(data.0).to_repr());
-        out.extend_from_slice(&Fp::from(data.1.0).to_repr());
-        out.extend_from_slice(&Fp::from(data.1.1).to_repr());
+        let mut out = Vec::with_capacity(32 + 32 + 32 + 32);
+        let cv_bytes: [u8; 32] = data.0.into();
+        let rk_bytes: [u8; 32] = data.1.into();
+        out.extend_from_slice(&cv_bytes);
+        out.extend_from_slice(&rk_bytes);
+        out.extend_from_slice(&Fp::from(data.2.0).to_repr());
+        out.extend_from_slice(&Fp::from(data.2.1).to_repr());
         out
     }
 }
 
 /// Fuses two epoch-adjacent nullifier leaves and binds them to an action.
 ///
-/// One `cm`-equality fold ties together same-wallet binding between the
-/// two leaves and note-binding for the witnessed `(note, pak)`:
-/// `note.commitment() == left_cm == right_cm`. The `DelegationTrapdoor` is
-/// not needed — `delegation_id` is consumed only by the sync-service-side
-/// rollover steps on `DelegateNullifierHeader`.
+/// The `note.commitment() == left_cm == right_cm` fold is the cv-to-value
+/// seam: the witnessed note's value flows into `cv = rcv.commit(note.value)`,
+/// which becomes the on-chain action's value commitment. Without binding
+/// the witnessed note to the upstream nullifier's `cm`, a prover could
+/// publish a nullifier for a high-value note while committing `cv` to a
+/// low-value note.
+///
+/// [`NullifierRolloverHeader`](super::spendable::NullifierRolloverHeader)
+/// drops `cm` and cannot expose it without leaking note material via
+/// [`DelegateRolloverFuse`](super::spendable::DelegateRolloverFuse), so
+/// this step is the only place where `cm` is in scope alongside the
+/// action witness.
+///
+/// Outputs `SpendHeader::Data = (cv, rk, (now_nf, next_nf))`. The
+/// `ActionDigest = Poseidon(cv, rk)` derivation lives downstream in
+/// [`SpendStamp`](super::stamp::SpendStamp) to keep this step's gate
+/// budget under the per-step bound. `SpendBind` and `SpendStamp` are both
+/// wallet-private; the `SpendHeader` boundary between them is not exposed
+/// to consensus or the sync service.
+///
+/// The `DelegationTrapdoor` is not needed because `delegation_id` is
+/// consumed only by the sync-service rollover steps on
+/// `DelegateNullifierHeader`.
 #[derive(Debug)]
 pub struct SpendBind;
 
@@ -106,9 +129,7 @@ impl Step for SpendBind {
 
         let cv = rcv.commit(i64::from(note.value));
         let rk = pak.ak.derive_action_public(&alpha);
-        let action_digest = ActionDigest::new(cv, rk)
-            .map_err(|_err| mock_ragu::Error("SpendBind: action digest failed"))?;
 
-        Ok(((action_digest, (nf0, nf1)), ()))
+        Ok(((cv, rk, (nf0, nf1)), ()))
     }
 }

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -109,8 +109,7 @@ impl Step for OutputStamp {
 ///
 /// `SpendStamp` derives `action_digest = Poseidon(cv, rk)` from the
 /// `(cv, rk)` carried in `SpendHeader` before constructing the
-/// `ActionSetCommit`. The derivation lives here, not in `SpendBind`, so
-/// that `SpendBind` stays under its per-step gate budget.
+/// `ActionSetCommit`.
 #[derive(Debug)]
 pub struct SpendStamp;
 

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -135,9 +135,8 @@ impl Step for SpendStamp {
             ));
         }
 
-        let action_digest = ActionDigest::new(cv, rk).map_err(|_err| {
-            mock_ragu::Error("SpendStamp: action digest construction failed")
-        })?;
+        let action_digest = ActionDigest::new(cv, rk)
+            .map_err(|_err| mock_ragu::Error("SpendStamp: action digest construction failed"))?;
 
         let data = (
             ActionSetCommit::from([action_digest].as_slice()),

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -106,6 +106,11 @@ impl Step for OutputStamp {
 /// The spend's first nullifier must equal the spendable's `nf`;
 /// anchor-binding is implicit via `spendable.anchor` (already validated by
 /// the spendable lineage). Epoch alignment is consumer-side.
+///
+/// `SpendStamp` derives `action_digest = Poseidon(cv, rk)` from the
+/// `(cv, rk)` carried in `SpendHeader` before constructing the
+/// `ActionSetCommit`. The derivation lives here, not in `SpendBind`, so
+/// that `SpendBind` stays under its per-step gate budget.
 #[derive(Debug)]
 pub struct SpendStamp;
 
@@ -121,7 +126,7 @@ impl Step for SpendStamp {
     fn witness<'source>(
         &self,
         _witness: Self::Witness<'source>,
-        (action_digest, (now_nf, next_nf)): <Self::Left as Header>::Data<'source>,
+        (cv, rk, (now_nf, next_nf)): <Self::Left as Header>::Data<'source>,
         (anchored_nf, anchor): <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
         if now_nf != anchored_nf {
@@ -129,6 +134,10 @@ impl Step for SpendStamp {
                 "SpendStamp: spend's now_nf must equal spendable's nf",
             ));
         }
+
+        let action_digest = ActionDigest::new(cv, rk).map_err(|_err| {
+            mock_ragu::Error("SpendStamp: action digest construction failed")
+        })?;
 
         let data = (
             ActionSetCommit::from([action_digest].as_slice()),

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -245,11 +245,7 @@ fn spend_stamp_rejects_identity_cv() {
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(rng, 500);
 
-    pool.mine(random_block_with(
-        rng,
-        &[alloc::vec![note.commitment()]],
-        4,
-    ));
+    pool.mine(random_block_with(rng, &[alloc::vec![note.commitment()]], 4));
     let init_height = pool.height();
     let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
     let spendable = user.spendable_init(rng, note, &pool, init_height, nf_pcd);
@@ -268,9 +264,10 @@ fn spend_stamp_rejects_identity_cv() {
 
     let (_real_cv, real_rk, real_nfs) = real_spend.data;
     let identity_cv = value::Commitment::balance(0);
-    let forged_spend = real_spend
-        .proof
-        .carry::<spend::SpendHeader>((identity_cv, real_rk, real_nfs));
+    let forged_spend =
+        real_spend
+            .proof
+            .carry::<spend::SpendHeader>((identity_cv, real_rk, real_nfs));
 
     let err = PROOF_SYSTEM
         .fuse(rng, stamp::SpendStamp, (), forged_spend, spendable)

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -239,6 +239,46 @@ fn step_rejects_zero_value_note() {
 }
 
 #[test]
+fn spend_stamp_rejects_identity_cv() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(rng, 500);
+
+    pool.mine(random_block_with(
+        rng,
+        &[alloc::vec![note.commitment()]],
+        4,
+    ));
+    let init_height = pool.height();
+    let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
+    let spendable = user.spendable_init(rng, note, &pool, init_height, nf_pcd);
+
+    let (nf_now_pcd, nf_next_pcd) = user.nullifier_pair_pcd(rng, note, EpochIndex(0));
+    let (rcv, _theta, alpha) = spend_witness(rng, &note);
+    let (real_spend, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spend::SpendBind,
+            (rcv, alpha, user.pak, note),
+            nf_now_pcd,
+            nf_next_pcd,
+        )
+        .expect("SpendBind");
+
+    let (_real_cv, real_rk, real_nfs) = real_spend.data;
+    let identity_cv = value::Commitment::balance(0);
+    let forged_spend = real_spend
+        .proof
+        .carry::<spend::SpendHeader>((identity_cv, real_rk, real_nfs));
+
+    let err = PROOF_SYSTEM
+        .fuse(rng, stamp::SpendStamp, (), forged_spend, spendable)
+        .unwrap_err();
+    assert_eq!(err.0, "SpendStamp: action digest construction failed");
+}
+
+#[test]
 fn spendable_epoch_lift_across_boundary() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);


### PR DESCRIPTION
fixes https://github.com/tachyon-zcash/tachyon/issues/102

Moves action digest from `SpendBind` into `SpendStamp`.

`SpendBind` now emits `(cv, rk)` to `SpendHeader`; `SpendStamp` derives the digest.

This is partly informed by [new reasoning about per-step capacity](https://github.com/tachyon-zcash/ragu/pull/720). By current estimates (Poseidon ~288, scalar mul ~455, Pedersen ~910 against a 2048 per-step bound), `SpendBind` was at ~2229 gates: one Pedersen commit, one scalar mul, and three Poseidons (action digest, note commitment, payment-key derivation). Removing the action-digest Poseidon drops it to ~1941; `SpendStamp` absorbs the ~288 in its large remaining gate budget. Both steps are wallet-private, so the `SpendHeader` boundary is internal; the consensus-facing `StampHeader` shape is unchanged.

- `SpendHeader::Data` changes from `(ActionDigest, (Nullifier, Nullifier))` to `(value::Commitment, public::ActionVerificationKey, (Nullifier, Nullifier))`; `encode()` updated.
- `SpendBind::witness` drops the `ActionDigest::new` call and returns `(cv, rk, (nf0, nf1))`.
- `SpendStamp::witness` calls `ActionDigest::new(cv, rk)` with a new error string `"SpendStamp: action digest construction failed"` before building `ActionSetCommit`.
- New test `spend_stamp_rejects_identity_cv` covers the relocated failure path. Existing `SpendBind` tests are unchanged.
- `book/src/proof-tree.md` narrative and the `SpendHeader` row of the headers table reflect the new shape and the relocated derivation.