### PR TITLE
Introduce `RangeSummary` proof

### DIFF
--- a/book/src/anchor.md
+++ b/book/src/anchor.md
@@ -42,5 +42,3 @@ This is the only domain that absorbs the new epoch index. Nothing else in the ch
 Within a block, each stamp's absorption produces an intermediate hash value.
 
 Consensus actors should know about intermediate states, but may only acknowledge the anchor state at the end of a block.
-
-A proof such as `SpendableInit` will produce a header that is likely at an intra-block state, and should be lifted to the end of a block by proving state continuity.

--- a/book/src/anchor.md
+++ b/book/src/anchor.md
@@ -42,3 +42,5 @@ This is the only domain that absorbs the new epoch index. Nothing else in the ch
 Within a block, each stamp's absorption produces an intermediate hash value.
 
 Consensus actors should know about intermediate states, but may only acknowledge the anchor state at the end of a block.
+
+A proof such as `SpendableInitStamp` will produce a header that is likely at an intra-block state, and should be lifted to the end of a block by proving state continuity.

--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -17,7 +17,7 @@ A note is essentially created when the wallet runs `SpendableInitStamp` or `Spen
 
 Maintaining the spendable means advancing its anchor forward over `Unspent` segments.
 `SpendableLift` consumes one `Unspent` whose nullifier matches the spendable's and whose start matches the spendable's current anchor, producing a fresh `SpendableHeader` at the segment's end.
-Each `Unspent` is built either by running `UnspentFromRange` against a `RangeSummary` or directly from a single stamp via `UnspentSeed` / `EmptyBlockUnspentSeed`; `UnspentFuse` composes adjacent segments.
+Each `Unspent` is built either by running `UnspentRange` against a `RangeSummary` or directly from a single stamp via `UnspentSeed` / `EmptyBlockUnspentSeed`; `UnspentFuse` composes adjacent segments.
 
 Crossing an epoch boundary requires a new-epoch nullifier and the cross-epoch anchor advance.
 `RolloverFuse` consumes two consecutive-epoch `NullifierHeader`s that share a note commitment and emits a `NullifierRolloverHeader`.
@@ -54,7 +54,7 @@ It seeds and walks the private GGM tree (`NfMasterSeed`, `NfMasterStep`, `NfPref
 
 The sync service holds a `DelegateNfPrefixHeader` produced by the wallet at delegation time.
 From there it climbs the blinded subtree (`DelegateNfPrefixStep`) to whichever leaf an epoch requires and emits a `DelegateNullifierHeader` (`DelegateNullifierStep`); it fuses two consecutive-epoch leaves with `DelegateRolloverFuse` when an epoch boundary is approached.
-It produces the `Unspent` segments that carry the spendable forward (`RangeSummaryStampSeed`, `RangeSummaryEmptySeed`, `RangeSummaryFuse`, `UnspentFromRange`, `UnspentSeed`, `EmptyBlockUnspentSeed`, `UnspentFuse`), and runs the lifts that consume them (`SpendableLift`, `SpendableRollover`, `SpendableEpochLift`).
+It produces the `Unspent` segments that carry the spendable forward (`RangeSummaryStampSeed`, `RangeSummaryEmptySeed`, `RangeSummaryFuse`, `UnspentRange`, `UnspentSeed`, `EmptyBlockUnspentSeed`, `UnspentFuse`), and runs the lifts that consume them (`SpendableLift`, `SpendableRollover`, `SpendableEpochLift`).
 
 The aggregator works only with published `StampHeader`s.
 It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `EmptyBlockSeed`, `AnchorFuse`) and fuses with `MergeStamp`.
@@ -67,7 +67,7 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `E
 | RangeSummaryStampSeed | possible | yes | no |
 | RangeSummaryEmptySeed | possible | yes | no |
 | RangeSummaryFuse | possible | yes | no |
-| UnspentFromRange | possible | yes | no |
+| UnspentRange | possible | yes | no |
 | UnspentSeed | possible | yes | no |
 | EmptyBlockUnspentSeed | possible | yes | no |
 | UnspentFuse | possible | yes | no |
@@ -112,7 +112,7 @@ A fresh trapdoor per delegation makes the delegation identifier unlinkable acros
 
 `AnchorSeed` / `EmptyBlockSeed` build single-link `AnchorChain` segments; `AnchorFuse` composes adjacent segments.
 `RangeSummaryStampSeed` / `RangeSummaryEmptySeed` build single-link `RangeSummary` segments, which additionally carry the union of every absorbed stamp's tachygram set; `RangeSummaryFuse` composes adjacent segments.
-`UnspentFromRange` consumes a `RangeSummary` and emits an `Unspent` after proving the witnessed nullifier absent from the summary's tachygram set; `UnspentSeed` / `EmptyBlockUnspentSeed` build single-stamp `Unspent` segments directly, collapsing the `RangeSummary` step for callers that already hold the stamp's tachygram set and the target nullifier; `UnspentFuse` composes adjacent `Unspent` segments.
+`UnspentRange` consumes a `RangeSummary` and emits an `Unspent` after proving the witnessed nullifier absent from the summary's tachygram set; `UnspentSeed` / `EmptyBlockUnspentSeed` build single-stamp `Unspent` segments directly, collapsing the `RangeSummary` step for callers that already hold the stamp's tachygram set and the target nullifier; `UnspentFuse` composes adjacent `Unspent` segments.
 A segment ties to real chain history only when a stamp-emitting step consumes it and the resulting stamp's anchor matches a consensus-published end-of-block value.
 
 ### Spendable lifecycle
@@ -121,7 +121,7 @@ A spendable bootstraps one of two ways.
 `SpendableInitStamp` fuses the wallet's `NullifierHeader` with a freely-witnessed pre-stamp anchor and the cm-stamp's tachygram set, verifies the note's commitment[^notes] is among those tachygrams, and advances the anchor through that stamp; it skips the absence check because the cm-stamp cannot contain the note's own nullifier.
 `SpendableInitRange` instead fuses the `NullifierHeader` with a `RangeSummary` covering the cm-stamp, verifies the commitment is among the summary's tachygrams and the nullifier is absent, and emits a `SpendableHeader` carrying the nullifier and the summary's `end` anchor; the absence check guards against a range that also covers the note's later spend.
 `SpendableLift` advances the spendable's anchor further by consuming an `Unspent` segment whose nullifier equals the spendable's and whose start matches the spendable's current anchor.
-Each `Unspent` is produced by `UnspentFromRange` against a `RangeSummary`, witnessing the nullifier and proving it absent from the summary's tachygram set[^tachygrams]; `UnspentFuse` requires both halves to share a nullifier and to meet at a common anchor.
+Each `Unspent` is produced by `UnspentRange` against a `RangeSummary`, witnessing the nullifier and proving it absent from the summary's tachygram set[^tachygrams]; `UnspentFuse` requires both halves to share a nullifier and to meet at a common anchor.
 
 ### Epoch rollover
 
@@ -301,7 +301,7 @@ flowchart LR
   s_rempty[RangeSummaryEmptySeed]
   s_rfuse[RangeSummaryFuse]
   w_unspent[/nf, tg_gadget/]
-  s_unspent[UnspentFromRange]
+  s_unspent[UnspentRange]
   w_useed[/start, stamp_tg_set, nf/]
   s_useed[UnspentSeed]
   w_uempty[/start, nf/]
@@ -378,7 +378,7 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | RangeSummaryStampSeed | — | — | start, stamp_tg_set | RangeSummary |
 | RangeSummaryEmptySeed | — | — | start | RangeSummary |
 | RangeSummaryFuse | RangeSummary | RangeSummary | left_tg_gadget, right_tg_gadget | RangeSummary |
-| UnspentFromRange | RangeSummary | — | nf, tg_gadget | Unspent |
+| UnspentRange | RangeSummary | — | nf, tg_gadget | Unspent |
 | UnspentSeed | — | — | start, stamp_tg_set, nf | Unspent |
 | EmptyBlockUnspentSeed | — | — | start, nf | Unspent |
 | UnspentFuse | Unspent | Unspent | — | Unspent |

--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -12,13 +12,11 @@ Multiple parties execute the proof tree.
 ## Lifecycle
 
 A note is essentially created when the wallet runs `SpendableInit`.
-The step takes the wallet's `NullifierHeader` for the creation epoch, a pre-stamp anchor, and the tachygram set of the stamp that produced the note; it checks the note's commitment[^notes] is among those tachygrams and advances the anchor through the stamp.
-The output is a `SpendableHeader` carrying the nullifier and the post-stamp anchor.
+The step takes the wallet's `NullifierHeader` for the creation epoch and a `RangeSummary` covering the cm-stamp; it checks the note's commitment[^notes] is among the summary's tachygrams and the nullifier is absent, then emits a `SpendableHeader` carrying the nullifier and the summary's `end` anchor.
 
 Maintaining the spendable means advancing its anchor forward over `Unspent` segments.
 `SpendableLift` consumes one `Unspent` whose nullifier matches the spendable's and whose start matches the spendable's current anchor, producing a fresh `SpendableHeader` at the segment's end.
-Each `UnspentSeed` link absorbs one stamp and proves the spendable's nullifier was absent from that stamp's tachygram set[^tachygrams]; `EmptyBlockUnspentSeed` covers empty blocks; `UnspentFuse` composes adjacent segments.
-The sync service produces the `Unspent` segments and may perform lifts on the wallet's behalf.
+Each `Unspent` is built by running `UnspentFromRange` against a `RangeSummary`; `UnspentFuse` composes adjacent segments.
 
 Crossing an epoch boundary requires a new-epoch nullifier and the cross-epoch anchor advance.
 `RolloverFuse` consumes two consecutive-epoch `NullifierHeader`s that share a note commitment and emits a `NullifierRolloverHeader`.
@@ -55,7 +53,7 @@ It seeds and walks the private GGM tree (`NfMasterSeed`, `NfMasterStep`, `NfPref
 
 The sync service holds a `DelegateNfPrefixHeader` produced by the wallet at delegation time.
 From there it climbs the blinded subtree (`DelegateNfPrefixStep`) to whichever leaf an epoch requires and emits a `DelegateNullifierHeader` (`DelegateNullifierStep`); it fuses two consecutive-epoch leaves with `DelegateRolloverFuse` when an epoch boundary is approached.
-It produces the `Unspent` segments that carry the spendable forward (`UnspentSeed`, `EmptyBlockUnspentSeed`, `UnspentFuse`), and runs the lifts that consume them (`SpendableLift`, `SpendableRollover`, `SpendableEpochLift`).
+It produces the `Unspent` segments that carry the spendable forward (`RangeSummaryStampSeed`, `RangeSummaryEmptySeed`, `RangeSummaryFuse`, `UnspentFromRange`, `UnspentFuse`), and runs the lifts that consume them (`SpendableLift`, `SpendableRollover`, `SpendableEpochLift`).
 
 The aggregator works only with published `StampHeader`s.
 It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `EmptyBlockSeed`, `AnchorFuse`) and fuses with `MergeStamp`.
@@ -65,8 +63,10 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `E
 | AnchorSeed | possible | yes | yes |
 | EmptyBlockSeed | possible | yes | yes |
 | AnchorFuse | possible | yes | yes |
-| UnspentSeed | possible | yes | no |
-| EmptyBlockUnspentSeed | possible | yes | no |
+| RangeSummaryStampSeed | possible | yes | no |
+| RangeSummaryEmptySeed | possible | yes | no |
+| RangeSummaryFuse | possible | yes | no |
+| UnspentFromRange | possible | yes | no |
 | UnspentFuse | possible | yes | no |
 | NfMasterSeed | yes | no | no |
 | NfMasterStep | yes | no | no |
@@ -106,15 +106,16 @@ A fresh trapdoor per delegation makes the delegation identifier unlinkable acros
 
 ### Anchor segments
 
-`AnchorSeed`, `EmptyBlockSeed`, `UnspentSeed`, and `EmptyBlockUnspentSeed` each witness a starting anchor and prove one anchor step.
-`AnchorFuse` and `UnspentFuse` compose adjacent segments by checking endpoint equality.
+`AnchorSeed` / `EmptyBlockSeed` build single-link `AnchorChain` segments; `AnchorFuse` composes adjacent segments.
+`RangeSummaryStampSeed` / `RangeSummaryEmptySeed` build single-link `RangeSummary` segments, which additionally carry the union of every absorbed stamp's tachygram set; `RangeSummaryFuse` composes adjacent segments.
+`UnspentFromRange` consumes a `RangeSummary` and emits an `Unspent` after proving the witnessed nullifier absent from the summary's tachygram set; `UnspentFuse` composes adjacent `Unspent` segments.
 A segment ties to real chain history only when a stamp-emitting step consumes it and the resulting stamp's anchor matches a consensus-published end-of-block value.
 
 ### Spendable lifecycle
 
-A spendable bootstraps at `SpendableInit`, which fuses the wallet's `NullifierHeader` with a pre-stamp anchor and the tachygram set of the stamp that produced the note, verifies the note's commitment[^notes] is among those tachygrams, and advances the anchor through that stamp.
+A spendable bootstraps at `SpendableInit`, which fuses the wallet's `NullifierHeader` with a `RangeSummary` covering the cm-stamp, verifies the note's commitment[^notes] is among the summary's tachygrams and the nullifier is absent, and emits a `SpendableHeader` carrying the nullifier and the summary's `end` anchor.
 `SpendableLift` advances the spendable's anchor further by consuming an `Unspent` segment whose nullifier equals the spendable's and whose start matches the spendable's current anchor.
-Each `UnspentSeed` link absorbs one stamp into the anchor and proves the spendable's nullifier is absent from that stamp's tachygram set[^tachygrams]; `EmptyBlockUnspentSeed` skips the absence check (no tachygrams to scan); `UnspentFuse` requires both halves to share a nullifier and to meet at a common anchor.
+Each `Unspent` is produced by `UnspentFromRange` against a `RangeSummary`, witnessing the nullifier and proving it absent from the summary's tachygram set[^tachygrams]; `UnspentFuse` requires both halves to share a nullifier and to meet at a common anchor.
 
 ### Epoch rollover
 
@@ -165,7 +166,8 @@ flowchart TB
   end
 
   subgraph spendable [spendable advance]
-    w_init[/anchor, stamp_tg_set/]
+    w_init[/tg_gadget/]
+    cm_range((RangeSummary))
     s_init[SpendableInit]
     s_rfuse[RolloverFuse]
     s_rollover[SpendableRollover]
@@ -202,6 +204,7 @@ flowchart TB
 
   s_leaf_old -->|NullifierHeader e-1| s_init
   w_init --> s_init
+  cm_range --> s_init
   s_init -->|SpendableHeader| s_rollover
 
   s_leaf_old -->|NullifierHeader e-1| s_rfuse
@@ -280,18 +283,24 @@ flowchart LR
 ```mermaid
 flowchart LR
   sp_in((SpendableHeader))
-  w_seed[/start, stamp_tg_set, nf/]
-  s_useed[UnspentSeed]
-  w_empty[/start, nf/]
-  s_uempty[EmptyBlockUnspentSeed]
+  w_seed[/start, stamp_tg_set/]
+  s_rseed[RangeSummaryStampSeed]
+  w_empty[/start/]
+  s_rempty[RangeSummaryEmptySeed]
+  s_rfuse[RangeSummaryFuse]
+  w_unspent[/nf, tg_gadget/]
+  s_unspent[UnspentFromRange]
   s_ufuse[UnspentFuse]
   s_lift[SpendableLift]
   sp_out((SpendableHeader))
 
-  w_seed --> s_useed
-  w_empty --> s_uempty
-  s_useed -->|Unspent| s_ufuse
-  s_uempty -->|Unspent| s_ufuse
+  w_seed --> s_rseed
+  w_empty --> s_rempty
+  s_rseed -->|RangeSummary| s_rfuse
+  s_rempty -->|RangeSummary| s_rfuse
+  w_unspent --> s_unspent
+  s_rfuse -->|RangeSummary| s_unspent
+  s_unspent -->|Unspent| s_ufuse
   sp_in --> s_lift
   s_ufuse -->|Unspent| s_lift
   s_lift --> sp_out
@@ -326,6 +335,7 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | Header | Fields |
 | ------ | ------ |
 | AnchorChain | (prev_anchor, end_anchor) |
+| RangeSummary | (start, end, tg_set) |
 | Unspent | (nf, prev_anchor, end_anchor) |
 | NfMasterHeader | (mk, cm) |
 | NfPrefixHeader | (prefix{key, depth, index}, mk, cm) |
@@ -345,8 +355,10 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | AnchorSeed | — | — | start, stamp_commit | AnchorChain |
 | EmptyBlockSeed | — | — | start | AnchorChain |
 | AnchorFuse | AnchorChain | AnchorChain | — | AnchorChain |
-| UnspentSeed | — | — | start, stamp_tg_set, nf | Unspent |
-| EmptyBlockUnspentSeed | — | — | start, nf | Unspent |
+| RangeSummaryStampSeed | — | — | start, stamp_tg_set | RangeSummary |
+| RangeSummaryEmptySeed | — | — | start | RangeSummary |
+| RangeSummaryFuse | RangeSummary | RangeSummary | left_tg_gadget, right_tg_gadget | RangeSummary |
+| UnspentFromRange | RangeSummary | — | nf, tg_gadget | Unspent |
 | UnspentFuse | Unspent | Unspent | — | Unspent |
 | NfMasterSeed | — | — | note, pak | NfMasterHeader |
 | NfMasterStep | NfMasterHeader | — | chunk | NfPrefixHeader |
@@ -357,7 +369,7 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | DelegateNullifierStep | DelegateNfPrefixHeader | — | — | DelegateNullifierHeader |
 | RolloverFuse | NullifierHeader | NullifierHeader | — | NullifierRolloverHeader |
 | DelegateRolloverFuse | DelegateNullifierHeader | DelegateNullifierHeader | — | NullifierRolloverHeader |
-| SpendableInit | NullifierHeader | — | anchor, stamp_tg_set | SpendableHeader |
+| SpendableInit | NullifierHeader | RangeSummary | tg_gadget | SpendableHeader |
 | SpendableLift | SpendableHeader | Unspent | — | SpendableHeader |
 | SpendableRollover | SpendableHeader | NullifierRolloverHeader | — | SpendableRolloverHeader |
 | SpendableEpochLift | SpendableRolloverHeader | Unspent | — | SpendableHeader |

--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -17,7 +17,7 @@ A note is essentially created when the wallet runs `SpendableInitStamp` or `Spen
 
 Maintaining the spendable means advancing its anchor forward over `Unspent` segments.
 `SpendableLift` consumes one `Unspent` whose nullifier matches the spendable's and whose start matches the spendable's current anchor, producing a fresh `SpendableHeader` at the segment's end.
-Each `Unspent` is built by running `UnspentFromRange` against a `RangeSummary`; `UnspentFuse` composes adjacent segments.
+Each `Unspent` is built either by running `UnspentFromRange` against a `RangeSummary` or directly from a single stamp via `UnspentSeed` / `EmptyBlockUnspentSeed`; `UnspentFuse` composes adjacent segments.
 
 Crossing an epoch boundary requires a new-epoch nullifier and the cross-epoch anchor advance.
 `RolloverFuse` consumes two consecutive-epoch `NullifierHeader`s that share a note commitment and emits a `NullifierRolloverHeader`.
@@ -54,7 +54,7 @@ It seeds and walks the private GGM tree (`NfMasterSeed`, `NfMasterStep`, `NfPref
 
 The sync service holds a `DelegateNfPrefixHeader` produced by the wallet at delegation time.
 From there it climbs the blinded subtree (`DelegateNfPrefixStep`) to whichever leaf an epoch requires and emits a `DelegateNullifierHeader` (`DelegateNullifierStep`); it fuses two consecutive-epoch leaves with `DelegateRolloverFuse` when an epoch boundary is approached.
