### PR TITLE
feat(zips): ZIP-248

### DIFF
--- a/book/src/zips/zip-248.md
+++ b/book/src/zips/zip-248.md
@@ -12,78 +12,10 @@
 
 ## II. Design Considerations
 
-### Background
-
-[ZIP-248](https://github.com/zcash/zips/pull/1156) introduces a type-length-value (TLV) encoding for V6 transactions. Instead of a monolithic format where every field is hardcoded in a fixed order, a transaction becomes a sequence of **protocol bundles**, each identified by a `(bundleType, bundleVariant)` pair.
-
-The key insight is forward compatibility: a wallet that doesn't understand a bundle type can skip over it (it knows the length), still compute the txid by hashing the opaque effecting data, and still understand the value flows via a separate value pool delta map. It just alerts the user that unknown bundles are present.
-
-This means new pools like Tachyon can be added without breaking every wallet's parser. Previously, adding Sapling or Orchard forced transparent-only wallets to update, which caused real problems (funds locked in wallets that couldn't parse post-upgrade transactions).
-
-### Tachyon's Context
-
-Assuming ZIP-248 lands, Tachyon just registers a `(bundleType, bundleVariant)` pair and slots in as another bundle in the TLV sequence. Wallets that don't care about Tachyon skip over it. `librustzcash` wouldn't need to hardcode a Tachyon field in a v6 struct; it would emit a Tachyon bundle in the TLV sequence.
-
-The bundle would have:
-- **Effecting data:** tachyactions (`cv`, `rk`), `value_balance`, and the stamp (anchor, tachygrams, proof) or stripped reference (`tachyonAggregateId`)
-- **Authorizing data:** action signatures (`sig`), binding signature (`binding_sig`)
-
-This separation already matches our existing split between bundle commitment (effecting, contributes to `txid`) and auth digest (authorizing, contributes to `wtxid`). See [Transaction Identifiers](../transaction-identifiers.md).
-
-The value pool delta for Tachyon is just `valueBalanceTachyon`, same field that ZIP-209 tracks for the turnstile check. Under ZIP-248 this moves from a hardcoded transaction field into the `mValuePoolDeltas` map keyed by Tachyon's bundle type.
-
-### Do we need a separate Update ZIP?
-
-ZIP-248 defines a bundle type registry where new pools register their `(bundleType, bundleVariant)` pair. The [Tachyon Shielded Protocol ZIP (#103)](https://github.com/tachyon-zcash/tachyon/issues/103) and [Tachyon Bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104) will request a registration as part of their specification, following the process defined in ZIP-248.
+[ZIP-248](https://github.com/zcash/zips/pull/1156) (Extensible Transaction Format) reworks the V6 transaction into a type-length-value sequence of protocol bundles, each identified by a `(bundleType, bundleVariant)` pair, so a new pool can be added without breaking the parser of any wallet that does not support it (it skips the bundle, still computes the txid from the opaque effecting data, and tracks value flows via `mValuePoolDeltas`). Assuming ZIP-248 lands, Tachyon would register a bundle type and slot into the TLV sequence rather than hardcoding a field in the V6 structure, so the open question is how the Tachyon bundle registers and serializes under ZIP-248 — this is blocked on ZIP-248 reaching editor consensus, and nothing has been decided yet.
 
 ## III. ZIP Draft
 
-Following the bundle type registration process defined in [ZIP-248](https://github.com/zcash/zips/pull/1156), the Tachyon bundle is registered as follows:
+The ZIP draft has been extracted into a standalone, [ZIP 0](https://zips.z.cash/zip-0000)-conformant draft in the Tachyon [ZIPs fork](https://github.com/tachyon-zcash/zips), proposed in [tachyon-zcash/zips#4](https://github.com/tachyon-zcash/zips/pull/4), so it can be reviewed in ZIP form and registered under ZIP-248 by the editors:
 
-### Bundle Type Registration
-
-Request allocation of a `(bundleType, bundleVariant)` pair in the V6 transaction bundle type registry:
-
-| Field | Value |
-|---|---|
-| `bundleType` | TBD (requested) |
-| `bundleVariant` | 0 |
-| `mValuePoolDeltas` | Yes (Tachyon pool has a value balance) |
-| `mEffectBundles` | Yes |
-| `mAuthBundles` | Yes |
-
-### Effecting Data
-
-The effecting data for a Tachyon bundle encodes:
-
-| Field | Size | Description |
-|---|---|---|
-| `nActionsTachyon` | compactSize | Number of tachyactions |
-| `vActionsTachyon` | 64 * nActions | `cv` (32B) + `rk` (32B) per action |
-| `tachyonBundleState` | 1 byte | `0x01` stamped, `0x02` stripped |
-| stamped: `anchorTachyon` | 32 bytes | Pool state reference |
-| stamped: `nTachygrams` | compactSize | Number of tachygrams |
-| stamped: `vTachygrams` | 32 * nTachygrams | Tachygram field elements |
-| stamped: `proofTachyon` | PROOF_SIZE_COMPRESSED | Recursive proof |
-| stripped: `tachyonAggregateId` | 64 bytes | `wtxid` of covering aggregate |
-
-### Authorizing Data
-
-| Field | Size | Description |
-|---|---|---|
-| `vActionSigsTachyon` | 64 * nActions | RedPallas signature per action |
-| `bindingSigTachyon` | 64 bytes | Binding signature |
-
-### Transaction Identifier Contribution
-
-The Tachyon bundle's contribution to the txid is:
-
-```
-BLAKE2b-512("ZTxIdTachyonHash", action_acc || value_balance)
-```
-
-This excludes the stamp (which is stripped during aggregation) and signatures (which are authorizing data).
-
-### Authorizing Data Commitment Contribution
-
-The Tachyon bundle's contribution to the auth digest depends on stamp state. See [Transaction Identifiers](../transaction-identifiers.md) for the full formula.
+- [`zips/tachyon-bundle-registration.md` (tachyon-zcash/zips#4)](https://github.com/tachyon-zcash/zips/pull/4)

--- a/book/src/zips/zip-248.md
+++ b/book/src/zips/zip-248.md
@@ -1,4 +1,4 @@
-# [ZIP-248](https://zips.z.cash/zip-0248)
+# [ZIP-248](https://github.com/zcash/zips/pull/1156)
 
 **Tracking:** [#110](https://github.com/tachyon-zcash/tachyon/issues/110)
 
@@ -6,6 +6,84 @@
 
 ## I. Dependencies
 
+- [Tachyon Shielded Protocol (#103)](https://github.com/tachyon-zcash/tachyon/issues/103) defines the Tachyon pool, its actions, and bundle format
+- [Tachyon Bundle (#104)](https://github.com/tachyon-zcash/tachyon/issues/104) defines the wire format for stamped/stripped bundles
+- [ZIP-248](https://github.com/zcash/zips/pull/1156) (Extensible Transaction Format) must land
+
 ## II. Design Considerations
 
+### Background
+
+[ZIP-248](https://github.com/zcash/zips/pull/1156) introduces a type-length-value (TLV) encoding for V6 transactions. Instead of a monolithic format where every field is hardcoded in a fixed order, a transaction becomes a sequence of **protocol bundles**, each identified by a `(bundleType, bundleVariant)` pair.
+
+The key insight is forward compatibility: a wallet that doesn't understand a bundle type can skip over it (it knows the length), still compute the txid by hashing the opaque effecting data, and still understand the value flows via a separate value pool delta map. It just alerts the user that unknown bundles are present.
+
+This means new pools like Tachyon can be added without breaking every wallet's parser. Previously, adding Sapling or Orchard forced transparent-only wallets to update, which caused real problems (funds locked in wallets that couldn't parse post-upgrade transactions).
+
+### Tachyon's Context
+
+Assuming ZIP-248 lands, Tachyon just registers a `(bundleType, bundleVariant)` pair and slots in as another bundle in the TLV sequence. Wallets that don't care about Tachyon skip over it. `librustzcash` wouldn't need to hardcode a Tachyon field in a v6 struct; it would emit a Tachyon bundle in the TLV sequence.
+
+The bundle would have:
+- **Effecting data:** tachyactions (`cv`, `rk`), `value_balance`, and the stamp (anchor, tachygrams, proof) or stripped reference (`tachyonAggregateId`)
+- **Authorizing data:** action signatures (`sig`), binding signature (`binding_sig`)
+
+This separation already matches our existing split between bundle commitment (effecting, contributes to `txid`) and auth digest (authorizing, contributes to `wtxid`). See [Transaction Identifiers](../transaction-identifiers.md).
+
+The value pool delta for Tachyon is just `valueBalanceTachyon`, same field that ZIP-209 tracks for the turnstile check. Under ZIP-248 this moves from a hardcoded transaction field into the `mValuePoolDeltas` map keyed by Tachyon's bundle type.
+
+### Do we need a separate Update ZIP?
+
+ZIP-248 defines a bundle type registry where new pools register their `(bundleType, bundleVariant)` pair. The [Tachyon Shielded Protocol ZIP (#103)](https://github.com/tachyon-zcash/tachyon/issues/103) and [Tachyon Bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104) will request a registration as part of their specification, following the process defined in ZIP-248.
+
 ## III. ZIP Draft
+
+Following the bundle type registration process defined in [ZIP-248](https://github.com/zcash/zips/pull/1156), the Tachyon bundle is registered as follows:
+
+### Bundle Type Registration
+
+Request allocation of a `(bundleType, bundleVariant)` pair in the V6 transaction bundle type registry:
+
+| Field | Value |
+|---|---|
+| `bundleType` | TBD (requested) |
+| `bundleVariant` | 0 |
+| `mValuePoolDeltas` | Yes (Tachyon pool has a value balance) |
+| `mEffectBundles` | Yes |
+| `mAuthBundles` | Yes |
+
+### Effecting Data
+
+The effecting data for a Tachyon bundle encodes:
+
+| Field | Size | Description |
+|---|---|---|
+| `nActionsTachyon` | compactSize | Number of tachyactions |
+| `vActionsTachyon` | 64 * nActions | `cv` (32B) + `rk` (32B) per action |
+| `tachyonBundleState` | 1 byte | `0x01` stamped, `0x02` stripped |
+| stamped: `anchorTachyon` | 32 bytes | Pool state reference |
+| stamped: `nTachygrams` | compactSize | Number of tachygrams |
+| stamped: `vTachygrams` | 32 * nTachygrams | Tachygram field elements |
+| stamped: `proofTachyon` | PROOF_SIZE_COMPRESSED | Recursive proof |
+| stripped: `tachyonAggregateId` | 64 bytes | `wtxid` of covering aggregate |
+
+### Authorizing Data
+
+| Field | Size | Description |
+|---|---|---|
+| `vActionSigsTachyon` | 64 * nActions | RedPallas signature per action |
+| `bindingSigTachyon` | 64 bytes | Binding signature |
+
+### Transaction Identifier Contribution
+
+The Tachyon bundle's contribution to the txid is:
+
+```
+BLAKE2b-512("ZTxIdTachyonHash", action_acc || value_balance)
+```
+
+This excludes the stamp (which is stripped during aggregation) and signatures (which are authorizing data).
+
+### Authorizing Data Commitment Contribution
+
+The Tachyon bundle's contribution to the auth digest depends on stamp state. See [Transaction Identifiers](../transaction-identifiers.md) for the full formula.


### PR DESCRIPTION
References https://github.com/tachyon-zcash/tachyon/issues/110. Design considerations and draft ZIP for registering a Tachyon bundle type under [ZIP-248](https://github.com/zcash/zips/pull/1156) (Extensible Transaction Format), assuming it lands in some form. It'll be blocked until there's consensus on the precise defintion / interpretation of that ZIP from the ZIP editors. 