### PR TITLE
Let `Unspent` ranges cross epoch boundaries

### DIFF
--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -16,15 +16,15 @@ The step takes the wallet's `NullifierHeader` for the creation epoch, a pre-stam
 The output is a `SpendableHeader` carrying the nullifier and the post-stamp anchor.
 
 Maintaining the spendable means advancing its anchor forward over `Unspent` segments.
-`SpendableLift` consumes one `Unspent` whose nullifier matches the spendable's and whose start matches the spendable's current anchor, producing a fresh `SpendableHeader` at the segment's end.
+`SpendableLift` consumes one `Unspent` whose start nullifier matches the spendable's and whose start anchor matches the spendable's current anchor, producing a fresh `SpendableHeader` at the segment's end and adopting the segment's end nullifier (which differs from the start only when the segment crossed an epoch boundary).
 Each `UnspentSeed` link absorbs one stamp and proves the spendable's nullifier was absent from that stamp's tachygram set[^tachygrams]; `EmptyBlockUnspentSeed` covers empty blocks; `UnspentFuse` composes adjacent segments.
 The sync service produces the `Unspent` segments and may perform lifts on the wallet's behalf.
 
-Crossing an epoch boundary requires a new-epoch nullifier and the cross-epoch anchor advance.
+Crossing an epoch boundary happens inside the `Unspent` lineage, so a single segment can span the boundary.
 `RolloverFuse` consumes two consecutive-epoch `NullifierHeader`s that share a note commitment and emits a `NullifierRolloverHeader`.
 `DelegateRolloverFuse` is the sync-service analog, fusing two `DelegateNullifierHeader`s by `delegation_id` equality; the resulting `NullifierRolloverHeader` is the same shape either way.
-`SpendableRollover` then fuses the spendable with the rollover header and advances the anchor across the boundary, emitting a `SpendableRolloverHeader`.
-`SpendableEpochLift` consumes that header and a new-epoch `Unspent` whose start equals the boundary anchor, producing a fresh spendable in the new epoch.
+`UnspentRollover` consumes that rollover header and emits a zero-stamp `Unspent` segment that applies the cross-epoch anchor advance and rotates the exclusion nullifier from the old epoch's to the new epoch's.
+Fusing the prior-epoch and new-epoch segments onto it with `UnspentFuse` yields one `Unspent` spanning the boundary, which `SpendableLift` then consumes exactly as it consumes an intra-epoch one.
 
 To spend, the wallet derives two `NullifierHeader`s (for the present epoch and the next) by running the GGM walk[^nullifiers] twice on the same note.
 `SpendBind` fuses these two leaves, checks that the witnessed note's commitment[^notes] matches the commitment carried on each, and emits a `SpendHeader` containing the value commitment, action verification key, and both nullifiers.
