### PR TITLE
feat(zips): ZIP-221

### DIFF
--- a/book/src/zips/zip-221.md
+++ b/book/src/zips/zip-221.md
@@ -26,11 +26,11 @@ When Orchard was introduced, its three fields were [added directly to ZIP-221](h
 
 ### Tachyon's Context
 
-Tachyon needs the same treatment: append Tachyon-specific fields to the MMR leaf so light clients can verify Tachyon pool state. But there's a design question here since Tachyon's pool state is structurally different from Sapling/Orchard.
+So Tachyon obviously needs the same treatment here: append Tachyon-specific fields to the MMR leaf so light clients can verify Tachyon pool state. But there's a design question since Tachyon's pool state is structurally different from Sapling/Orchard.
 
 For Sapling and Orchard, the "root" committed in the MMR leaf is the **note commitment tree root**, a Merkle tree over all note commitments in the pool. Light clients need this to verify treestates when anchoring transactions.
 
-For Tachyon, there's no note commitment tree. The pool state is an **anchor**, a sequential Poseidon hash chain that absorbs each stamp's tachygram-set commitment coordinates (see [Anchor](../anchor.md)). The end-of-block anchor serves the same role as a treestate root: it's the value that spendable notes reference to prove they're spending against a valid pool state.
+For Tachyon, there's no note commitment tree. The pool state is an **anchor**, a sequential Poseidon hash chain that absorbs each stamp's tachygram-set commitment coordinates (see [Anchor](../anchor.md)). The end-of-block anchor basically serves the same role as a treestate root: it's the value that spendable notes reference to prove they're spending against a valid pool state.
 
 So the natural mapping is:
 
@@ -39,13 +39,13 @@ So the natural mapping is:
 | Note commitment tree root | End-of-block anchor |
 | Transaction count with pool activity | Transaction count with Tachyon actions |
 
-The anchor is a 32-byte $\mathbb{F}_p$ element, same size as the Sapling/Orchard roots.
+The anchor is a 32-byte $\mathbb{F}_p$ element, same size as the Sapling/Orchard roots. So it slots right in.
 
 The `nTachyonTxCount` field is useful for the same reasons as the other pools: light clients can detect withheld transactions, and bandwidth can be optimized by skipping block ranges with no Tachyon activity.
 
 ### Do we need a separate Update ZIP?
 
-Same precedent as ZIP-209 and ZIP-317. The [Tachyon Shielded Protocol ZIP (#103)](https://github.com/tachyon-zcash/tachyon/issues/103) will include a "Changes to ZIP 221" section, the editors fold it into ZIP-221's text, and ZIP-221 gets an `Updated-By` header once #103 reaches a Released status. No extra ZIP needed.
+Same precedent as ZIP-209 and ZIP-317. The [Tachyon Shielded Protocol ZIP (#103)](https://github.com/tachyon-zcash/tachyon/issues/103) will include a "Changes to ZIP 221" section, the editors fold it into ZIP-221's text, and ZIP-221 gets an `Updated-By` header once #103 reaches a Released status.
 
 ## III. ZIP Draft
 
@@ -70,5 +70,3 @@ Update the node serialized size accordingly (3 additional fields: 32 + 32 + Comp
 The Tachyon anchor is the end-of-block Poseidon hash chain state, serving the same role as a note commitment tree root for Sapling and Orchard. Spendable notes reference an anchor to prove they're spending against a valid pool state, so light clients need access to anchor values at block boundaries to verify transaction validity.
 
 `nTachyonTxCount` follows the same rationale as `nSaplingTxCount` and `nOrchardTxCount`: it lets light clients detect withheld transactions and skip block ranges with no Tachyon activity, reducing bandwidth.
-
-The three-field pattern (earliest root, latest root, tx count) mirrors Orchard exactly. Internal and root nodes inherit boundary values from children and sum counts, consistent with the existing MMR semantics.

--- a/book/src/zips/zip-221.md
+++ b/book/src/zips/zip-221.md
@@ -6,6 +6,69 @@
 
 ## I. Dependencies
 
+- [Tachyon Shielded Protocol (#103)](https://github.com/tachyon-zcash/tachyon/issues/103) defines the Tachyon pool and its actions
+- [Tachyon Accumulator (#105)](https://github.com/tachyon-zcash/tachyon/issues/105) defines the anchor (Poseidon hash chain state)
+
 ## II. Design Considerations
 
+### Background
+
+[ZIP-221](https://zips.z.cash/zip-0221) replaces the old `hashFinalSaplingRoot` block header field with `hashBlockCommitments`, which commits to a Merkle Mountain Range (MMR) tree. Each leaf in the MMR contains metadata about a block, and the root hash lets light clients efficiently verify chain history in logarithmic time (FlyClient protocol).
+
+Each MMR leaf node has 14 fields (post-NU5). The relevant ones for our purposes are the per-pool fields:
+
+- `hashEarliestSaplingRoot` / `hashLatestSaplingRoot` — Sapling note commitment tree root
+- `nSaplingTxCount` — transactions with Sapling spends/outputs
+- `hashEarliestOrchardRoot` / `hashLatestOrchardRoot` — Orchard note commitment tree root (added at NU5)
+- `nOrchardTxCount` — transactions with Orchard actions (added at NU5)
+
+When Orchard was introduced, its three fields were [added directly to ZIP-221](https://github.com/zcash/zips/commit) ("ZIP 221: NU5 updates"). No separate Update ZIP.
+
+### Tachyon's Context
+
+Tachyon needs the same treatment: append Tachyon-specific fields to the MMR leaf so light clients can verify Tachyon pool state. But there's a design question here since Tachyon's pool state is structurally different from Sapling/Orchard.
+
+For Sapling and Orchard, the "root" committed in the MMR leaf is the **note commitment tree root**, a Merkle tree over all note commitments in the pool. Light clients need this to verify treestates when anchoring transactions.
+
+For Tachyon, there's no note commitment tree. The pool state is an **anchor**, a sequential Poseidon hash chain that absorbs each stamp's tachygram-set commitment coordinates (see [Anchor](../anchor.md)). The end-of-block anchor serves the same role as a treestate root: it's the value that spendable notes reference to prove they're spending against a valid pool state.
+
+So the natural mapping is:
+
+| Sapling/Orchard | Tachyon |
+|---|---|
+| Note commitment tree root | End-of-block anchor |
+| Transaction count with pool activity | Transaction count with Tachyon actions |
+
+The anchor is a 32-byte $\mathbb{F}_p$ element, same size as the Sapling/Orchard roots.
+
+The `nTachyonTxCount` field is useful for the same reasons as the other pools: light clients can detect withheld transactions, and bandwidth can be optimized by skipping block ranges with no Tachyon activity.
+
+### Do we need a separate Update ZIP?
+
+Same precedent as ZIP-209 and ZIP-317. The [Tachyon Shielded Protocol ZIP (#103)](https://github.com/tachyon-zcash/tachyon/issues/103) will include a "Changes to ZIP 221" section, the editors fold it into ZIP-221's text, and ZIP-221 gets an `Updated-By` header once #103 reaches a Released status. No extra ZIP needed.
+
 ## III. ZIP Draft
+
+Following the pattern of Orchard's addition to ZIP-221, the Tachyon fields are specified here and folded into ZIP-221's [Specification](https://zips.z.cash/zip-0221#specification) section.
+
+### Changes to ZIP 221
+
+In the node field table of ZIP 221, append the following fields to the MMR leaf/node definition:
+
+| Field | Type | Leaf value | Internal/Root value |
+|---|---|---|---|
+| `hashEarliestTachyonRoot` | char[32] | End-of-block Tachyon anchor | Inherited from left child |
+| `hashLatestTachyonRoot` | char[32] | End-of-block Tachyon anchor | Inherited from right child |
+| `nTachyonTxCount` | CompactSize | Number of transactions with Tachyon actions in the block | Sum of both children |
+
+Before the Tachyon network upgrade has activated, `hashEarliestTachyonRoot` and `hashLatestTachyonRoot` MUST be set to all zero bytes, and `nTachyonTxCount` MUST be zero.
+
+Update the node serialized size accordingly (3 additional fields: 32 + 32 + CompactSize bytes).
+
+#### Rationale
+
+The Tachyon anchor is the end-of-block Poseidon hash chain state, serving the same role as a note commitment tree root for Sapling and Orchard. Spendable notes reference an anchor to prove they're spending against a valid pool state, so light clients need access to anchor values at block boundaries to verify transaction validity.
+
+`nTachyonTxCount` follows the same rationale as `nSaplingTxCount` and `nOrchardTxCount`: it lets light clients detect withheld transactions and skip block ranges with no Tachyon activity, reducing bandwidth.
+
+The three-field pattern (earliest root, latest root, tx count) mirrors Orchard exactly. Internal and root nodes inherit boundary values from children and sum counts, consistent with the existing MMR semantics.

--- a/book/src/zips/zip-221.md
+++ b/book/src/zips/zip-221.md
@@ -11,62 +11,10 @@
 
 ## II. Design Considerations
 
-### Background
-
-[ZIP-221](https://zips.z.cash/zip-0221) replaces the old `hashFinalSaplingRoot` block header field with `hashBlockCommitments`, which commits to a Merkle Mountain Range (MMR) tree. Each leaf in the MMR contains metadata about a block, and the root hash lets light clients efficiently verify chain history in logarithmic time (FlyClient protocol).
-
-Each MMR leaf node has 14 fields (post-NU5). The relevant ones for our purposes are the per-pool fields:
-
-- `hashEarliestSaplingRoot` / `hashLatestSaplingRoot` — Sapling note commitment tree root
-- `nSaplingTxCount` — transactions with Sapling spends/outputs
-- `hashEarliestOrchardRoot` / `hashLatestOrchardRoot` — Orchard note commitment tree root (added at NU5)
-- `nOrchardTxCount` — transactions with Orchard actions (added at NU5)
-
-When Orchard was introduced, its three fields were [added directly to ZIP-221](https://github.com/zcash/zips/commit) ("ZIP 221: NU5 updates"). No separate Update ZIP.
-
-### Tachyon's Context
-
-So Tachyon obviously needs the same treatment here: append Tachyon-specific fields to the MMR leaf so light clients can verify Tachyon pool state. But there's a design question since Tachyon's pool state is structurally different from Sapling/Orchard.
-
-For Sapling and Orchard, the "root" committed in the MMR leaf is the **note commitment tree root**, a Merkle tree over all note commitments in the pool. Light clients need this to verify treestates when anchoring transactions.
-
-For Tachyon, there's no note commitment tree. The pool state is an **anchor**, a sequential Poseidon hash chain that absorbs each stamp's tachygram-set commitment coordinates (see [Anchor](../anchor.md)). The end-of-block anchor basically serves the same role as a treestate root: it's the value that spendable notes reference to prove they're spending against a valid pool state.
-
-So the natural mapping is:
-
-| Sapling/Orchard | Tachyon |
-|---|---|
-| Note commitment tree root | End-of-block anchor |
-| Transaction count with pool activity | Transaction count with Tachyon actions |
-
-The anchor is a 32-byte $\mathbb{F}_p$ element, same size as the Sapling/Orchard roots. So it slots right in.
-
-The `nTachyonTxCount` field is useful for the same reasons as the other pools: light clients can detect withheld transactions, and bandwidth can be optimized by skipping block ranges with no Tachyon activity.
-
-### Do we need a separate Update ZIP?
-
-Same precedent as ZIP-209 and ZIP-317. The [Tachyon Shielded Protocol ZIP (#103)](https://github.com/tachyon-zcash/tachyon/issues/103) will include a "Changes to ZIP 221" section, the editors fold it into ZIP-221's text, and ZIP-221 gets an `Updated-By` header once #103 reaches a Released status.
+[ZIP-221](https://zips.z.cash/zip-0221) commits block history to a Merkle Mountain Range (MMR) via `hashBlockCommitments`, whose leaves carry per-pool state — a note commitment tree root and a transaction count for Sapling and Orchard — so light clients can verify chain and pool state in logarithmic time (FlyClient). Tachyon has no note commitment tree; its pool state is an end-of-block anchor (a Poseidon hash chain, see [Anchor](../anchor.md)), so the open question is how to extend the MMR leaf to commit Tachyon pool state — this is still under discussion and nothing has been decided yet.
 
 ## III. ZIP Draft
 
-Following the pattern of Orchard's addition to ZIP-221, the Tachyon fields are specified here and folded into ZIP-221's [Specification](https://zips.z.cash/zip-0221#specification) section.
+The ZIP draft has been extracted into a standalone, [ZIP 0](https://zips.z.cash/zip-0000)-conformant draft in the Tachyon [ZIPs fork](https://github.com/tachyon-zcash/zips), proposed in [tachyon-zcash/zips#3](https://github.com/tachyon-zcash/zips/pull/3), so it can be reviewed in ZIP form and folded into ZIP-221 by the editors:
 
-### Changes to ZIP 221
-
-In the node field table of ZIP 221, append the following fields to the MMR leaf/node definition:
-
-| Field | Type | Leaf value | Internal/Root value |
-|---|---|---|---|
-| `hashEarliestTachyonRoot` | char[32] | End-of-block Tachyon anchor | Inherited from left child |
-| `hashLatestTachyonRoot` | char[32] | End-of-block Tachyon anchor | Inherited from right child |
-| `nTachyonTxCount` | CompactSize | Number of transactions with Tachyon actions in the block | Sum of both children |
-
-Before the Tachyon network upgrade has activated, `hashEarliestTachyonRoot` and `hashLatestTachyonRoot` MUST be set to all zero bytes, and `nTachyonTxCount` MUST be zero.
-
-Update the node serialized size accordingly (3 additional fields: 32 + 32 + CompactSize bytes).
-
-#### Rationale
-
-The Tachyon anchor is the end-of-block Poseidon hash chain state, serving the same role as a note commitment tree root for Sapling and Orchard. Spendable notes reference an anchor to prove they're spending against a valid pool state, so light clients need access to anchor values at block boundaries to verify transaction validity.
-
-`nTachyonTxCount` follows the same rationale as `nSaplingTxCount` and `nOrchardTxCount`: it lets light clients detect withheld transactions and skip block ranges with no Tachyon activity, reducing bandwidth.
+- [`zips/tachyon-mmr-commitment.md` (tachyon-zcash/zips#3)](https://github.com/tachyon-zcash/zips/pull/3)


### PR DESCRIPTION
References https://github.com/tachyon-zcash/tachyon/issues/108. Design considerations and draft ZIP for extending the MMR leaf definition in [ZIP-221](https://zips.z.cash/zip-0221) to commit Tachyon pool state (anchor defined by sequential hash chain) for light client verification.