### PR TITLE
fix: seperate poseidon domain for nullifier m-key derivation

### DIFF
--- a/book/src/bundle.md
+++ b/book/src/bundle.md
@@ -50,16 +50,30 @@ The proof establishes:
 - tachygrams are correctly bound to action keys
 - action balance effect matches pool balance effect
 
-The nullifier derivation uses a Poseidon-based GGM tree PRF (domain `Tachyon-NfDerive`):
+The nullifier derivation uses a Poseidon-based
+Goldreich-Goldwasser-Micali (GGM) tree PRF:
 
-$$ \mathsf{nf} = F_{\mathsf{nk}}(\Psi \parallel \tau) $$
+$$
+\mathsf{mk} = \mathsf{Poseidon}_\texttt{Tachyon-NfMaster}(\psi, \mathsf{nk})
+$$
+
+$$
+\mathsf{leaf}_e = \mathsf{GGM}_\texttt{Tachyon-NfPrefix}(\mathsf{mk}, e)
+$$
+
+$$
+\mathsf{nf}_e = \mathsf{Poseidon}_\texttt{Tachyon-NfDerive}(\mathsf{leaf}_e)
+$$
 
 where
 
-- $\Psi$ is the nullifier trapdoor[^commitment]
-- $\tau$ is an epoch index
+- $\mathsf{mk}$ is the per-note master key (tree root)
+- $\psi$ is the nullifier trapdoor[^commitment]
+- $e$ is an epoch index
 