@@ -55,7 +55,7 @@ It seeds and walks the private GGM tree (`NfMasterSeed`, `NfMasterStep`, `NfPref
 
 The sync service holds a `DelegateNfPrefixHeader` produced by the wallet at delegation time.
 From there it climbs the blinded subtree (`DelegateNfPrefixStep`) to whichever leaf an epoch requires and emits a `DelegateNullifierHeader` (`DelegateNullifierStep`); it fuses two consecutive-epoch leaves with `DelegateRolloverFuse` when an epoch boundary is approached.
-It produces the `Unspent` segments that carry the spendable forward (`UnspentSeed`, `EmptyBlockUnspentSeed`, `UnspentFuse`), and runs the lifts that consume them (`SpendableLift`, `SpendableRollover`, `SpendableEpochLift`).
+It produces the `Unspent` segments that carry the spendable forward (`UnspentSeed`, `EmptyBlockUnspentSeed`, `UnspentFuse`, and `UnspentRollover` to cross a boundary), and runs the lifts that consume them (`SpendableLift`).
 
 The aggregator works only with published `StampHeader`s.
 It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `EmptyBlockSeed`, `AnchorFuse`) and fuses with `MergeStamp`.
@@ -68,6 +68,7 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `E
 | UnspentSeed | possible | yes | no |
 | EmptyBlockUnspentSeed | possible | yes | no |
 | UnspentFuse | possible | yes | no |
+| UnspentRollover | possible | yes | no |
 | NfMasterSeed | yes | no | no |
 | NfMasterStep | yes | no | no |
 | NfPrefixStep | yes | no | no |
@@ -79,8 +80,6 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `E
 | DelegateRolloverFuse | no | yes | no |
 | SpendableInit | yes | no | no |
 | SpendableLift | yes | possible | no |
-| SpendableRollover | yes | possible | no |
-| SpendableEpochLift | yes | possible | no |
 | SpendBind | yes | no | no |
 | OutputStamp | yes | no | no |
 | SpendStamp | yes | no | no |
@@ -113,16 +112,18 @@ A segment ties to real chain history only when a stamp-emitting step consumes it
 ### Spendable lifecycle
 
 A spendable bootstraps at `SpendableInit`, which fuses the wallet's `NullifierHeader` with a pre-stamp anchor and the tachygram set of the stamp that produced the note, verifies the note's commitment[^notes] is among those tachygrams, and advances the anchor through that stamp.
-`SpendableLift` advances the spendable's anchor further by consuming an `Unspent` segment whose nullifier equals the spendable's and whose start matches the spendable's current anchor.
-Each `UnspentSeed` link absorbs one stamp into the anchor and proves the spendable's nullifier is absent from that stamp's tachygram set[^tachygrams]; `EmptyBlockUnspentSeed` skips the absence check (no tachygrams to scan); `UnspentFuse` requires both halves to share a nullifier and to meet at a common anchor.
+`SpendableLift` advances the spendable's anchor further by consuming an `Unspent` segment whose start nullifier equals the spendable's and whose start anchor matches the spendable's current anchor; the spendable adopts the segment's end nullifier and end anchor.
+An `Unspent` carries the nullifier excluded at its start and the one at its end; the two are equal within an epoch and differ only when the segment crosses a boundary.
+Each `UnspentSeed` link absorbs one stamp into the anchor and proves the spendable's nullifier is absent from that stamp's tachygram set[^tachygrams]; `EmptyBlockUnspentSeed` skips the absence check (no tachygrams to scan); `UnspentFuse` requires the left segment's end nullifier to equal the right's start nullifier and the two to meet at a common anchor.
 
 ### Epoch rollover
 
+Crossing a boundary is handled within the `Unspent` lineage, so one segment can span it.
 `RolloverFuse` consumes two consecutive-epoch `NullifierHeader`s, checks they share a note commitment, and emits a `NullifierRolloverHeader`.
 `DelegateRolloverFuse` is the sync-service analog, fusing two `DelegateNullifierHeader`s by `delegation_id` equality; the resulting `NullifierRolloverHeader` is the same shape either way.
-`SpendableRollover` then fuses the spendable with the rollover header and applies the cross-epoch anchor advance, emitting a `SpendableRolloverHeader`.
-`SpendableEpochLift` consumes that header plus a new-epoch `Unspent` whose start equals the boundary anchor, producing a fresh spendable in the new epoch.
-The cross-epoch anchor advance is the only such transition in the proof tree; same-epoch advances always run through `AnchorChain` or `Unspent` segments.
+`UnspentRollover` consumes that rollover header, witnesses the pre-boundary anchor, and emits a zero-stamp `Unspent` segment that applies the cross-epoch anchor advance and rotates the exclusion nullifier from old to new.
+`UnspentFuse` then composes the prior-epoch and new-epoch segments around it into one boundary-spanning `Unspent`, which an ordinary `SpendableLift` consumes.
+The cross-epoch anchor advance is the only such transition in the proof tree; same-epoch advances always run through `AnchorChain` or `Unspent` segments, and only `UnspentRollover` emits the boundary step.
 
 ### Spend binding
 
@@ -168,8 +169,10 @@ flowchart TB
     w_init[/anchor, stamp_tg_set/]
     s_init[SpendableInit]
     s_rfuse[RolloverFuse]
-    s_rollover[SpendableRollover]
-    s_epochlift[SpendableEpochLift]
+    w_roll[/anchor/]
+    s_unspentroll[UnspentRollover]
+    u_fuse[UnspentFuse]
+    s_lift[SpendableLift]
     unspent_new((Unspent))
   end
 
@@ -202,14 +205,16 @@ flowchart TB
 
   s_leaf_old -->|NullifierHeader e-1| s_init
   w_init --> s_init
-  s_init -->|SpendableHeader| s_rollover
+  s_init -->|SpendableHeader| s_lift
 
   s_leaf_old -->|NullifierHeader e-1| s_rfuse
   s_leaf_now -->|NullifierHeader e| s_rfuse
-  s_rfuse -->|NullifierRolloverHeader| s_rollover
-  s_rollover -->|SpendableRolloverHeader| s_epochlift
-  unspent_new --> s_epochlift
-  s_epochlift -->|SpendableHeader| s_spendstamp
+  s_rfuse -->|NullifierRolloverHeader| s_unspentroll
+  w_roll --> s_unspentroll
+  s_unspentroll -->|Unspent| u_fuse
+  unspent_new -->|Unspent| u_fuse
+  u_fuse -->|Unspent| s_lift
+  s_lift -->|SpendableHeader| s_spendstamp
 
   s_leaf_now -->|NullifierHeader e| s_spendbind
   s_leaf_next -->|NullifierHeader e+1| s_spendbind
@@ -304,29 +309,33 @@ flowchart LR
   nh_old((NullifierHeader))
   nh_new((NullifierHeader))
   s_rfuse[RolloverFuse]
-  sp_in((SpendableHeader))
-  s_rollover[SpendableRollover]
-  s_epochlift[SpendableEpochLift]
+  w_roll[/anchor/]
+  s_unspentroll[UnspentRollover]
   unspent_new((Unspent))
+  s_ufuse[UnspentFuse]
+  sp_in((SpendableHeader))
+  s_lift[SpendableLift]
   sp_out((SpendableHeader))
 
   nh_old --> s_rfuse
   nh_new --> s_rfuse
-  sp_in --> s_rollover
-  s_rfuse -->|NullifierRolloverHeader| s_rollover
-  s_rollover -->|SpendableRolloverHeader| s_epochlift
-  unspent_new --> s_epochlift
-  s_epochlift --> sp_out
+  s_rfuse -->|NullifierRolloverHeader| s_unspentroll
+  w_roll --> s_unspentroll
+  s_unspentroll -->|Unspent| s_ufuse
+  unspent_new -->|Unspent| s_ufuse
+  sp_in --> s_lift
+  s_ufuse -->|Unspent| s_lift
+  s_lift --> sp_out
 ```
 
-A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `DelegateNullifierHeader`s) for `RolloverFuse`; the resulting `NullifierRolloverHeader` is identical, so the downstream rollover and lift are unchanged.
+A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `DelegateNullifierHeader`s) for `RolloverFuse`; the resulting `NullifierRolloverHeader` is identical, so the downstream `UnspentRollover`, fuse, and lift are unchanged.
 
 ## Headers
 
 | Header | Fields |
 | ------ | ------ |
 | AnchorChain | (prev_anchor, end_anchor) |
-| Unspent | (nf, prev_anchor, end_anchor) |
+| Unspent | (start_nf, end_nf, start_anchor, end_anchor) |
 | NfMasterHeader | (mk, cm) |
 | NfPrefixHeader | (prefix{key, depth, index}, mk, cm) |
 | NullifierHeader | (cm, nf, epoch) |
@@ -334,7 +343,6 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | DelegateNullifierHeader | (nf, epoch, delegation_id) |
 | NullifierRolloverHeader | (old_nf, new_nf, new_epoch) |
 | SpendableHeader | (nf, anchor) |
-| SpendableRolloverHeader | (new_nf, epoch_anchor) |
 | SpendHeader | (cv, rk, present_nf, future_nf) |
 | StampHeader | (action_acc, tachygram_acc, anchor) |
 
@@ -348,6 +356,7 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | UnspentSeed | — | — | start, stamp_tg_set, nf | Unspent |
 | EmptyBlockUnspentSeed | — | — | start, nf | Unspent |
 | UnspentFuse | Unspent | Unspent | — | Unspent |
+| UnspentRollover | NullifierRolloverHeader | — | start | Unspent |
 | NfMasterSeed | — | — | note, pak | NfMasterHeader |
 | NfMasterStep | NfMasterHeader | — | chunk | NfPrefixHeader |
 | NfPrefixStep | NfPrefixHeader | — | chunk | NfPrefixHeader |
@@ -359,8 +368,6 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | DelegateRolloverFuse | DelegateNullifierHeader | DelegateNullifierHeader | — | NullifierRolloverHeader |
 | SpendableInit | NullifierHeader | — | anchor, stamp_tg_set | SpendableHeader |
 | SpendableLift | SpendableHeader | Unspent | — | SpendableHeader |
-| SpendableRollover | SpendableHeader | NullifierRolloverHeader | — | SpendableRolloverHeader |
-| SpendableEpochLift | SpendableRolloverHeader | Unspent | — | SpendableHeader |
 | SpendBind | NullifierHeader | NullifierHeader | rcv, alpha, pak, note | SpendHeader |
 | OutputStamp | — | — | rcv, alpha, note, anchor | StampHeader |
 | SpendStamp | SpendHeader | SpendableHeader | — | StampHeader |

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -739,8 +739,11 @@ impl<'source> SyncSim<'source> {
                 continue;
             }
 
