### PR TITLE
fix: standardize error handling conventions

### DIFF
--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -206,7 +206,7 @@ pub enum SignatureError {
 }
 
 /// Errors that can occur while signing a bundle plan.
-#[derive(Debug, Display, Error)]
+#[derive(Clone, Copy, Debug, Display, Error)]
 #[non_exhaustive]
 pub enum SignError {
     /// The derived rk does not match the stored rk.

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -194,15 +194,15 @@ pub enum BuildError {
 }
 
 /// Errors from bundle signature verification.
-#[derive(Debug, Display, Error)]
+#[derive(Clone, Copy, Debug, Display, Error)]
 #[non_exhaustive]
 pub enum SignatureError {
     /// The binding signature is invalid.
-    #[display("invalid binding signature")]
-    Binding,
+    #[display("invalid binding signature {_0:?}")]
+    Binding(#[error(not(source))] Signature),
     /// An action signature is invalid.
-    #[display("invalid action signature for {_0:?}")]
-    Action(#[error(not(source))] reddsa::VerificationKeyBytes<reddsa::ActionAuth>),
+    #[display("invalid action signature {_0:?}")]
+    Action(#[error(not(source))] action::Signature),
 }
 
 /// Errors that can occur while signing a bundle plan.
@@ -724,14 +724,14 @@ impl<S: StampState> Bundle<S> {
 
         // 2. Verify binding signature
         bvk.verify(sighash, &self.binding_sig)
-            .map_err(|_err| SignatureError::Binding)?;
+            .map_err(|_err| SignatureError::Binding(self.binding_sig))?;
 
         // 3. Verify each action signature against the SAME sighash
         for action in &self.actions {
             action
                 .rk
                 .verify(sighash, &action.sig)
-                .map_err(|_err| SignatureError::Action(action.rk.0.into()))?;
+                .map_err(|_err| SignatureError::Action(action.sig))?;
         }
 
         Ok(())

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -182,13 +182,27 @@ impl TryFrom<TachyonBundle> for Bundle<AggregateId> {
 }
 
 /// Errors during bundle construction.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Display, Error)]
 pub enum BuildError {
-    /// Ragu proof verification failed
+    /// Ragu proof verification failed.
+    #[display("proof verification failed")]
     ProofInvalid,
 
-    /// BSK/BVK mismatch (see Protocol §4.14)
+    /// BSK/BVK mismatch (see Protocol §4.14).
+    #[display("binding signing key does not match verification key")]
     BalanceKeyMismatch,
+}
+
+/// Errors from bundle signature verification.
+#[derive(Debug, Display, Error)]
+#[non_exhaustive]
+pub enum SignatureError {
+    /// The binding signature is invalid.
+    #[display("invalid binding signature")]
+    Binding,
+    /// An action signature is invalid.
+    #[display("invalid action signature for {_0:?}")]
+    Action(#[error(not(source))] reddsa::VerificationKeyBytes<reddsa::ActionAuth>),
 }
 
 /// Errors that can occur while signing a bundle plan.
@@ -704,16 +718,20 @@ impl<S: StampState> Bundle<S> {
     }
 
     /// Verify the bundle's binding signature and all action signatures.
-    pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), reddsa::Error> {
+    pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), SignatureError> {
         // 1. Derive bvk from public data (validator-side, §4.14)
         let bvk = public::BindingVerificationKey::derive(&self.actions, self.value_balance);
 
         // 2. Verify binding signature
-        bvk.verify(sighash, &self.binding_sig)?;
+        bvk.verify(sighash, &self.binding_sig)
+            .map_err(|_err| SignatureError::Binding)?;
 
         // 3. Verify each action signature against the SAME sighash
         for action in &self.actions {
-            action.rk.verify(sighash, &action.sig)?;
+            action
+                .rk
+                .verify(sighash, &action.sig)
+                .map_err(|_err| SignatureError::Action(action.rk.0.into()))?;
         }
 
         Ok(())

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -13,7 +13,6 @@ use crate::{
         random_action, random_block, random_block_with,
     },
     primitives::BlockHeight,
-    reddsa,
 };
 
 #[test]
@@ -25,7 +24,7 @@ fn wrong_value_balance_fails_verification() {
 
     bundle.value_balance = 999;
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let SignatureError::Binding = err else {
+    let SignatureError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
     };
 }
@@ -341,14 +340,14 @@ fn invalid_action_sig_fails_verification() {
 
     let mut sig_bytes: [u8; 64] = bundle.actions[0].sig.into();
     sig_bytes[0] ^= 0xFF;
-    bundle.actions[0].sig = action::Signature::from(sig_bytes);
+    let bad_sig = action::Signature::from(sig_bytes);
+    bundle.actions[0].sig = bad_sig;
 
-    let expected_rk = reddsa::VerificationKeyBytes::from(bundle.actions[0].rk.0);
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let SignatureError::Action(rk) = err else {
+    let SignatureError::Action(sig) = err else {
         panic!("expected SignatureError::Action, got {err:?}");
     };
-    assert_eq!(rk, expected_rk);
+    assert_eq!(sig, bad_sig);
 }
 
 #[test]

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic, reason = "test code")]
+
 use alloc::{vec, vec::Vec};
 
 use rand::{SeedableRng as _, rngs::StdRng};
@@ -22,10 +24,10 @@ fn wrong_value_balance_fails_verification() {
     let sighash = mock_sighash(bundle.commitment().unwrap());
 
     bundle.value_balance = 999;
-    assert!(matches!(
-        bundle.verify_signatures(&sighash),
-        Err(SignatureError::Binding)
-    ));
+    let err = bundle.verify_signatures(&sighash).unwrap_err();
+    let SignatureError::Binding = err else {
+        panic!("expected SignatureError::Binding, got {err:?}");
+    };
 }
 
 #[test]
@@ -342,10 +344,11 @@ fn invalid_action_sig_fails_verification() {
     bundle.actions[0].sig = action::Signature::from(sig_bytes);
 
     let expected_rk = reddsa::VerificationKeyBytes::from(bundle.actions[0].rk.0);
-    assert!(matches!(
-        bundle.verify_signatures(&sighash),
-        Err(SignatureError::Action(rk)) if rk == expected_rk
-    ));
+    let err = bundle.verify_signatures(&sighash).unwrap_err();
+    let SignatureError::Action(rk) = err else {
+        panic!("expected SignatureError::Action, got {err:?}");
+    };
+    assert_eq!(rk, expected_rk);
 }
 
 #[test]
@@ -484,10 +487,7 @@ fn tachyon_bundle_wire_round_trip() {
 
 #[test]
 fn aggregate_id_try_from_rejects_zero() {
-    assert!(matches!(
-        AggregateId::try_from([0u8; 64]),
-        Err(AggregateIdError::Zero)
-    ));
+    AggregateId::try_from([0u8; 64]).unwrap_err();
 }
 
 #[test]
@@ -497,10 +497,7 @@ fn assign_wtxid_rejects_zero_with_actions() {
     let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
 
     assert!(!unassigned.actions.is_empty());
-    assert!(matches!(
-        unassigned.assign_wtxid(AggregateId::ZERO),
-        Err(AggregateIdError::Zero)
-    ));
+    unassigned.assign_wtxid(AggregateId::ZERO).unwrap_err();
 }
 
 #[test]

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -11,6 +11,7 @@ use crate::{
         random_action, random_block, random_block_with,
     },
     primitives::BlockHeight,
+    reddsa,
 };
 
 #[test]
@@ -21,7 +22,10 @@ fn wrong_value_balance_fails_verification() {
     let sighash = mock_sighash(bundle.commitment().unwrap());
 
     bundle.value_balance = 999;
-    assert!(bundle.verify_signatures(&sighash).is_err());
+    assert!(matches!(
+        bundle.verify_signatures(&sighash),
+        Err(SignatureError::Binding)
+    ));
 }
 
 #[test]
@@ -337,7 +341,11 @@ fn invalid_action_sig_fails_verification() {
     sig_bytes[0] ^= 0xFF;
     bundle.actions[0].sig = action::Signature::from(sig_bytes);
 
-    assert!(bundle.verify_signatures(&sighash).is_err());
+    let expected_rk = reddsa::VerificationKeyBytes::from(bundle.actions[0].rk.0);
+    assert!(matches!(
+        bundle.verify_signatures(&sighash),
+        Err(SignatureError::Action(rk)) if rk == expected_rk
+    ));
 }
 
 #[test]

--- a/crates/tachyon/src/keys/private.rs
+++ b/crates/tachyon/src/keys/private.rs
@@ -250,12 +250,15 @@ impl ActionSigningKey<effect::Output> {
 #[derive(Clone, Copy, Debug)]
 pub struct BindingSigningKey(#[debug(skip)] reddsa::SigningKey<reddsa::BindingAuth>);
 
-impl BindingSigningKey {
-    /// Attempt to parse a binding signing key from 32 bytes.
-    pub fn from_bytes(bytes: [u8; 32]) -> Result<Self, reddsa::Error> {
+impl TryFrom<[u8; 32]> for BindingSigningKey {
+    type Error = reddsa::Error;
+
+    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
         reddsa::SigningKey::<reddsa::BindingAuth>::try_from(bytes).map(Self)
     }
+}
 
+impl BindingSigningKey {
     /// Sign a transaction sighash with this binding key.
     pub fn sign<RNG: RngCore + CryptoRng>(
         &self,

--- a/crates/tachyon/src/keys/private.rs
+++ b/crates/tachyon/src/keys/private.rs
@@ -52,9 +52,9 @@ impl SpendingKey {
     /// # Key derivation (Orchard §4.2.3)
     ///
     /// $$\mathsf{ask} = \text{ToScalar}\bigl(\text{PRF}^{\text{expand}}_
-    /// {\mathsf{sk}}([0\text{x}09])\bigr)$$
+    /// {\mathsf{sk}}([0\text{x}21])\bigr)$$
     ///
-    /// BLAKE2b-512 of $(\mathsf{sk} \| \texttt{0x09})$, reduced to
+    /// BLAKE2b-512 of $(\mathsf{sk} \| \texttt{0x21})$, reduced to
     /// $\mathbb{F}_q$ via `from_uniform_bytes`.
     ///
     /// # Sign normalization (§5.4.7.1)
@@ -101,7 +101,7 @@ impl SpendingKey {
 
     /// Derive `nk` from `sk`.
     ///
-    /// `nk = ToBase(PRF^expand_sk([0x0a]))` — BLAKE2b-512 reduced to Fp.
+    /// `nk = ToBase(PRF^expand_sk([0x22]))` — BLAKE2b-512 reduced to Fp.
     #[must_use]
     pub fn derive_nullifier_private(&self) -> NullifierKey {
         NullifierKey(Fp::from_uniform_bytes(&blake2b::prf_expand_nk(&self.0)))
@@ -252,11 +252,8 @@ pub struct BindingSigningKey(#[debug(skip)] reddsa::SigningKey<reddsa::BindingAu
 
 impl BindingSigningKey {
     /// Attempt to parse a binding signing key from 32 bytes.
-    #[must_use]
-    pub fn from_bytes(bytes: [u8; 32]) -> Option<Self> {
-        reddsa::SigningKey::<reddsa::BindingAuth>::try_from(bytes)
-            .ok()
-            .map(Self)
+    pub fn from_bytes(bytes: [u8; 32]) -> Result<Self, reddsa::Error> {
+        reddsa::SigningKey::<reddsa::BindingAuth>::try_from(bytes).map(Self)
     }
 
     /// Sign a transaction sighash with this binding key.

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -21,6 +21,9 @@ pub enum ActionDigestError {
     /// The rk is the identity point, so the digest cannot be computed.
     #[display("rk is the identity point")]
     IdentityRk,
+    /// Bytes do not represent a valid field element.
+    #[display("invalid field element encoding")]
+    InvalidEncoding,
 }
 
 impl ActionDigest {
@@ -48,10 +51,11 @@ impl From<ActionDigest> for [u8; 32] {
 }
 
 impl TryFrom<&[u8; 32]> for ActionDigest {
-    type Error = &'static str;
+    type Error = ActionDigestError;
 
     fn try_from(bytes: &[u8; 32]) -> Result<Self, Self::Error> {
-        let fp: Fp = Option::from(Fp::from_repr(*bytes)).ok_or("invalid field element")?;
+        let fp: Fp =
+            Option::from(Fp::from_repr(*bytes)).ok_or(ActionDigestError::InvalidEncoding)?;
         Ok(Self(fp))
     }
 }
@@ -125,6 +129,16 @@ mod tests {
         assert!(matches!(
             ActionDigest::new(cv, rk),
             Err(ActionDigestError::IdentityRk)
+        ));
+    }
+
+    /// Invalid field element bytes are rejected.
+    #[test]
+    fn try_from_rejects_invalid_encoding() {
+        let bytes = [0xFF; 32];
+        assert!(matches!(
+            ActionDigest::try_from(&bytes),
+            Err(ActionDigestError::InvalidEncoding)
         ));
     }
 }

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -21,9 +21,6 @@ pub enum ActionDigestError {
     /// The rk is the identity point, so the digest cannot be computed.
     #[display("rk is the identity point")]
     IdentityRk,
-    /// Bytes do not represent a valid field element.
-    #[display("invalid field element encoding")]
-    InvalidEncoding,
 }
 
 impl ActionDigest {
@@ -47,16 +44,6 @@ impl ActionDigest {
 impl From<ActionDigest> for [u8; 32] {
     fn from(digest: ActionDigest) -> Self {
         digest.0.to_repr()
-    }
-}
-
-impl TryFrom<&[u8; 32]> for ActionDigest {
-    type Error = ActionDigestError;
-
-    fn try_from(bytes: &[u8; 32]) -> Result<Self, Self::Error> {
-        let fp: Fp =
-            Option::from(Fp::from_repr(*bytes)).ok_or(ActionDigestError::InvalidEncoding)?;
-        Ok(Self(fp))
     }
 }
 
@@ -129,16 +116,6 @@ mod tests {
         assert!(matches!(
             ActionDigest::new(cv, rk),
             Err(ActionDigestError::IdentityRk)
-        ));
-    }
-
-    /// Invalid field element bytes are rejected.
-    #[test]
-    fn try_from_rejects_invalid_encoding() {
-        let bytes = [0xFF; 32];
-        assert!(matches!(
-            ActionDigest::try_from(&bytes),
-            Err(ActionDigestError::InvalidEncoding)
         ));
     }
 }

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -81,7 +81,7 @@ impl AggregateId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Display, Error, PartialEq, TotalEq)]
+#[derive(Clone, Copy, Debug, Display, Error)]
 /// Errors that can occur when handling an aggregate id.
 pub enum AggregateIdError {
     /// The aggregate id is zero and refers to no aggregate.


### PR DESCRIPTION
fixes #82 
- BuildError: add `Display` + `Error` impls (was the only public error missing them)
- `ActionDigest::TryFrom`: return `ActionDigestError` instead of `&'static str`
- `verify_signatures`: return `SignatureError` with Binding/Action(idx) context instead of leaking `reddsa::Error`
- `BindingSigningKey::from_bytes`: return Result nstead of Option
- Fix stale domain byte values in `private.rs` doc comments (0x09→0x21, 0x0a→0x22)
- Add targeted tests for new error variants