-It produces the `Unspent` segments that carry the spendable forward (`RangeSummaryStampSeed`, `RangeSummaryEmptySeed`, `RangeSummaryFuse`, `UnspentFromRange`, `UnspentFuse`), and runs the lifts that consume them (`SpendableLift`, `SpendableRollover`, `SpendableEpochLift`).
+It produces the `Unspent` segments that carry the spendable forward (`RangeSummaryStampSeed`, `RangeSummaryEmptySeed`, `RangeSummaryFuse`, `UnspentFromRange`, `UnspentSeed`, `EmptyBlockUnspentSeed`, `UnspentFuse`), and runs the lifts that consume them (`SpendableLift`, `SpendableRollover`, `SpendableEpochLift`).
 
 The aggregator works only with published `StampHeader`s.
 It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `EmptyBlockSeed`, `AnchorFuse`) and fuses with `MergeStamp`.
@@ -68,6 +68,8 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `E
 | RangeSummaryEmptySeed | possible | yes | no |
 | RangeSummaryFuse | possible | yes | no |
 | UnspentFromRange | possible | yes | no |
+| UnspentSeed | possible | yes | no |
+| EmptyBlockUnspentSeed | possible | yes | no |
 | UnspentFuse | possible | yes | no |
 | NfMasterSeed | yes | no | no |
 | NfMasterStep | yes | no | no |
@@ -110,7 +112,7 @@ A fresh trapdoor per delegation makes the delegation identifier unlinkable acros
 
 `AnchorSeed` / `EmptyBlockSeed` build single-link `AnchorChain` segments; `AnchorFuse` composes adjacent segments.
 `RangeSummaryStampSeed` / `RangeSummaryEmptySeed` build single-link `RangeSummary` segments, which additionally carry the union of every absorbed stamp's tachygram set; `RangeSummaryFuse` composes adjacent segments.
-`UnspentFromRange` consumes a `RangeSummary` and emits an `Unspent` after proving the witnessed nullifier absent from the summary's tachygram set; `UnspentFuse` composes adjacent `Unspent` segments.
+`UnspentFromRange` consumes a `RangeSummary` and emits an `Unspent` after proving the witnessed nullifier absent from the summary's tachygram set; `UnspentSeed` / `EmptyBlockUnspentSeed` build single-stamp `Unspent` segments directly, collapsing the `RangeSummary` step for callers that already hold the stamp's tachygram set and the target nullifier; `UnspentFuse` composes adjacent `Unspent` segments.
 A segment ties to real chain history only when a stamp-emitting step consumes it and the resulting stamp's anchor matches a consensus-published end-of-block value.
 
 ### Spendable lifecycle
@@ -300,6 +302,10 @@ flowchart LR
   s_rfuse[RangeSummaryFuse]
   w_unspent[/nf, tg_gadget/]
   s_unspent[UnspentFromRange]
+  w_useed[/start, stamp_tg_set, nf/]
+  s_useed[UnspentSeed]
+  w_uempty[/start, nf/]
+  s_uempty[EmptyBlockUnspentSeed]
   s_ufuse[UnspentFuse]
   s_lift[SpendableLift]
   sp_out((SpendableHeader))
@@ -311,6 +317,10 @@ flowchart LR
   w_unspent --> s_unspent
   s_rfuse -->|RangeSummary| s_unspent
   s_unspent -->|Unspent| s_ufuse
+  w_useed --> s_useed
+  w_uempty --> s_uempty
+  s_useed -->|Unspent| s_ufuse
+  s_uempty -->|Unspent| s_ufuse
   sp_in --> s_lift
   s_ufuse -->|Unspent| s_lift
   s_lift --> sp_out
@@ -369,6 +379,8 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | RangeSummaryEmptySeed | — | — | start | RangeSummary |
 | RangeSummaryFuse | RangeSummary | RangeSummary | left_tg_gadget, right_tg_gadget | RangeSummary |
 | UnspentFromRange | RangeSummary | — | nf, tg_gadget | Unspent |
+| UnspentSeed | — | — | start, stamp_tg_set, nf | Unspent |
+| EmptyBlockUnspentSeed | — | — | start, nf | Unspent |
 | UnspentFuse | Unspent | Unspent | — | Unspent |
 | NfMasterSeed | — | — | note, pak | NfMasterHeader |
 | NfMasterStep | NfMasterHeader | — | chunk | NfPrefixHeader |

--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -54,7 +54,7 @@ It seeds and walks the private GGM tree (`NfMasterSeed`, `NfMasterStep`, `NfPref
 
 The sync service holds a `DelegateNfPrefixHeader` produced by the wallet at delegation time.
 From there it climbs the blinded subtree (`DelegateNfPrefixStep`) to whichever leaf an epoch requires and emits a `DelegateNullifierHeader` (`DelegateNullifierStep`); it fuses two consecutive-epoch leaves with `DelegateRolloverFuse` when an epoch boundary is approached.
-It produces the `Unspent` segments that carry the spendable forward (`RangeSummaryStampSeed`, `RangeSummaryEmptySeed`, `RangeSummaryFuse`, `UnspentRange`, `UnspentSeed`, `EmptyBlockUnspentSeed`, `UnspentFuse`), and runs the lifts that consume them (`SpendableLift`, `SpendableRollover`, `SpendableEpochLift`).
+It produces the `Unspent` segments that carry the spendable forward (`SummarySeed`, `EmptyBlockSummarySeed`, `SummaryFuse`, `UnspentRange`, `UnspentSeed`, `EmptyBlockUnspentSeed`, `UnspentFuse`), and runs the lifts that consume them (`SpendableLift`, `SpendableRollover`, `SpendableEpochLift`).
 
 The aggregator works only with published `StampHeader`s.
 It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `EmptyBlockSeed`, `AnchorFuse`) and fuses with `MergeStamp`.
@@ -64,9 +64,9 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `E
 | AnchorSeed | possible | yes | yes |
 | EmptyBlockSeed | possible | yes | yes |
 | AnchorFuse | possible | yes | yes |
-| RangeSummaryStampSeed | possible | yes | no |
-| RangeSummaryEmptySeed | possible | yes | no |
-| RangeSummaryFuse | possible | yes | no |
+| SummarySeed | possible | yes | no |
+| EmptyBlockSummarySeed | possible | yes | no |
+| SummaryFuse | possible | yes | no |
 | UnspentRange | possible | yes | no |
 | UnspentSeed | possible | yes | no |
 | EmptyBlockUnspentSeed | possible | yes | no |
@@ -111,7 +111,7 @@ A fresh trapdoor per delegation makes the delegation identifier unlinkable acros
 ### Anchor segments
 
 `AnchorSeed` / `EmptyBlockSeed` build single-link `AnchorChain` segments; `AnchorFuse` composes adjacent segments.
-`RangeSummaryStampSeed` / `RangeSummaryEmptySeed` build single-link `RangeSummary` segments, which additionally carry the union of every absorbed stamp's tachygram set; `RangeSummaryFuse` composes adjacent segments.
+`SummarySeed` / `EmptyBlockSummarySeed` build single-link `RangeSummary` segments, which additionally carry the union of every absorbed stamp's tachygram set; `SummaryFuse` composes adjacent segments.
 `UnspentRange` consumes a `RangeSummary` and emits an `Unspent` after proving the witnessed nullifier absent from the summary's tachygram set; `UnspentSeed` / `EmptyBlockUnspentSeed` build single-stamp `Unspent` segments directly, collapsing the `RangeSummary` step for callers that already hold the stamp's tachygram set and the target nullifier; `UnspentFuse` composes adjacent `Unspent` segments.
 A segment ties to real chain history only when a stamp-emitting step consumes it and the resulting stamp's anchor matches a consensus-published end-of-block value.
 
@@ -296,10 +296,10 @@ flowchart LR
 flowchart LR
   sp_in((SpendableHeader))
   w_seed[/start, stamp_tg_set/]
-  s_rseed[RangeSummaryStampSeed]
+  s_rseed[SummarySeed]
   w_empty[/start/]
-  s_rempty[RangeSummaryEmptySeed]
-  s_rfuse[RangeSummaryFuse]
+  s_rempty[EmptyBlockSummarySeed]
+  s_rfuse[SummaryFuse]
   w_unspent[/nf, tg_gadget/]
   s_unspent[UnspentRange]
   w_useed[/start, stamp_tg_set, nf/]
@@ -375,9 +375,9 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | AnchorSeed | — | — | start, stamp_commit | AnchorChain |
 | EmptyBlockSeed | — | — | start | AnchorChain |
 | AnchorFuse | AnchorChain | AnchorChain | — | AnchorChain |
-| RangeSummaryStampSeed | — | — | start, stamp_tg_set | RangeSummary |
-| RangeSummaryEmptySeed | — | — | start | RangeSummary |
-| RangeSummaryFuse | RangeSummary | RangeSummary | left_tg_gadget, right_tg_gadget | RangeSummary |
+| SummarySeed | — | — | start, stamp_tg_set | RangeSummary |
+| EmptyBlockSummarySeed | — | — | start | RangeSummary |
+| SummaryFuse | RangeSummary | RangeSummary | left_tg_gadget, right_tg_gadget | RangeSummary |
 | UnspentRange | RangeSummary | — | nf, tg_gadget | Unspent |
 | UnspentSeed | — | — | start, stamp_tg_set, nf | Unspent |
 | EmptyBlockUnspentSeed | — | — | start, nf | Unspent |

--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -11,8 +11,9 @@ Multiple parties execute the proof tree.
 
 ## Lifecycle
 
-A note is essentially created when the wallet runs `SpendableInit`.
-The step takes the wallet's `NullifierHeader` for the creation epoch and a `RangeSummary` covering the cm-stamp; it checks the note's commitment[^notes] is among the summary's tachygrams and the nullifier is absent, then emits a `SpendableHeader` carrying the nullifier and the summary's `end` anchor.
+A note is essentially created when the wallet runs `SpendableInitStamp` or `SpendableInitRange`.
+`SpendableInitStamp` is the direct one-step path: it takes the wallet's `NullifierHeader` for the creation epoch, a freely-witnessed pre-stamp anchor, and the tachygram set of the cm-stamp; it checks the note's commitment[^notes] is among those tachygrams and advances the anchor through the stamp, emitting a `SpendableHeader` at the post-stamp anchor. No nullifier-absence check is needed: a note's nullifier cannot appear in its own creation block.
+`SpendableInitRange` instead takes the `NullifierHeader` and a `RangeSummary` covering the cm-stamp; it checks the commitment is among the summary's tachygrams and the nullifier is absent, then emits a `SpendableHeader` carrying the nullifier and the summary's `end` anchor. The absence check is required because a range may also cover a later block in which the note was spent.
 
 Maintaining the spendable means advancing its anchor forward over `Unspent` segments.
 `SpendableLift` consumes one `Unspent` whose nullifier matches the spendable's and whose start matches the spendable's current anchor, producing a fresh `SpendableHeader` at the segment's end.
@@ -49,7 +50,7 @@ The aggregated stamp has the same shape as any other, so it is itself eligible f
 ## Roles
 
 The wallet runs every step that touches the note's commitment or master key.
-It seeds and walks the private GGM tree (`NfMasterSeed`, `NfMasterStep`, `NfPrefixStep`, `NullifierStep`), produces blinded handoffs for the sync service (`DelegationStep`), fuses leaves across an epoch boundary (`RolloverFuse`), derives spendable status from its own leaf (`SpendableInit`), and produces spend and output stamps (`SpendBind`, `OutputStamp`, `SpendStamp`).
+It seeds and walks the private GGM tree (`NfMasterSeed`, `NfMasterStep`, `NfPrefixStep`, `NullifierStep`), produces blinded handoffs for the sync service (`DelegationStep`), fuses leaves across an epoch boundary (`RolloverFuse`), derives spendable status from its own leaf (`SpendableInitRange`), and produces spend and output stamps (`SpendBind`, `OutputStamp`, `SpendStamp`).
 
 The sync service holds a `DelegateNfPrefixHeader` produced by the wallet at delegation time.
 From there it climbs the blinded subtree (`DelegateNfPrefixStep`) to whichever leaf an epoch requires and emits a `DelegateNullifierHeader` (`DelegateNullifierStep`); it fuses two consecutive-epoch leaves with `DelegateRolloverFuse` when an epoch boundary is approached.
@@ -77,7 +78,8 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `E
 | DelegateNullifierStep | possible | yes | no |
 | RolloverFuse | yes | no | no |
 | DelegateRolloverFuse | no | yes | no |
-| SpendableInit | yes | no | no |
+| SpendableInitRange | yes | no | no |
+| SpendableInitStamp | yes | no | no |
 | SpendableLift | yes | possible | no |
 | SpendableRollover | yes | possible | no |
 | SpendableEpochLift | yes | possible | no |
@@ -113,7 +115,9 @@ A segment ties to real chain history only when a stamp-emitting step consumes it
 
 ### Spendable lifecycle
 
-A spendable bootstraps at `SpendableInit`, which fuses the wallet's `NullifierHeader` with a `RangeSummary` covering the cm-stamp, verifies the note's commitment[^notes] is among the summary's tachygrams and the nullifier is absent, and emits a `SpendableHeader` carrying the nullifier and the summary's `end` anchor.
+A spendable bootstraps one of two ways.
+`SpendableInitStamp` fuses the wallet's `NullifierHeader` with a freely-witnessed pre-stamp anchor and the cm-stamp's tachygram set, verifies the note's commitment[^notes] is among those tachygrams, and advances the anchor through that stamp; it skips the absence check because the cm-stamp cannot contain the note's own nullifier.
+`SpendableInitRange` instead fuses the `NullifierHeader` with a `RangeSummary` covering the cm-stamp, verifies the commitment is among the summary's tachygrams and the nullifier is absent, and emits a `SpendableHeader` carrying the nullifier and the summary's `end` anchor; the absence check guards against a range that also covers the note's later spend.
 `SpendableLift` advances the spendable's anchor further by consuming an `Unspent` segment whose nullifier equals the spendable's and whose start matches the spendable's current anchor.
 Each `Unspent` is produced by `UnspentFromRange` against a `RangeSummary`, witnessing the nullifier and proving it absent from the summary's tachygram set[^tachygrams]; `UnspentFuse` requires both halves to share a nullifier and to meet at a common anchor.
 
@@ -168,7 +172,9 @@ flowchart TB
   subgraph spendable [spendable advance]
     w_init[/tg_gadget/]
     cm_range((RangeSummary))
-    s_init[SpendableInit]
+    s_init[SpendableInitRange]
+    w_init_stamp[/pre_cm_anchor, stamp_tg_set/]
+    s_init_stamp[SpendableInitStamp]
     s_rfuse[RolloverFuse]
     s_rollover[SpendableRollover]
     s_epochlift[SpendableEpochLift]
@@ -206,6 +212,10 @@ flowchart TB
   w_init --> s_init
   cm_range --> s_init
   s_init -->|SpendableHeader| s_rollover
+
+  s_leaf_old -->|NullifierHeader e-1| s_init_stamp
+  w_init_stamp --> s_init_stamp
+  s_init_stamp -->|SpendableHeader| s_rollover
 
   s_leaf_old -->|NullifierHeader e-1| s_rfuse
   s_leaf_now -->|NullifierHeader e| s_rfuse
@@ -369,7 +379,8 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | DelegateNullifierStep | DelegateNfPrefixHeader | — | — | DelegateNullifierHeader |
 | RolloverFuse | NullifierHeader | NullifierHeader | — | NullifierRolloverHeader |
 | DelegateRolloverFuse | DelegateNullifierHeader | DelegateNullifierHeader | — | NullifierRolloverHeader |
-| SpendableInit | NullifierHeader | RangeSummary | tg_gadget | SpendableHeader |
+| SpendableInitRange | NullifierHeader | RangeSummary | tg_gadget | SpendableHeader |
+| SpendableInitStamp | NullifierHeader | — | pre_cm_anchor, stamp_tg_set | SpendableHeader |
 | SpendableLift | SpendableHeader | Unspent | — | SpendableHeader |
 | SpendableRollover | SpendableHeader | NullifierRolloverHeader | — | SpendableRolloverHeader |
 | SpendableEpochLift | SpendableRolloverHeader | Unspent | — | SpendableHeader |

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -331,9 +331,9 @@ pub(crate) fn build_anchor_chain_pcd<'source>(
 
 /// Build a [`RangeSummary`] covering a single block height, returning
 /// the PCD alongside the accumulated tachygram gadget. Stamp links:
-/// one [`RangeSummaryStampSeed`] per stamp, fused via
-/// [`RangeSummaryFuse`]. Empty block: a single
-/// [`RangeSummaryEmptySeed`]. Per-height granularity keeps each
+/// one [`SummarySeed`] per stamp, fused via
+/// [`SummaryFuse`]. Empty block: a single
+/// [`EmptyBlockSummarySeed`]. Per-height granularity keeps each
 /// summary small (well under the per-step multiset budget) and
 /// matches the natural chunking the sync service produces.
 ///
@@ -348,8 +348,8 @@ pub(crate) fn build_range_summary_at<'source>(
     let stamps = pool.tachygrams_at(height);
     if stamps.is_empty() {
         let (pcd, ()) = PROOF_SYSTEM
-            .seed(rng, pool::RangeSummaryEmptySeed, (start,))
-            .expect("RangeSummaryEmptySeed");
+            .seed(rng, pool::EmptyBlockSummarySeed, (start,))
+            .expect("EmptyBlockSummarySeed");
         return (pcd, TachygramSetGadget::from([].as_slice()));
     }
     let mut chain: Option<(Pcd<'source, pool::RangeSummary>, TachygramSetGadget)> = None;
@@ -360,12 +360,8 @@ pub(crate) fn build_range_summary_at<'source>(
             | Some(prior) => prior.0.data.1,
         };
         let (seed, ()) = PROOF_SYSTEM
-            .seed(
-                rng,
-                pool::RangeSummaryStampSeed,
-                (seed_start, stamp_gadget.clone()),
-            )
-            .expect("RangeSummaryStampSeed");
+            .seed(rng, pool::SummarySeed, (seed_start, stamp_gadget.clone()))
+            .expect("SummarySeed");
         chain = Some(match chain.take() {
             | None => (seed, stamp_gadget),
             | Some((left_pcd, left_gadget)) => {
@@ -374,12 +370,12 @@ pub(crate) fn build_range_summary_at<'source>(
                 let (fused, ()) = PROOF_SYSTEM
                     .fuse(
                         rng,
-                        pool::RangeSummaryFuse,
+                        pool::SummaryFuse,
                         (left_gadget, right_gadget),
                         left_pcd,
                         seed,
                     )
-                    .expect("RangeSummaryFuse");
+                    .expect("SummaryFuse");
                 (fused, merged)
             },
         });