-            // Cross the epoch boundary. Walk the local delegates cover
-            // directly so we don't have to re-insert the popped entry.
+            // Cross the epoch boundary with a single cross-epoch Unspent:
+            // an UnspentRollover seed rotates the nf at the boundary, then a
+            // new-epoch segment is fused on, and one SpendableLift consumes
+            // the whole span. Walk the local delegates cover directly so we
+            // don't have to re-insert the popped entry.
             let new_epoch = EpochIndex(stored_epoch.0 + 1);
             let old_nf_pcd = walk_delegate_for_epoch(rng, &delegates, stored_epoch);
             let new_nf_pcd = walk_delegate_for_epoch(rng, &delegates, new_epoch);
@@ -756,28 +759,37 @@ impl<'source> SyncSim<'source> {
                 )
                 .expect("DelegateRolloverFuse");
 
-            let (rollover_header_pcd, ()) = PROOF_SYSTEM
+            // Seed the boundary-crossing segment at the spendable's
+            // epoch-final anchor.
+            let boundary_start = after_same_epoch_pcd.data.1;
+            let (rollover_seg, ()) = PROOF_SYSTEM
                 .fuse(
                     rng,
-                    spendable::SpendableRollover,
-                    (),
-                    after_same_epoch_pcd,
+                    pool::UnspentRollover,
+                    (boundary_start,),
                     rollover_pcd,
+                    Proof::trivial().carry::<()>(()),
                 )
-                .expect("SpendableRollover");
+                .expect("UnspentRollover");
 
+            // Cover the new epoch and fuse onto the rollover segment.
             let next_target = cmp::min(target_height, epoch_final_of(new_epoch));
             let new_epoch_first = BlockHeight(stored_epoch_final.0 + 1);
-            let unspent = build_unspent_pcd(rng, pool, new_nf, new_epoch_first..=next_target);
+            let new_epoch_unspent =
+                build_unspent_pcd(rng, pool, new_nf, new_epoch_first..=next_target);
+            let (cross_unspent, ()) = PROOF_SYSTEM
+                .fuse(rng, pool::UnspentFuse, (), rollover_seg, new_epoch_unspent)
+                .expect("UnspentFuse");
+
             let (landed, ()) = PROOF_SYSTEM
                 .fuse(
                     rng,
-                    spendable::SpendableEpochLift,
+                    spendable::SpendableLift,
                     (),
-                    rollover_header_pcd,
-                    unspent,
+                    after_same_epoch_pcd,
+                    cross_unspent,
                 )
-                .expect("SpendableEpochLift");
+                .expect("SpendableLift");
             self.entries.push((delegation_id, delegates, landed));
         }
     }

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -14,7 +14,8 @@ use crate::{digest::poseidon, serialization};
 /// - [`Anchor::next_empty`] (`Tachyon-EmptyBlk`) advances through one block
 ///   that contains zero stamps, preserving per-height anchor uniqueness.
 /// - [`Anchor::next_epoch`] (`Tachyon-EpochStp`) lifts across an epoch
-///   boundary; performed by `SpendableRollover`.
+///   boundary; performed by `UnspentRollover` within a cross-epoch `Unspent`
+///   segment.
 ///
 /// Opening reveals each link's role by its domain.
 #[derive(Clone, Copy, Debug, Eq)]

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -33,12 +33,11 @@ fn make_app() -> Result<Application, mock_ragu::Error> {
         .register(pool::UnspentSeed)?
         .register(pool::EmptyBlockUnspentSeed)?
         .register(pool::UnspentFuse)?
+        .register(pool::UnspentRollover)?
         .register(spendable::SpendableInit)?
         .register(spendable::SpendableLift)?
         .register(spendable::RolloverFuse)?
         .register(spendable::DelegateRolloverFuse)?
-        .register(spendable::SpendableRollover)?
-        .register(spendable::SpendableEpochLift)?
         .register(stamp::OutputStamp)?
         .register(spend::SpendBind)?
         .register(stamp::SpendStamp)?

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -21,6 +21,7 @@ use ff::{Field as _, PrimeField as _};
 use mock_ragu::{Header, Index, Step, Suffix};
 use pasta_curves::Fp;
 
+use super::spendable::NullifierRolloverHeader;
 use crate::{
     note::Nullifier,
     primitives::{Anchor, TachygramSetCommit, TachygramSetGadget},
@@ -35,7 +36,7 @@ use crate::{
 /// Structurally intra-epoch because only intra-epoch [`Anchor::next_stamp`]
 /// is invoked anywhere in the [`AnchorChain`] builders — crossing an
 /// epoch boundary requires the [`Anchor::next_epoch`] domain only
-/// emitted by `SpendableRollover`.
+/// emitted by [`UnspentRollover`] in the [`Unspent`] lineage.
 ///
 /// The within-epoch property pairs with a consensus-side two-epoch
 /// tachygram scan that catches any tachygram already published earlier
@@ -66,21 +67,25 @@ impl Header for AnchorChain {
     }
 }
 
-/// Per-nf range exclusion proof.
+/// Per-nf range exclusion proof, possibly spanning an epoch boundary.
 ///
-/// `nf` is absent from every stamp covered by the anchor segment from
-/// `start` to `end`. Built per-stamp at seed and fused with adjacent
-/// fragments — fusion now spans block boundaries because anchor
-/// advances are continuous.
+/// The covered note's nullifier is absent from every stamp on the anchor
+/// segment from `start` to `end`. `start_nf` is the nullifier excluded at
+/// `start`'s epoch and `end_nf` at `end`'s epoch; for an intra-epoch
+/// segment they are equal, and a segment that crosses one boundary rotates
+/// `start_nf = nf_E` to `end_nf = nf_{E+1}` at [`UnspentRollover`]. Built
+/// per-stamp at seed and fused with adjacent fragments; fusion spans both
+/// block and (via [`UnspentRollover`]) epoch boundaries.
 ///
-/// Same-epoch is structurally guaranteed by GGM-binding of `nf` to one
-/// epoch and by the intra-epoch-only `Anchor::next_stamp` advances —
-/// crossing an epoch boundary requires matching a boundary anchor that
-/// no `Unspent` builder ever emits.
+/// Within each single-epoch run the nf is GGM-bound to that one epoch and
+/// advances run through the intra-epoch-only `Anchor::next_stamp` /
+/// `Anchor::next_empty`; the sole cross-epoch transition is
+/// [`UnspentRollover`]'s `Anchor::next_epoch`, which rotates the nf using a
+/// lineage-bound [`NullifierRolloverHeader`].
 ///
-/// At the seed steps the PCD lineage of `nf` and `start` roots in
-/// freely-chosen witnesses. `nf`'s binding closes at the consumer
-/// ([`super::spendable::SpendableLift`] checks `unspent.nf ==
+/// At the seed steps the PCD lineage of `start_nf` and `start` roots in
+/// freely-chosen witnesses. `start_nf`'s binding closes at the consumer
+/// ([`super::spendable::SpendableLift`] checks `unspent.start_nf ==
 /// spendable.nf`; the spendable's `nf` is itself bound upstream at
 /// [`super::delegation::NullifierHeader`]); `start`'s binding closes
 /// through the spendable lineage plus consensus anchor membership.
@@ -88,22 +93,25 @@ impl Header for AnchorChain {
 pub struct Unspent;
 
 impl Header for Unspent {
-    /// `(nf, start, end)`. `nf` roots in a seed witness, bound by the
-    /// consumer ([`super::spendable::SpendableLift`] checks
-    /// `unspent.nf == spendable.nf`, and the spendable's `nf` is
-    /// GGM-bound upstream). `start` roots in a seed witness, bound
-    /// through the spendable lineage plus consensus anchor membership.
-    /// `end` is always computed in-circuit as `start.next_stamp(...)`
-    /// or `start.next_empty()`.
-    type Data<'source> = (Nullifier, Anchor, Anchor);
+    /// `(start_nf, end_nf, start, end)`. `start_nf` is the nf excluded at
+    /// `start`'s epoch (roots in a seed witness, bound by the consumer
+    /// [`super::spendable::SpendableLift`]); `end_nf` is the nf at
+    /// `end`'s epoch (equal to `start_nf` within an epoch, rotated at
+    /// [`UnspentRollover`] across a boundary). `start` roots in a seed
+    /// witness, bound through the spendable lineage plus consensus anchor
+    /// membership. `end` is always computed in-circuit as
+    /// `start.next_stamp(...)`, `start.next_empty()`, or
+    /// `prev.next_epoch(...)`.
+    type Data<'source> = (Nullifier, Nullifier, Anchor, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(6);
 
     fn encode(data: &Self::Data<'_>) -> Vec<u8> {
-        let mut out = Vec::with_capacity(32 + 32 + 32);
+        let mut out = Vec::with_capacity(32 + 32 + 32 + 32);
         out.extend_from_slice(&Fp::from(data.0).to_repr());
         out.extend_from_slice(&Fp::from(data.1).to_repr());
         out.extend_from_slice(&Fp::from(data.2).to_repr());
+        out.extend_from_slice(&Fp::from(data.3).to_repr());
         out
     }
 }
@@ -223,7 +231,8 @@ impl Step for UnspentSeed {
         }
         let stamp_commit = TachygramSetCommit::from(stamp_tg_set);
         let end = start.next_stamp(&stamp_commit);
-        Ok(((nf, start, end), ()))
+        // A single stamp is within one epoch, so start_nf == end_nf.
+        Ok(((nf, nf, start, end), ()))
     }
 }
 
@@ -255,12 +264,16 @@ impl Step for EmptyBlockUnspentSeed {
         _left: <Self::Left as Header>::Data<'source>,
         _right: <Self::Right as Header>::Data<'source>,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        Ok(((nf, start, start.next_empty()), ()))
+        // An empty block is within one epoch, so start_nf == end_nf.
+        Ok(((nf, nf, start, start.next_empty()), ()))
     }
 }
 
