### PR TITLE
fix: prevent serialization of stripped bundles

### DIFF
--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -665,11 +665,20 @@ impl TachyonBundle {
             },
             | BundleState::Stripped => {
                 let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
+                let stamp = AggregateId::read(&mut reader)?;
+
+                if stamp == AggregateId::ZERO && !actions.is_empty() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "stripped bundle with actions has zero aggregate id",
+                    ));
+                }
+
                 Some(Self::Adjunct(Bundle {
                     actions,
                     value_balance,
                     binding_sig,
-                    stamp: AggregateId::read(&mut reader)?,
+                    stamp,
                 }))
             },
         })

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -3,8 +3,8 @@
 //! A bundle is parameterized by stamp state `S: StampState`.
 //! Actions are constant through state transitions; only the stamp changes.
 //!
-//! - [`Stamped`] — self-contained bundle with a stamp
-//! - [`Stripped`] — stamp removed, depends on an aggregate
+//! - `Bundle<Stamp>` — self-contained bundle with a stamp
+//! - `Bundle<AggregateId>` — stamp removed, references the covering aggregate
 //! - [`TachyonBundle`] — enum of stamped-or-stripped for mixed contexts
 //!
 //! # Consensus wire format
@@ -97,10 +97,12 @@ impl BundleState {
             | 0b0000_0000u8 => Ok(Self::NoBundle),
             | 0b0000_0001u8 => Ok(Self::Stamped),
             | 0b0000_0010u8 => Ok(Self::Stripped),
-            | _other => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "invalid bundle state",
-            )),
+            | _other => {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid bundle state",
+                ))
+            },
         }
     }
 
@@ -138,14 +140,14 @@ pub struct Bundle<S: StampState> {
     /// Binding signature over the transaction sighash.
     pub binding_sig: Signature,
 
-    /// Stamp state: `Stamp`, `Unassigned`, or `Adjunct`.
+    /// Stamp state: `Unproven`, `Stamp`, `Stripped`, or `AggregateId`.
     pub stamp: S,
 }
 
 /// A Tachyon bundle in one of its two on-wire states: stamped or stripped.
 ///
 /// Used where code accepts either form — reading from the wire, dispatching
-/// `auth_digest`, etc. The `Unproven` and `Unassigned` intermediate states are
+/// `auth_digest`, etc. The `Unproven` and `Stripped` intermediate states are
 /// outside this enum because they have no wire representation.
 #[expect(clippy::module_name_repetitions, reason = "intentional name")]
 #[derive(Clone, Debug)]
@@ -153,7 +155,7 @@ pub enum TachyonBundle {
     /// A bundle with its own stamp (autonome or aggregate).
     Stamped(Bundle<Stamp>),
     /// A bundle whose stamp has been stripped; carries a reference to the
-    /// covering aggregate via [`Adjunct`].
+    /// covering aggregate via its [`AggregateId`].
     Adjunct(Bundle<AggregateId>),
 }
 