@@ -588,8 +584,8 @@ impl WalletSim {
             let next_state = state.next_stamp(commit);
             let tg_gadget = TachygramSetGadget::from(tgs.as_slice());
             let (summary, ()) = PROOF_SYSTEM
-                .seed(rng, pool::RangeSummaryStampSeed, (state, tg_gadget.clone()))
-                .expect("RangeSummaryStampSeed");
+                .seed(rng, pool::SummarySeed, (state, tg_gadget.clone()))
+                .expect("SummarySeed");
             let (unspent, ()) = PROOF_SYSTEM
                 .fuse(
                     rng,

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -329,71 +329,100 @@ pub(crate) fn build_anchor_chain_pcd<'source>(
     chain.expect("AnchorChain range must cover at least one block")
 }
 
-pub(crate) fn build_unspent_seed_pcd<'source>(
+/// Build a [`RangeSummary`] covering a single block height, returning
+/// the PCD alongside the accumulated tachygram gadget. Stamp links:
+/// one [`RangeSummaryStampSeed`] per stamp, fused via
+/// [`RangeSummaryFuse`]. Empty block: a single
+/// [`RangeSummaryEmptySeed`]. Per-height granularity keeps each
+/// summary small (well under the per-step multiset budget) and
+/// matches the natural chunking the sync service produces.
+///
+/// The returned gadget commits to the summary's `tg_set` and is the
+/// witness a downstream consumer must supply.
+pub(crate) fn build_range_summary_at<'source>(
     rng: &mut (impl RngCore + CryptoRng),
-    start: Anchor,
-    stamp_tgs: &[Tachygram],
-    nf: Nullifier,
-) -> Pcd<'source, pool::Unspent> {
-    let stamp_gadget = TachygramSetGadget::from(stamp_tgs);
-    let (pcd, ()) = PROOF_SYSTEM
-        .seed(rng, pool::UnspentSeed, (start, stamp_gadget, nf))
-        .expect("UnspentSeed");
-    pcd
+    pool: &PoolSim,
+    height: BlockHeight,
+) -> (Pcd<'source, pool::RangeSummary>, TachygramSetGadget) {
+    let start = pool.prev_anchor_at(height);
+    let stamps = pool.tachygrams_at(height);
+    if stamps.is_empty() {
+        let (pcd, ()) = PROOF_SYSTEM
+            .seed(rng, pool::RangeSummaryEmptySeed, (start,))
+            .expect("RangeSummaryEmptySeed");
+        return (pcd, TachygramSetGadget::from([].as_slice()));
+    }
+    let mut chain: Option<(Pcd<'source, pool::RangeSummary>, TachygramSetGadget)> = None;
+    for tgs in &stamps {
+        let stamp_gadget = TachygramSetGadget::from(tgs.as_slice());
+        let seed_start = match chain.as_ref() {
+            | None => start,
+            | Some(prior) => prior.0.data.1,
+        };
+        let (seed, ()) = PROOF_SYSTEM
+            .seed(
+                rng,
+                pool::RangeSummaryStampSeed,
+                (seed_start, stamp_gadget.clone()),
+            )
+            .expect("RangeSummaryStampSeed");
+        chain = Some(match chain.take() {
+            | None => (seed, stamp_gadget),
+            | Some((left_pcd, left_gadget)) => {
+                let right_gadget = stamp_gadget;
+                let merged = TachygramSetGadget(left_gadget.0.merge(&right_gadget.0));
+                let (fused, ()) = PROOF_SYSTEM
+                    .fuse(
+                        rng,
+                        pool::RangeSummaryFuse,
+                        (left_gadget, right_gadget),
+                        left_pcd,
+                        seed,
+                    )
+                    .expect("RangeSummaryFuse");
+                (fused, merged)
+            },
+        });
+    }
+    chain.expect("non-empty stamps")
 }
 
-/// Build an [`Unspent`] for `nf` covering blocks `range`. Per non-empty
-/// block: one [`UnspentSeed`] per stamp. Per empty block: one
-/// [`EmptyBlockUnspentSeed`]. All segments fused linearly via
-/// [`UnspentFuse`].
+/// Build an [`Unspent`] for `nf` covering blocks `range`. Per height:
+/// one [`build_range_summary_at`] then [`UnspentFromRange`].
+/// Cross-height composition via [`UnspentFuse`].
 pub(crate) fn build_unspent_pcd<'source>(
     rng: &mut (impl RngCore + CryptoRng),
     pool: &PoolSim,
     nf: Nullifier,
     range: RangeInclusive<BlockHeight>,
-) -> Pcd<'source, pool::Unspent> {
+) -> Pcd<'source, spendable::Unspent> {
     let start = *range.start();
     let end = *range.end();
     assert_eq!(start.epoch(), end.epoch(), "Unspent single-epoch range");
     assert!(start <= end);
 