-/// Compose two adjacent [`Unspent`] segments for the same `nf`.
-/// Verify same `nf` and `left.end == right.start`.
+/// Compose two adjacent [`Unspent`] segments.
+///
+/// Verify nf continuity at the join (`left.end_nf == right.start_nf`,
+/// which equates the shared nf within an epoch and chains a rotation
+/// across a boundary) and anchor continuity (`left.end == right.start`).
 #[derive(Debug)]
 pub struct UnspentFuse;
 
@@ -276,12 +289,14 @@ impl Step for UnspentFuse {
     fn witness<'source>(
         &self,
         _witness: Self::Witness<'source>,
-        (left_nf, left_start, left_end): <Self::Left as Header>::Data<'source>,
-        (right_nf, right_start, right_end): <Self::Right as Header>::Data<'source>,
+        (left_start_nf, left_end_nf, left_start, left_end): <Self::Left as Header>::Data<'source>,
+        (right_start_nf, right_end_nf, right_start, right_end): <Self::Right as Header>::Data<
+            'source,
+        >,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        if left_nf != right_nf {
+        if left_end_nf != right_start_nf {
             return Err(mock_ragu::Error(
-                "UnspentFuse: left and right must share the same nf",
+                "UnspentFuse: left.end_nf must equal right.start_nf",
             ));
         }
         if left_end != right_start {
@@ -289,6 +304,51 @@ impl Step for UnspentFuse {
                 "UnspentFuse: left.end must equal right.start",
             ));
         }
-        Ok(((left_nf, left_start, right_end), ()))
+        Ok(((left_start_nf, right_end_nf, left_start, right_end), ()))
+    }
+}
+
+/// Cross-epoch [`Unspent`] rollover seed: a zero-stamp segment that crosses
+/// one epoch boundary, rotating the exclusion nullifier.
+///
+/// Witnesses the pre-boundary `start` anchor (freely chosen, bound at the
+/// consumer like other seeds) and consumes a lineage-bound
+/// [`super::spendable::NullifierRolloverHeader`] `(old_nf, new_nf,
+/// new_epoch)`. Emits `Unspent(old_nf, new_nf, start,
+/// start.next_epoch(new_epoch))`. The segment excludes nothing itself (the
+/// boundary link absorbs no stamps); it carries the nf rotation and the
+/// sole [`Anchor::next_epoch`] advance in the proof tree. Fuse a
+/// prior-epoch segment (ending at `start`, nf `old_nf`) and a new-epoch
+/// segment (starting at the boundary, nf `new_nf`) onto it with
+/// [`UnspentFuse`]; when the spendable already sits at the epoch-final
+/// anchor, the prior-epoch segment is empty and this seed's `start` binds
+/// directly to the spendable's anchor at [`super::spendable::SpendableLift`].
+///
+/// `new_epoch` enters the boundary hash directly; its binding to a real
+/// published anchor closes at consensus when the consuming spend's stamp is
+/// accepted (anchor membership), exactly as the spendable lineage's anchors
+/// do. The rotation's lineage (same note, consecutive epochs) is carried by
+/// the [`super::spendable::NullifierRolloverHeader`].
+#[derive(Debug)]
+pub struct UnspentRollover;
+
+impl Step for UnspentRollover {
+    type Aux<'source> = ();
+    type Left = NullifierRolloverHeader;
+    type Output = Unspent;
+    type Right = ();
+    /// `(start,)` — the pre-boundary anchor.
+    type Witness<'source> = (Anchor,);
+
+    const INDEX: Index = Index::new(13);
+
+    fn witness<'source>(
+        &self,
+        (start,): Self::Witness<'source>,
+        (old_nf, new_nf, new_epoch): <Self::Left as Header>::Data<'source>,
+        _right: <Self::Right as Header>::Data<'source>,
+    ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
+        let boundary = start.next_epoch(new_epoch);
+        Ok(((old_nf, new_nf, start, boundary), ()))
     }
 }

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -97,7 +97,7 @@ impl Step for SpendBind {
         Note,
     );
 