@@ -352,7 +354,7 @@ impl Plan {
     /// signature.
     ///
     /// The result is a `Bundle<Unproven>` — combine with a [`Stamp`] via
-    /// [`Bundle::stamp`] to produce a [`Stamped`] bundle.
+    /// [`Bundle::stamp`] to produce a `Bundle<Stamp>`.
     pub fn sign<RNG: RngCore + CryptoRng>(
         &self,
         sighash: &[u8; 32],
@@ -442,7 +444,7 @@ impl Plan {
 }
 
 impl Bundle<Unproven> {
-    /// Attach a stamp, producing a [`Stamped`] bundle.
+    /// Attach a stamp, producing a `Bundle<Stamp>`.
     #[must_use]
     pub fn stamp(self, stamp: Stamp) -> Bundle<Stamp> {
         Bundle {
@@ -456,10 +458,10 @@ impl Bundle<Unproven> {
 
 impl Bundle<Stripped> {
     /// Assign the covering aggregate's `wtxid`, producing a serializable
-    /// [`Stripped`] bundle.
+    /// `Bundle<AggregateId>`.
     ///
-    /// This is the only path from [`strip()`](Stamped::strip) to a wire-ready
-    /// stripped bundle — `Bundle<Unassigned>` has no `write()` method. The
+    /// This is the only path from [`strip()`](Bundle::strip) to a wire-ready
+    /// stripped bundle — `Bundle<Stripped>` has no `write()` method. The
     /// zero wtxid is allowed only for empty stripped innocents.
     pub fn assign_wtxid(self, wtxid: AggregateId) -> Result<Bundle<AggregateId>, AggregateIdError> {
         if wtxid == AggregateId::ZERO && !self.actions.is_empty() {
@@ -479,8 +481,8 @@ impl Bundle<Stamp> {
     /// Strips the stamp, producing an unassigned bundle and the extracted
     /// stamp.
     ///
-    /// The returned `Bundle<Unassigned>` must be assigned a covering
-    /// aggregate's `wtxid` via [`assign_wtxid`](Bundle::<Unassigned>::assign_wtxid)
+    /// The returned `Bundle<Stripped>` must be assigned a covering
+    /// aggregate's `wtxid` via [`assign_wtxid`](Bundle::assign_wtxid)
     /// before it can be serialized. The stamp should be merged into an
     /// aggregate.
     #[must_use]
@@ -695,8 +697,8 @@ impl TachyonBundle {
     }
 
     /// Tachyon's contribution to the transaction `auth_digest`, dispatching
-    /// on the variant. See [`Stamped::auth_digest`] and
-    /// [`Stripped::auth_digest`].
+    /// on the variant. See the `auth_digest` methods on `Bundle<Stamp>` and
+    /// `Bundle<AggregateId>`.
     #[must_use]
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn auth_digest(&self) -> [u8; 64] {

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -75,7 +75,7 @@ use crate::{
     keys::{private, public},
     primitives::{ActionDigest, ActionDigestError, ActionSetCommit, Anchor, effect},
     reddsa, serialization,
-    stamp::{self, Adjunct, Stamp, Unproven},
+    stamp::{self, Adjunct, Stamp, Unassigned, Unproven},
     value,
 };
 
@@ -121,6 +121,7 @@ mod sealed {
     impl Sealed for super::Stamp {}
     impl Sealed for super::Adjunct {}
     impl Sealed for super::Unproven {}
+    impl Sealed for super::Unassigned {}
 }
 
 /// Sealed trait constraining stamp state types.
@@ -139,7 +140,7 @@ pub struct Bundle<S: StampState> {
     /// Binding signature over the transaction sighash.
     pub binding_sig: Signature,
 
-    /// Stamp state: `Stamp` when present, `Adjunct` when stripped.
+    /// Stamp state: `Stamp`, `Unassigned`, or `Adjunct`.
     pub stamp: S,
 }
 
@@ -152,8 +153,8 @@ pub type Stripped = Bundle<Adjunct>;
 /// A Tachyon bundle in one of its two on-wire states: stamped or stripped.
 ///
 /// Used where code accepts either form — reading from the wire, dispatching
-/// `auth_digest`, etc. The `Unproven` intermediate state is outside this
-/// enum because it has no wire representation.
+/// `auth_digest`, etc. The `Unproven` and `Unassigned` intermediate states are
+/// outside this enum because they have no wire representation.
 #[expect(clippy::module_name_repetitions, reason = "intentional name")]
 #[derive(Clone, Debug)]
 pub enum TachyonBundle {
@@ -207,6 +208,25 @@ pub enum BuildError {
     /// BSK/BVK mismatch (see Protocol §4.14)
     BalanceKeyMismatch,
 }
+
+/// Errors that can occur when assigning a covering aggregate wtxid.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AssignWtxidError {
+    /// A non-empty stripped bundle cannot be assigned the zero wtxid.
+    UnassignedNonEmpty,
+}
+
+impl fmt::Display for AssignWtxidError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            | Self::UnassignedNonEmpty => {
+                write!(f, "non-empty stripped bundle has unassigned wtxid")
+            },
+        }
+    }
+}
+
+impl Error for AssignWtxidError {}
 
 /// Errors that can occur while signing a bundle plan.
 #[derive(Debug)]
@@ -461,18 +481,43 @@ impl Bundle<Unproven> {
     }
 }
 
-impl Stamped {
-    /// Strips the stamp, producing a stripped bundle and the extracted stamp.
+impl Bundle<Unassigned> {
+    /// Assign the covering aggregate's `wtxid`, producing a serializable
+    /// [`Stripped`] bundle.
     ///
-    /// The stamp should be merged into an aggregate's stamped bundle.
+    /// This is the only path from [`strip()`](Stamped::strip) to a wire-ready
+    /// stripped bundle — `Bundle<Unassigned>` has no `write()` method. The
+    /// zero wtxid is allowed only for empty stripped innocents.
+    pub fn assign_wtxid(self, wtxid: [u8; 64]) -> Result<Stripped, AssignWtxidError> {
+        if !self.actions.is_empty() && wtxid == [0u8; 64] {
+            return Err(AssignWtxidError::UnassignedNonEmpty);
+        }
+
+        Ok(Bundle {
+            actions: self.actions,
+            value_balance: self.value_balance,
+            binding_sig: self.binding_sig,
+            stamp: Adjunct { wtxid },
+        })
+    }
+}
+
+impl Stamped {
+    /// Strips the stamp, producing an unassigned bundle and the extracted
+    /// stamp.
+    ///
+    /// The returned `Bundle<Unassigned>` must be assigned a covering
+    /// aggregate's `wtxid` via [`assign_wtxid`](Bundle::<Unassigned>::assign_wtxid)
+    /// before it can be serialized. The stamp should be merged into an
+    /// aggregate.
     #[must_use]
-    pub fn strip(self) -> (Stripped, Stamp) {
+    pub fn strip(self) -> (Bundle<Unassigned>, Stamp) {
         (
             Bundle {
                 actions: self.actions,
                 value_balance: self.value_balance,
                 binding_sig: self.binding_sig,
-                stamp: Adjunct::default(),
+                stamp: Unassigned,
             },
             self.stamp,
         )
@@ -585,6 +630,13 @@ impl Stripped {
     /// broadcast. Stripped innocents (empty actions) may serialize with a
     /// zero wtxid if no absorbing aggregate was recorded.
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        if !self.actions.is_empty() && self.stamp.wtxid == [0u8; 64] {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "non-empty stripped bundle has unassigned wtxid",
+            ));
+        }
+
         BundleState::Stripped.write(&mut writer)?;
 
         write_bundle_body(

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -75,7 +75,7 @@ use crate::{
     keys::{private, public},
     primitives::{ActionDigest, ActionDigestError, ActionSetCommit, Anchor, effect},
     reddsa, serialization,
-    stamp::{self, Adjunct, Stamp, Unassigned, Unproven},
+    stamp::{self, AggregateId, AggregateIdError, Stamp, Stripped, Unproven},
     value,
 };
 
@@ -97,12 +97,10 @@ impl BundleState {
             | 0b0000_0000u8 => Ok(Self::NoBundle),
             | 0b0000_0001u8 => Ok(Self::Stamped),
             | 0b0000_0010u8 => Ok(Self::Stripped),
-            | _other => {
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid bundle state",
-                ))
-            },
+            | _other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid bundle state",
+            )),
         }
     }
 
@@ -118,10 +116,10 @@ impl BundleState {
 
 mod sealed {
     pub trait Sealed {}
-    impl Sealed for super::Stamp {}
-    impl Sealed for super::Adjunct {}
     impl Sealed for super::Unproven {}
-    impl Sealed for super::Unassigned {}
+    impl Sealed for super::Stamp {}
+    impl Sealed for super::AggregateId {}
+    impl Sealed for super::Stripped {}
 }
 
 /// Sealed trait constraining stamp state types.
@@ -144,12 +142,6 @@ pub struct Bundle<S: StampState> {
     pub stamp: S,
 }
 
-/// A bundle with a stamp — can stand alone or cover adjunct bundles.
-pub type Stamped = Bundle<Stamp>;
-
-/// A bundle whose stamp has been stripped — depends on a stamped bundle.
-pub type Stripped = Bundle<Adjunct>;
-
 /// A Tachyon bundle in one of its two on-wire states: stamped or stripped.
 ///
 /// Used where code accepts either form — reading from the wire, dispatching
@@ -159,41 +151,41 @@ pub type Stripped = Bundle<Adjunct>;
 #[derive(Clone, Debug)]
 pub enum TachyonBundle {
     /// A bundle with its own stamp (autonome or aggregate).
-    Stamped(Stamped),
+    Stamped(Bundle<Stamp>),
     /// A bundle whose stamp has been stripped; carries a reference to the
     /// covering aggregate via [`Adjunct`].
-    Stripped(Stripped),
+    Adjunct(Bundle<AggregateId>),
 }
 
-impl From<Stamped> for TachyonBundle {
-    fn from(bundle: Stamped) -> Self {
+impl From<Bundle<Stamp>> for TachyonBundle {
+    fn from(bundle: Bundle<Stamp>) -> Self {
         Self::Stamped(bundle)
     }
 }
 
-impl From<Stripped> for TachyonBundle {
-    fn from(bundle: Stripped) -> Self {
-        Self::Stripped(bundle)
+impl From<Bundle<AggregateId>> for TachyonBundle {
+    fn from(bundle: Bundle<AggregateId>) -> Self {
+        Self::Adjunct(bundle)
     }
 }
 
-impl TryFrom<TachyonBundle> for Stamped {
-    type Error = Stripped;
+impl TryFrom<TachyonBundle> for Bundle<Stamp> {
+    type Error = Bundle<AggregateId>;
 
     fn try_from(bundle: TachyonBundle) -> Result<Self, Self::Error> {
         match bundle {
+            | TachyonBundle::Adjunct(stripped) => Err(stripped),
             | TachyonBundle::Stamped(stamped) => Ok(stamped),
-            | TachyonBundle::Stripped(stripped) => Err(stripped),
         }
     }
 }
 
-impl TryFrom<TachyonBundle> for Stripped {
-    type Error = Stamped;
+impl TryFrom<TachyonBundle> for Bundle<AggregateId> {
+    type Error = Bundle<Stamp>;
 
     fn try_from(bundle: TachyonBundle) -> Result<Self, Self::Error> {
         match bundle {
-            | TachyonBundle::Stripped(stripped) => Ok(stripped),
+            | TachyonBundle::Adjunct(stripped) => Ok(stripped),
             | TachyonBundle::Stamped(stamped) => Err(stamped),
         }
     }
@@ -208,25 +200,6 @@ pub enum BuildError {
     /// BSK/BVK mismatch (see Protocol §4.14)
     BalanceKeyMismatch,
 }
-
-/// Errors that can occur when assigning a covering aggregate wtxid.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum AssignWtxidError {
-    /// A non-empty stripped bundle cannot be assigned the zero wtxid.
-    UnassignedNonEmpty,
-}
-
-impl fmt::Display for AssignWtxidError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            | Self::UnassignedNonEmpty => {
-                write!(f, "non-empty stripped bundle has unassigned wtxid")
-            },
-        }
-    }
-}
-
-impl Error for AssignWtxidError {}
 
 /// Errors that can occur while signing a bundle plan.
 #[derive(Debug)]
@@ -471,7 +444,7 @@ impl Plan {
 impl Bundle<Unproven> {
     /// Attach a stamp, producing a [`Stamped`] bundle.
     #[must_use]
-    pub fn stamp(self, stamp: Stamp) -> Stamped {
+    pub fn stamp(self, stamp: Stamp) -> Bundle<Stamp> {
         Bundle {
             actions: self.actions,
             value_balance: self.value_balance,
@@ -481,28 +454,28 @@ impl Bundle<Unproven> {
     }
 }
 
-impl Bundle<Unassigned> {
+impl Bundle<Stripped> {
     /// Assign the covering aggregate's `wtxid`, producing a serializable
     /// [`Stripped`] bundle.
     ///
     /// This is the only path from [`strip()`](Stamped::strip) to a wire-ready
     /// stripped bundle — `Bundle<Unassigned>` has no `write()` method. The
     /// zero wtxid is allowed only for empty stripped innocents.
-    pub fn assign_wtxid(self, wtxid: [u8; 64]) -> Result<Stripped, AssignWtxidError> {
-        if !self.actions.is_empty() && wtxid == [0u8; 64] {
-            return Err(AssignWtxidError::UnassignedNonEmpty);
+    pub fn assign_wtxid(self, wtxid: AggregateId) -> Result<Bundle<AggregateId>, AggregateIdError> {
+        if wtxid == AggregateId::ZERO && !self.actions.is_empty() {
+            return Err(AggregateIdError::Zero);
         }
 
         Ok(Bundle {
             actions: self.actions,
             value_balance: self.value_balance,
             binding_sig: self.binding_sig,
-            stamp: Adjunct { wtxid },
+            stamp: wtxid,
         })
     }
 }
 
-impl Stamped {
+impl Bundle<Stamp> {
     /// Strips the stamp, producing an unassigned bundle and the extracted
     /// stamp.
     ///
@@ -511,13 +484,13 @@ impl Stamped {
     /// before it can be serialized. The stamp should be merged into an
     /// aggregate.
     #[must_use]
-    pub fn strip(self) -> (Bundle<Unassigned>, Stamp) {
+    pub fn strip(self) -> (Bundle<Stripped>, Stamp) {
         (
             Bundle {
                 actions: self.actions,
                 value_balance: self.value_balance,
                 binding_sig: self.binding_sig,
-                stamp: Unassigned,
+                stamp: Stripped,
             },
             self.stamp,
         )
@@ -592,7 +565,7 @@ impl Stamped {
     }
 }
 
-impl Stripped {
+impl Bundle<AggregateId> {
     /// Read a stripped bundle from the consensus wire format.
     ///
     /// Expects `tachyonBundleState` 0x02. Always reads a 64-byte
@@ -609,7 +582,14 @@ impl Stripped {
 
         let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
 
-        let stamp = Adjunct::read(&mut reader)?;
+        let stamp = AggregateId::read(&mut reader)?;
+
+        if stamp == AggregateId::ZERO && !actions.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "stripped bundle with actions has zero aggregate id",
+            ));
+        }
 
         Ok(Self {
             actions,
@@ -630,10 +610,10 @@ impl Stripped {
     /// broadcast. Stripped innocents (empty actions) may serialize with a
     /// zero wtxid if no absorbing aggregate was recorded.
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        if !self.actions.is_empty() && self.stamp.wtxid == [0u8; 64] {
+        if !self.actions.is_empty() && self.stamp == AggregateId::ZERO {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "non-empty stripped bundle has unassigned wtxid",
+                "stripped bundle with actions has zero aggregate id",
             ));
         }
 
@@ -657,7 +637,7 @@ impl Stripped {
     pub fn auth_digest(&self) -> [u8; 64] {
         let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig.into()).collect();
         let binding_sig: [u8; 64] = self.binding_sig.into();
-        blake2b::stripped_auth_digest(&action_sigs, &binding_sig, &self.stamp.wtxid)
+        blake2b::stripped_auth_digest(&action_sigs, &binding_sig, &self.stamp.into())
     }
 }
 
@@ -669,13 +649,14 @@ impl TachyonBundle {
     /// `0x00` (non-tachyon — the caller should decide absence at its own
     /// layer) and any other byte.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Option<Self>> {
+        // TODO: just peek at state, then delegate to the appropriate read method
         let state = BundleState::read(&mut reader)?;
 
         Ok(match state {
             | BundleState::NoBundle => None,
             | BundleState::Stamped => {
                 let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
-                Some(Self::Stamped(Stamped {
+                Some(Self::Stamped(Bundle {
                     actions,
                     value_balance,
                     binding_sig,
@@ -684,11 +665,11 @@ impl TachyonBundle {
             },
             | BundleState::Stripped => {
                 let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
-                Some(Self::Stripped(Stripped {
+                Some(Self::Adjunct(Bundle {
                     actions,
                     value_balance,
                     binding_sig,
-                    stamp: Adjunct::read(&mut reader)?,
+                    stamp: AggregateId::read(&mut reader)?,
                 }))
             },
         })
@@ -700,7 +681,7 @@ impl TachyonBundle {
     pub fn write<W: Write>(&self, writer: W) -> io::Result<()> {
         match *self {
             | Self::Stamped(ref stamped) => stamped.write(writer),
-            | Self::Stripped(ref stripped) => stripped.write(writer),
+            | Self::Adjunct(ref stripped) => stripped.write(writer),
         }
     }
 
@@ -712,7 +693,7 @@ impl TachyonBundle {
     pub fn auth_digest(&self) -> [u8; 64] {
         match *self {
             | Self::Stamped(ref stamped) => stamped.auth_digest(),
-            | Self::Stripped(ref stripped) => stripped.auth_digest(),
+            | Self::Adjunct(ref stripped) => stripped.auth_digest(),
         }
     }
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -29,8 +29,8 @@ fn stripped_bundle_retains_signatures() {
     let bundle = build_autonome(rng, &wallet, 1000, 700);
     let sighash = mock_sighash(bundle.commitment().unwrap());
 
-    let (stripped, _stamp) = bundle.strip();
-    stripped.verify_signatures(&sighash).unwrap();
+    let (unassigned, _stamp) = bundle.strip();
+    unassigned.verify_signatures(&sighash).unwrap();
 }
 
 #[test]
@@ -325,8 +325,8 @@ fn stripped_read_write_round_trip() {
     {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::random(rng);
-        let (mut stripped, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        stripped.stamp.wtxid = [0x42u8; 64];
+        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+        let stripped = unassigned.assign_wtxid([0x42u8; 64]).expect("assign wtxid");
 
         let mut buf = Vec::new();
         stripped.write(&mut buf).expect("write");
@@ -378,8 +378,8 @@ fn tachyon_bundle_in_memory_round_trip() {
     {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::random(rng);
-        let (mut stripped, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        stripped.stamp.wtxid = [0xABu8; 64];
+        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+        let stripped = unassigned.assign_wtxid([0xABu8; 64]).expect("assign wtxid");
 
         let erased: TachyonBundle = stripped.clone().into();
         let back = Stripped::try_from(erased).expect("stripped variant");
@@ -393,8 +393,8 @@ fn tachyon_bundle_in_memory_round_trip() {
 fn bundle_wire_round_trip_via_tachyon_bundle() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);
-    let (mut stripped, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-    stripped.stamp.wtxid = [0xCDu8; 64];
+    let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+    let stripped = unassigned.assign_wtxid([0xCDu8; 64]).expect("assign wtxid");
 
     let erased: TachyonBundle = stripped.clone().into();
     let mut buf = Vec::new();
@@ -405,6 +405,66 @@ fn bundle_wire_round_trip_via_tachyon_bundle() {
     let back = Stripped::try_from(decoded).expect("stripped variant");
 
     assert_eq!(stripped, back);
+}
+
+#[test]
+fn assign_wtxid_rejects_zero_wtxid_with_actions() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+
+    assert!(!unassigned.actions.is_empty());
+    assert!(matches!(
+        unassigned.assign_wtxid([0u8; 64]),
+        Err(AssignWtxidError::UnassignedNonEmpty)
+    ));
+}
+
+#[test]
+fn write_rejects_unassigned_wtxid_with_actions() {
+    // The type-state prevents this via the strip() -> assign_wtxid() path, but
+    // the runtime guard defends against direct construction or re-serialization
+    // of invalid wire data.
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+
+    let stripped: Stripped = Bundle {
+        actions: unassigned.actions,
+        value_balance: unassigned.value_balance,
+        binding_sig: unassigned.binding_sig,
+        stamp: Adjunct::default(),
+    };
+
+    assert!(!stripped.actions.is_empty());
+    assert_eq!(stripped.stamp.wtxid, [0u8; 64]);
+
+    let mut buf = Vec::new();
+    let err = stripped
+        .write(&mut buf)
+        .expect_err("unassigned wtxid with non-empty actions should reject");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+}
+
+/// Stripped innocents (zero actions) may serialize with a zero wtxid.
+#[test]
+fn write_allows_zero_wtxid_for_innocents() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let plan = Plan::new(alloc::vec![], alloc::vec![]);
+    let sighash = mock_sighash(plan.commitment());
+
+    let stripped: Stripped = Bundle {
+        actions: alloc::vec![],
+        value_balance: 0,
+        binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
+        stamp: Adjunct::default(),
+    };
+
+    assert!(stripped.actions.is_empty());
+    let mut buf = Vec::new();
+    stripped
+        .write(&mut buf)
+        .expect("innocent with zero wtxid should serialize");
 }
 
 #[test]
@@ -425,8 +485,8 @@ fn auth_digest_invariants() {
         let stamped = build_autonome(rng, &wallet, 1000, 700);
         let stamped_digest = stamped.auth_digest();
 
-        let (mut stripped, _stamp) = stamped.strip();
-        stripped.stamp.wtxid = [0x11u8; 64];
+        let (unassigned, _stamp) = stamped.strip();
+        let stripped = unassigned.assign_wtxid([0x11u8; 64]).expect("assign wtxid");
         assert_ne!(stamped_digest, stripped.auth_digest());
     }
 
@@ -435,12 +495,15 @@ fn auth_digest_invariants() {
     {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::random(rng);
-        let (mut stripped, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
 
-        stripped.stamp.wtxid = [0xAAu8; 64];
-        let digest_aa = stripped.auth_digest();
-        stripped.stamp.wtxid = [0xBBu8; 64];
-        let digest_bb = stripped.auth_digest();
+        let stripped_aa = unassigned
+            .clone()
+            .assign_wtxid([0xAAu8; 64])
+            .expect("assign wtxid");
+        let digest_aa = stripped_aa.auth_digest();
+        let stripped_bb = unassigned.assign_wtxid([0xBBu8; 64]).expect("assign wtxid");
+        let digest_bb = stripped_bb.auth_digest();
         assert_ne!(digest_aa, digest_bb);
     }
 
@@ -455,8 +518,8 @@ fn auth_digest_invariants() {
         assert_eq!(erased.auth_digest(), stamped_direct);
 
         let wallet2 = WalletSim::random(rng);
-        let (mut stripped, _stamp) = build_autonome(rng, &wallet2, 1000, 700).strip();
-        stripped.stamp.wtxid = [0x33u8; 64];
+        let (unassigned, _stamp) = build_autonome(rng, &wallet2, 1000, 700).strip();
+        let stripped = unassigned.assign_wtxid([0x33u8; 64]).expect("assign wtxid");
         let stripped_direct = stripped.auth_digest();
         let erased_stripped: TachyonBundle = stripped.into();
         assert_eq!(erased_stripped.auth_digest(), stripped_direct);

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -321,51 +321,27 @@ fn stamped_read_write_round_trip() {
 
 #[test]
 fn stripped_read_write_round_trip() {
-    // Adjunct shape: wtxid preserved.
-    {
-        let rng = &mut StdRng::seed_from_u64(0);
-        let wallet = WalletSim::random(rng);
-        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        let stripped = unassigned
-            .assign_wtxid(AggregateId::try_from([0x42u8; 64]).expect("nonzero id"))
-            .expect("assign wtxid");
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+    let stripped = unassigned
+        .assign_wtxid(AggregateId::try_from([0x42u8; 64]).expect("nonzero id"))
+        .expect("assign wtxid");
 
-        let mut buf = Vec::new();
-        stripped.write(&mut buf).expect("write");
-        let deserialized = Bundle::<AggregateId>::read(&*buf).expect("read");
+    let mut buf = Vec::new();
+    stripped.write(&mut buf).expect("write");
+    let deserialized = Bundle::<AggregateId>::read(&*buf).expect("read");
 
-        assert_eq!(stripped, deserialized);
-        assert_eq!(
-            deserialized.stamp,
-            AggregateId::try_from([0x42u8; 64]).expect("nonzero id")
-        );
-    }
-
-    // Innocent shape: empty actions, zero wtxid.
-    {
-        let rng = &mut StdRng::seed_from_u64(0);
-        let plan = Plan::new(alloc::vec![], alloc::vec![]);
-        let sighash = mock_sighash(plan.commitment());
-
-        let stripped = Bundle {
-            actions: alloc::vec![],
-            value_balance: 0,
-            binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-            stamp: AggregateId::ZERO,
-        };
-
-        let mut buf = Vec::new();
-        stripped.write(&mut buf).expect("write");
-        let deserialized = Bundle::<AggregateId>::read(&*buf).expect("read");
-
-        assert_eq!(stripped, deserialized);
-        assert_eq!(deserialized.stamp, AggregateId::ZERO);
-    }
+    assert_eq!(stripped, deserialized);
+    assert_eq!(
+        deserialized.stamp,
+        AggregateId::try_from([0x42u8; 64]).expect("nonzero id")
+    );
 }
 
 #[test]
-fn tachyon_bundle_in_memory_round_trip() {
-    // Stamped: actions, value_balance, tachygrams, anchor.
+fn tachyon_bundle_conversions() {
+    // Stamped Ok: actions, value_balance, tachygrams, anchor preserved.
     {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::random(rng);
@@ -379,7 +355,7 @@ fn tachyon_bundle_in_memory_round_trip() {
         assert_eq!(original.stamp.anchor, back.stamp.anchor);
     }
 
-    // Stripped: wtxid preserved.
+    // Stripped Ok: wtxid preserved.
     {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::random(rng);
@@ -397,30 +373,76 @@ fn tachyon_bundle_in_memory_round_trip() {
             AggregateId::try_from([0xABu8; 64]).expect("nonzero id")
         );
     }
+
+    // Err: TryFrom rejects the wrong variant in both directions.
+    {
+        let rng = &mut StdRng::seed_from_u64(0);
+        let wallet = WalletSim::random(rng);
+        let stamped = build_autonome(rng, &wallet, 1000, 700);
+        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+        let adjunct = unassigned
+            .assign_wtxid(AggregateId::try_from([0x55u8; 64]).expect("nonzero id"))
+            .expect("assign wtxid");
+
+        let stamped_erased: TachyonBundle = stamped.into();
+        Bundle::<AggregateId>::try_from(stamped_erased).expect_err("stamped is not an adjunct");
+
+        let adjunct_erased: TachyonBundle = adjunct.into();
+        Bundle::<Stamp>::try_from(adjunct_erased).expect_err("adjunct is not stamped");
+    }
 }
 
 #[test]
-fn bundle_wire_round_trip_via_tachyon_bundle() {
+fn tachyon_bundle_wire_round_trip() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);
-    let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-    let stripped = unassigned
-        .assign_wtxid(AggregateId::try_from([0xCDu8; 64]).expect("nonzero id"))
-        .expect("assign wtxid");
 
-    let erased: TachyonBundle = stripped.clone().into();
-    let mut buf = Vec::new();
-    erased.write(&mut buf).expect("write");
-    let decoded = TachyonBundle::read(&*buf)
-        .expect("read")
-        .expect("some bundle");
-    let back = Bundle::<AggregateId>::try_from(decoded).expect("stripped variant");
+    // Stamped variant (0x01).
+    {
+        let stamped = build_autonome(rng, &wallet, 1000, 700);
+        let erased: TachyonBundle = stamped.clone().into();
+        let mut buf = Vec::new();
+        erased.write(&mut buf).expect("write");
+        let decoded = TachyonBundle::read(&*buf)
+            .expect("read")
+            .expect("some bundle");
+        let back = Bundle::<Stamp>::try_from(decoded).expect("stamped variant");
 
-    assert_eq!(stripped, back);
+        // Stamp carries a proof and is not PartialEq, so compare fields.
+        assert_eq!(stamped.actions, back.actions);
+        assert_eq!(stamped.value_balance, back.value_balance);
+        assert_eq!(stamped.stamp.tachygrams, back.stamp.tachygrams);
+        assert_eq!(stamped.stamp.anchor, back.stamp.anchor);
+    }
+
+    // Stripped variant (0x02).
+    {
+        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+        let stripped = unassigned
+            .assign_wtxid(AggregateId::try_from([0xCDu8; 64]).expect("nonzero id"))
+            .expect("assign wtxid");
+        let erased: TachyonBundle = stripped.clone().into();
+        let mut buf = Vec::new();
+        erased.write(&mut buf).expect("write");
+        let decoded = TachyonBundle::read(&*buf)
+            .expect("read")
+            .expect("some bundle");
+        let back = Bundle::<AggregateId>::try_from(decoded).expect("stripped variant");
+
+        assert_eq!(stripped, back);
+    }
 }
 
 #[test]
-fn assign_wtxid_rejects_zero_wtxid_with_actions() {
+fn aggregate_id_try_from_rejects_zero() {
+    assert!(matches!(
+        AggregateId::try_from([0u8; 64]),
+        Err(AggregateIdError::Zero)
+    ));
+}
+
+#[test]
+fn assign_wtxid_rejects_zero_with_actions() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);
     let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
@@ -430,6 +452,26 @@ fn assign_wtxid_rejects_zero_wtxid_with_actions() {
         unassigned.assign_wtxid(AggregateId::ZERO),
         Err(AggregateIdError::Zero)
     ));
+}
+
+#[test]
+fn assign_wtxid_allows_zero_with_no_actions() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let plan = Plan::new(alloc::vec![], alloc::vec![]);
+    let sighash = mock_sighash(plan.commitment());
+
+    let unassigned: Bundle<Stripped> = Bundle {
+        actions: alloc::vec![],
+        value_balance: 0,
+        binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
+        stamp: Stripped,
+    };
+
+    let adjunct = unassigned
+        .assign_wtxid(AggregateId::ZERO)
+        .expect("zero wtxid allowed for empty innocent");
+    assert!(adjunct.actions.is_empty());
+    assert_eq!(adjunct.stamp, AggregateId::ZERO);
 }
 
 #[test]
@@ -460,7 +502,7 @@ fn write_rejects_zero_wtxid_with_actions() {
 
 /// Stripped innocents (zero actions) may serialize with a zero wtxid.
 #[test]
-fn write_allows_zero_wtxid_without_actions() {
+fn write_allows_zero_wtxid_with_no_actions() {
     let rng = &mut StdRng::seed_from_u64(0);
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
     let sighash = mock_sighash(plan.commitment());
@@ -483,11 +525,102 @@ fn write_allows_zero_wtxid_without_actions() {
 }
 
 #[test]
-fn wire_rejects_invalid_state_byte() {
-    let buf: &[u8] = &[0x03];
-    Bundle::<Stamp>::read(buf).expect_err("invalid state byte must be rejected");
-    Bundle::<AggregateId>::read(buf).expect_err("invalid state byte must be rejected");
-    TachyonBundle::read(buf).expect_err("invalid state byte must be rejected");
+fn wire_state_byte_dispatch() {
+    // Garbage state byte: rejected by every reader.
+    {
+        let buf: &[u8] = &[0x03];
+        Bundle::<Stamp>::read(buf).expect_err("invalid state byte must be rejected");
+        Bundle::<AggregateId>::read(buf).expect_err("invalid state byte must be rejected");
+        TachyonBundle::read(buf).expect_err("invalid state byte must be rejected");
+    }
+
+    // No-bundle (0x00): the enum reader decodes to None, not an error.
+    {
+        let buf: &[u8] = &[0x00];
+        let decoded = TachyonBundle::read(buf).expect("read");
+        assert!(decoded.is_none(), "0x00 must decode to None");
+    }
+
+    // Valid-but-mismatched state byte: each definite reader rejects the other's.
+    {
+        let rng = &mut StdRng::seed_from_u64(0);
+        let wallet = WalletSim::random(rng);
+
+        let stamped = build_autonome(rng, &wallet, 1000, 700);
+        let mut stamped_buf = Vec::new();
+        stamped.write(&mut stamped_buf).expect("write stamped");
+
+        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+        let adjunct = unassigned
+            .assign_wtxid(AggregateId::try_from([0x66u8; 64]).expect("nonzero id"))
+            .expect("assign wtxid");
+        let mut adjunct_buf = Vec::new();
+        adjunct.write(&mut adjunct_buf).expect("write adjunct");
+
+        Bundle::<AggregateId>::read(&*stamped_buf)
+            .expect_err("Adjunct::read must reject a stamped (0x01) buffer");
+        Bundle::<Stamp>::read(&*adjunct_buf)
+            .expect_err("Stamped::read must reject a stripped (0x02) buffer");
+    }
+}
+
+/// Both wire readers must reject the invalid shape (non-empty actions + zero
+/// wtxid) that `write()` / `assign_wtxid()` refuse to produce. Forge it by
+/// zeroing the wtxid trailer of a valid encoding.
+#[test]
+fn read_rejects_zero_wtxid_with_actions() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+    let stripped = unassigned
+        .assign_wtxid(AggregateId::try_from([0x42u8; 64]).expect("nonzero id"))
+        .expect("assign wtxid");
+    assert!(!stripped.actions.is_empty());
+
+    let mut buf = Vec::new();
+    stripped.write(&mut buf).expect("write");
+
+    // The wtxid is the trailing 64 bytes; zero it to forge the invalid shape.
+    for byte in buf.iter_mut().rev().take(64) {
+        *byte = 0;
+    }
+
+    let adjunct_err = Bundle::<AggregateId>::read(&*buf)
+        .expect_err("Adjunct::read must reject zero wtxid with actions");
+    assert_eq!(adjunct_err.kind(), io::ErrorKind::InvalidData);
+
+    let enum_err = TachyonBundle::read(&*buf)
+        .expect_err("TachyonBundle::read must reject zero wtxid with actions");
+    assert_eq!(enum_err.kind(), io::ErrorKind::InvalidData);
+}
+
+/// Partner to `read_rejects_zero_wtxid_with_actions`: the guard is scoped to
+/// bundles with actions, so an empty innocent with a zero wtxid is accepted by
+/// both readers.
+#[test]
+fn read_allows_zero_wtxid_with_no_actions() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let plan = Plan::new(alloc::vec![], alloc::vec![]);
+    let sighash = mock_sighash(plan.commitment());
+
+    let innocent = Bundle {
+        actions: alloc::vec![],
+        value_balance: 0,
+        binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
+        stamp: AggregateId::ZERO,
+    };
+
+    let mut buf = Vec::new();
+    innocent.write(&mut buf).expect("write innocent");
+
+    let via_adjunct = Bundle::<AggregateId>::read(&*buf).expect("Adjunct::read innocent");
+    assert_eq!(innocent, via_adjunct);
+
+    let decoded = TachyonBundle::read(&*buf)
+        .expect("TachyonBundle::read")
+        .expect("some bundle");
+    let via_enum = Bundle::<AggregateId>::try_from(decoded).expect("adjunct variant");
+    assert_eq!(innocent, via_enum);
 }
 
 #[test]

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -45,7 +45,7 @@ fn plan_commitment_matches_bundle_commitment() {
     let bundle_plan = Plan::new(alloc::vec![], alloc::vec![output_plan]);
     let sighash = mock_sighash(bundle_plan.commitment());
 
-    let bundle: Stamped = bundle_plan
+    let bundle = bundle_plan
         .sign(&sighash, &ask, rng)
         .expect("sign output bundle")
         .stamp(stamp);
@@ -69,11 +69,11 @@ fn zero_action_bundle_is_valid() {
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
     let sighash = mock_sighash(plan.commitment());
 
-    let bundle: Stripped = Bundle {
+    let bundle = Bundle {
         actions: alloc::vec![],
         value_balance: 0,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-        stamp: Adjunct::default(),
+        stamp: AggregateId::ZERO,
     };
 
     bundle.verify_signatures(&sighash).unwrap();
@@ -180,7 +180,7 @@ fn innocent_aggregate_from_two_autonomes() {
     let (adjunct_a, stamp_a) = autonome_a.strip();
     let (adjunct_b, stamp_b) = autonome_b.strip();
 
-    let innocent: Stamped = {
+    let innocent = {
         let innocent_plan = Plan::new(alloc::vec![], alloc::vec![]);
         let innocent_sighash = mock_sighash(innocent_plan.commitment());
 
@@ -306,7 +306,7 @@ fn stamped_read_write_round_trip() {
     let original = build_autonome(rng, &wallet, 1000, 700);
     let mut buf = Vec::new();
     original.write(&mut buf).expect("write");
-    let deserialized = Stamped::read(&*buf).expect("read");
+    let deserialized = Bundle::<Stamp>::read(&*buf).expect("read");
 
     assert_eq!(original.actions, deserialized.actions);
     assert_eq!(original.value_balance, deserialized.value_balance);
@@ -326,14 +326,19 @@ fn stripped_read_write_round_trip() {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::random(rng);
         let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        let stripped = unassigned.assign_wtxid([0x42u8; 64]).expect("assign wtxid");
+        let stripped = unassigned
+            .assign_wtxid(AggregateId::try_from([0x42u8; 64]).expect("nonzero id"))
+            .expect("assign wtxid");
 
         let mut buf = Vec::new();
         stripped.write(&mut buf).expect("write");
-        let deserialized = Stripped::read(&*buf).expect("read");
+        let deserialized = Bundle::<AggregateId>::read(&*buf).expect("read");
 
         assert_eq!(stripped, deserialized);
-        assert_eq!(deserialized.stamp.wtxid, [0x42u8; 64]);
+        assert_eq!(
+            deserialized.stamp,
+            AggregateId::try_from([0x42u8; 64]).expect("nonzero id")
+        );
     }
 
     // Innocent shape: empty actions, zero wtxid.
@@ -342,19 +347,19 @@ fn stripped_read_write_round_trip() {
         let plan = Plan::new(alloc::vec![], alloc::vec![]);
         let sighash = mock_sighash(plan.commitment());
 
-        let stripped: Stripped = Bundle {
+        let stripped = Bundle {
             actions: alloc::vec![],
             value_balance: 0,
             binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-            stamp: Adjunct::default(),
+            stamp: AggregateId::ZERO,
         };
 
         let mut buf = Vec::new();
         stripped.write(&mut buf).expect("write");
-        let deserialized = Stripped::read(&*buf).expect("read");
+        let deserialized = Bundle::<AggregateId>::read(&*buf).expect("read");
 
         assert_eq!(stripped, deserialized);
-        assert_eq!(deserialized.stamp.wtxid, [0; 64]);
+        assert_eq!(deserialized.stamp, AggregateId::ZERO);
     }
 }
 
@@ -366,7 +371,7 @@ fn tachyon_bundle_in_memory_round_trip() {
         let wallet = WalletSim::random(rng);
         let original = build_autonome(rng, &wallet, 1000, 700);
         let erased: TachyonBundle = original.clone().into();
-        let back = Stamped::try_from(erased).expect("stamped variant");
+        let back = Bundle::<Stamp>::try_from(erased).expect("stamped variant");
 
         assert_eq!(original.actions, back.actions);
         assert_eq!(original.value_balance, back.value_balance);
@@ -379,13 +384,18 @@ fn tachyon_bundle_in_memory_round_trip() {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::random(rng);
         let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        let stripped = unassigned.assign_wtxid([0xABu8; 64]).expect("assign wtxid");
+        let stripped = unassigned
+            .assign_wtxid(AggregateId::try_from([0xABu8; 64]).expect("nonzero id"))
+            .expect("assign wtxid");
 
         let erased: TachyonBundle = stripped.clone().into();
-        let back = Stripped::try_from(erased).expect("stripped variant");
+        let back = Bundle::<AggregateId>::try_from(erased).expect("stripped variant");
 
         assert_eq!(stripped, back);
-        assert_eq!(back.stamp.wtxid, [0xABu8; 64]);
+        assert_eq!(
+            back.stamp,
+            AggregateId::try_from([0xABu8; 64]).expect("nonzero id")
+        );
     }
 }
 
@@ -394,7 +404,9 @@ fn bundle_wire_round_trip_via_tachyon_bundle() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);
     let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-    let stripped = unassigned.assign_wtxid([0xCDu8; 64]).expect("assign wtxid");
+    let stripped = unassigned
+        .assign_wtxid(AggregateId::try_from([0xCDu8; 64]).expect("nonzero id"))
+        .expect("assign wtxid");
 
     let erased: TachyonBundle = stripped.clone().into();
     let mut buf = Vec::new();
@@ -402,7 +414,7 @@ fn bundle_wire_round_trip_via_tachyon_bundle() {
     let decoded = TachyonBundle::read(&*buf)
         .expect("read")
         .expect("some bundle");
-    let back = Stripped::try_from(decoded).expect("stripped variant");
+    let back = Bundle::<AggregateId>::try_from(decoded).expect("stripped variant");
 
     assert_eq!(stripped, back);
 }
@@ -415,13 +427,13 @@ fn assign_wtxid_rejects_zero_wtxid_with_actions() {
 
     assert!(!unassigned.actions.is_empty());
     assert!(matches!(
-        unassigned.assign_wtxid([0u8; 64]),
-        Err(AssignWtxidError::UnassignedNonEmpty)
+        unassigned.assign_wtxid(AggregateId::ZERO),
+        Err(AggregateIdError::Zero)
     ));
 }
 
 #[test]
-fn write_rejects_unassigned_wtxid_with_actions() {
+fn write_rejects_zero_wtxid_with_actions() {
     // The type-state prevents this via the strip() -> assign_wtxid() path, but
     // the runtime guard defends against direct construction or re-serialization
     // of invalid wire data.
@@ -429,15 +441,15 @@ fn write_rejects_unassigned_wtxid_with_actions() {
     let wallet = WalletSim::random(rng);
     let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
 
-    let stripped: Stripped = Bundle {
+    let stripped = Bundle {
         actions: unassigned.actions,
         value_balance: unassigned.value_balance,
         binding_sig: unassigned.binding_sig,
-        stamp: Adjunct::default(),
+        stamp: AggregateId::ZERO,
     };
 
     assert!(!stripped.actions.is_empty());
-    assert_eq!(stripped.stamp.wtxid, [0u8; 64]);
+    assert_eq!(stripped.stamp, AggregateId::ZERO);
 
     let mut buf = Vec::new();
     let err = stripped
@@ -448,16 +460,16 @@ fn write_rejects_unassigned_wtxid_with_actions() {
 
 /// Stripped innocents (zero actions) may serialize with a zero wtxid.
 #[test]
-fn write_allows_zero_wtxid_for_innocents() {
+fn write_allows_zero_wtxid_without_actions() {
     let rng = &mut StdRng::seed_from_u64(0);
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
     let sighash = mock_sighash(plan.commitment());
 
-    let stripped: Stripped = Bundle {
+    let stripped = Bundle {
         actions: alloc::vec![],
         value_balance: 0,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-        stamp: Adjunct::default(),
+        stamp: AggregateId::ZERO,
     };
 
     assert!(stripped.actions.is_empty());
@@ -465,13 +477,16 @@ fn write_allows_zero_wtxid_for_innocents() {
     stripped
         .write(&mut buf)
         .expect("innocent with zero wtxid should serialize");
+
+    let deserialized = Bundle::<AggregateId>::read(&*buf).expect("read");
+    assert_eq!(stripped, deserialized);
 }
 
 #[test]
 fn wire_rejects_invalid_state_byte() {
     let buf: &[u8] = &[0x03];
-    Stamped::read(buf).expect_err("invalid state byte must be rejected");
-    Stripped::read(buf).expect_err("invalid state byte must be rejected");
+    Bundle::<Stamp>::read(buf).expect_err("invalid state byte must be rejected");
+    Bundle::<AggregateId>::read(buf).expect_err("invalid state byte must be rejected");
     TachyonBundle::read(buf).expect_err("invalid state byte must be rejected");
 }
 
@@ -486,7 +501,9 @@ fn auth_digest_invariants() {
         let stamped_digest = stamped.auth_digest();
 
         let (unassigned, _stamp) = stamped.strip();
-        let stripped = unassigned.assign_wtxid([0x11u8; 64]).expect("assign wtxid");
+        let stripped = unassigned
+            .assign_wtxid(AggregateId::try_from([0x11u8; 64]).expect("nonzero id"))
+            .expect("assign wtxid");
         assert_ne!(stamped_digest, stripped.auth_digest());
     }
 
@@ -499,10 +516,12 @@ fn auth_digest_invariants() {
 
         let stripped_aa = unassigned
             .clone()
-            .assign_wtxid([0xAAu8; 64])
+            .assign_wtxid(AggregateId::try_from([0xAAu8; 64]).expect("nonzero id"))
             .expect("assign wtxid");
         let digest_aa = stripped_aa.auth_digest();
-        let stripped_bb = unassigned.assign_wtxid([0xBBu8; 64]).expect("assign wtxid");
+        let stripped_bb = unassigned
+            .assign_wtxid(AggregateId::try_from([0xBBu8; 64]).expect("nonzero id"))
+            .expect("assign wtxid");
         let digest_bb = stripped_bb.auth_digest();
         assert_ne!(digest_aa, digest_bb);
     }
@@ -519,7 +538,9 @@ fn auth_digest_invariants() {
 
         let wallet2 = WalletSim::random(rng);
         let (unassigned, _stamp) = build_autonome(rng, &wallet2, 1000, 700).strip();
-        let stripped = unassigned.assign_wtxid([0x33u8; 64]).expect("assign wtxid");
+        let stripped = unassigned
+            .assign_wtxid(AggregateId::try_from([0x33u8; 64]).expect("nonzero id"))
+            .expect("assign wtxid");
         let stripped_direct = stripped.auth_digest();
         let erased_stripped: TachyonBundle = stripped.into();
         assert_eq!(erased_stripped.auth_digest(), stripped_direct);

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -16,7 +16,7 @@ use rand_core::{CryptoRng, RngCore};
 
 use crate::{
     action::{self, Action},
-    bundle::{self, Stamped},
+    bundle::{self, Bundle},
     constants::EPOCH_SIZE,
     entropy::{ActionEntropy, ActionRandomizer},
     keys::{ProofAuthorizingKey, private},
@@ -109,7 +109,7 @@ pub fn build_autonome(
     wallet: &WalletSim,
     spend_value: u64,
     output_value: u64,
-) -> Stamped {
+) -> Bundle<Stamp> {
     let spend_note = wallet.random_note(rng, spend_value);
     let output_note = wallet.random_note(rng, output_value);
     let mut pool = PoolSim::genesis(rng);
@@ -586,7 +586,7 @@ impl WalletSim {
             Pcd<'source, spendable::SpendableHeader>,
         )>,
         output_notes: Vec<Note>,
-    ) -> Stamped {
+    ) -> Bundle<Stamp> {
         let ask = self.sk.derive_auth_private();
 
         let mut spend_plans = Vec::with_capacity(spends.len());

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -16,7 +16,8 @@
 //!
 //! - `Bundle<Unproven>` — actions signed but no proof yet
 //! - [`Stamped`] — `Bundle<Stamp>`, aggregate or self-contained with stamp
-//! - [`Stripped`] — `Bundle<Adjunct>`, stamp stripped, depends on aggregate
+//! - `Bundle<Unassigned>` — stamp stripped, wtxid not yet assigned
+//! - [`Stripped`] — `Bundle<Adjunct>`, stamp stripped with wtxid, depends on aggregate
 //! - [`TachyonBundle`] — enum of stamped-or-stripped for mixed contexts
 //!
 //! ## Block Structure

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -15,9 +15,10 @@
 //! [`Bundle<S>`](Bundle) is parameterized by stamp state `S: StampState`:
 //!
 //! - `Bundle<Unproven>` — actions signed but no proof yet
-//! - [`Stamped`] — `Bundle<Stamp>`, aggregate or self-contained with stamp
-//! - `Bundle<Unassigned>` — stamp stripped, wtxid not yet assigned
-//! - [`Stripped`] — `Bundle<Adjunct>`, stamp stripped with wtxid, depends on aggregate
+//! - `Bundle<Stamp>` — aggregate or self-contained, carries a [`Stamp`]
+//! - `Bundle<Stripped>` — stamp stripped, covering wtxid not yet assigned
+//! - `Bundle<AggregateId>` — stamp stripped, carries the covering
+//!   [`AggregateId`]
 //! - [`TachyonBundle`] — enum of stamped-or-stripped for mixed contexts
 //!
 //! ## Block Structure

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -67,8 +67,8 @@ mod serialization;
 #[cfg(test)]
 pub(crate) mod fixtures;
 
-pub use action::Action;
-pub use bundle::{Bundle, Plan as BundlePlan, Stamped, Stripped, TachyonBundle};
+pub use action::{Action, Plan as ActionPlan};
+pub use bundle::{Bundle, Plan as BundlePlan, TachyonBundle};
 pub use note::Note;
 pub use primitives::*;
-pub use stamp::Stamp;
+pub use stamp::{AggregateId, Stamp, Stripped, Unproven};

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -48,6 +48,16 @@ use crate::{
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Unproven;
 
+/// Marker for a stripped bundle whose covering-aggregate `wtxid` has not
+/// yet been assigned.
+///
+/// Produced by [`Stamped::strip()`](crate::bundle::Stamped::strip). Must
+/// transition to [`Adjunct`] via
+/// [`assign_wtxid`](crate::Bundle::<Unassigned>::assign_wtxid) before
+/// serialization.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Unassigned;
+
 /// Marker for a stripped bundle.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Adjunct {

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -56,37 +56,63 @@ pub struct Unproven;
 /// [`assign_wtxid`](crate::Bundle::<Unassigned>::assign_wtxid) before
 /// serialization.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Unassigned;
+pub struct Stripped;
 
-/// Marker for a stripped bundle.
+/// A 64-byte `wtxid` of the covering aggregate in the same block, assigned by
+/// the miner during block assembly.
+///
+/// This uses the aggregate's wtxid (not txid) so it unambiguously pins the
+/// covering aggregate's authorization state, including stamp.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Adjunct {
-    /// 64-byte `wtxid` (`txid || auth_digest`) of the covering aggregate in
-    /// the block. Assigned by the miner during block assembly; defaults to
-    /// all-zero bytes.
-    ///
-    /// The ref is the aggregate's wtxid (not txid) so it uniquely pins the
-    /// covering aggregate's physical auth form — different stamps on the
-    /// same effecting data produce different wtxids, so this ref remains
-    /// unambiguous even across aggregation forms.
-    pub wtxid: [u8; 64],
-}
+pub struct AggregateId([u8; 64]);
 
-impl Adjunct {
+impl AggregateId {
+    /// This zero wtxid is only suitable for a bundle with no actions.
+    pub const ZERO: Self = Self([0u8; 64]);
+
     pub(super) fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut wtxid = [0u8; 64];
         reader.read_exact(&mut wtxid)?;
-        Ok(Self { wtxid })
+        Ok(Self(wtxid))
     }
 
     pub(super) fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        writer.write_all(&self.wtxid)
+        writer.write_all(&self.0)
     }
 }
 
-impl Default for Adjunct {
-    fn default() -> Self {
-        Self { wtxid: [0u8; 64] }
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Errors that can occur when handling an aggregate id.
+pub enum AggregateIdError {
+    /// The aggregate id is zero and refers to no aggregate.
+    Zero,
+}
+impl Error for AggregateIdError {}
+
+impl fmt::Display for AggregateIdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            | Self::Zero => {
+                write!(f, "aggregate id is zero and refers to no aggregate")
+            },
+        }
+    }
+}
+
+impl TryFrom<[u8; 64]> for AggregateId {
+    type Error = AggregateIdError;
+
+    fn try_from(wtxid: [u8; 64]) -> Result<Self, Self::Error> {
+        if wtxid == [0u8; 64] {
+            return Err(AggregateIdError::Zero);
+        }
+        Ok(Self(wtxid))
+    }
+}
+
+impl From<AggregateId> for [u8; 64] {
+    fn from(aggregate_id: AggregateId) -> Self {
+        aggregate_id.0
     }
 }
 

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -44,17 +44,16 @@ use crate::{
 /// Marker for a bundle that has not yet been proven.
 ///
 /// This is the initial state for a newly constructed bundle.
-/// Proving produces a [`Stamp`]; stripping produces an [`Adjunct`].
+/// Proving produces a [`Stamp`]; stripping produces a `Bundle<Stripped>`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Unproven;
 
 /// Marker for a stripped bundle whose covering-aggregate `wtxid` has not
 /// yet been assigned.
 ///
-/// Produced by [`Stamped::strip()`](crate::bundle::Stamped::strip). Must
-/// transition to [`Adjunct`] via
-/// [`assign_wtxid`](crate::Bundle::<Unassigned>::assign_wtxid) before
-/// serialization.
+/// Produced by [`strip()`](crate::Bundle::strip). Must transition to a
+/// `Bundle<AggregateId>` via [`assign_wtxid`](crate::Bundle::assign_wtxid)
+/// before serialization.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Stripped;
 
@@ -320,7 +319,7 @@ impl Error for ProveError {}
 
 /// A stamp carrying tachygrams, anchor, and proof.
 ///
-/// Present in [`Stamped`](crate::Stamped) bundles.
+/// Present in `Bundle<Stamp>` bundles.
 /// Stripped during aggregation and merged into the aggregate's stamp.
 ///
 /// The PCD header `(action_acc, tachygram_acc, anchor)` is not stored here —


### PR DESCRIPTION
fixes #96 
- adds `Bundle<Unassigned>` type-state between Stamped and Stripped.
  `strip()` now returns `Bundle<Unassigned>` which has no write() method;
  assign_wtxid() validates and transitions to Stripped.
  Keeps the `Stripped::write()` runtime guard as defense-in-depth.