-    let mut state = pool.prev_anchor_at(start);
-    let mut chain: Option<Pcd<'source, pool::Unspent>> = None;
+    let mut chain: Option<Pcd<'source, spendable::Unspent>> = None;
     let mut height = start;
     loop {
-        let stamps = pool.tachygrams_at(height);
-        let stamp_commits = pool.stamp_commits_at(height);
-        if stamps.is_empty() {
-            let next_state = state.next_empty();
-            let (seed, ()) = PROOF_SYSTEM
-                .seed(rng, pool::EmptyBlockUnspentSeed, (state, nf))
-                .expect("EmptyBlockUnspentSeed");
-            chain = Some(match chain.take() {
-                | None => seed,
-                | Some(left) => {
-                    let (fused, ()) = PROOF_SYSTEM
-                        .fuse(rng, pool::UnspentFuse, (), left, seed)
-                        .expect("UnspentFuse");
-                    fused
-                },
-            });
-            state = next_state;
-        } else {
-            for (tgs, commit) in stamps.iter().zip(stamp_commits.iter()) {
-                let next_state = state.next_stamp(commit);
-                let seed = build_unspent_seed_pcd(rng, state, tgs, nf);
-                chain = Some(match chain.take() {
-                    | None => seed,
-                    | Some(left) => {
-                        let (fused, ()) = PROOF_SYSTEM
-                            .fuse(rng, pool::UnspentFuse, (), left, seed)
-                            .expect("UnspentFuse");
-                        fused
-                    },
-                });
-                state = next_state;
-            }
-        }
+        let (summary, gadget) = build_range_summary_at(rng, pool, height);
+        let (unspent, ()) = PROOF_SYSTEM
+            .fuse(
+                rng,
+                spendable::UnspentFromRange,
+                (nf, gadget),
+                summary,
+                Proof::trivial().carry::<()>(()),
+            )
+            .expect("UnspentFromRange");
+        chain = Some(match chain.take() {
+            | None => unspent,
+            | Some(left) => {
+                let (fused, ()) = PROOF_SYSTEM
+                    .fuse(rng, spendable::UnspentFuse, (), left, unspent)
+                    .expect("UnspentFuse");
+                fused
+            },
+        });
         if height >= end {
             break;
         }
@@ -528,14 +557,23 @@ impl WalletSim {
             .iter()
             .fold(pool.prev_anchor_at(height), Anchor::next_stamp);
 
+        // Single-stamp RangeSummary over the cm-stamp.
         let stamp_gadget = TachygramSetGadget::from(stamps[cm_idx].as_slice());
+        let (cm_summary, ()) = PROOF_SYSTEM
+            .seed(
+                rng,
+                pool::RangeSummaryStampSeed,
+                (pre_cm_anchor, stamp_gadget.clone()),
+            )
+            .expect("RangeSummaryStampSeed");
+
         let (spendable, ()) = PROOF_SYSTEM
             .fuse(
                 rng,
                 spendable::SpendableInit,
-                (pre_cm_anchor, stamp_gadget),
+                (stamp_gadget,),
                 nf_pcd,
-                Proof::trivial().carry::<()>(()),
+                cm_summary,
             )
             .expect("SpendableInit");
 
@@ -545,22 +583,35 @@ impl WalletSim {
             return spendable;
         }
 
-        // Build an Unspent over stamps cm_idx+1..end of the cm-block,
-        // chained from post_cm_anchor, then SpendableLift.
+        // Build an Unspent over stamps cm_idx+1..end of the cm-block
+        // — per-stamp RangeSummary then UnspentFromRange, fused
+        // linearly — chained from post_cm_anchor, then SpendableLift.
         let nf = spendable.data.0;
         let mut state = spendable.data.1;
-        let mut acc: Option<Pcd<'source, pool::Unspent>> = None;
+        let mut acc: Option<Pcd<'source, spendable::Unspent>> = None;
         for (tgs, commit) in stamps[cm_idx + 1..]
             .iter()
             .zip(stamp_commits[cm_idx + 1..].iter())
         {
             let next_state = state.next_stamp(commit);
-            let seed = build_unspent_seed_pcd(rng, state, tgs, nf);
+            let tg_gadget = TachygramSetGadget::from(tgs.as_slice());
+            let (summary, ()) = PROOF_SYSTEM
+                .seed(rng, pool::RangeSummaryStampSeed, (state, tg_gadget.clone()))
+                .expect("RangeSummaryStampSeed");
+            let (unspent, ()) = PROOF_SYSTEM
+                .fuse(
+                    rng,
+                    spendable::UnspentFromRange,
+                    (nf, tg_gadget),
+                    summary,
+                    Proof::trivial().carry::<()>(()),
+                )
+                .expect("UnspentFromRange");
             acc = Some(match acc.take() {
-                | None => seed,
+                | None => unspent,
                 | Some(left) => {
                     let (fused, ()) = PROOF_SYSTEM
-                        .fuse(rng, pool::UnspentFuse, (), left, seed)
+                        .fuse(rng, spendable::UnspentFuse, (), left, unspent)
                         .expect("UnspentFuse");
                     fused
                 },

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -557,25 +557,17 @@ impl WalletSim {
             .iter()
             .fold(pool.prev_anchor_at(height), Anchor::next_stamp);
 
-        // Single-stamp RangeSummary over the cm-stamp.
+        // Direct one-step bootstrap from the single cm-stamp.
         let stamp_gadget = TachygramSetGadget::from(stamps[cm_idx].as_slice());
-        let (cm_summary, ()) = PROOF_SYSTEM
-            .seed(
-                rng,
-                pool::RangeSummaryStampSeed,
-                (pre_cm_anchor, stamp_gadget.clone()),
-            )
-            .expect("RangeSummaryStampSeed");
-
         let (spendable, ()) = PROOF_SYSTEM
             .fuse(
                 rng,
-                spendable::SpendableInit,
-                (stamp_gadget,),
+                spendable::SpendableInitStamp,
+                (pre_cm_anchor, stamp_gadget),
                 nf_pcd,
-                cm_summary,
+                Proof::trivial().carry::<()>(()),
             )
-            .expect("SpendableInit");
+            .expect("SpendableInitStamp");
 
         // If cm is the last stamp, post_cm_anchor is already the
         // block-final anchor — no rest-of-block lift needed.

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -388,7 +388,7 @@ pub(crate) fn build_range_summary_at<'source>(
 }
 
 /// Build an [`Unspent`] for `nf` covering blocks `range`. Per height:
-/// one [`build_range_summary_at`] then [`UnspentFromRange`].
+/// one [`build_range_summary_at`] then [`UnspentRange`].
 /// Cross-height composition via [`UnspentFuse`].
 pub(crate) fn build_unspent_pcd<'source>(
     rng: &mut (impl RngCore + CryptoRng),
@@ -408,12 +408,12 @@ pub(crate) fn build_unspent_pcd<'source>(
         let (unspent, ()) = PROOF_SYSTEM
             .fuse(
                 rng,
-                spendable::UnspentFromRange,
+                spendable::UnspentRange,
                 (nf, gadget),
                 summary,
                 Proof::trivial().carry::<()>(()),
             )
-            .expect("UnspentFromRange");
+            .expect("UnspentRange");
         chain = Some(match chain.take() {
             | None => unspent,
             | Some(left) => {
@@ -576,7 +576,7 @@ impl WalletSim {
         }
 
         // Build an Unspent over stamps cm_idx+1..end of the cm-block
-        // — per-stamp RangeSummary then UnspentFromRange, fused
+        // — per-stamp RangeSummary then UnspentRange, fused
         // linearly — chained from post_cm_anchor, then SpendableLift.
         let nf = spendable.data.0;
         let mut state = spendable.data.1;
@@ -593,12 +593,12 @@ impl WalletSim {
             let (unspent, ()) = PROOF_SYSTEM
                 .fuse(
                     rng,
-                    spendable::UnspentFromRange,
+                    spendable::UnspentRange,
                     (nf, tg_gadget),
                     summary,
                     Proof::trivial().carry::<()>(()),
                 )
-                .expect("UnspentFromRange");
+                .expect("UnspentRange");
             acc = Some(match acc.take() {
                 | None => unspent,
                 | Some(left) => {

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -70,8 +70,8 @@ impl Header for NfPrefixHeader {
 /// Private header after nullifier derivation.
 ///
 /// Carries `(cm, nf, epoch)` — the wallet's private GGM-leaf state. `cm` is
-/// required at [`SpendableInitRange`](super::spendable::SpendableInitRange) to bind
-/// the spendable to the cm-stamp's anchor advance, and at
+/// required at [`SpendableInitRange`](super::spendable::SpendableInitRange) to
+/// bind the spendable to the cm-stamp's anchor advance, and at
 /// [`SpendBind`](super::spend::SpendBind) to bind the action to the note
 /// via `note.commitment() == cm_tg`. User device only — `cm` is private.
 #[derive(Clone, Debug)]

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -70,7 +70,7 @@ impl Header for NfPrefixHeader {
 /// Private header after nullifier derivation.
 ///
 /// Carries `(cm, nf, epoch)` — the wallet's private GGM-leaf state. `cm` is
-/// required at [`SpendableInit`](super::spendable::SpendableInit) to bind
+/// required at [`SpendableInitRange`](super::spendable::SpendableInitRange) to bind
 /// the spendable to the cm-stamp's anchor advance, and at
 /// [`SpendBind`](super::spend::SpendBind) to bind the action to the note
 /// via `note.commitment() == cm_tg`. User device only — `cm` is private.

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -30,9 +30,11 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
         .register(pool::AnchorSeed)?
         .register(pool::EmptyBlockSeed)?
         .register(pool::AnchorFuse)?
-        .register(pool::UnspentSeed)?
-        .register(pool::EmptyBlockUnspentSeed)?
-        .register(pool::UnspentFuse)?
+        .register(pool::RangeSummaryStampSeed)?
+        .register(pool::RangeSummaryEmptySeed)?
+        .register(pool::RangeSummaryFuse)?
+        .register(spendable::UnspentFromRange)?
+        .register(spendable::UnspentFuse)?
         .register(spendable::SpendableInit)?
         .register(spendable::SpendableLift)?
         .register(spendable::RolloverFuse)?

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -33,7 +33,7 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
         .register(pool::RangeSummaryStampSeed)?
         .register(pool::RangeSummaryEmptySeed)?
         .register(pool::RangeSummaryFuse)?
-        .register(spendable::UnspentFromRange)?
+        .register(spendable::UnspentRange)?
         .register(spendable::UnspentFuse)?
         .register(spendable::SpendableInitRange)?
         .register(spendable::SpendableLift)?

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -30,11 +30,14 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
         .register(pool::AnchorSeed)?
         .register(pool::EmptyBlockSeed)?
         .register(pool::AnchorFuse)?
-        .register(pool::RangeSummaryStampSeed)?
-        .register(pool::RangeSummaryEmptySeed)?
-        .register(pool::RangeSummaryFuse)?
-        .register(spendable::UnspentRange)?
+        .register(pool::SummarySeed)?
+        .register(pool::EmptyBlockSummarySeed)?
+        .register(pool::SummaryFuse)?
+        .register(spendable::UnspentSeed)?
+        .register(spendable::EmptyBlockUnspentSeed)?
         .register(spendable::UnspentFuse)?
+        .register(spendable::UnspentRange)?
+        .register(spendable::SpendableInitStamp)?
         .register(spendable::SpendableInitRange)?
         .register(spendable::SpendableLift)?
         .register(spendable::RolloverFuse)?
@@ -46,9 +49,6 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
         .register(stamp::SpendStamp)?
         .register(stamp::MergeStamp)?
         .register(stamp::StampLift)?
-        .register(spendable::SpendableInitStamp)?
-        .register(spendable::UnspentSeed)?
-        .register(spendable::EmptyBlockUnspentSeed)?
         .finalize()
 }
 

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -47,6 +47,8 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
         .register(stamp::MergeStamp)?
         .register(stamp::StampLift)?
         .register(spendable::SpendableInitStamp)?
+        .register(spendable::UnspentSeed)?
+        .register(spendable::EmptyBlockUnspentSeed)?
         .finalize()
 }
 

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -35,7 +35,7 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
         .register(pool::RangeSummaryFuse)?
         .register(spendable::UnspentFromRange)?
         .register(spendable::UnspentFuse)?
-        .register(spendable::SpendableInit)?
+        .register(spendable::SpendableInitRange)?
         .register(spendable::SpendableLift)?
         .register(spendable::RolloverFuse)?
         .register(spendable::DelegateRolloverFuse)?
@@ -46,6 +46,7 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
         .register(stamp::SpendStamp)?
         .register(stamp::MergeStamp)?
         .register(stamp::StampLift)?
+        .register(spendable::SpendableInitStamp)?
         .finalize()
 }
 

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -101,7 +101,7 @@ impl Header for AnchorChain {
 /// # Bounded by the per-step multiset budget
 ///
 /// The per-step multiset budget caps total items across all sets at
-/// roughly 8192. Every [`RangeSummaryFuse`] merges two
+/// roughly 8192. Every [`SummaryFuse`] merges two
 /// `TachygramSetGadget`s, so a segment can only grow as long as the
 /// union of all its absorbed tachygrams stays under that ceiling
 /// (minus the bookkeeping for the merge itself). Above that, build
@@ -112,7 +112,7 @@ pub struct RangeSummary;
 
 impl Header for RangeSummary {
     /// `(start, end, tg_set)`. `start` is freely witnessed at the seed
-    /// steps ([`RangeSummaryStampSeed`] / [`RangeSummaryEmptySeed`]).
+    /// steps ([`SummarySeed`] / [`EmptyBlockSummarySeed`]).
     /// `end` is computed in-circuit as `start.next_stamp(...)` or
     /// `start.next_empty()`. `tg_set` is the commitment of the gadget
     /// multiset witnessed at the seed (a single stamp's tachygram set,
@@ -228,9 +228,9 @@ impl Step for AnchorFuse {
 /// one step each, useful for wallets/sync services that build summaries
 /// of known shape.
 #[derive(Debug)]
-pub struct RangeSummaryStampSeed;
+pub struct SummarySeed;
 
-impl Step for RangeSummaryStampSeed {
+impl Step for SummarySeed {
     type Aux<'source> = ();
     type Left = ();
     type Output = RangeSummary;
@@ -260,9 +260,9 @@ impl Step for RangeSummaryStampSeed {
 /// empty-block summary cleanly carries the "no tachygrams here"
 /// semantics needed by [`super::spendable::UnspentRange`].
 #[derive(Debug)]
-pub struct RangeSummaryEmptySeed;
+pub struct EmptyBlockSummarySeed;
 
-impl Step for RangeSummaryEmptySeed {
+impl Step for EmptyBlockSummarySeed {
     type Aux<'source> = ();
     type Left = ();
     type Output = RangeSummary;
@@ -288,9 +288,9 @@ impl Step for RangeSummaryEmptySeed {
 /// right.start`. Witness gadgets bind to each side's `tg_set` so the
 /// merged commitment is verifiable.
 #[derive(Debug)]
-pub struct RangeSummaryFuse;
+pub struct SummaryFuse;
 
-impl Step for RangeSummaryFuse {
+impl Step for SummaryFuse {
     type Aux<'source> = ();
     type Left = RangeSummary;
     type Output = RangeSummary;
@@ -307,11 +307,11 @@ impl Step for RangeSummaryFuse {
         (right_start, right_end, right_tg_commit): <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
         if left_end != right_start {
-            return Err(mock_ragu::Error("RangeSummaryFuse: segments not adjacent"));
+            return Err(mock_ragu::Error("SummaryFuse: segments not adjacent"));
         }
         if tgs0.0.commit() != left_tg_commit.0 || tgs1.0.commit() != right_tg_commit.0 {
             return Err(mock_ragu::Error(
-                "RangeSummaryFuse: witness gadgets must commit to header tg_set",
+                "SummaryFuse: witness gadgets must commit to header tg_set",
             ));
         }
         let merged_tg = TachygramSetGadget(tgs0.0.merge(&tgs1.0));

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -220,7 +220,7 @@ impl Step for AnchorFuse {
 ///
 /// `start` is freely witnessed; binding closes downstream at
 /// [`super::spendable::UnspentFromRange`] /
-/// [`super::spendable::SpendableInit`] and ultimately through consensus
+/// [`super::spendable::SpendableInitRange`] and ultimately through consensus
 /// anchor membership.
 ///
 /// TODO: Multi-stamp composition steps (e.g. a two-stamp seed and a

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -9,7 +9,7 @@
 //!   inclusion and exclusion tests against a segment.
 //!
 //! Per-nf exclusion lives in [`super::spendable`] as `Unspent`, built
-//! from a [`RangeSummary`] via `UnspentFromRange`.
+//! from a [`RangeSummary`] via `UnspentRange`.
 //!
 //! Anchor advances are single-level: every link absorbs one stamp's
 //! tachygram-set commitment into the running [`Anchor`] via
@@ -20,7 +20,7 @@
 //! `RangeSummary` is bounded by the per-step multiset budget (~8192
 //! items across all sets in a single step). Above that ceiling, proofs
 //! transition into set-free `Unspent` (for per-nf exclusion) or
-//! `AnchorChain` (for anchor-only continuity); the `UnspentFromRange`
+//! `AnchorChain` (for anchor-only continuity); the `UnspentRange`
 //! step in [`super::spendable`] is the natural transition.
 
 #![allow(clippy::module_name_repetitions, reason = "intentional names")]
@@ -106,7 +106,7 @@ impl Header for AnchorChain {
 /// union of all its absorbed tachygrams stays under that ceiling
 /// (minus the bookkeeping for the merge itself). Above that, build
 /// the segment in chunks and transition to [`super::spendable::Unspent`]
-/// via [`super::spendable::UnspentFromRange`] before fusing further.
+/// via [`super::spendable::UnspentRange`] before fusing further.
 #[derive(Clone, Debug)]
 pub struct RangeSummary;
 
@@ -219,7 +219,7 @@ impl Step for AnchorFuse {
 /// the anchor, and emits `(start, end, tg_commit)`.
 ///
 /// `start` is freely witnessed; binding closes downstream at
-/// [`super::spendable::UnspentFromRange`] /
+/// [`super::spendable::UnspentRange`] /
 /// [`super::spendable::SpendableInitRange`] and ultimately through consensus
 /// anchor membership.
 ///
@@ -258,7 +258,7 @@ impl Step for RangeSummaryStampSeed {
 /// `empty_tg` is the commitment of the empty multiset; downstream
 /// queries (`query(x)` for any x) return non-zero against it, so an
 /// empty-block summary cleanly carries the "no tachygrams here"
-/// semantics needed by [`super::spendable::UnspentFromRange`].
+/// semantics needed by [`super::spendable::UnspentRange`].
 #[derive(Debug)]
 pub struct RangeSummaryEmptySeed;
 

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -1,15 +1,27 @@
 //! Anchor-bound primitives over consensus state.
 //!
-//! Hosts the nf-free anchor segment ([`AnchorChain`]) used by
-//! [`super::stamp::StampLift`] to advance a stamp's anchor, and the
-//! multi-stamp exclusion proof ([`Unspent`]) used by
-//! [`super::spendable::SpendableLift`] to advance a spendable.
+//! Hosts two range shapes:
+//!
+//! - [`AnchorChain`] — set-free anchor continuity, consumed by
+//!   [`super::stamp::StampLift`] to advance a stamp's anchor.
+//! - [`RangeSummary`] — bounded anchor segment that additionally carries the
+//!   union of every absorbed stamp's tachygram set, the foundation for
+//!   inclusion and exclusion tests against a segment.
+//!
+//! Per-nf exclusion lives in [`super::spendable`] as `Unspent`, built
+//! from a [`RangeSummary`] via `UnspentFromRange`.
 //!
 //! Anchor advances are single-level: every link absorbs one stamp's
 //! tachygram-set commitment into the running [`Anchor`] via
 //! [`Anchor::next_stamp`]. There is no per-block hash domain — block
 //! alignment is a consensus convention (validators check that anchor
 //! endpoints belong to the published per-block anchor sequence).
+//!
+//! `RangeSummary` is bounded by the per-step multiset budget (~8192
+//! items across all sets in a single step). Above that ceiling, proofs
+//! transition into set-free `Unspent` (for per-nf exclusion) or
+//! `AnchorChain` (for anchor-only continuity); the `UnspentFromRange`
+//! step in [`super::spendable`] is the natural transition.
 
 #![allow(clippy::module_name_repetitions, reason = "intentional names")]
 
@@ -17,20 +29,19 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use ff::{Field as _, PrimeField as _};
+use ff::PrimeField as _;
 use mock_ragu::{Header, Index, Step, Suffix};
 use pasta_curves::Fp;
 
-use crate::{
-    note::Nullifier,
-    primitives::{Anchor, TachygramSetCommit, TachygramSetGadget},
-};
+use crate::primitives::{Anchor, TachygramSetCommit, TachygramSetGadget};
 
-/// Anchor segment between two endpoints. Composable via [`AnchorFuse`].
+/// Set-free anchor segment between two endpoints. Composable via
+/// [`AnchorFuse`].
 ///
 /// Direction-agnostic: `start` and `end` are both anchors. Consumed only
 /// by [`super::stamp::StampLift`] — extending a spendable's anchor must
-/// instead go through [`Unspent`] so each step proves nf-exclusion.
+/// instead go through [`super::spendable::Unspent`] so each step proves
+/// nf-exclusion.
 ///
 /// Structurally intra-epoch because only intra-epoch [`Anchor::next_stamp`]
 /// is invoked anywhere in the [`AnchorChain`] builders — crossing an
@@ -46,6 +57,10 @@ use crate::{
 /// standalone segment proves nothing about real coverage. Final binding
 /// closes when [`super::stamp::StampLift`] consumes the segment and the
 /// resulting stamp is accepted by consensus (anchor membership).
+///
+/// Unlike [`RangeSummary`], `AnchorChain` carries no tachygram data, so
+/// it composes to arbitrary length without bumping into the per-step
+/// multiset budget — aggregator-side stamp lifts ride this set-free path.
 #[derive(Clone, Debug)]
 pub struct AnchorChain;
 
@@ -66,44 +81,51 @@ impl Header for AnchorChain {
     }
 }
 
-/// Per-nf range exclusion proof.
+/// Bounded anchor segment that additionally carries the union of every
+/// absorbed stamp's tachygram set — the foundation for inclusion and
+/// exclusion tests against the segment.
 ///
-/// `nf` is absent from every stamp covered by the anchor segment from
-/// `start` to `end`. Built per-stamp at seed and fused with adjacent
-/// fragments — fusion now spans block boundaries because anchor
-/// advances are continuous.
+/// `start` and `end` mark the segment's anchor endpoints exactly as in
+/// [`AnchorChain`]. `tg_set` is a Pedersen commitment to the union of
+/// every stamp link's tachygram set absorbed along the segment;
+/// empty-block links contribute the empty multiset (identity under
+/// merge).
 ///
-/// Same-epoch is structurally guaranteed by GGM-binding of `nf` to one
-/// epoch and by the intra-epoch-only `Anchor::next_stamp` advances —
-/// crossing an epoch boundary requires matching a boundary anchor that
-/// no `Unspent` builder ever emits.
+/// Intra-epoch is structurally inherited from [`AnchorChain`]: only
+/// [`Anchor::next_stamp`] / [`Anchor::next_empty`] are invoked, never
+/// [`Anchor::next_epoch`]. Crossing the boundary would require either a
+/// real anchor pair that the in-circuit hashes don't connect (the
+/// fuse's adjacency check rejects) or freely-witnessed endpoints that
+/// then fail consensus anchor membership at consumption.
 ///
-/// At the seed steps the PCD lineage of `nf` and `start` roots in
-/// freely-chosen witnesses. `nf`'s binding closes at the consumer
-/// ([`super::spendable::SpendableLift`] checks `unspent.nf ==
-/// spendable.nf`; the spendable's `nf` is itself bound upstream at
-/// [`super::delegation::NullifierHeader`]); `start`'s binding closes
-/// through the spendable lineage plus consensus anchor membership.
+/// # Bounded by the per-step multiset budget
+///
+/// The per-step multiset budget caps total items across all sets at
+/// roughly 8192. Every [`RangeSummaryFuse`] merges two
+/// `TachygramSetGadget`s, so a segment can only grow as long as the
+/// union of all its absorbed tachygrams stays under that ceiling
+/// (minus the bookkeeping for the merge itself). Above that, build
+/// the segment in chunks and transition to [`super::spendable::Unspent`]
+/// via [`super::spendable::UnspentFromRange`] before fusing further.
 #[derive(Clone, Debug)]
-pub struct Unspent;
+pub struct RangeSummary;
 
-impl Header for Unspent {
-    /// `(nf, start, end)`. `nf` roots in a seed witness, bound by the
-    /// consumer ([`super::spendable::SpendableLift`] checks
-    /// `unspent.nf == spendable.nf`, and the spendable's `nf` is
-    /// GGM-bound upstream). `start` roots in a seed witness, bound
-    /// through the spendable lineage plus consensus anchor membership.
-    /// `end` is always computed in-circuit as `start.next_stamp(...)`
-    /// or `start.next_empty()`.
-    type Data<'source> = (Nullifier, Anchor, Anchor);
+impl Header for RangeSummary {
+    /// `(start, end, tg_set)`. `start` is freely witnessed at the seed
+    /// steps ([`RangeSummaryStampSeed`] / [`RangeSummaryEmptySeed`]).
+    /// `end` is computed in-circuit as `start.next_stamp(...)` or
+    /// `start.next_empty()`. `tg_set` is the commitment of the gadget
+    /// multiset witnessed at the seed (a single stamp's tachygram set,
+    /// or the empty multiset for an empty-block link).
+    type Data<'source> = (Anchor, Anchor, TachygramSetCommit);
 
-    const SUFFIX: Suffix = Suffix::new(6);
+    const SUFFIX: Suffix = Suffix::new(12);
 
     fn encode(data: &Self::Data<'_>) -> Vec<u8> {
         let mut out = Vec::with_capacity(32 + 32 + 32);
         out.extend_from_slice(&Fp::from(data.0).to_repr());
         out.extend_from_slice(&Fp::from(data.1).to_repr());
-        out.extend_from_slice(&Fp::from(data.2).to_repr());
+        out.extend_from_slice(&<[u8; 32]>::from(data.2.0));
         out
     }
 }
@@ -192,103 +214,108 @@ impl Step for AnchorFuse {
     }
 }
 
-/// Per-stamp exclusion seed: verify `nf ∉ stamp_tg_set` and absorb the
-/// stamp's commit at `start`, producing a one-stamp [`Unspent`].
+/// Single-stamp [`RangeSummary`] seed. Witness `(start, stamp_tg_set)`;
+/// commits `stamp_tg_set` to a `TachygramSetCommit`, absorbs it into
+/// the anchor, and emits `(start, end, tg_commit)`.
 ///
-/// `start` is freely witnessed — the seed proves nothing about real
-/// coverage on its own. Final binding happens transitively through the
-/// spendable lineage plus consensus-side anchor membership.
+/// `start` is freely witnessed; binding closes downstream at
+/// [`super::spendable::UnspentFromRange`] /
+/// [`super::spendable::SpendableInit`] and ultimately through consensus
+/// anchor membership.
+///
+/// TODO: Multi-stamp composition steps (e.g. a two-stamp seed and a
+/// stamp-absorb step) would collapse a sequence of seed+fuse pairs into
+/// one step each, useful for wallets/sync services that build summaries
+/// of known shape.
 #[derive(Debug)]
-pub struct UnspentSeed;
+pub struct RangeSummaryStampSeed;
 
-impl Step for UnspentSeed {
+impl Step for RangeSummaryStampSeed {
     type Aux<'source> = ();
     type Left = ();
-    type Output = Unspent;
+    type Output = RangeSummary;
     type Right = ();
-    /// `(start, stamp_tg_set, nf)`.
-    type Witness<'source> = (Anchor, TachygramSetGadget, Nullifier);
+    /// `(start, stamp_tg_set)`.
+    type Witness<'source> = (Anchor, TachygramSetGadget);
 
     const INDEX: Index = Index::new(10);
 
     fn witness<'source>(
         &self,
-        (start, stamp_tg_set, nf): Self::Witness<'source>,
+        (start, stamp_tg_set): Self::Witness<'source>,
         _left: <Self::Left as Header>::Data<'source>,
         _right: <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        // Exclusion: nf ∉ set ⇔ query(nf) != 0.
-        if stamp_tg_set.0.query(Fp::from(nf)) == Fp::ZERO {
-            return Err(mock_ragu::Error("UnspentSeed: found nullifier in set"));
-        }
-        let stamp_commit = TachygramSetCommit::from(stamp_tg_set);
-        let end = start.next_stamp(&stamp_commit);
-        Ok(((nf, start, end), ()))
+        let tg_commit = TachygramSetCommit::from(stamp_tg_set);
+        let end = start.next_stamp(&tg_commit);
+        Ok(((start, end, tg_commit), ()))
     }
 }
 
-/// One-empty-block [`Unspent`] seed for any `nf`. No exclusion check is
-/// needed — an empty block contains no stamps, so any nf is trivially
-/// absent.
+/// One-empty-block [`RangeSummary`] seed. Witness `(start,)`;
+/// emits `(start, start.next_empty(), empty_tg)`.
 ///
-/// Witness `(start, nf)`; emit `(nf, start, start.next_empty())`. An
-/// attacker can claim any nf at an empty-block segment, but the consumer
-/// (`SpendableLift`) checks `unspent.nf == spendable.nf` and the
-/// spendable's nf is GGM-bound upstream — so a fake-nf empty segment can
-/// only "advance" a non-existent fake spendable.
+/// `empty_tg` is the commitment of the empty multiset; downstream
+/// queries (`query(x)` for any x) return non-zero against it, so an
+/// empty-block summary cleanly carries the "no tachygrams here"
+/// semantics needed by [`super::spendable::UnspentFromRange`].
 #[derive(Debug)]
-pub struct EmptyBlockUnspentSeed;
+pub struct RangeSummaryEmptySeed;
 
-impl Step for EmptyBlockUnspentSeed {
+impl Step for RangeSummaryEmptySeed {
     type Aux<'source> = ();
     type Left = ();
-    type Output = Unspent;
+    type Output = RangeSummary;
     type Right = ();
-    /// `(start, nf)`.
-    type Witness<'source> = (Anchor, Nullifier);
+    /// `(start,)`.
+    type Witness<'source> = (Anchor,);
 
     const INDEX: Index = Index::new(11);
 
     fn witness<'source>(
         &self,
-        (start, nf): Self::Witness<'source>,
+        (start,): Self::Witness<'source>,
         _left: <Self::Left as Header>::Data<'source>,
         _right: <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        Ok(((nf, start, start.next_empty()), ()))
+        let empty_tg = TachygramSetCommit::from([].as_slice());
+        let end = start.next_empty();
+        Ok(((start, end, empty_tg), ()))
     }
 }
 
-/// Compose two adjacent [`Unspent`] segments for the same `nf`.
-/// Verify same `nf` and `left.end == right.start`.
+/// Compose two adjacent [`RangeSummary`] segments — `left.end ==
+/// right.start`. Witness gadgets bind to each side's `tg_set` so the
+/// merged commitment is verifiable.
 #[derive(Debug)]
-pub struct UnspentFuse;
+pub struct RangeSummaryFuse;
 
-impl Step for UnspentFuse {
+impl Step for RangeSummaryFuse {
     type Aux<'source> = ();
-    type Left = Unspent;
-    type Output = Unspent;
-    type Right = Unspent;
-    type Witness<'source> = ();
+    type Left = RangeSummary;
+    type Output = RangeSummary;
+    type Right = RangeSummary;
+    /// `(left_tg_gadget, right_tg_gadget)`.
+    type Witness<'source> = (TachygramSetGadget, TachygramSetGadget);
 
     const INDEX: Index = Index::new(12);
 
     fn witness<'source>(
         &self,
-        _witness: Self::Witness<'source>,
-        (left_nf, left_start, left_end): <Self::Left as Header>::Data<'source>,
-        (right_nf, right_start, right_end): <Self::Right as Header>::Data<'source>,
+        (tgs0, tgs1): Self::Witness<'source>,
+        (left_start, left_end, left_tg_commit): <Self::Left as Header>::Data<'source>,
+        (right_start, right_end, right_tg_commit): <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        if left_nf != right_nf {
-            return Err(mock_ragu::Error(
-                "UnspentFuse: left and right must share the same nf",
-            ));
-        }
         if left_end != right_start {
+            return Err(mock_ragu::Error("RangeSummaryFuse: segments not adjacent"));
+        }
+        if tgs0.0.commit() != left_tg_commit.0 || tgs1.0.commit() != right_tg_commit.0 {
             return Err(mock_ragu::Error(
-                "UnspentFuse: left.end must equal right.start",
+                "RangeSummaryFuse: witness gadgets must commit to header tg_set",
             ));
         }
-        Ok(((left_nf, left_start, right_end), ()))
+        let merged_tg = TachygramSetGadget(tgs0.0.merge(&tgs1.0));
+        let merged_commit = TachygramSetCommit::from(merged_tg);
+        Ok(((left_start, right_end, merged_commit), ()))
     }
 }

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -97,7 +97,7 @@ impl Step for SpendBind {
         Note,
     );
 
-    const INDEX: Index = Index::new(22);
+    const INDEX: Index = Index::new(25);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -97,7 +97,7 @@ impl Step for SpendBind {
         Note,
     );
 
-    const INDEX: Index = Index::new(20);
+    const INDEX: Index = Index::new(22);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -1,7 +1,7 @@
 //! Spendable bootstrap, lift, and cross-epoch rollover.
 //!
 //! Bootstrap runs entirely on the user device. The wallet's
-//! [`NullifierHeader`] carries `(cm, nf, epoch)`; [`SpendableInit`]
+//! [`NullifierHeader`] carries `(cm, nf, epoch)`; [`SpendableInitRange`]
 //! fuses it with a [`RangeSummary`] that covers the cm-stamp,
 //! verifying `cm ∈ range.tg_set` and `nf ∉ range.tg_set`, and emits a
 //! [`SpendableHeader`] carrying `(nf, range.end)` — the running anchor
@@ -15,6 +15,12 @@
 //! [`SpendableLift`] over [`Unspent`] segments, which by construction
 //! prove nf-exclusion at every covered stamp. There is no path that
 //! advances a spendable's anchor without a per-stamp nf-check.
+//!
+//! [`SpendableInitStamp`] is the one-step counterpart for the common
+//! case: the wallet seeds a spendable from a single freely-witnessed
+//! cm-stamp without first building a [`RangeSummary`]. It omits the
+//! nf-exclusion check, sound because a single cm-stamp cannot contain
+//! the note's own `nf`.
 //!
 //! Sync services update spendables via lifts ([`SpendableLift`]) and
 //! cross-epoch rollovers ([`SpendableRollover`] →
@@ -38,7 +44,7 @@ use super::{
 };
 use crate::{
     note::Nullifier,
-    primitives::{Anchor, EpochIndex, TachygramSetGadget},
+    primitives::{Anchor, EpochIndex, TachygramSetCommit, TachygramSetGadget},
 };
 
 /// Per-nf range exclusion proof.
@@ -167,7 +173,7 @@ impl Step for UnspentFuse {
 /// encodes `(key, epoch)` via GGM determinism, so sync services can update
 /// a spendable by `nf` without knowing `delegation_id`.
 ///
-/// `anchor` at [`SpendableInit`] is inherited as the `end` of the
+/// `anchor` at [`SpendableInitRange`] is inherited as the `end` of the
 /// consumed [`RangeSummary`], but its PCD lineage roots in the
 /// freely-witnessed `start` at the [`RangeSummary`] seed steps.
 /// Binding closes only through subsequent [`SpendableLift`] steps over
@@ -180,7 +186,7 @@ pub struct SpendableHeader;
 impl Header for SpendableHeader {
     /// `(nf, anchor)`. `nf` is GGM-bound to `(note, epoch)` upstream
     /// in [`super::delegation::NullifierHeader`]. `anchor` is inherited
-    /// at [`SpendableInit`] as the `end` of a [`RangeSummary`] whose
+    /// at [`SpendableInitRange`] as the `end` of a [`RangeSummary`] whose
     /// `tg_set` contains the note's commitment and excludes the
     /// nullifier, then advanced over [`Unspent`] segments at
     /// [`SpendableLift`] / [`SpendableEpochLift`].
@@ -269,9 +275,9 @@ impl Header for SpendableRolloverHeader {
 /// on each downstream `Unspent` — without it, the bootstrap could
 /// land past a spend already made within the range.
 #[derive(Debug)]
-pub struct SpendableInit;
+pub struct SpendableInitRange;
 
-impl Step for SpendableInit {
+impl Step for SpendableInitRange {
     type Aux<'source> = ();
     type Left = NullifierHeader;
     type Output = SpendableHeader;
@@ -289,19 +295,92 @@ impl Step for SpendableInit {
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
         if tg_gadget.0.commit() != tg_commit.0 {
             return Err(mock_ragu::Error(
-                "SpendableInit: witness gadget must commit to range tg_set",
+                "SpendableInitRange: witness gadget must commit to range tg_set",
             ));
         }
         // Inclusion: cm ∈ set ⇔ query(cm) == 0.
         if tg_gadget.0.query(Fp::from(cm)) != Fp::ZERO {
-            return Err(mock_ragu::Error("SpendableInit: commitment not in set"));
+            return Err(mock_ragu::Error(
+                "SpendableInitRange: commitment not in set",
+            ));
         }
         // Exclusion: nf ∉ set ⇔ query(nf) != 0. The note must not have
         // already been spent within the range.
         if tg_gadget.0.query(Fp::from(nf)) == Fp::ZERO {
-            return Err(mock_ragu::Error("SpendableInit: nullifier found in set"));
+            return Err(mock_ragu::Error(
+                "SpendableInitRange: nullifier found in set",
+            ));
         }
         Ok(((nf, end), ()))
+    }
+}
+
+/// Bootstrap a [`SpendableHeader`] directly from the wallet's
+/// [`NullifierHeader`] and a single freely-witnessed cm-stamp.
+///
+/// The one-step counterpart to [`SpendableInitRange`]: where `SpendableInitRange`
+/// consumes a [`RangeSummary`] covering the cm-stamp, this step takes
+/// the cm-stamp's tachygram set as a bare witness, so the wallet can
+/// seed a spendable from its note's creation stamp without first
+/// building a [`RangeSummary`] PCD.
+///
+/// Witness `(pre_cm_anchor, stamp_tg_set)`: verifies `cm ∈ stamp_tg_set`
+/// (cm comes from the left header) and emits a [`SpendableHeader`]
+/// carrying `(nf, pre_cm_anchor.next_stamp(commit))` — the running
+/// anchor immediately after the cm-stamp's absorption (an intra-block
+/// state, lifted to a block boundary downstream).
+///
+/// Field roles: `nf` is threaded from the [`NullifierHeader`] and
+/// GGM-bound to `(note, epoch)` upstream; `pre_cm_anchor` and
+/// `stamp_tg_set` are freely witnessed; the output anchor is derived in
+/// circuit.
+///
+/// Unlike [`SpendableInitRange`], this step performs **no** nf-exclusion
+/// check, and it is sound to omit precisely because the witnessed set
+/// is a single cm-stamp:
+///
+/// - `cm ∈ stamp_tg_set` pins the set to the note's creation stamp (a `cm`
+///   appears in exactly one stamp chain-wide).
+/// - A note's `nf` cannot appear in its own creation block: a shielded spend
+///   references a prior finalized anchor, so a note can never be created and
+///   spent in the same block.
+/// - `pre_cm_anchor` is freely witnessed; its binding closes only downstream
+///   through [`SpendableLift`] over [`Unspent`] segments (each proving
+///   per-stamp nf-exclusion) plus consensus anchor membership. A prover who
+///   witnesses a multi-stamp union as `stamp_tg_set` produces a `commit` that
+///   no real single published stamp matches, so the resulting anchor can never
+///   reach a real consensus anchor and the spendable can never be spent.
+///
+/// That single-block argument is what fails for a [`RangeSummary`] (a
+/// range can mint at its start and spend later within the same range),
+/// which is why [`SpendableInitRange`] keeps the `nf ∉ tg_set` check.
+#[derive(Debug)]
+pub struct SpendableInitStamp;
+
+impl Step for SpendableInitStamp {
+    type Aux<'source> = ();
+    type Left = NullifierHeader;
+    type Output = SpendableHeader;
+    type Right = ();
+    /// `(pre_cm_anchor, stamp_tg_set)`.
+    type Witness<'source> = (Anchor, TachygramSetGadget);
+
+    const INDEX: Index = Index::new(26);
+
+    fn witness<'source>(
+        &self,
+        (pre_cm_anchor, stamp_tg_set): Self::Witness<'source>,
+        (cm, nf, _nf_epoch): <Self::Left as Header>::Data<'source>,
+        _right: <Self::Right as Header>::Data<'source>,
+    ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        // Inclusion: cm ∈ set ⇔ query(cm) == 0.
+        if stamp_tg_set.0.query(Fp::from(cm)) != Fp::ZERO {
+            return Err(mock_ragu::Error(
+                "SpendableInitStamp: commitment not in set",
+            ));
+        }
+        let stamp_commit = TachygramSetCommit::from(stamp_tg_set);
+        Ok(((nf, pre_cm_anchor.next_stamp(&stamp_commit)), ()))
     }
 }
 

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -176,7 +176,7 @@ impl Step for UnspentFuse {
 ///
 /// Verifies `nf ∉ stamp_tg_set`, absorbs the stamp's commit at `start`,
 /// and produces a one-stamp [`Unspent`]. Equivalent to a
-/// [`super::pool::RangeSummaryStampSeed`] followed by [`UnspentRange`],
+/// [`super::pool::SummarySeed`] followed by [`UnspentRange`],
 /// collapsed into one step for callers that already hold the stamp's
 /// tachygram set and the target `nf`.
 ///

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -50,8 +50,9 @@ use crate::{
 /// Per-nf range exclusion proof.
 ///
 /// `nf` is absent from every stamp covered by the anchor segment from
-/// `start` to `end`. Built from a [`RangeSummary`] via
-/// [`UnspentFromRange`] and fused with adjacent fragments via
+/// `start` to `end`. Built either directly from a single stamp via
+/// [`UnspentSeed`] / [`EmptyBlockUnspentSeed`], or from a [`RangeSummary`]
+/// via [`UnspentFromRange`], then fused with adjacent fragments via
 /// [`UnspentFuse`] — fusion spans block boundaries because anchor
 /// advances are continuous.
 ///
@@ -74,10 +75,11 @@ use crate::{
 pub struct Unspent;
 
 impl Header for Unspent {
-    /// `(nf, start, end)`. `nf` roots in a [`UnspentFromRange`] witness,
+    /// `(nf, start, end)`. `nf` roots in a seed/bridge witness
+    /// ([`UnspentSeed`], [`EmptyBlockUnspentSeed`], or [`UnspentFromRange`]),
     /// bound by the consumer ([`SpendableLift`] checks `unspent.nf ==
     /// spendable.nf`, and the spendable's `nf` is GGM-bound upstream).
-    /// `start` and `end` are inherited from the consumed [`RangeSummary`].
+    /// `start` is freely witnessed at a seed; `end` is the absorbed advance.
     type Data<'source> = (Nullifier, Anchor, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(6);
@@ -166,6 +168,79 @@ impl Step for UnspentFuse {
             ));
         }
         Ok(((left_nf, left_start, right_end), ()))
+    }
+}
+
+/// Per-stamp exclusion seed: the direct path from a single stamp to an
+/// [`Unspent`], without an intervening [`RangeSummary`].
+///
+/// Verifies `nf ∉ stamp_tg_set`, absorbs the stamp's commit at `start`,
+/// and produces a one-stamp [`Unspent`]. Equivalent to a
+/// [`super::pool::RangeSummaryStampSeed`] followed by [`UnspentFromRange`],
+/// collapsed into one step for callers that already hold the stamp's
+/// tachygram set and the target `nf`.
+///
+/// `start` is freely witnessed, so the seed proves nothing about real
+/// coverage on its own. Final binding happens transitively through the
+/// spendable lineage plus consensus-side anchor membership.
+#[derive(Debug)]
+pub struct UnspentSeed;
+
+impl Step for UnspentSeed {
+    type Aux<'source> = ();
+    type Left = ();
+    type Output = Unspent;
+    type Right = ();
+    /// `(start, stamp_tg_set, nf)`.
+    type Witness<'source> = (Anchor, TachygramSetGadget, Nullifier);
+
+    const INDEX: Index = Index::new(27);
+
+    fn witness<'source>(
+        &self,
+        (start, stamp_tg_set, nf): Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data<'source>,
+        _right: <Self::Right as Header>::Data<'source>,
+    ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        // Exclusion: nf ∉ set ⇔ query(nf) != 0.
+        if stamp_tg_set.0.query(Fp::from(nf)) == Fp::ZERO {
+            return Err(mock_ragu::Error("UnspentSeed: found nullifier in set"));
+        }
+        let stamp_commit = TachygramSetCommit::from(stamp_tg_set);
+        let end = start.next_stamp(&stamp_commit);
+        Ok(((nf, start, end), ()))
+    }
+}
+
+/// One-empty-block [`Unspent`] seed for any `nf`, the direct path across
+/// an empty block. No exclusion check is needed: an empty block contains
+/// no stamps, so any nf is trivially absent.
+///
+/// Witness `(start, nf)`; emit `(nf, start, start.next_empty())`. An
+/// attacker can claim any nf at an empty-block segment, but the consumer
+/// ([`SpendableLift`]) checks `unspent.nf == spendable.nf` and the
+/// spendable's nf is GGM-bound upstream, so a fake-nf empty segment can
+/// only "advance" a non-existent fake spendable.
+#[derive(Debug)]
+pub struct EmptyBlockUnspentSeed;
+
+impl Step for EmptyBlockUnspentSeed {
+    type Aux<'source> = ();
+    type Left = ();
+    type Output = Unspent;
+    type Right = ();
+    /// `(start, nf)`.
+    type Witness<'source> = (Anchor, Nullifier);
+
+    const INDEX: Index = Index::new(28);
+
+    fn witness<'source>(
+        &self,
+        (start, nf): Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data<'source>,
+        _right: <Self::Right as Header>::Data<'source>,
+    ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        Ok(((nf, start, start.next_empty()), ()))
     }
 }
 
@@ -318,9 +393,9 @@ impl Step for SpendableInitRange {
 /// Bootstrap a [`SpendableHeader`] directly from the wallet's
 /// [`NullifierHeader`] and a single freely-witnessed cm-stamp.
 ///
-/// The one-step counterpart to [`SpendableInitRange`]: where `SpendableInitRange`
-/// consumes a [`RangeSummary`] covering the cm-stamp, this step takes
-/// the cm-stamp's tachygram set as a bare witness, so the wallet can
+/// The one-step counterpart to [`SpendableInitRange`]: where
+/// `SpendableInitRange` consumes a [`RangeSummary`] covering the cm-stamp, this
+/// step takes the cm-stamp's tachygram set as a bare witness, so the wallet can
 /// seed a spendable from its note's creation stamp without first
 /// building a [`RangeSummary`] PCD.
 ///

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -2,16 +2,16 @@
 //!
 //! Bootstrap runs entirely on the user device. The wallet's
 //! [`NullifierHeader`] carries `(cm, nf, epoch)`; [`SpendableInit`]
-//! fuses it with a freely-witnessed `(pre_cm_anchor, stamp_tg_set)`,
-//! verifying `cm ∈ stamp_tg_set`, and emits a [`SpendableHeader`]
-//! carrying `(nf, post_cm_anchor)` — the running anchor immediately
-//! after the cm-stamp's absorption. The cm↔nf binding is structurally
-//! inherited through the [`NullifierHeader`] (GGM-bound). The wallet's
-//! epoch claim flows through `nf` itself, so no epoch alignment check
-//! is needed here.
+//! fuses it with a [`RangeSummary`] that covers the cm-stamp,
+//! verifying `cm ∈ range.tg_set` and `nf ∉ range.tg_set`, and emits a
+//! [`SpendableHeader`] carrying `(nf, range.end)` — the running anchor
+//! at the end of the input range. The cm↔nf binding is structurally
+//! inherited through the [`NullifierHeader`] (GGM-bound). Because the
+//! range may cover many stamps, the bootstrap checks nf-exclusion the
+//! same way every downstream lift does.
 //!
-//! `pre_cm_anchor` is freely witnessed at this step; the spendable
-//! reaches a real published anchor only by extending through
+//! `start` of the range is freely witnessed at the seed steps; the
+//! spendable reaches a real published anchor only by extending through
 //! [`SpendableLift`] over [`Unspent`] segments, which by construction
 //! prove nf-exclusion at every covered stamp. There is no path that
 //! advances a spendable's anchor without a per-stamp nf-check.
@@ -34,35 +34,156 @@ use pasta_curves::Fp;
 
 use super::{
     delegation::{DelegateNullifierHeader, NullifierHeader},
-    pool::Unspent,
+    pool::RangeSummary,
 };
 use crate::{
     note::Nullifier,
-    primitives::{Anchor, EpochIndex, TachygramSetCommit, TachygramSetGadget},
+    primitives::{Anchor, EpochIndex, TachygramSetGadget},
 };
+
+/// Per-nf range exclusion proof.
+///
+/// `nf` is absent from every stamp covered by the anchor segment from
+/// `start` to `end`. Built from a [`RangeSummary`] via
+/// [`UnspentFromRange`] and fused with adjacent fragments via
+/// [`UnspentFuse`] — fusion spans block boundaries because anchor
+/// advances are continuous.
+///
+/// Same-epoch is structurally guaranteed by GGM-binding of `nf` to one
+/// epoch and by the intra-epoch-only `Anchor::next_stamp` advances —
+/// crossing an epoch boundary requires matching a boundary anchor that
+/// no [`Unspent`] builder ever emits.
+///
+/// `nf`'s binding closes at the consumer ([`SpendableLift`] checks
+/// `unspent.nf == spendable.nf`; the spendable's `nf` is itself bound
+/// upstream at [`super::delegation::NullifierHeader`]); `start`'s
+/// binding closes through the spendable lineage plus consensus anchor
+/// membership.
+///
+/// `Unspent` is the natural transition point from bounded
+/// [`RangeSummary`] segments to unbounded long-range proofs: above the
+/// per-step multiset budget the proof carries an `Unspent` (no set)
+/// rather than a `RangeSummary` (with set).
+#[derive(Clone, Debug)]
+pub struct Unspent;
+
+impl Header for Unspent {
+    /// `(nf, start, end)`. `nf` roots in a [`UnspentFromRange`] witness,
+    /// bound by the consumer ([`SpendableLift`] checks `unspent.nf ==
+    /// spendable.nf`, and the spendable's `nf` is GGM-bound upstream).
+    /// `start` and `end` are inherited from the consumed [`RangeSummary`].
+    type Data<'source> = (Nullifier, Anchor, Anchor);
+
+    const SUFFIX: Suffix = Suffix::new(6);
+
+    fn encode(data: &Self::Data<'_>) -> Vec<u8> {
+        let mut out = Vec::with_capacity(32 + 32 + 32);
+        out.extend_from_slice(&Fp::from(data.0).to_repr());
+        out.extend_from_slice(&Fp::from(data.1).to_repr());
+        out.extend_from_slice(&Fp::from(data.2).to_repr());
+        out
+    }
+}
+
+/// Per-nf exclusion bridge from a [`RangeSummary`] to an [`Unspent`].
+///
+/// Witnesses `(nf, tg_gadget)`; binds the gadget to the segment's
+/// `tg_set` (so the merged commitment is real), proves `nf ∉ tg_set`
+/// via a multiset query, and emits `Unspent { nf, start: range.start,
+/// end: range.end }`. The empty-block case is folded in naturally —
+/// the empty multiset's `query(x)` is non-zero for every x, so an
+/// empty-block summary trivially excludes any nf.
+///
+/// This is the transition step from bounded [`RangeSummary`] segments
+/// (set-bearing, multiset-budget-bounded) to set-free [`Unspent`]
+/// segments (composable to arbitrary length via [`UnspentFuse`]).
+#[derive(Debug)]
+pub struct UnspentFromRange;
+
+impl Step for UnspentFromRange {
+    type Aux<'source> = ();
+    type Left = RangeSummary;
+    type Output = Unspent;
+    type Right = ();
+    /// `(nf, tg_gadget)`.
+    type Witness<'source> = (Nullifier, TachygramSetGadget);
+
+    const INDEX: Index = Index::new(13);
+
+    fn witness<'source>(
+        &self,
+        (nf, tg_gadget): Self::Witness<'source>,
+        (start, end, tg_commit): <Self::Left as Header>::Data<'source>,
+        _right: <Self::Right as Header>::Data<'source>,
+    ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        if tg_gadget.0.commit() != tg_commit.0 {
+            return Err(mock_ragu::Error(
+                "UnspentFromRange: witness gadget must commit to range tg_set",
+            ));
+        }
+        // Exclusion: nf ∉ set ⇔ query(nf) != 0.
+        if tg_gadget.0.query(Fp::from(nf)) == Fp::ZERO {
+            return Err(mock_ragu::Error("UnspentFromRange: found nullifier in set"));
+        }
+        Ok(((nf, start, end), ()))
+    }
+}
+
+/// Compose two adjacent [`Unspent`] segments for the same `nf`.
+/// Verify same `nf` and `left.end == right.start`.
+#[derive(Debug)]
+pub struct UnspentFuse;
+
+impl Step for UnspentFuse {
+    type Aux<'source> = ();
+    type Left = Unspent;
+    type Output = Unspent;
+    type Right = Unspent;
+    type Witness<'source> = ();
+
+    const INDEX: Index = Index::new(14);
+
+    fn witness<'source>(
+        &self,
+        _witness: Self::Witness<'source>,
+        (left_nf, left_start, left_end): <Self::Left as Header>::Data<'source>,
+        (right_nf, right_start, right_end): <Self::Right as Header>::Data<'source>,
+    ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        if left_nf != right_nf {
+            return Err(mock_ragu::Error(
+                "UnspentFuse: left and right must share the same nf",
+            ));
+        }
+        if left_end != right_start {
+            return Err(mock_ragu::Error(
+                "UnspentFuse: left.end must equal right.start",
+            ));
+        }
+        Ok(((left_nf, left_start, right_end), ()))
+    }
+}
 
 /// Wallet's spendable position. Identified by `nf` alone — `nf` uniquely
 /// encodes `(key, epoch)` via GGM determinism, so sync services can update
 /// a spendable by `nf` without knowing `delegation_id`.
 ///
-/// `anchor` at [`SpendableInit`] is computed in-circuit as
-/// `pre_cm_anchor.next_stamp(stamp_commit)`, but its PCD lineage roots
-/// in `SpendableInit`'s unbound `pre_cm_anchor: Anchor` witness.
-/// Binding on that witness closes only through subsequent
-/// [`SpendableLift`] steps over [`Unspent`] segments (each `Unspent`
-/// proves nf-exclusion at a real stamp), plus consensus anchor
-/// membership. There is no path that advances a spendable's anchor
-/// without a per-stamp nf-check.
+/// `anchor` at [`SpendableInit`] is inherited as the `end` of the
+/// consumed [`RangeSummary`], but its PCD lineage roots in the
+/// freely-witnessed `start` at the [`RangeSummary`] seed steps.
+/// Binding closes only through subsequent [`SpendableLift`] steps over
+/// [`Unspent`] segments (each `Unspent` proves nf-exclusion at a real
+/// stamp), plus consensus anchor membership. There is no path that
+/// advances a spendable's anchor without a per-stamp nf-check.
 #[derive(Clone, Debug)]
 pub struct SpendableHeader;
 
 impl Header for SpendableHeader {
     /// `(nf, anchor)`. `nf` is GGM-bound to `(note, epoch)` upstream
-    /// in [`super::delegation::NullifierHeader`]. `anchor` is computed
-    /// at [`SpendableInit`] as `pre_cm_anchor.next_stamp(stamp_commit)`
-    /// over a freely-witnessed `pre_cm_anchor`, then advanced over
-    /// [`Unspent`] segments at [`SpendableLift`] /
-    /// [`SpendableEpochLift`].
+    /// in [`super::delegation::NullifierHeader`]. `anchor` is inherited
+    /// at [`SpendableInit`] as the `end` of a [`RangeSummary`] whose
+    /// `tg_set` contains the note's commitment and excludes the
+    /// nullifier, then advanced over [`Unspent`] segments at
+    /// [`SpendableLift`] / [`SpendableEpochLift`].
     type Data<'source> = (Nullifier, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(7);
@@ -137,19 +258,16 @@ impl Header for SpendableRolloverHeader {
     }
 }
 
-/// Bootstrap a [`SpendableHeader`] from the wallet's [`NullifierHeader`].
+/// Bootstrap a [`SpendableHeader`] from the wallet's [`NullifierHeader`]
+/// and a [`RangeSummary`] covering the cm-stamp.
 ///
-/// Witness `(pre_cm_anchor, stamp_tg_set)`: verifies `cm ∈ stamp_tg_set`
-/// (cm comes from the left header) and emits a [`SpendableHeader`]
-/// carrying `(nf, pre_cm_anchor.next_stamp(commit))` — the running
-/// anchor immediately after the cm-stamp's absorption.
+/// Witness `(tg_gadget,)` that commits to `range.tg_set`; verifies
+/// `cm ∈ range.tg_set` and `nf ∉ range.tg_set`, and emits
+/// `(nf, range.end)`.
 ///
-/// `pre_cm_anchor` is freely witnessed; the spendable reaches a real
-/// published anchor only by extending through [`SpendableLift`] over
-/// [`Unspent`] segments built from real stamps. The cm-block itself
-/// cannot contain the wallet's `nf` (`nf` is GGM-bound to `cm`), so no
-/// nf-exclusion check is needed at the cm-stamp; the wallet's epoch
-/// claim flows through `nf` (GGM-bound at the [`NullifierHeader`]).
+/// The nf-exclusion check matches the one [`SpendableLift`] performs
+/// on each downstream `Unspent` — without it, the bootstrap could
+/// land past a spend already made within the range.
 #[derive(Debug)]
 pub struct SpendableInit;
 
@@ -157,25 +275,33 @@ impl Step for SpendableInit {
     type Aux<'source> = ();
     type Left = NullifierHeader;
     type Output = SpendableHeader;
-    type Right = ();
-    /// `(pre_cm_anchor, stamp_tg_set)`.
-    type Witness<'source> = (Anchor, TachygramSetGadget);
+    type Right = RangeSummary;
+    /// `(tg_gadget,)` — the multiset gadget binding to `range.tg_set`.
+    type Witness<'source> = (TachygramSetGadget,);
 
-    const INDEX: Index = Index::new(13);
+    const INDEX: Index = Index::new(15);
 
     fn witness<'source>(
         &self,
-        (pre_cm_anchor, stamp_tg_set): Self::Witness<'source>,
-        (cm, nf, _epoch): <Self::Left as Header>::Data<'source>,
-        _right: <Self::Right as Header>::Data<'source>,
+        (tg_gadget,): Self::Witness<'source>,
+        (cm, nf, _nf_epoch): <Self::Left as Header>::Data<'source>,
+        (_start, end, tg_commit): <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        if tg_gadget.0.commit() != tg_commit.0 {
+            return Err(mock_ragu::Error(
+                "SpendableInit: witness gadget must commit to range tg_set",
+            ));
+        }
         // Inclusion: cm ∈ set ⇔ query(cm) == 0.
-        if stamp_tg_set.0.query(Fp::from(cm)) != Fp::ZERO {
+        if tg_gadget.0.query(Fp::from(cm)) != Fp::ZERO {
             return Err(mock_ragu::Error("SpendableInit: commitment not in set"));
         }
-        let stamp_commit = TachygramSetCommit::from(stamp_tg_set);
-        let post_cm_anchor = pre_cm_anchor.next_stamp(&stamp_commit);
-        Ok(((nf, post_cm_anchor), ()))
+        // Exclusion: nf ∉ set ⇔ query(nf) != 0. The note must not have
+        // already been spent within the range.
+        if tg_gadget.0.query(Fp::from(nf)) == Fp::ZERO {
+            return Err(mock_ragu::Error("SpendableInit: nullifier found in set"));
+        }
+        Ok(((nf, end), ()))
     }
 }
 
@@ -191,7 +317,7 @@ impl Step for SpendableLift {
     type Right = Unspent;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(14);
+    const INDEX: Index = Index::new(16);
 
     fn witness<'source>(
         &self,
@@ -227,7 +353,7 @@ impl Step for RolloverFuse {
     type Right = NullifierHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(15);
+    const INDEX: Index = Index::new(17);
 
     fn witness<'source>(
         &self,
@@ -258,7 +384,7 @@ impl Step for DelegateRolloverFuse {
     type Right = DelegateNullifierHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(16);
+    const INDEX: Index = Index::new(18);
 
     fn witness<'source>(
         &self,
@@ -301,7 +427,7 @@ impl Step for SpendableRollover {
     type Right = NullifierRolloverHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(17);
+    const INDEX: Index = Index::new(19);
 
     fn witness<'source>(
         &self,
@@ -339,7 +465,7 @@ impl Step for SpendableEpochLift {
     type Right = Unspent;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(18);
+    const INDEX: Index = Index::new(20);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -52,7 +52,7 @@ use crate::{
 /// `nf` is absent from every stamp covered by the anchor segment from
 /// `start` to `end`. Built either directly from a single stamp via
 /// [`UnspentSeed`] / [`EmptyBlockUnspentSeed`], or from a [`RangeSummary`]
-/// via [`UnspentFromRange`], then fused with adjacent fragments via
+/// via [`UnspentRange`], then fused with adjacent fragments via
 /// [`UnspentFuse`] — fusion spans block boundaries because anchor
 /// advances are continuous.
 ///
@@ -76,7 +76,7 @@ pub struct Unspent;
 
 impl Header for Unspent {
     /// `(nf, start, end)`. `nf` roots in a seed/bridge witness
-    /// ([`UnspentSeed`], [`EmptyBlockUnspentSeed`], or [`UnspentFromRange`]),
+    /// ([`UnspentSeed`], [`EmptyBlockUnspentSeed`], or [`UnspentRange`]),
     /// bound by the consumer ([`SpendableLift`] checks `unspent.nf ==
     /// spendable.nf`, and the spendable's `nf` is GGM-bound upstream).
     /// `start` is freely witnessed at a seed; `end` is the absorbed advance.
@@ -106,9 +106,9 @@ impl Header for Unspent {
 /// (set-bearing, multiset-budget-bounded) to set-free [`Unspent`]
 /// segments (composable to arbitrary length via [`UnspentFuse`]).
 #[derive(Debug)]
-pub struct UnspentFromRange;
+pub struct UnspentRange;
 
-impl Step for UnspentFromRange {
+impl Step for UnspentRange {
     type Aux<'source> = ();
     type Left = RangeSummary;
     type Output = Unspent;
@@ -126,12 +126,12 @@ impl Step for UnspentFromRange {
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
         if tg_gadget.0.commit() != tg_commit.0 {
             return Err(mock_ragu::Error(
-                "UnspentFromRange: witness gadget must commit to range tg_set",
+                "UnspentRange: witness gadget must commit to range tg_set",
             ));
         }
         // Exclusion: nf ∉ set ⇔ query(nf) != 0.
         if tg_gadget.0.query(Fp::from(nf)) == Fp::ZERO {
-            return Err(mock_ragu::Error("UnspentFromRange: found nullifier in set"));
+            return Err(mock_ragu::Error("UnspentRange: found nullifier in set"));
         }
         Ok(((nf, start, end), ()))
     }
@@ -176,7 +176,7 @@ impl Step for UnspentFuse {
 ///
 /// Verifies `nf ∉ stamp_tg_set`, absorbs the stamp's commit at `start`,
 /// and produces a one-stamp [`Unspent`]. Equivalent to a
-/// [`super::pool::RangeSummaryStampSeed`] followed by [`UnspentFromRange`],
+/// [`super::pool::RangeSummaryStampSeed`] followed by [`UnspentRange`],
 /// collapsed into one step for callers that already hold the stamp's
 /// tachygram set and the target `nf`.
 ///

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -116,7 +116,7 @@ impl Step for UnspentRange {
     /// `(nf, tg_gadget)`.
     type Witness<'source> = (Nullifier, TachygramSetGadget);
 
-    const INDEX: Index = Index::new(13);
+    const INDEX: Index = Index::new(16);
 
     fn witness<'source>(
         &self,
@@ -149,7 +149,7 @@ impl Step for UnspentFuse {
     type Right = Unspent;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(14);
+    const INDEX: Index = Index::new(15);
 
     fn witness<'source>(
         &self,
@@ -194,7 +194,7 @@ impl Step for UnspentSeed {
     /// `(start, stamp_tg_set, nf)`.
     type Witness<'source> = (Anchor, TachygramSetGadget, Nullifier);
 
-    const INDEX: Index = Index::new(27);
+    const INDEX: Index = Index::new(13);
 
     fn witness<'source>(
         &self,
@@ -232,7 +232,7 @@ impl Step for EmptyBlockUnspentSeed {
     /// `(start, nf)`.
     type Witness<'source> = (Anchor, Nullifier);
 
-    const INDEX: Index = Index::new(28);
+    const INDEX: Index = Index::new(14);
 
     fn witness<'source>(
         &self,
@@ -360,7 +360,7 @@ impl Step for SpendableInitRange {
     /// `(tg_gadget,)` — the multiset gadget binding to `range.tg_set`.
     type Witness<'source> = (TachygramSetGadget,);
 
-    const INDEX: Index = Index::new(15);
+    const INDEX: Index = Index::new(18);
 
     fn witness<'source>(
         &self,
@@ -440,7 +440,7 @@ impl Step for SpendableInitStamp {
     /// `(pre_cm_anchor, stamp_tg_set)`.
     type Witness<'source> = (Anchor, TachygramSetGadget);
 
-    const INDEX: Index = Index::new(26);
+    const INDEX: Index = Index::new(17);
 
     fn witness<'source>(
         &self,
@@ -471,7 +471,7 @@ impl Step for SpendableLift {
     type Right = Unspent;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(16);
+    const INDEX: Index = Index::new(19);
 
     fn witness<'source>(
         &self,
@@ -507,7 +507,7 @@ impl Step for RolloverFuse {
     type Right = NullifierHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(17);
+    const INDEX: Index = Index::new(20);
 
     fn witness<'source>(
         &self,
@@ -538,7 +538,7 @@ impl Step for DelegateRolloverFuse {
     type Right = DelegateNullifierHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(18);
+    const INDEX: Index = Index::new(21);
 
     fn witness<'source>(
         &self,
@@ -581,7 +581,7 @@ impl Step for SpendableRollover {
     type Right = NullifierRolloverHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(19);
+    const INDEX: Index = Index::new(22);
 
     fn witness<'source>(
         &self,
@@ -619,7 +619,7 @@ impl Step for SpendableEpochLift {
     type Right = Unspent;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(20);
+    const INDEX: Index = Index::new(23);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -72,7 +72,7 @@ impl Step for OutputStamp {
         Anchor,
     );
 
-    const INDEX: Index = Index::new(19);
+    const INDEX: Index = Index::new(21);
 
     fn witness<'source>(
         &self,
@@ -120,7 +120,7 @@ impl Step for SpendStamp {
     type Right = SpendableHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(21);
+    const INDEX: Index = Index::new(23);
 
     fn witness<'source>(
         &self,
@@ -164,11 +164,11 @@ impl Step for MergeStamp {
         TachygramSetGadget,
     );
 
-    const INDEX: Index = Index::new(22);
+    const INDEX: Index = Index::new(24);
 
     fn witness<'source>(
         &self,
-        (left_action, right_action, left_tachygram, right_tachygram): Self::Witness<'source>,
+        (actions0, actions1, tgs0, tgs1): Self::Witness<'source>,
         (left_action_commit, left_tachygram_commit, left_anchor): <Self::Left as Header>::Data<
             'source,
         >,
@@ -182,18 +182,18 @@ impl Step for MergeStamp {
         }
 
         // Bind witness accumulators to the public commitments on Data.
-        if left_action.0.commit() != left_action_commit.0
-            || right_action.0.commit() != right_action_commit.0
-            || left_tachygram.0.commit() != left_tachygram_commit.0
-            || right_tachygram.0.commit() != right_tachygram_commit.0
+        if actions0.0.commit() != left_action_commit.0
+            || actions1.0.commit() != right_action_commit.0
+            || tgs0.0.commit() != left_tachygram_commit.0
+            || tgs1.0.commit() != right_tachygram_commit.0
         {
             return Err(mock_ragu::Error(
                 "MergeStamp: witness accumulators must commit to header commits",
             ));
         }
 
-        let merged_action = ActionSetGadget(left_action.0.merge(&right_action.0));
-        let merged_tachygram = TachygramSetGadget(left_tachygram.0.merge(&right_tachygram.0));
+        let merged_action = ActionSetGadget(actions0.0.merge(&actions1.0));
+        let merged_tachygram = TachygramSetGadget(tgs0.0.merge(&tgs1.0));
 
         let data = (
             ActionSetCommit::from(merged_action),
@@ -217,7 +217,7 @@ impl Step for StampLift {
     type Right = AnchorChain;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(23);
+    const INDEX: Index = Index::new(25);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -72,7 +72,7 @@ impl Step for OutputStamp {
         Anchor,
     );
 
-    const INDEX: Index = Index::new(21);
+    const INDEX: Index = Index::new(24);
 
     fn witness<'source>(
         &self,
@@ -120,7 +120,7 @@ impl Step for SpendStamp {
     type Right = SpendableHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(23);
+    const INDEX: Index = Index::new(26);
 
     fn witness<'source>(
         &self,
@@ -164,7 +164,7 @@ impl Step for MergeStamp {
         TachygramSetGadget,
     );
 
-    const INDEX: Index = Index::new(24);
+    const INDEX: Index = Index::new(27);
 
     fn witness<'source>(
         &self,
@@ -217,7 +217,7 @@ impl Step for StampLift {
     type Right = AnchorChain;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(25);
+    const INDEX: Index = Index::new(28);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -739,6 +739,59 @@ fn unspent_from_range_handles_empty() {
 }
 
 #[test]
+fn unspent_seed_rejects_tg_present() {
+    // Direct stamp -> Unspent path: a stamp containing the nullifier
+    // must be rejected by the exclusion query.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let note = user.random_note(rng, 500);
+    let nf = note.nullifier(&user.pak.nk, EpochIndex(0));
+
+    let containing_set = TachygramSetGadget::from([nf.into()].as_slice());
+    let err = PROOF_SYSTEM
+        .seed(
+            rng,
+            spendable::UnspentSeed,
+            (Anchor::default(), containing_set, nf),
+        )
+        .unwrap_err();
+    assert_eq!(err.0, "UnspentSeed: found nullifier in set");
+}
+
+#[test]
+fn unspent_seed_succeeds() {
+    // Direct stamp -> Unspent: nf absent, anchor advanced through the
+    // stamp, matching the RangeSummaryStampSeed + UnspentFromRange path.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let nf = Nullifier::from(Fp::random(&mut *rng));
+    let stamp_set = TachygramSetGadget::from([tg(rng)].as_slice());
+    let start = Anchor::default();
+    let expected_end = start.next_stamp(&TachygramSetCommit::from(stamp_set.clone()));
+
+    let (unspent, ()) = PROOF_SYSTEM
+        .seed(rng, spendable::UnspentSeed, (start, stamp_set, nf))
+        .expect("UnspentSeed");
+    assert_eq!(unspent.data.0, nf);
+    assert_eq!(unspent.data.1, start);
+    assert_eq!(unspent.data.2, expected_end);
+}
+
+#[test]
+fn empty_block_unspent_seed_succeeds() {
+    // Direct empty-block -> Unspent: any nf is trivially absent.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let nf = Nullifier::from(Fp::random(&mut *rng));
+    let start = Anchor::default();
+
+    let (unspent, ()) = PROOF_SYSTEM
+        .seed(rng, spendable::EmptyBlockUnspentSeed, (start, nf))
+        .expect("EmptyBlockUnspentSeed");
+    assert_eq!(unspent.data.0, nf);
+    assert_eq!(unspent.data.1, start);
+    assert_eq!(unspent.data.2, start.next_empty());
+}
+
+#[test]
 fn delegate_rollover_fuse_rejects_invalid_inputs() {
     // delegation_id mismatch (different traps yield different ids).
     {

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -552,13 +552,13 @@ fn unspent_from_range_rejects_tg_present() {
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            spendable::UnspentFromRange,
+            spendable::UnspentRange,
             (nf, containing_set),
             summary,
             Proof::trivial().carry::<()>(()),
         )
         .unwrap_err();
-    assert_eq!(err.0, "UnspentFromRange: found nullifier in set");
+    assert_eq!(err.0, "UnspentRange: found nullifier in set");
 }
 
 #[test]
@@ -580,7 +580,7 @@ fn unspent_from_range_rejects_unbound_gadget() {
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            spendable::UnspentFromRange,
+            spendable::UnspentRange,
             (nf, unrelated),
             summary,
             Proof::trivial().carry::<()>(()),
@@ -588,7 +588,7 @@ fn unspent_from_range_rejects_unbound_gadget() {
         .unwrap_err();
     assert_eq!(
         err.0,
-        "UnspentFromRange: witness gadget must commit to range tg_set"
+        "UnspentRange: witness gadget must commit to range tg_set"
     );
 }
 
@@ -727,12 +727,12 @@ fn unspent_from_range_handles_empty() {
     let (unspent, ()) = PROOF_SYSTEM
         .fuse(
             rng,
-            spendable::UnspentFromRange,
+            spendable::UnspentRange,
             (nf, empty_gadget),
             summary,
             Proof::trivial().carry::<()>(()),
         )
-        .expect("UnspentFromRange over empty block");
+        .expect("UnspentRange over empty block");
     assert_eq!(unspent.data.0, nf);
     assert_eq!(unspent.data.1, Anchor::default());
     assert_eq!(unspent.data.2, summary_end);
@@ -761,7 +761,7 @@ fn unspent_seed_rejects_tg_present() {
 #[test]
 fn unspent_seed_succeeds() {
     // Direct stamp -> Unspent: nf absent, anchor advanced through the
-    // stamp, matching the RangeSummaryStampSeed + UnspentFromRange path.
+    // stamp, matching the RangeSummaryStampSeed + UnspentRange path.
     let rng = &mut StdRng::seed_from_u64(0);
     let nf = Nullifier::from(Fp::random(&mut *rng));
     let stamp_set = TachygramSetGadget::from([tg(rng)].as_slice());
@@ -1003,12 +1003,12 @@ fn build_single_stamp_unspent<'source>(
     let (unspent, ()) = PROOF_SYSTEM
         .fuse(
             rng,
-            spendable::UnspentFromRange,
+            spendable::UnspentRange,
             (nf, tg_gadget),
             summary,
             Proof::trivial().carry::<()>(()),
         )
-        .expect("UnspentFromRange");
+        .expect("UnspentRange");
     unspent
 }
 
@@ -1165,7 +1165,7 @@ fn empty_block_anchor_unique_per_height() {
 #[test]
 fn empty_block_unspent_lifts_spendable() {
     // Build a spendable, then lift it across an empty block via an
-    // Unspent built from an empty-block RangeSummary + UnspentFromRange.
+    // Unspent built from an empty-block RangeSummary + UnspentRange.
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
     let note = user.random_note(rng, 100);
@@ -1187,7 +1187,7 @@ fn empty_block_unspent_lifts_spendable() {
     let empty_height = pool.height();
 
     // Build an Unspent over the empty block via RangeSummaryEmptySeed +
-    // UnspentFromRange, then lift the spendable.
+    // UnspentRange, then lift the spendable.
     let nf = spendable.data.0;
     let unspent = build_unspent_pcd(rng, &pool, nf, empty_height..=empty_height);
     let (lifted, ()) = PROOF_SYSTEM

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -394,13 +394,13 @@ fn spendable_init_rejects_tg_absent() {
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            spendable::SpendableInit,
+            spendable::SpendableInitRange,
             (absent_set,),
             nf_pcd_absent,
             summary,
         )
         .unwrap_err();
-    assert_eq!(err.0, "SpendableInit: commitment not in set");
+    assert_eq!(err.0, "SpendableInitRange: commitment not in set");
 }
 
 #[test]
@@ -424,9 +424,114 @@ fn spendable_init_rejects_nf_present() {
         )
         .expect("RangeSummaryStampSeed");
     let err = PROOF_SYSTEM
-        .fuse(rng, spendable::SpendableInit, (set,), nf_pcd, summary)
+        .fuse(rng, spendable::SpendableInitRange, (set,), nf_pcd, summary)
         .unwrap_err();
-    assert_eq!(err.0, "SpendableInit: nullifier found in set");
+    assert_eq!(err.0, "SpendableInitRange: nullifier found in set");
+}
+
+#[test]
+fn spendable_init_stamp_succeeds() {
+    // Direct one-step bootstrap from a single cm-stamp: the spendable
+    // lands at the anchor immediately after the cm-stamp's absorption.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let note = user.random_note(rng, 500);
+    let cm = note.commitment();
+    let nf = note.nullifier(&user.pak.nk, EpochIndex(0));
+
+    let stamp_set = TachygramSetGadget::from([cm.into(), tg(rng)].as_slice());
+    let pre_cm_anchor = Anchor::default();
+    let expected = pre_cm_anchor.next_stamp(&TachygramSetCommit::from(stamp_set.clone()));
+    let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
+
+    let (spendable, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::SpendableInitStamp,
+            (pre_cm_anchor, stamp_set),
+            nf_pcd,
+            Proof::trivial().carry::<()>(()),
+        )
+        .expect("SpendableInitStamp");
+
+    assert_eq!(spendable.data.0, nf);
+    assert_eq!(spendable.data.1, expected);
+}
+
+#[test]
+fn spendable_init_stamp_rejects_tg_absent() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let note = user.random_note(rng, 500);
+
+    let absent_set = TachygramSetGadget::from([tg(rng)].as_slice());
+    let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
+    let err = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::SpendableInitStamp,
+            (Anchor::default(), absent_set),
+            nf_pcd,
+            Proof::trivial().carry::<()>(()),
+        )
+        .unwrap_err();
+    assert_eq!(err.0, "SpendableInitStamp: commitment not in set");
+}
+
+#[test]
+fn spendable_init_from_range_succeeds() {
+    // Bootstrap from a multi-stamp RangeSummary: cm present somewhere in
+    // the range, nf absent everywhere, landing at the summary's end.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let note = user.random_note(rng, 500);
+    let cm = note.commitment();
+    let nf = note.nullifier(&user.pak.nk, EpochIndex(0));
+
+    // Stamp A carries cm; stamp B is unrelated. Neither carries nf.
+    let gadget_a = TachygramSetGadget::from([cm.into(), tg(rng)].as_slice());
+    let gadget_b = TachygramSetGadget::from([tg(rng)].as_slice());
+
+    let (left, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (Anchor::default(), gadget_a.clone()),
+        )
+        .expect("RangeSummaryStampSeed left");
+    let left_end = left.data.1;
+    let (right, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (left_end, gadget_b.clone()),
+        )
+        .expect("RangeSummaryStampSeed right");
+    let (summary, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            pool::RangeSummaryFuse,
+            (gadget_a.clone(), gadget_b.clone()),
+            left,
+            right,
+        )
+        .expect("RangeSummaryFuse");
+    let range_end = summary.data.1;
+
+    let merged = TachygramSetGadget(gadget_a.0.merge(&gadget_b.0));
+    let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
+    let (spendable, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::SpendableInitRange,
+            (merged,),
+            nf_pcd,
+            summary,
+        )
+        .expect("SpendableInitRange");
+
+    assert_eq!(spendable.data.0, nf);
+    assert_eq!(spendable.data.1, range_end);
 }
 
 #[test]

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -385,12 +385,8 @@ fn spendable_init_rejects_tg_absent() {
     let pre_cm_anchor = Anchor::default();
     let nf_pcd_absent = user.nullifier_pcd(rng, note, EpochIndex(0));
     let (summary, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::RangeSummaryStampSeed,
-            (pre_cm_anchor, absent_set.clone()),
-        )
-        .expect("RangeSummaryStampSeed");
+        .seed(rng, pool::SummarySeed, (pre_cm_anchor, absent_set.clone()))
+        .expect("SummarySeed");
     let err = PROOF_SYSTEM
         .fuse(
             rng,
@@ -417,12 +413,8 @@ fn spendable_init_rejects_nf_present() {
     let pre_cm_anchor = Anchor::default();
     let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
     let (summary, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::RangeSummaryStampSeed,
-            (pre_cm_anchor, set.clone()),
-        )
-        .expect("RangeSummaryStampSeed");
+        .seed(rng, pool::SummarySeed, (pre_cm_anchor, set.clone()))
+        .expect("SummarySeed");
     let err = PROOF_SYSTEM
         .fuse(rng, spendable::SpendableInitRange, (set,), nf_pcd, summary)
         .unwrap_err();
@@ -495,27 +487,23 @@ fn spendable_init_from_range_succeeds() {
     let (left, ()) = PROOF_SYSTEM
         .seed(
             rng,
-            pool::RangeSummaryStampSeed,
+            pool::SummarySeed,
             (Anchor::default(), gadget_a.clone()),
         )
-        .expect("RangeSummaryStampSeed left");
+        .expect("SummarySeed left");
     let left_end = left.data.1;
     let (right, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::RangeSummaryStampSeed,
-            (left_end, gadget_b.clone()),
-        )
-        .expect("RangeSummaryStampSeed right");
+        .seed(rng, pool::SummarySeed, (left_end, gadget_b.clone()))
+        .expect("SummarySeed right");
     let (summary, ()) = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::RangeSummaryFuse,
+            pool::SummaryFuse,
             (gadget_a.clone(), gadget_b.clone()),
             left,
             right,
         )
-        .expect("RangeSummaryFuse");
+        .expect("SummaryFuse");
     let range_end = summary.data.1;
 
     let merged = TachygramSetGadget(gadget_a.0.merge(&gadget_b.0));
@@ -545,10 +533,10 @@ fn unspent_from_range_rejects_tg_present() {
     let (summary, ()) = PROOF_SYSTEM
         .seed(
             rng,
-            pool::RangeSummaryStampSeed,
+            pool::SummarySeed,
             (Anchor::default(), containing_set.clone()),
         )
-        .expect("RangeSummaryStampSeed");
+        .expect("SummarySeed");
     let err = PROOF_SYSTEM
         .fuse(
             rng,
@@ -571,12 +559,8 @@ fn unspent_from_range_rejects_unbound_gadget() {
     let nf = Nullifier::from(Fp::random(&mut *rng));
 
     let (summary, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::RangeSummaryStampSeed,
-            (Anchor::default(), range_set),
-        )
-        .expect("RangeSummaryStampSeed");
+        .seed(rng, pool::SummarySeed, (Anchor::default(), range_set))
+        .expect("SummarySeed");
     let err = PROOF_SYSTEM
         .fuse(
             rng,
@@ -606,12 +590,12 @@ fn range_summary_fuse_rejects_unbound_gadget() {
         Pcd<'source, pool::RangeSummary>,
     ) {
         let (left, ()) = PROOF_SYSTEM
-            .seed(rng, pool::RangeSummaryStampSeed, (Anchor::default(), tg_a))
-            .expect("RangeSummaryStampSeed left");
+            .seed(rng, pool::SummarySeed, (Anchor::default(), tg_a))
+            .expect("SummarySeed left");
         let left_end = left.data.1;
         let (right, ()) = PROOF_SYSTEM
-            .seed(rng, pool::RangeSummaryStampSeed, (left_end, tg_b))
-            .expect("RangeSummaryStampSeed right");
+            .seed(rng, pool::SummarySeed, (left_end, tg_b))
+            .expect("SummarySeed right");
         (left, right)
     }
 
@@ -623,11 +607,11 @@ fn range_summary_fuse_rejects_unbound_gadget() {
         let unrelated = TachygramSetGadget::from([tg(rng)].as_slice());
         let (left, right) = build_pair(rng, tg_a, tg_b.clone());
         let err = PROOF_SYSTEM
-            .fuse(rng, pool::RangeSummaryFuse, (unrelated, tg_b), left, right)
+            .fuse(rng, pool::SummaryFuse, (unrelated, tg_b), left, right)
             .unwrap_err();
         assert_eq!(
             err.0,
-            "RangeSummaryFuse: witness gadgets must commit to header tg_set"
+            "SummaryFuse: witness gadgets must commit to header tg_set"
         );
     }
 
@@ -639,11 +623,11 @@ fn range_summary_fuse_rejects_unbound_gadget() {
         let unrelated = TachygramSetGadget::from([tg(rng)].as_slice());
         let (left, right) = build_pair(rng, tg_a.clone(), tg_b);
         let err = PROOF_SYSTEM
-            .fuse(rng, pool::RangeSummaryFuse, (tg_a, unrelated), left, right)
+            .fuse(rng, pool::SummaryFuse, (tg_a, unrelated), left, right)
             .unwrap_err();
         assert_eq!(
             err.0,
-            "RangeSummaryFuse: witness gadgets must commit to header tg_set"
+            "SummaryFuse: witness gadgets must commit to header tg_set"
         );
     }
 }
@@ -656,25 +640,17 @@ fn range_summary_fuse_rejects_non_adjacent() {
     let tg_b = TachygramSetGadget::from([tg(rng)].as_slice());
 
     let (left, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::RangeSummaryStampSeed,
-            (Anchor::default(), tg_a.clone()),
-        )
-        .expect("RangeSummaryStampSeed left");
+        .seed(rng, pool::SummarySeed, (Anchor::default(), tg_a.clone()))
+        .expect("SummarySeed left");
     let unrelated_start = Anchor(Fp::random(&mut *rng));
     let (right, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::RangeSummaryStampSeed,
-            (unrelated_start, tg_b.clone()),
-        )
-        .expect("RangeSummaryStampSeed right");
+        .seed(rng, pool::SummarySeed, (unrelated_start, tg_b.clone()))
+        .expect("SummarySeed right");
 
     let err = PROOF_SYSTEM
-        .fuse(rng, pool::RangeSummaryFuse, (tg_a, tg_b), left, right)
+        .fuse(rng, pool::SummaryFuse, (tg_a, tg_b), left, right)
         .unwrap_err();
-    assert_eq!(err.0, "RangeSummaryFuse: segments not adjacent");
+    assert_eq!(err.0, "SummaryFuse: segments not adjacent");
 }
 
 #[test]
@@ -688,28 +664,18 @@ fn range_summary_fuse_merges_tachygrams() {
     let (left, ()) = PROOF_SYSTEM
         .seed(
             rng,
-            pool::RangeSummaryStampSeed,
+            pool::SummarySeed,
             (Anchor::default(), gadget_a.clone()),
         )
-        .expect("RangeSummaryStampSeed left");
+        .expect("SummarySeed left");
     let left_end = left.data.1;
     let (right, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::RangeSummaryStampSeed,
-            (left_end, gadget_b.clone()),
-        )
-        .expect("RangeSummaryStampSeed right");
+        .seed(rng, pool::SummarySeed, (left_end, gadget_b.clone()))
+        .expect("SummarySeed right");
 
     let (fused, ()) = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::RangeSummaryFuse,
-            (gadget_a, gadget_b),
-            left,
-            right,
-        )
-        .expect("RangeSummaryFuse");
+        .fuse(rng, pool::SummaryFuse, (gadget_a, gadget_b), left, right)
+        .expect("SummaryFuse");
 
     let expected = TachygramSetCommit::from([tg_a, tg_b].as_slice());
     assert_eq!(fused.data.2, expected);
@@ -721,8 +687,8 @@ fn unspent_from_range_handles_empty() {
     let nf = Nullifier::from(Fp::random(&mut *rng));
     let empty_gadget = TachygramSetGadget::from([].as_slice());
     let (summary, ()) = PROOF_SYSTEM
-        .seed(rng, pool::RangeSummaryEmptySeed, (Anchor::default(),))
-        .expect("RangeSummaryEmptySeed");
+        .seed(rng, pool::EmptyBlockSummarySeed, (Anchor::default(),))
+        .expect("EmptyBlockSummarySeed");
     let summary_end = summary.data.1;
     let (unspent, ()) = PROOF_SYSTEM
         .fuse(
@@ -761,7 +727,7 @@ fn unspent_seed_rejects_tg_present() {
 #[test]
 fn unspent_seed_succeeds() {
     // Direct stamp -> Unspent: nf absent, anchor advanced through the
-    // stamp, matching the RangeSummaryStampSeed + UnspentRange path.
+    // stamp, matching the SummarySeed + UnspentRange path.
     let rng = &mut StdRng::seed_from_u64(0);
     let nf = Nullifier::from(Fp::random(&mut *rng));
     let stamp_set = TachygramSetGadget::from([tg(rng)].as_slice());
@@ -998,8 +964,8 @@ fn build_single_stamp_unspent<'source>(
 ) -> Pcd<'source, spendable::Unspent> {
     let tg_gadget = TachygramSetGadget::from(stamp_tgs);
     let (summary, ()) = PROOF_SYSTEM
-        .seed(rng, pool::RangeSummaryStampSeed, (start, tg_gadget.clone()))
-        .expect("RangeSummaryStampSeed");
+        .seed(rng, pool::SummarySeed, (start, tg_gadget.clone()))
+        .expect("SummarySeed");
     let (unspent, ()) = PROOF_SYSTEM
         .fuse(
             rng,
@@ -1186,7 +1152,7 @@ fn empty_block_unspent_lifts_spendable() {
     pool.mine(vec![]);
     let empty_height = pool.height();
 
-    // Build an Unspent over the empty block via RangeSummaryEmptySeed +
+    // Build an Unspent over the empty block via EmptyBlockSummarySeed +
     // UnspentRange, then lift the spendable.
     let nf = spendable.data.0;
     let unspent = build_unspent_pcd(rng, &pool, nf, empty_height..=empty_height);

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::vec;
 
 use ff::Field as _;
-use mock_ragu::Proof;
+use mock_ragu::{Pcd, Proof};
 use pasta_curves::Fp;
 use rand::{SeedableRng as _, rngs::StdRng};
 use rand_core::{CryptoRng, RngCore};
@@ -18,7 +18,7 @@ use crate::{
     entropy::ActionEntropy,
     fixtures::{
         PoolSim, SyncSim, WalletSim, build_anchor_chain_pcd, build_nullifier_rollover_pcd,
-        build_output_stamp, build_unspent_pcd, build_unspent_seed_pcd,
+        build_output_stamp, build_unspent_pcd,
         ggm_tools::{delegate_nullifier_from_master, delegate_range},
         random_block, random_block_with, spend_witness,
     },
@@ -384,32 +384,253 @@ fn spendable_init_rejects_tg_absent() {
     let absent_set = TachygramSetGadget::from([tg(rng)].as_slice());
     let pre_cm_anchor = Anchor::default();
     let nf_pcd_absent = user.nullifier_pcd(rng, note, EpochIndex(0));
+    let (summary, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (pre_cm_anchor, absent_set.clone()),
+        )
+        .expect("RangeSummaryStampSeed");
     let err = PROOF_SYSTEM
         .fuse(
             rng,
             spendable::SpendableInit,
-            (pre_cm_anchor, absent_set),
+            (absent_set,),
             nf_pcd_absent,
-            Proof::trivial().carry::<()>(()),
+            summary,
         )
         .unwrap_err();
     assert_eq!(err.0, "SpendableInit: commitment not in set");
 }
 
 #[test]
-fn unspent_seed_rejects_tg_present() {
+fn spendable_init_rejects_nf_present() {
+    // A range that contains both cm (note minted) and nf (note already
+    // spent within the range) must not bootstrap a spendable.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let note = user.random_note(rng, 500);
+    let cm = note.commitment();
+    let nf = note.nullifier(&user.pak.nk, EpochIndex(0));
+
+    let set = TachygramSetGadget::from([cm.into(), nf.into()].as_slice());
+    let pre_cm_anchor = Anchor::default();
+    let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
+    let (summary, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (pre_cm_anchor, set.clone()),
+        )
+        .expect("RangeSummaryStampSeed");
+    let err = PROOF_SYSTEM
+        .fuse(rng, spendable::SpendableInit, (set,), nf_pcd, summary)
+        .unwrap_err();
+    assert_eq!(err.0, "SpendableInit: nullifier found in set");
+}
+
+#[test]
+fn unspent_from_range_rejects_tg_present() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
     let note = user.random_note(rng, 500);
     let nf = note.nullifier(&user.pak.nk, EpochIndex(0));
 
     let containing_set = TachygramSetGadget::from([nf.into()].as_slice());
-    let start = Anchor::default();
+    let (summary, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (Anchor::default(), containing_set.clone()),
+        )
+        .expect("RangeSummaryStampSeed");
+    let err = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::UnspentFromRange,
+            (nf, containing_set),
+            summary,
+            Proof::trivial().carry::<()>(()),
+        )
+        .unwrap_err();
+    assert_eq!(err.0, "UnspentFromRange: found nullifier in set");
+}
+
+#[test]
+fn unspent_from_range_rejects_unbound_gadget() {
+    // A witness gadget that doesn't commit to the range's tg_set must
+    // be rejected before the nf-exclusion query runs.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let range_set = TachygramSetGadget::from([tg(rng)].as_slice());
+    let unrelated = TachygramSetGadget::from([tg(rng)].as_slice());
+    let nf = Nullifier::from(Fp::random(&mut *rng));
+
+    let (summary, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (Anchor::default(), range_set),
+        )
+        .expect("RangeSummaryStampSeed");
+    let err = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::UnspentFromRange,
+            (nf, unrelated),
+            summary,
+            Proof::trivial().carry::<()>(()),
+        )
+        .unwrap_err();
+    assert_eq!(
+        err.0,
+        "UnspentFromRange: witness gadget must commit to range tg_set"
+    );
+}
+
+#[test]
+fn range_summary_fuse_rejects_unbound_gadget() {
+    // Both halves of the witness must commit to their respective header
+    // tg_set. Exercise each `||` arm via a left-unrelated and a
+    // right-unrelated sub-case.
+    fn build_pair<'source>(
+        rng: &mut (impl RngCore + CryptoRng),
+        tg_a: TachygramSetGadget,
+        tg_b: TachygramSetGadget,
+    ) -> (
+        Pcd<'source, pool::RangeSummary>,
+        Pcd<'source, pool::RangeSummary>,
+    ) {
+        let (left, ()) = PROOF_SYSTEM
+            .seed(rng, pool::RangeSummaryStampSeed, (Anchor::default(), tg_a))
+            .expect("RangeSummaryStampSeed left");
+        let left_end = left.data.1;
+        let (right, ()) = PROOF_SYSTEM
+            .seed(rng, pool::RangeSummaryStampSeed, (left_end, tg_b))
+            .expect("RangeSummaryStampSeed right");
+        (left, right)
+    }
+
+    // Left witness unrelated to left.tg_set.
+    {
+        let rng = &mut StdRng::seed_from_u64(0);
+        let tg_a = TachygramSetGadget::from([tg(rng)].as_slice());
+        let tg_b = TachygramSetGadget::from([tg(rng)].as_slice());
+        let unrelated = TachygramSetGadget::from([tg(rng)].as_slice());
+        let (left, right) = build_pair(rng, tg_a, tg_b.clone());
+        let err = PROOF_SYSTEM
+            .fuse(rng, pool::RangeSummaryFuse, (unrelated, tg_b), left, right)
+            .unwrap_err();
+        assert_eq!(
+            err.0,
+            "RangeSummaryFuse: witness gadgets must commit to header tg_set"
+        );
+    }
+
+    // Right witness unrelated to right.tg_set.
+    {
+        let rng = &mut StdRng::seed_from_u64(0);
+        let tg_a = TachygramSetGadget::from([tg(rng)].as_slice());
+        let tg_b = TachygramSetGadget::from([tg(rng)].as_slice());
+        let unrelated = TachygramSetGadget::from([tg(rng)].as_slice());
+        let (left, right) = build_pair(rng, tg_a.clone(), tg_b);
+        let err = PROOF_SYSTEM
+            .fuse(rng, pool::RangeSummaryFuse, (tg_a, unrelated), left, right)
+            .unwrap_err();
+        assert_eq!(
+            err.0,
+            "RangeSummaryFuse: witness gadgets must commit to header tg_set"
+        );
+    }
+}
+
+#[test]
+fn range_summary_fuse_rejects_non_adjacent() {
+    // TODO: add cross-epoch nonadjacency to demonstrate
+    let rng = &mut StdRng::seed_from_u64(0);
+    let tg_a = TachygramSetGadget::from([tg(rng)].as_slice());
+    let tg_b = TachygramSetGadget::from([tg(rng)].as_slice());
+
+    let (left, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (Anchor::default(), tg_a.clone()),
+        )
+        .expect("RangeSummaryStampSeed left");
+    let unrelated_start = Anchor(Fp::random(&mut *rng));
+    let (right, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (unrelated_start, tg_b.clone()),
+        )
+        .expect("RangeSummaryStampSeed right");
 
     let err = PROOF_SYSTEM
-        .seed(rng, pool::UnspentSeed, (start, containing_set, nf))
+        .fuse(rng, pool::RangeSummaryFuse, (tg_a, tg_b), left, right)
         .unwrap_err();
-    assert_eq!(err.0, "UnspentSeed: found nullifier in set");
+    assert_eq!(err.0, "RangeSummaryFuse: segments not adjacent");
+}
+
+#[test]
+fn range_summary_fuse_merges_tachygrams() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let tg_a = tg(rng);
+    let tg_b = tg(rng);
+    let gadget_a = TachygramSetGadget::from([tg_a].as_slice());
+    let gadget_b = TachygramSetGadget::from([tg_b].as_slice());
+
+    let (left, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (Anchor::default(), gadget_a.clone()),
+        )
+        .expect("RangeSummaryStampSeed left");
+    let left_end = left.data.1;
+    let (right, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::RangeSummaryStampSeed,
+            (left_end, gadget_b.clone()),
+        )
+        .expect("RangeSummaryStampSeed right");
+
+    let (fused, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            pool::RangeSummaryFuse,
+            (gadget_a, gadget_b),
+            left,
+            right,
+        )
+        .expect("RangeSummaryFuse");
+
+    let expected = TachygramSetCommit::from([tg_a, tg_b].as_slice());
+    assert_eq!(fused.data.2, expected);
+}
+
+#[test]
+fn unspent_from_range_handles_empty() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let nf = Nullifier::from(Fp::random(&mut *rng));
+    let empty_gadget = TachygramSetGadget::from([].as_slice());
+    let (summary, ()) = PROOF_SYSTEM
+        .seed(rng, pool::RangeSummaryEmptySeed, (Anchor::default(),))
+        .expect("RangeSummaryEmptySeed");
+    let summary_end = summary.data.1;
+    let (unspent, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::UnspentFromRange,
+            (nf, empty_gadget),
+            summary,
+            Proof::trivial().carry::<()>(()),
+        )
+        .expect("UnspentFromRange over empty block");
+    assert_eq!(unspent.data.0, nf);
+    assert_eq!(unspent.data.1, Anchor::default());
+    assert_eq!(unspent.data.2, summary_end);
 }
 
 #[test]
@@ -611,6 +832,28 @@ fn rollover_fuse_rejects_invalid_inputs() {
     }
 }
 
+fn build_single_stamp_unspent<'source>(
+    rng: &mut (impl RngCore + CryptoRng),
+    start: Anchor,
+    stamp_tgs: &[Tachygram],
+    nf: Nullifier,
+) -> Pcd<'source, spendable::Unspent> {
+    let tg_gadget = TachygramSetGadget::from(stamp_tgs);
+    let (summary, ()) = PROOF_SYSTEM
+        .seed(rng, pool::RangeSummaryStampSeed, (start, tg_gadget.clone()))
+        .expect("RangeSummaryStampSeed");
+    let (unspent, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::UnspentFromRange,
+            (nf, tg_gadget),
+            summary,
+            Proof::trivial().carry::<()>(()),
+        )
+        .expect("UnspentFromRange");
+    unspent
+}
+
 #[test]
 fn unspent_fuse_rejects_invalid_compositions() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -623,10 +866,10 @@ fn unspent_fuse_rejects_invalid_compositions() {
     {
         let nf_a = Nullifier::from(Fp::random(&mut *rng));
         let nf_b = Nullifier::from(Fp::random(&mut *rng));
-        let shard_a = build_unspent_seed_pcd(rng, start, &stamps_left, nf_a);
-        let shard_b = build_unspent_seed_pcd(rng, mid, &stamps_right, nf_b);
+        let shard_a = build_single_stamp_unspent(rng, start, &stamps_left, nf_a);
+        let shard_b = build_single_stamp_unspent(rng, mid, &stamps_right, nf_b);
         let err = PROOF_SYSTEM
-            .fuse(rng, pool::UnspentFuse, (), shard_a, shard_b)
+            .fuse(rng, spendable::UnspentFuse, (), shard_a, shard_b)
             .unwrap_err();
         assert_eq!(err.0, "UnspentFuse: left and right must share the same nf");
     }
@@ -635,10 +878,10 @@ fn unspent_fuse_rejects_invalid_compositions() {
     // instead of `left.end`.
     {
         let nf = Nullifier::from(Fp::random(&mut *rng));
-        let shard_a = build_unspent_seed_pcd(rng, start, &stamps_left, nf);
-        let shard_b = build_unspent_seed_pcd(rng, start, &stamps_right, nf);
+        let shard_a = build_single_stamp_unspent(rng, start, &stamps_left, nf);
+        let shard_b = build_single_stamp_unspent(rng, start, &stamps_right, nf);
         let err = PROOF_SYSTEM
-            .fuse(rng, pool::UnspentFuse, (), shard_a, shard_b)
+            .fuse(rng, spendable::UnspentFuse, (), shard_a, shard_b)
             .unwrap_err();
         assert_eq!(err.0, "UnspentFuse: left.end must equal right.start");
     }
@@ -715,7 +958,7 @@ fn unspent_fuse_rejects_cross_pool_or_cross_epoch() {
         let right = build_unspent_pcd(rng, &pool_b, nf, BlockHeight(3)..=BlockHeight(3));
 
         let err = PROOF_SYSTEM
-            .fuse(rng, pool::UnspentFuse, (), left, right)
+            .fuse(rng, spendable::UnspentFuse, (), left, right)
             .unwrap_err();
         assert_eq!(err.0, "UnspentFuse: left.end must equal right.start");
     }
@@ -740,7 +983,7 @@ fn unspent_fuse_rejects_cross_pool_or_cross_epoch() {
         );
 
         let err = PROOF_SYSTEM
-            .fuse(rng, pool::UnspentFuse, (), left, right)
+            .fuse(rng, spendable::UnspentFuse, (), left, right)
             .unwrap_err();
         assert_eq!(err.0, "UnspentFuse: left.end must equal right.start");
     }
@@ -764,7 +1007,7 @@ fn empty_block_anchor_unique_per_height() {
 #[test]
 fn empty_block_unspent_lifts_spendable() {
     // Build a spendable, then lift it across an empty block via an
-    // Unspent built solely from EmptyBlockUnspentSeed.
+    // Unspent built from an empty-block RangeSummary + UnspentFromRange.
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
     let note = user.random_note(rng, 100);
@@ -785,8 +1028,8 @@ fn empty_block_unspent_lifts_spendable() {
     pool.mine(vec![]);
     let empty_height = pool.height();
 
-    // Build an Unspent over the empty block via EmptyBlockUnspentSeed,
-    // then lift the spendable.
+    // Build an Unspent over the empty block via RangeSummaryEmptySeed +
+    // UnspentFromRange, then lift the spendable.
     let nf = spendable.data.0;
     let unspent = build_unspent_pcd(rng, &pool, nf, empty_height..=empty_height);
     let (lifted, ()) = PROOF_SYSTEM

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -523,6 +523,94 @@ fn spendable_init_from_range_succeeds() {
 }
 
 #[test]
+fn spendable_init_range_multi_stamp_succeeds() {
+    // cm sits in a middle stamp of a three-stamp range; nf absent
+    // everywhere. The spendable lands at the range's end anchor.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let note = user.random_note(rng, 500);
+    let cm = note.commitment();
+    let nf = note.nullifier(&user.pak.nk, EpochIndex(0));
+
+    let stamp_a = TachygramSetGadget::from([tg(rng)].as_slice());
+    let stamp_b = TachygramSetGadget::from([cm.into(), tg(rng)].as_slice());
+    let stamp_c = TachygramSetGadget::from([tg(rng)].as_slice());
+    let (summary, merged) =
+        build_summary_over(rng, Anchor::default(), &[stamp_a, stamp_b, stamp_c]);
+    let range_end = summary.data.1;
+
+    let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
+    let (spendable, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::SpendableInitRange,
+            (merged,),
+            nf_pcd,
+            summary,
+        )
+        .expect("SpendableInitRange");
+
+    assert_eq!(spendable.data.0, nf);
+    assert_eq!(spendable.data.1, range_end);
+}
+
+#[test]
+fn spendable_init_range_rejects_nf_in_later_stamp() {
+    // Note minted in stamp A, then spent in a later stamp C of the same
+    // range. The fused tg_set contains both cm and nf, so the exclusion
+    // check must reject the bootstrap.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let note = user.random_note(rng, 500);
+    let cm = note.commitment();
+    let nf = note.nullifier(&user.pak.nk, EpochIndex(0));
+
+    let stamp_a = TachygramSetGadget::from([cm.into(), tg(rng)].as_slice());
+    let stamp_b = TachygramSetGadget::from([tg(rng)].as_slice());
+    let stamp_c = TachygramSetGadget::from([nf.into(), tg(rng)].as_slice());
+    let (summary, merged) =
+        build_summary_over(rng, Anchor::default(), &[stamp_a, stamp_b, stamp_c]);
+
+    let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
+    let err = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::SpendableInitRange,
+            (merged,),
+            nf_pcd,
+            summary,
+        )
+        .unwrap_err();
+    assert_eq!(err.0, "SpendableInitRange: nullifier found in set");
+}
+
+#[test]
+fn spendable_init_range_rejects_cm_absent_multi() {
+    // cm appears in none of the range's stamps; inclusion fails.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let note = user.random_note(rng, 500);
+
+    let stamp_a = TachygramSetGadget::from([tg(rng)].as_slice());
+    let stamp_b = TachygramSetGadget::from([tg(rng)].as_slice());
+    let stamp_c = TachygramSetGadget::from([tg(rng)].as_slice());
+    let (summary, merged) =
+        build_summary_over(rng, Anchor::default(), &[stamp_a, stamp_b, stamp_c]);
+
+    let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
+    let err = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::SpendableInitRange,
+            (merged,),
+            nf_pcd,
+            summary,
+        )
+        .unwrap_err();
+    assert_eq!(err.0, "SpendableInitRange: commitment not in set");
+}
+
+#[test]
 fn unspent_from_range_rejects_tg_present() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
@@ -976,6 +1064,41 @@ fn build_single_stamp_unspent<'source>(
         )
         .expect("UnspentRange");
     unspent
+}
+
+/// Build a multi-stamp [`RangeSummary`] from explicit per-stamp gadgets,
+/// seeding each via [`pool::SummarySeed`] and fusing adjacent segments
+/// via [`pool::SummaryFuse`]. Returns the final summary PCD plus the
+/// merged gadget (the witness `SpendableInitRange` / `UnspentRange`
+/// require). Mirrors `build_range_summary_at` in fixtures, but over
+/// caller-chosen gadgets so a test controls which stamp holds cm/nf.
+fn build_summary_over<'source>(
+    rng: &mut (impl RngCore + CryptoRng),
+    start: Anchor,
+    stamps: &[TachygramSetGadget],
+) -> (Pcd<'source, pool::RangeSummary>, TachygramSetGadget) {
+    let (first, rest) = stamps.split_first().expect("at least one stamp");
+    let (mut summary, ()) = PROOF_SYSTEM
+        .seed(rng, pool::SummarySeed, (start, first.clone()))
+        .expect("SummarySeed");
+    let mut merged = first.clone();
+    for next in rest {
+        let (right, ()) = PROOF_SYSTEM
+            .seed(rng, pool::SummarySeed, (summary.data.1, next.clone()))
+            .expect("SummarySeed");
+        let (fused, ()) = PROOF_SYSTEM
+            .fuse(
+                rng,
+                pool::SummaryFuse,
+                (merged.clone(), next.clone()),
+                summary,
+                right,
+            )
+            .expect("SummaryFuse");
+        merged = TachygramSetGadget(merged.0.merge(&next.0));
+        summary = fused;
+    }
+    (summary, merged)
 }
 
 #[test]


### PR DESCRIPTION
Work on #98

Introduces `RangeSummary`, a bounded anchor segment that additionally carries the union of every absorbed stamp's tachygram set, and reworks the spendable bootstrap and per-nf exclusion path to consume it.

A `RangeSummary` is assembled via `RangeSummaryStampSeed` / `RangeSummaryEmptySeed` / `RangeSummaryFuse`. It may be feasible to add more elaborate steps that improve composition https://github.com/tachyon-zcash/tachyon/issues/99. A range may grow only as long as the multiset content stays under a defined maximum (presently 8192 items).

A `SpendableInitRange` fuses the wallet's `NullifierHeader` with a `RangeSummary` covering the inclusion stamp and verifies both `cm ∈ range.tg_set` (inclusion) and `nf ∉ range.tg_set` (exclusion). The exclusion check is new and required: because the bootstrap range can cover many stamps, the nullifier could have already been spent within it, so the bootstrap now checks exclusion the same way every downstream `SpendableLift` does.

`Unspent` is now also produced via `UnspentRange`, which consumes a `RangeSummary`, witnesses a nullifier + matching tachygram set, and emits an `Unspent` after proving `nf ∉ range.tg_set`.

The range additions are purely additive: every original path is retained. `SpendableInitStamp` still bootstraps a spendable directly from an individual stamp, and `UnspentSeed` / `EmptyBlockUnspentSeed` still seed an `Unspent` from a single stamp or empty block without an intervening `RangeSummary`. `UnspentRange` is exactly equivalent to a `RangeSummaryStampSeed` followed by `UnspentSeed`, so it adds no new trust surface, only a reusable intermediate.

This should improve sync service costs for providing `Unspent` proofs. The `RangeSummary` should be re-useable input for any nullifier exclusion test, and it might also be served to any user device interested in initializing a spendable.