-    const INDEX: Index = Index::new(20);
+    const INDEX: Index = Index::new(19);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -16,13 +16,12 @@
 //! prove nf-exclusion at every covered stamp. There is no path that
 //! advances a spendable's anchor without a per-stamp nf-check.
 //!
-//! Sync services update spendables via lifts ([`SpendableLift`]) and
-//! cross-epoch rollovers ([`SpendableRollover`] →
-//! [`SpendableEpochLift`]). [`SpendableRollover`] is the only step that
-//! emits the [`Anchor::next_epoch`] boundary domain — it lifts the old
-//! epoch's terminal anchor into the new epoch's initial anchor, which
-//! the new-epoch [`Unspent`] then extends with ordinary per-stamp
-//! advances.
+//! Sync services update spendables entirely through lifts
+//! ([`SpendableLift`]) over [`Unspent`] segments, which may themselves
+//! span an epoch boundary: a cross-epoch [`Unspent`] rotates its
+//! exclusion nf and applies the [`Anchor::next_epoch`] boundary domain at
+//! [`super::pool::UnspentRollover`], so the spendable advances across a
+//! boundary in a single ordinary lift.
 
 extern crate alloc;
 
@@ -61,8 +60,8 @@ impl Header for SpendableHeader {
     /// in [`super::delegation::NullifierHeader`]. `anchor` is computed
     /// at [`SpendableInit`] as `pre_cm_anchor.next_stamp(stamp_commit)`
     /// over a freely-witnessed `pre_cm_anchor`, then advanced over
-    /// [`Unspent`] segments at [`SpendableLift`] /
-    /// [`SpendableEpochLift`].
+    /// [`Unspent`] segments at [`SpendableLift`] (a cross-epoch
+    /// [`Unspent`] also rotates `nf` across a boundary).
     type Data<'source> = (Nullifier, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(7);
@@ -78,9 +77,9 @@ impl Header for SpendableHeader {
 /// Cross-epoch nf rotation pair.
 ///
 /// `nfs[0]` is the old-epoch `nf`, `nfs[1]` the new-epoch `nf`; the new
-/// epoch index is exposed for downstream consumers (specifically
-/// [`SpendableRollover`]'s boundary hash). Consecutive epochs are
-/// verified at construction.
+/// epoch index is exposed for the downstream consumer
+/// ([`super::pool::UnspentRollover`]'s boundary hash). Consecutive epochs
+/// are verified at construction.
 ///
 /// Produced by either [`RolloverFuse`] (user device, lineage = `cm`
 /// equality) or [`DelegateRolloverFuse`] (sync service, lineage =
@@ -103,36 +102,6 @@ impl Header for NullifierRolloverHeader {
         out.extend_from_slice(&Fp::from(data.0).to_repr());
         out.extend_from_slice(&Fp::from(data.1).to_repr());
         out.extend_from_slice(&data.2.0.to_le_bytes());
-        out
-    }
-}
-
-/// A spendable rolled forward through an nf rotation, awaiting a
-/// new-epoch anchor from [`SpendableEpochLift`].
-///
-/// Carries `new_nf` (which the new-epoch [`Unspent`] must cover) and
-/// `boundary_anchor` (output of [`Anchor::next_epoch`] applied to the
-/// old epoch's terminal anchor — i.e., the new epoch's initial
-/// anchor). The new-epoch `Unspent`'s `prev_anchor` must equal this
-/// boundary anchor. The old-epoch nullifier is dropped: [`SpendableRollover`]
-/// has already discharged it against the input spendable's `nf`.
-#[derive(Clone, Debug)]
-pub struct SpendableRolloverHeader;
-
-impl Header for SpendableRolloverHeader {
-    /// `(new_nf, boundary_anchor)`. `boundary_anchor` is computed at
-    /// [`SpendableRollover`] via `Anchor::next_epoch` on the
-    /// spendable's prior anchor, the only place the `Tachyon-EpochStp`
-    /// domain is invoked. The new-epoch [`Unspent`]'s `prev_anchor` is
-    /// the only way to discharge it.
-    type Data<'source> = (Nullifier, Anchor);
-
-    const SUFFIX: Suffix = Suffix::new(9);
-
-    fn encode(data: &Self::Data<'_>) -> Vec<u8> {
-        let mut out = Vec::with_capacity(32 + 32);
-        out.extend_from_slice(&Fp::from(data.0).to_repr());
-        out.extend_from_slice(&Fp::from(data.1).to_repr());
         out
     }
 }
@@ -161,7 +130,7 @@ impl Step for SpendableInit {
     /// `(pre_cm_anchor, stamp_tg_set)`.
     type Witness<'source> = (Anchor, TachygramSetGadget);
 
-    const INDEX: Index = Index::new(13);
+    const INDEX: Index = Index::new(14);
 
     fn witness<'source>(
         &self,
@@ -179,8 +148,15 @@ impl Step for SpendableInit {
     }
 }
 
-/// Advance a [`SpendableHeader`]'s `anchor` along an [`Unspent`]
-/// segment whose `prev_anchor` equals the spendable's current anchor.
+/// Advance a [`SpendableHeader`] along an [`Unspent`] segment whose
+/// `start` equals the spendable's current anchor.
+///
+/// The segment may be intra-epoch (`start_nf == end_nf`) or cross-epoch
+/// (the [`Unspent`] rotated `start_nf -> end_nf` at
+/// [`super::pool::UnspentRollover`]); either way the spendable adopts the
+/// segment's `end_nf` and `end`. The `start_nf == spendable.nf` check is
+/// where the [`Unspent`]'s freely-witnessed `start_nf` binds to the
+/// GGM-bound spendable nf.
 #[derive(Debug)]
 pub struct SpendableLift;
 
@@ -191,27 +167,27 @@ impl Step for SpendableLift {
     type Right = Unspent;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(14);
+    const INDEX: Index = Index::new(15);
 
     fn witness<'source>(
         &self,
         _witness: Self::Witness<'source>,
         (spendable_nf, spendable_anchor): <Self::Left as Header>::Data<'source>,
-        (unspent_nf, unspent_prev_anchor, unspent_end_anchor): <Self::Right as Header>::Data<
+        (unspent_start_nf, unspent_end_nf, unspent_start, unspent_end): <Self::Right as Header>::Data<
             'source,
         >,
     ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        if unspent_nf != spendable_nf {
+        if unspent_start_nf != spendable_nf {
             return Err(mock_ragu::Error(
                 "SpendableLift: unspent does not relate to spendable",
             ));
         }
-        if unspent_prev_anchor != spendable_anchor {
+        if unspent_start != spendable_anchor {
             return Err(mock_ragu::Error(
                 "SpendableLift: unspent not adjacent to spendable",
             ));
         }
-        Ok(((spendable_nf, unspent_end_anchor), ()))
+        Ok(((unspent_end_nf, unspent_end), ()))
     }
 }
 
@@ -227,7 +203,7 @@ impl Step for RolloverFuse {
     type Right = NullifierHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(15);
+    const INDEX: Index = Index::new(16);
 
     fn witness<'source>(
         &self,
@@ -258,7 +234,7 @@ impl Step for DelegateRolloverFuse {
     type Right = DelegateNullifierHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(16);
+    const INDEX: Index = Index::new(17);
 
     fn witness<'source>(
         &self,
@@ -277,88 +253,5 @@ impl Step for DelegateRolloverFuse {
             ));
         }
         Ok(((left_nf, right_nf, right_epoch), ()))
-    }
-}
-
-/// Lift a [`SpendableHeader`] across an epoch boundary.
-///
-/// Checks `spendable.nf == old_nf` from the [`NullifierRolloverHeader`],
-/// then applies [`Anchor::next_epoch`] to the spendable's current anchor
-/// to produce the new epoch's `boundary_anchor`. Emits `(new_nf,
-/// boundary_anchor)` for [`SpendableEpochLift`] to consume against a
-/// new-epoch [`Unspent`] whose `prev_anchor` equals this boundary.
-///
-/// This is the only step in the proof tree that invokes the
-/// [`Anchor::next_epoch`] domain. `new_epoch` enters the boundary hash
-/// directly, so any tampered value diverges from the published anchor.
-#[derive(Debug)]
-pub struct SpendableRollover;
-
-impl Step for SpendableRollover {
-    type Aux<'source> = ();
-    type Left = SpendableHeader;
-    type Output = SpendableRolloverHeader;
-    type Right = NullifierRolloverHeader;
-    type Witness<'source> = ();
-
-    const INDEX: Index = Index::new(17);
-
-    fn witness<'source>(
-        &self,
-        _witness: Self::Witness<'source>,
-        (spendable_nf, spendable_anchor): <Self::Left as Header>::Data<'source>,
-        (rollover_old_nf, rollover_new_nf, rollover_new_epoch): <Self::Right as Header>::Data<
-            'source,
-        >,
-    ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        if spendable_nf != rollover_old_nf {
-            return Err(mock_ragu::Error(
-                "SpendableRollover: nullifiers don't match",
-            ));
-        }
-        let boundary_anchor = spendable_anchor.next_epoch(rollover_new_epoch);
-        Ok(((rollover_new_nf, boundary_anchor), ()))
-    }
-}
-
-/// Land a rolled-over spendable on a new-epoch anchor.
-///
-/// Merges with a new-epoch [`Unspent`] whose `prev_anchor` equals the
-/// rollover's `boundary_anchor`. The boundary anchor cryptographically
-/// binds `new_epoch` via [`Anchor::next_epoch`], and the new-epoch
-/// [`Unspent`] is bound to the wallet's new-epoch identity via
-/// `unspent.nf == new_nf` (GGM-bound upstream in the NullifierHeader).
-/// Together these pin the wallet to the real E→E+1 epoch transition.
-#[derive(Debug)]
-pub struct SpendableEpochLift;
-
-impl Step for SpendableEpochLift {
-    type Aux<'source> = ();
-    type Left = SpendableRolloverHeader;
-    type Output = SpendableHeader;
-    type Right = Unspent;
-    type Witness<'source> = ();
-
-    const INDEX: Index = Index::new(18);
-
-    fn witness<'source>(
-        &self,
-        _witness: Self::Witness<'source>,
-        (rollover_new_nf, rollover_boundary_anchor): <Self::Left as Header>::Data<'source>,
-        (unspent_nf, unspent_prev_anchor, unspent_end_anchor): <Self::Right as Header>::Data<
-            'source,
-        >,
-    ) -> mock_ragu::Result<(<Self::Output as Header>::Data<'source>, Self::Aux<'source>)> {
-        if unspent_nf != rollover_new_nf {
-            return Err(mock_ragu::Error(
-                "SpendableEpochLift: nullifiers not related",
-            ));
-        }
-        if unspent_prev_anchor != rollover_boundary_anchor {
-            return Err(mock_ragu::Error(
-                "SpendableEpochLift: unspent prev_anchor must equal rollover boundary_anchor",
-            ));
-        }
-        Ok(((rollover_new_nf, unspent_end_anchor), ()))
     }
 }

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -72,7 +72,7 @@ impl Step for OutputStamp {
         Anchor,
     );
 