-[^commitment]: User-controlled randomness [commitment trapdoor](https://zips.z.cash/protocol/protocol.pdf#commitment)
+See [Nullifiers](./nullifiers.md) for the full GGM tree derivation.
+
+[^commitment]: $\psi$ is user-controlled randomness for nullifier derivation. See [commitment trapdoor](https://zips.z.cash/protocol/protocol.pdf#commitment) in the protocol spec.
 
 ## Bundle Structure
 

--- a/book/src/domain-separators.md
+++ b/book/src/domain-separators.md
@@ -15,7 +15,7 @@ Deterministic action randomizer for Tachyon, privately handled by transaction au
 
 ### Transaction identifiers
 
-Digests used to commit to Tachyon bundle contents for sighash and and auth digest.
+Digests used to commit to Tachyon bundle contents for sighash and auth digest.
 
 <!-- see 
     https://github.com/zcash/orchard/blob/main/src/bundle/commitments.rs 
@@ -47,6 +47,7 @@ These are all Tachyon-specific digests, performed in-circuit.
 
 | Purpose | Value |
 | ------- | ----- |
+| Nullifier master-key derivation | `Tachyon-NfMaster` |
 | Nullifier prefix key | `Tachyon-NfPrefix` |
 | Nullifier derivation | `Tachyon-NfDerive` |
 | Note commitment | `Tachyon-CmDerive` |

--- a/book/src/keys.md
+++ b/book/src/keys.md
@@ -86,11 +86,28 @@ The spend authorization keys follow a three-tier scheme mapping to **private sca
 
 $$\mathsf{nk} = \text{ToBase}\bigl(\text{PRF}^{\text{expand}}_{\mathsf{sk}}([\texttt{0x22}])\bigr)$$
 
-An $\mathbb{F}_p$ element used in nullifier derivation. Tachyon simplifies Orchard's nullifier construction:[^faerie-gold]
+An $\mathbb{F}_p$ element used in nullifier derivation.
+Tachyon simplifies Orchard's nullifier construction
+by deriving a per-note Goldreich-Goldwasser-Micali
+(GGM) tree root from $\mathsf{nk}$ and the note's
+nullifier trapdoor, then deriving epoch-specific
+nullifiers from that tree:[^faerie-gold]
 
-$$\mathsf{nf} = F_{\mathsf{nk}}(\Psi \| \text{flavor})$$
+$$
+\mathsf{mk} = \mathsf{Poseidon}_\texttt{Tachyon-NfMaster}(\psi, \mathsf{nk})
+$$
 
-where $F$ is a keyed PRF (Poseidon with domain tag `Tachyon-NfDerive`), $\Psi$ is the note's nullifier trapdoor, and flavor is the epoch-id. See [Notes](./notes.md#nullifier-derivation).
+$$
+\mathsf{leaf}_e = \mathsf{GGM}_\texttt{Tachyon-NfPrefix}(\mathsf{mk}, e)
+$$
+
+$$
+\mathsf{nf}_e = \mathsf{Poseidon}_\texttt{Tachyon-NfDerive}(\mathsf{leaf}_e)
+$$
+
+where $\psi$ is the note's nullifier trapdoor and
+$e$ is the epoch-id. See [Nullifiers](./nullifiers.md)
+for the full GGM tree derivation.
 
 $\mathsf{nk}$ alone does NOT confer spend authority — combined with $\mathsf{ak}$ it forms the proof authorizing key $\mathsf{pak}$, enabling proof construction and nullifier derivation without signing capability.
 

--- a/book/src/nullifiers.md
+++ b/book/src/nullifiers.md
@@ -27,7 +27,7 @@ The note's master key $\mathsf{mk}$ is derived from the note's trapdoor $\psi$ a
 
 $$
 \mathsf{mk} = \mathsf{KDF}^{\mathsf{root}}_\psi(\mathsf{nk}) =
-    \mathsf{Poseidon}_\texttt{Tachyon-NfPrefix}\!(
+    \mathsf{Poseidon}_\texttt{Tachyon-NfMaster}\!(
         \psi, \mathsf{nk}
     )
 $$

--- a/crates/tachyon/src/digest/poseidon.rs
+++ b/crates/tachyon/src/digest/poseidon.rs
@@ -51,13 +51,14 @@ pub(crate) fn note_commitment(rcm: Fp, pk: Fp, value: u64, psi: Fp) -> Fp {
     ])
 }
 
+const NULLIFIER_MASTER_DOMAIN: &[u8; 16] = b"Tachyon-NfMaster";
 const NULLIFIER_PREFIX_DOMAIN: &[u8; 16] = b"Tachyon-NfPrefix";
 
 /// Derives a GGM root (master key) from note trapdoor and wallet nullifier key.
 #[must_use]
 pub(crate) fn nf_master(psi: Fp, nk: Fp) -> Fp {
     hash::<3>([
-        Fp::from_u128(u128::from_le_bytes(*NULLIFIER_PREFIX_DOMAIN)),
+        Fp::from_u128(u128::from_le_bytes(*NULLIFIER_MASTER_DOMAIN)),
         psi,
         nk,
     ])
@@ -140,4 +141,21 @@ pub(crate) fn anchor_epoch_step(anchor_prev: Fp, new_epoch: u32) -> Fp {
         anchor_prev,
         Fp::from(u64::from(new_epoch)),
     ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn domain_field(domain: &[u8; 16]) -> Fp {
+        Fp::from_u128(u128::from_le_bytes(*domain))
+    }
+
+    #[test]
+    fn nullifier_master_and_prefix_domains_are_separated() {
+        assert!(
+            domain_field(NULLIFIER_MASTER_DOMAIN) != domain_field(NULLIFIER_PREFIX_DOMAIN),
+            "nullifier root derivation and GGM prefix steps must be domain-separated",
+        );
+    }
 }

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -17,12 +17,13 @@ use crate::{
 /// Tachyon simplifies Orchard's nullifier construction
 /// ("Tachyaction at a Distance", Bowe 2025):
 ///
-/// $$\mathsf{nf} = F_{\mathsf{nk}}(\Psi \| \text{flavor})$$
+/// $$\mathsf{mk} = \mathsf{Poseidon}_\texttt{Tachyon-NfMaster}(\psi, \mathsf{nk})$$
+/// $$\mathsf{leaf}_e = \mathsf{GGM}_\texttt{Tachyon-NfPrefix}(\mathsf{mk}, e)$$
+/// $$\mathsf{nf}_e = \mathsf{Poseidon}_\texttt{Tachyon-NfDerive}(\mathsf{leaf}_e)$$
 ///
-/// where $F$ is a keyed PRF (Poseidon), $\Psi$ is the note's nullifier
-/// trapdoor, and flavor is the epoch-id. This replaces Orchard's more
-/// complex construction that defended against faerie gold attacks — which
-/// are moot under out-of-band payments.
+/// where $\psi$ is the note's nullifier trapdoor and $e$ is the epoch-id.
+/// This replaces Orchard's more complex construction that defended against
+/// faerie gold attacks — which are moot under out-of-band payments.
 ///
 /// ## Capabilities
 ///


### PR DESCRIPTION
fixes nullifier domain separation by giving GGM root derivation its own Poseidon domain tag.

previously, `nf_master` and `nf_prefix` both used `Tachyon-NfPrefix` even though they hash different protocol objects at the same Poseidon arity:

- `nf_master(psi, nk)` derives the per-note GGM root / master key.
- `nf_prefix(prefix_prev, step)` derives a child node during the GGM walk.

that meant root derivation and tree-step derivation were distinguished only by input meaning, not by the hash domain.