-    const INDEX: Index = Index::new(19);
+    const INDEX: Index = Index::new(18);
 
     fn witness<'source>(
         &self,
@@ -120,7 +120,7 @@ impl Step for SpendStamp {
     type Right = SpendableHeader;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(21);
+    const INDEX: Index = Index::new(20);
 
     fn witness<'source>(
         &self,
@@ -164,7 +164,7 @@ impl Step for MergeStamp {
         TachygramSetGadget,
     );
 
-    const INDEX: Index = Index::new(22);
+    const INDEX: Index = Index::new(21);
 
     fn witness<'source>(
         &self,
@@ -217,7 +217,7 @@ impl Step for StampLift {
     type Right = AnchorChain;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(23);
+    const INDEX: Index = Index::new(22);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -460,39 +460,71 @@ fn delegate_rollover_fuse_rejects_invalid_inputs() {
 }
 
 #[test]
-fn spendable_rollover_rejects_nf_mismatch() {
+fn unspent_rollover_crosses_boundary() {
+    // A spendable advances across an epoch boundary by consuming a single
+    // cross-epoch Unspent: an UnspentRollover seed rotates the nf at the
+    // boundary, a new-epoch segment is fused on, and one SpendableLift
+    // consumes the whole span.
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
     let mut pool = PoolSim::genesis(rng);
-    let note_a = user.random_note(rng, 100);
-    let note_b = user.random_note(rng, 200);
+    let note = user.random_note(rng, 500);
 
-    pool.mine(random_block_with(
-        rng,
-        &[alloc::vec![note_a.commitment()]],
-        4,
-    ));
+    pool.mine(random_block_with(rng, &[alloc::vec![note.commitment()]], 4));
     let init_height = pool.height();
-    let nf_pcd_a = user.nullifier_pcd(rng, note_a, EpochIndex(0));
-    let spendable_a = user.spendable_init(rng, note_a, &pool, init_height, nf_pcd_a);
+    let nf_pcd = user.nullifier_pcd(rng, note, EpochIndex(0));
+    let spendable = user.spendable_init(rng, note, &pool, init_height, nf_pcd);
 
-    let rollover_b = build_nullifier_rollover_pcd(rng, &user, note_b, EpochIndex(0));
+    pool.advance(
+        usize::try_from(EPOCH_SIZE + 1 - pool.height().0).expect("fits"),
+        |_| random_block(rng, 1, 4),
+    );
+    let epoch_0_final = BlockHeight(EPOCH_SIZE - 1);
+    let epoch_1_first = BlockHeight(EPOCH_SIZE);
 
-    let err = PROOF_SYSTEM
+    // Lift within epoch 0 up to its final block.
+    let nf_0 = note.nullifier(&user.pak.nk, EpochIndex(0));
+    let within = build_unspent_pcd(
+        rng,
+        &pool,
+        nf_0,
+        BlockHeight(init_height.0 + 1)..=epoch_0_final,
+    );
+    let (spendable_at_final, ()) = PROOF_SYSTEM
+        .fuse(rng, spendable::SpendableLift, (), spendable, within)
+        .expect("SpendableLift within epoch 0");
+
+    // UnspentRollover seed at the epoch-0 final anchor + epoch-1 segment.
+    let rollover = build_nullifier_rollover_pcd(rng, &user, note, EpochIndex(0));
+    let boundary_start = spendable_at_final.data.1;
+    let (rollover_seg, ()) = PROOF_SYSTEM
         .fuse(
             rng,
-            spendable::SpendableRollover,
-            (),
-            spendable_a,
-            rollover_b,
+            pool::UnspentRollover,
+            (boundary_start,),
+            rollover,
+            Proof::trivial().carry::<()>(()),
         )
-        .unwrap_err();
-    assert_eq!(err.0, "SpendableRollover: nullifiers don't match");
+        .expect("UnspentRollover");
+    let nf_1 = note.nullifier(&user.pak.nk, EpochIndex(1));
+    let e1_seg = build_unspent_pcd(rng, &pool, nf_1, epoch_1_first..=epoch_1_first);
+    let (cross, ()) = PROOF_SYSTEM
+        .fuse(rng, pool::UnspentFuse, (), rollover_seg, e1_seg)
+        .expect("UnspentFuse across boundary");
+
+    let (landed, ()) = PROOF_SYSTEM
+        .fuse(rng, spendable::SpendableLift, (), spendable_at_final, cross)
+        .expect("SpendableLift across boundary");
+
+    // The spendable now carries the epoch-1 nf at the epoch-1 anchor.
+    assert_eq!(landed.data.0, nf_1);
+    assert_eq!(landed.data.1, pool.anchor_at(epoch_1_first));
 }
 
 #[test]
-fn spendable_epoch_lift_rejects_invalid_inputs() {
-    // nf mismatch: rolled spendable for note_a, unspent for note_b's nf.
+fn cross_epoch_unspent_fuse_rejects_invalid_boundary() {
+    // nf discontinuity: the rollover seg rotates to note_a's epoch-1 nf, but
+    // the new-epoch segment covers a different note's nf.
     {
         let rng = &mut StdRng::seed_from_u64(0);
         let user = WalletSim::random(rng);
@@ -500,77 +532,65 @@ fn spendable_epoch_lift_rejects_invalid_inputs() {
         let note_a = user.random_note(rng, 100);
         let note_b = user.random_note(rng, 200);
 
-        pool.mine(random_block_with(
-            rng,
-            &[alloc::vec![note_a.commitment()]],
-            4,
-        ));
-        let init_height = pool.height();
-        let nf_pcd_a = user.nullifier_pcd(rng, note_a, EpochIndex(0));
-        let spendable_a = user.spendable_init(rng, note_a, &pool, init_height, nf_pcd_a);
+        pool.advance(usize::try_from(EPOCH_SIZE + 1).expect("fits"), |_| {
+            random_block(rng, 1, 4)
+        });
+        let epoch_0_final = BlockHeight(EPOCH_SIZE - 1);
+        let epoch_1_first = BlockHeight(EPOCH_SIZE);
 
         let rollover_a = build_nullifier_rollover_pcd(rng, &user, note_a, EpochIndex(0));
-        let (rolled_a, ()) = PROOF_SYSTEM
+        let boundary_start = pool.anchor_at(epoch_0_final);
+        let (rollover_seg, ()) = PROOF_SYSTEM
             .fuse(
                 rng,
-                spendable::SpendableRollover,
-                (),
-                spendable_a,
+                pool::UnspentRollover,
+                (boundary_start,),
                 rollover_a,
+                Proof::trivial().carry::<()>(()),
             )
-            .expect("SpendableRollover");
+            .expect("UnspentRollover");
 
-        let nf_b = note_b.nullifier(&user.pak.nk, EpochIndex(0));
-        let unspent_b = build_unspent_pcd(rng, &pool, nf_b, BlockHeight(0)..=init_height);
+        let nf_b_1 = note_b.nullifier(&user.pak.nk, EpochIndex(1));
+        let e1_seg = build_unspent_pcd(rng, &pool, nf_b_1, epoch_1_first..=epoch_1_first);
 
         let err = PROOF_SYSTEM
-            .fuse(rng, spendable::SpendableEpochLift, (), rolled_a, unspent_b)
+            .fuse(rng, pool::UnspentFuse, (), rollover_seg, e1_seg)
             .unwrap_err();
-        assert_eq!(err.0, "SpendableEpochLift: nullifiers not related");
+        assert_eq!(err.0, "UnspentFuse: left.end_nf must equal right.start_nf");
     }
 
-    // prev_anchor mismatch: last_old_anchor flows from the spendable at
-    // init_height, but the unspent is rooted at epoch_0_final's anchor.
+    // anchor discontinuity: seed the rollover at a bogus pre-boundary anchor,
+    // so its boundary does not meet the real epoch-1 segment's start.
     {
         let rng = &mut StdRng::seed_from_u64(0);
         let user = WalletSim::random(rng);
         let mut pool = PoolSim::genesis(rng);
-        let note_a = user.random_note(rng, 500);
+        let note = user.random_note(rng, 500);
 
-        pool.mine(random_block_with(
-            rng,
-            &[alloc::vec![note_a.commitment()]],
-            4,
-        ));
-        let init_height = pool.height();
-        pool.advance(usize::try_from(EPOCH_SIZE).expect("fits"), |_| {
+        pool.advance(usize::try_from(EPOCH_SIZE + 1).expect("fits"), |_| {
             random_block(rng, 1, 4)
         });
         let epoch_1_first = BlockHeight(EPOCH_SIZE);
 
-        let nf_pcd_a = user.nullifier_pcd(rng, note_a, EpochIndex(0));
-        let spendable_a = user.spendable_init(rng, note_a, &pool, init_height, nf_pcd_a);
-        let rollover_a = build_nullifier_rollover_pcd(rng, &user, note_a, EpochIndex(0));
-        let nf_a_e1 = note_a.nullifier(&user.pak.nk, EpochIndex(1));
-        let (rolled_a, ()) = PROOF_SYSTEM
+        let rollover = build_nullifier_rollover_pcd(rng, &user, note, EpochIndex(0));
+        let bogus_start = Anchor(Fp::random(&mut *rng));
+        let (rollover_seg, ()) = PROOF_SYSTEM
             .fuse(
                 rng,
-                spendable::SpendableRollover,
-                (),
-                spendable_a,
-                rollover_a,
+                pool::UnspentRollover,
+                (bogus_start,),
+                rollover,
+                Proof::trivial().carry::<()>(()),
             )
-            .expect("SpendableRollover");
+            .expect("UnspentRollover");
 
-        let unspent = build_unspent_pcd(rng, &pool, nf_a_e1, epoch_1_first..=epoch_1_first);
+        let nf_1 = note.nullifier(&user.pak.nk, EpochIndex(1));
+        let e1_seg = build_unspent_pcd(rng, &pool, nf_1, epoch_1_first..=epoch_1_first);
 
         let err = PROOF_SYSTEM
-            .fuse(rng, spendable::SpendableEpochLift, (), rolled_a, unspent)
+            .fuse(rng, pool::UnspentFuse, (), rollover_seg, e1_seg)
             .unwrap_err();
-        assert_eq!(
-            err.0,
-            "SpendableEpochLift: unspent prev_anchor must equal rollover boundary_anchor"
-        );
+        assert_eq!(err.0, "UnspentFuse: left.end must equal right.start");
     }
 }
 
@@ -628,7 +648,7 @@ fn unspent_fuse_rejects_invalid_compositions() {
         let err = PROOF_SYSTEM
             .fuse(rng, pool::UnspentFuse, (), shard_a, shard_b)
             .unwrap_err();
-        assert_eq!(err.0, "UnspentFuse: left and right must share the same nf");
+        assert_eq!(err.0, "UnspentFuse: left.end_nf must equal right.start_nf");
     }
 
     // state discontinuity: same nf, but right's start matches `start`


### PR DESCRIPTION


Relocates epoch-rollover work from the spendable lineage into the `Unspent` lineage. An `Unspent` range may now span one epoch boundary, rotating its exclusion nullifier `nf_E → nf_{E+1}` and applying `Anchor::next_epoch` internally. `SpendableLift` becomes the single way a spendable advances (intra- or cross-epoch); the two spendable-side rollover steps are removed.

### Before / after

Previously a spendable crossed a boundary via `RolloverFuse`/`DelegateRolloverFuse` → `SpendableRollover` (`next_epoch`) → `SpendableEpochLift`, while the `Unspent` was intra-epoch by construction. Now the boundary work lives in one `Unspent`-lineage step, and the spendable lineage shrinks to `SpendableInit` + `SpendableLift`.

### Changes

**`pool.rs`**
- `Unspent::Data`: `(nf, start, end)` → `(start_nf, end_nf, start, end)`. Intra-epoch: `start_nf == end_nf`; cross-epoch: `nf_E → nf_{E+1}`. `encode()` +32 bytes; `SUFFIX` (6) unchanged.
- `UnspentSeed` / `EmptyBlockUnspentSeed`: emit `(nf, nf, start, end)`.
- `UnspentFuse`: check `left.end_nf == right.start_nf` (+ `left.end == right.start`); emit `(left.start_nf, right.end_nf, left.start, right.end)`.
- **New `UnspentRollover`** (seed; `Left = NullifierRolloverHeader`, witness `(start,)`): emits `(old_nf, new_nf, start, start.next_epoch(new_epoch))`. The only step invoking `Anchor::next_epoch`. Seed form so a spendable at the epoch-final anchor needs no prior-epoch segment.

**`spendable.rs`**
- `SpendableLift`: check `start_nf == spendable.nf` and `start == spendable.anchor`; emit `(end_nf, end)`.
- Removed `SpendableRollover`, `SpendableEpochLift`, `SpendableRolloverHeader`.
- Kept `RolloverFuse`/`DelegateRolloverFuse`/`NullifierRolloverHeader` (now feed `UnspentRollover`). `SpendableInit`/`SpendableHeader` unchanged (spendable stays single-nf).

**Spend path / `AnchorChain`: untouched.** Spend still happens at a single-epoch anchor and publishes `(now_nf, next_nf)` via `SpendBind`.

**Indices** (`mod.rs`/`stamp.rs`/`spend.rs`): `UnspentRollover` registered after `UnspentFuse` (=13); `SpendableInit` 13→14, `SpendableLift` 14→15, `RolloverFuse` 15→16, `DelegateRolloverFuse` 16→17, stamp/spend steps 18–23→18–22. Freed `SpendableRolloverHeader` SUFFIX 9 left unused.

### Soundness
- **nf rotation** bound by `UnspentRollover` consuming a lineage-bound `NullifierRolloverHeader` (cm/`delegation_id` equality, GGM-consistent epochs).
- **`start_nf`** closes at the consumer (`SpendableLift`: `start_nf == spendable.nf`, GGM-bound upstream).
- **`next_epoch`**: wrong `start`/`new_epoch` yields a non-published boundary; closes at consensus anchor membership, as `SpendableRollover` did.
- **Bare boundary**: a spendable at `boundary` can't be spent until ≥1 E+1 block is lifted over (matches old `SpendableEpochLift`).
- **Cost**: one `next_epoch` Poseidon + equality checks (same as removed `SpendableRollover`).

### Testing
- `SyncSim::lift_one` rewritten: one cross-epoch `Unspent` (`UnspentRollover` + `UnspentFuse`) then one `SpendableLift`.
- New: `unspent_rollover_crosses_boundary`, `cross_epoch_unspent_fuse_rejects_invalid_boundary`; replaced old `spendable_rollover_*` / `spendable_epoch_lift_*`.
- `just test` 119 passed / 0 failed; `just lint` clean; `just fmt` applied. Book + `anchor.rs` docs updated.
