### PR TITLE
fix: implement safe value arithmetic types

### DIFF
--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -98,12 +98,10 @@ impl BundleState {
             | 0b0000_0000u8 => Ok(Self::NoBundle),
             | 0b0000_0001u8 => Ok(Self::Stamped),
             | 0b0000_0010u8 => Ok(Self::Stripped),
-            | _other => {
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid bundle state",
-                ))
-            },
+            | _other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid bundle state",
+            )),
         }
     }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -98,10 +98,12 @@ impl BundleState {
             | 0b0000_0000u8 => Ok(Self::NoBundle),
             | 0b0000_0001u8 => Ok(Self::Stamped),
             | 0b0000_0010u8 => Ok(Self::Stripped),
-            | _other => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "invalid bundle state",
-            )),
+            | _other => {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid bundle state",
+                ))
+            },
         }
     }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -99,10 +99,12 @@ impl BundleState {
             0b0000_0000u8 => Ok(Self::NoBundle),
             0b0000_0001u8 => Ok(Self::Stamped),
             0b0000_0010u8 => Ok(Self::Stripped),
-            _other => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "invalid bundle state",
-            )),
+            _other => {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid bundle state",
+                ))
+            },
         }
     }
 
@@ -781,7 +783,7 @@ impl ValueBalance {
 impl TryFrom<ValueBalance> for i64 {
     type Error = BalanceError;
 
-    // TODO: does this need to check against NOTE_VALUE_MAX?
+    // This doesn't need to check against NOTE_VALUE_MAX
     fn try_from(sum: ValueBalance) -> Result<Self, Self::Error> {
         Self::try_from(sum.0).map_err(|_err| BalanceError)
     }
@@ -792,7 +794,7 @@ impl ops::Add<note::Value> for ValueBalance {
 
     fn add(self, rhs: note::Value) -> Self::Output {
         self.0
-            .checked_add(i128::from(rhs.0))
+            .checked_add(u64::from(rhs).into())
             .map(Self)
             .ok_or(BalanceError)
     }
@@ -803,7 +805,7 @@ impl ops::Sub<note::Value> for ValueBalance {
 
     fn sub(self, rhs: note::Value) -> Self::Output {
         self.0
-            .checked_sub(i128::from(rhs.0))
+            .checked_sub(u64::from(rhs).into())
             .map(Self)
             .ok_or(BalanceError)
     }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -313,7 +313,7 @@ impl Plan {
         for plan in &self.outputs {
             sum = (sum - plan.note.value)?;
         }
-        sum.to_i64()
+        i64::try_from(sum)
     }
 
     /// Compute a digest of all the bundle's effecting data.

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -62,6 +62,7 @@
 //! | `tachyonAggregateId`  | 64 bytes             | wtxid of the relevant aggregate          |
 
 use alloc::vec::Vec;
+use core::ops;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, PartialEq};
@@ -98,12 +99,10 @@ impl BundleState {
             0b0000_0000u8 => Ok(Self::NoBundle),
             0b0000_0001u8 => Ok(Self::Stamped),
             0b0000_0010u8 => Ok(Self::Stripped),
-            _other => {
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid bundle state",
-                ))
-            },
+            _other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid bundle state",
+            )),
         }
     }
 
@@ -195,7 +194,7 @@ pub enum BuildError {
 }
 
 /// Errors that can occur when computing a bundle plan commitment.
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, Error, From)]
 #[non_exhaustive]
 pub enum CommitError {
     /// An action digest could not be constructed.
@@ -203,19 +202,7 @@ pub enum CommitError {
     ActionDigest(#[error(not(source))] ActionDigestError),
     /// The value balance overflows the representable range.
     #[display("value balance overflow")]
-    BalanceOverflow,
-}
-
-impl From<ActionDigestError> for CommitError {
-    fn from(err: ActionDigestError) -> Self {
-        Self::ActionDigest(err)
-    }
-}
-
-impl From<note::BalanceError> for CommitError {
-    fn from(_err: note::BalanceError) -> Self {
-        Self::BalanceOverflow
-    }
+    BalanceOverflow(#[error(not(source))] BalanceError),
 }
 
 /// Errors from bundle signature verification.
@@ -288,8 +275,8 @@ impl Plan {
     ///
     /// Returns `Err` if the intermediate sum overflows or the result
     /// does not fit in `i64`.
-    pub fn value_balance(&self) -> Result<i64, note::BalanceError> {
-        let mut sum = note::ValueSum::ZERO;
+    pub fn value_balance(&self) -> Result<i64, BalanceError> {
+        let mut sum = ValueBalance::ZERO;
         for plan in &self.spends {
             sum = (sum + plan.note.value)?;
         }
@@ -766,6 +753,59 @@ impl<S: StampState> Bundle<S> {
         }
 
         Ok(())
+    }
+}
+
+/// Signed sum of note values across actions.
+///
+/// Spends contribute positive values, outputs contribute negative.
+/// Uses `i128` internally to provide additional headroom while accumulating
+/// values. Checked arithmetic still reports overflow, and conversion to the
+/// wire-format `i64` fails if the final balance is out of range.
+///
+/// Use `i64::try_from(sum)` to narrow to the wire-format `i64`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ValueBalance(i128);
+
+/// Error returned when a [`ValueBalance`] operation overflows the
+/// representable range.
+#[derive(Clone, Copy, Debug, Display, Error)]
+#[display("value balance overflow")]
+pub struct BalanceError;
+
+impl ValueBalance {
+    /// The zero sum (identity for addition).
+    pub const ZERO: Self = Self(0);
+}
+
+impl TryFrom<ValueBalance> for i64 {
+    type Error = BalanceError;
+
+    // TODO: does this need to check against NOTE_VALUE_MAX?
+    fn try_from(sum: ValueBalance) -> Result<Self, Self::Error> {
+        Self::try_from(sum.0).map_err(|_err| BalanceError)
+    }
+}
+
+impl ops::Add<note::Value> for ValueBalance {
+    type Output = Result<Self, BalanceError>;
+
+    fn add(self, rhs: note::Value) -> Self::Output {
+        self.0
+            .checked_add(i128::from(rhs.0))
+            .map(Self)
+            .ok_or(BalanceError)
+    }
+}
+
+impl ops::Sub<note::Value> for ValueBalance {
+    type Output = Result<Self, BalanceError>;
+
+    fn sub(self, rhs: note::Value) -> Self::Output {
+        self.0
+            .checked_sub(i128::from(rhs.0))
+            .map(Self)
+            .ok_or(BalanceError)
     }
 }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -248,7 +248,6 @@ pub enum SignError {
     BalanceOverflow,
 }
 
-
 /// A complete bundle plan, awaiting authorization.
 #[derive(Clone, Debug)]
 pub struct Plan {

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -98,10 +98,12 @@ impl BundleState {
             | 0b0000_0000u8 => Ok(Self::NoBundle),
             | 0b0000_0001u8 => Ok(Self::Stamped),
             | 0b0000_0010u8 => Ok(Self::Stripped),
-            | _other => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "invalid bundle state",
-            )),
+            | _other => {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid bundle state",
+                ))
+            },
         }
     }
 
@@ -204,6 +206,7 @@ pub enum BuildError {
 
 /// Errors that can occur when computing a bundle plan commitment.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum CommitError {
     /// An action digest could not be constructed.
     ActionDigest(ActionDigestError),
@@ -305,10 +308,10 @@ impl Plan {
     pub fn value_balance(&self) -> Result<i64, note::BalanceError> {
         let mut sum = note::ValueSum::ZERO;
         for plan in &self.spends {
-            sum = (sum + plan.note.value).ok_or(note::BalanceError)?;
+            sum = (sum + plan.note.value)?;
         }
         for plan in &self.outputs {
-            sum = (sum - plan.note.value).ok_or(note::BalanceError)?;
+            sum = (sum - plan.note.value)?;
         }
         sum.to_i64()
     }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -73,6 +73,7 @@ use crate::{
     action::{self, Action},
     digest::blake2b,
     keys::{private, public},
+    note,
     primitives::{ActionDigest, ActionDigestError, ActionSetCommit, Anchor, effect},
     reddsa, serialization,
     stamp::{self, AggregateId, AggregateIdError, Stamp, Stripped, Unproven},
@@ -97,12 +98,10 @@ impl BundleState {
             | 0b0000_0000u8 => Ok(Self::NoBundle),
             | 0b0000_0001u8 => Ok(Self::Stamped),
             | 0b0000_0010u8 => Ok(Self::Stripped),
-            | _other => {
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid bundle state",
-                ))
-            },
+            | _other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid bundle state",
+            )),
         }
     }
 
@@ -203,6 +202,39 @@ pub enum BuildError {
     BalanceKeyMismatch,
 }
 
+/// Errors that can occur when computing a bundle plan commitment.
+#[derive(Debug)]
+pub enum CommitError {
+    /// An action digest could not be constructed.
+    ActionDigest(ActionDigestError),
+    /// The value balance overflows the representable range.
+    BalanceOverflow,
+}
+
+impl fmt::Display for CommitError {
+    #[expect(clippy::ref_patterns, reason = "match needs ref to avoid move")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            | Self::ActionDigest(ref err) => write!(f, "action digest: {err}"),
+            | Self::BalanceOverflow => write!(f, "value balance overflow"),
+        }
+    }
+}
+
+impl Error for CommitError {}
+
+impl From<ActionDigestError> for CommitError {
+    fn from(err: ActionDigestError) -> Self {
+        Self::ActionDigest(err)
+    }
+}
+
+impl From<note::BalanceError> for CommitError {
+    fn from(_err: note::BalanceError) -> Self {
+        Self::BalanceOverflow
+    }
+}
+
 /// Errors that can occur while signing a bundle plan.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -213,6 +245,8 @@ pub enum SignError {
     SigCountMismatch,
     /// An externally-provided signature is invalid at this index.
     InvalidActionSignature,
+    /// The value balance overflows the representable range.
+    BalanceOverflow,
 }
 
 impl fmt::Display for SignError {
@@ -221,6 +255,7 @@ impl fmt::Display for SignError {
             | Self::RkMismatch(idx) => write!(f, "derived rk mismatch at action {idx}"),
             | Self::SigCountMismatch => write!(f, "signature count mismatch"),
             | Self::InvalidActionSignature => write!(f, "invalid action signature"),
+            | Self::BalanceOverflow => write!(f, "value balance overflow"),
         }
     }
 }
@@ -264,19 +299,18 @@ impl Plan {
     ///
     /// $\mathsf{v\_balance} = \sum_i v_{\text{spend},i} - \sum_j
     /// v_{\text{output},j}$
-    #[must_use]
-    pub fn value_balance(&self) -> i64 {
-        let spend_sum: i64 = self
-            .spends
-            .iter()
-            .map(|plan| i64::from(plan.note.value))
-            .sum();
-        let output_sum: i64 = self
-            .outputs
-            .iter()
-            .map(|plan| i64::from(plan.note.value))
-            .sum();
-        spend_sum - output_sum
+    ///
+    /// Returns `Err` if the intermediate sum overflows or the result
+    /// does not fit in `i64`.
+    pub fn value_balance(&self) -> Result<i64, note::BalanceError> {
+        let mut sum = note::ValueSum::ZERO;
+        for plan in &self.spends {
+            sum = (sum + plan.note.value).ok_or(note::BalanceError)?;
+        }
+        for plan in &self.outputs {
+            sum = (sum - plan.note.value).ok_or(note::BalanceError)?;
+        }
+        sum.to_i64()
     }
 
     /// Compute a digest of all the bundle's effecting data.
@@ -293,17 +327,17 @@ impl Plan {
     /// permutation.
     ///
     /// The stamp is excluded because it is stripped during aggregation.
-    #[must_use]
-    pub fn commitment(&self) -> [u8; 64] {
-        #[expect(clippy::expect_used, reason = "todo")]
+    pub fn commitment(&self) -> Result<[u8; 64], CommitError> {
         let digests: Vec<ActionDigest> = self
             .iter_actions(action::Plan::digest, action::Plan::digest)
-            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
-            .expect("don't plan invalid actions");
+            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()?;
 
         let action_commit = ActionSetCommit::from(digests.as_slice());
 
-        blake2b::bundle_commitment(&Eq::from(action_commit).to_affine(), self.value_balance())
+        Ok(blake2b::bundle_commitment(
+            &Eq::from(action_commit).to_affine(),
+            self.value_balance()?,
+        ))
     }
 
     /// Build a [`stamp::Plan`] from this bundle plan.
@@ -397,7 +431,9 @@ impl Plan {
 
         Ok(Bundle {
             actions: authorized,
-            value_balance: self.value_balance(),
+            value_balance: self
+                .value_balance()
+                .map_err(|_err| SignError::BalanceOverflow)?,
             binding_sig,
             stamp: Unproven,
         })
@@ -436,7 +472,9 @@ impl Plan {
 
         Ok(Bundle {
             actions: authorized,
-            value_balance: self.value_balance(),
+            value_balance: self
+                .value_balance()
+                .map_err(|_err| SignError::BalanceOverflow)?,
             binding_sig,
             stamp: Unproven,
         })

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -16,6 +16,19 @@ use crate::{
 };
 
 #[test]
+fn value_sum_checked_arithmetic() {
+    let va = note::Value::try_from(100u64).unwrap();
+    let vb = note::Value::try_from(200u64).unwrap();
+
+    let sum = (ValueBalance::ZERO + va).unwrap();
+    let total = (sum + vb).unwrap();
+    assert_eq!(i64::try_from(total).unwrap(), 300);
+
+    let diff = (ValueBalance::ZERO - va).unwrap();
+    assert_eq!(i64::try_from(diff).unwrap(), -100);
+}
+
+#[test]
 fn wrong_value_balance_fails_verification() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -502,7 +502,7 @@ fn assign_wtxid_rejects_zero_with_actions() {
 fn assign_wtxid_allows_zero_with_no_actions() {
     let rng = &mut StdRng::seed_from_u64(0);
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
-    let sighash = mock_sighash(plan.commitment());
+    let sighash = mock_sighash(plan.commitment().unwrap());
 
     let unassigned: Bundle<Stripped> = Bundle {
         actions: alloc::vec![],
@@ -549,7 +549,7 @@ fn write_rejects_zero_wtxid_with_actions() {
 fn write_allows_zero_wtxid_with_no_actions() {
     let rng = &mut StdRng::seed_from_u64(0);
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
-    let sighash = mock_sighash(plan.commitment());
+    let sighash = mock_sighash(plan.commitment().unwrap());
 
     let stripped = Bundle {
         actions: alloc::vec![],
@@ -645,7 +645,7 @@ fn read_rejects_zero_wtxid_with_actions() {
 fn read_allows_zero_wtxid_with_no_actions() {
     let rng = &mut StdRng::seed_from_u64(0);
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
-    let sighash = mock_sighash(plan.commitment());
+    let sighash = mock_sighash(plan.commitment().unwrap());
 
     let innocent = Bundle {
         actions: alloc::vec![],

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -45,14 +45,17 @@ fn plan_commitment_matches_bundle_commitment() {
     let (stamp, output_plan) = build_output_stamp(rng, pool.anchor(), note);
 
     let bundle_plan = Plan::new(alloc::vec![], alloc::vec![output_plan]);
-    let sighash = mock_sighash(bundle_plan.commitment());
+    let sighash = mock_sighash(bundle_plan.commitment().unwrap());
 
     let bundle = bundle_plan
         .sign(&sighash, &ask, rng)
         .expect("sign output bundle")
         .stamp(stamp);
 
-    assert_eq!(bundle_plan.commitment(), bundle.commitment().unwrap());
+    assert_eq!(
+        bundle_plan.commitment().unwrap(),
+        bundle.commitment().unwrap()
+    );
 }
 
 #[test]
@@ -60,7 +63,7 @@ fn no_bundle_commitment_differs_from_empty_bundle() {
     let empty_plan = Plan::new(alloc::vec![], alloc::vec![]);
     assert_ne!(
         *COMMIT_NO_BUNDLE,
-        empty_plan.commitment(),
+        empty_plan.commitment().unwrap(),
         "absent bundle must differ from empty bundle"
     );
 }
@@ -69,7 +72,7 @@ fn no_bundle_commitment_differs_from_empty_bundle() {
 fn zero_action_bundle_is_valid() {
     let rng = &mut StdRng::seed_from_u64(0);
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
-    let sighash = mock_sighash(plan.commitment());
+    let sighash = mock_sighash(plan.commitment().unwrap());
 
     let bundle = Bundle {
         actions: alloc::vec![],
@@ -203,7 +206,7 @@ fn innocent_aggregate_from_two_autonomes() {
 
     let innocent = {
         let innocent_plan = Plan::new(alloc::vec![], alloc::vec![]);
-        let innocent_sighash = mock_sighash(innocent_plan.commitment());
+        let innocent_sighash = mock_sighash(innocent_plan.commitment().unwrap());
 
         let stamp = Stamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
             .expect("prove_merge");

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -58,7 +58,7 @@ pub fn random_action(rng: &mut (impl RngCore + CryptoRng)) -> Action {
     let note = wallet.random_note(rng, 400);
     let (_, _, plan) = build_output_plan(rng, note);
     let bundle_plan = bundle::Plan::new(alloc::vec![], alloc::vec![plan]);
-    let sighash = mock_sighash(bundle_plan.commitment());
+    let sighash = mock_sighash(bundle_plan.commitment().expect("fixture commitment"));
     let unproven = bundle_plan
         .sign(&sighash, &ask, rng)
         .expect("sign foreign output");
@@ -519,7 +519,7 @@ impl WalletSim {
     pub fn random_note(&self, rng: &mut (impl RngCore + CryptoRng), value_amount: u64) -> Note {
         Note {
             pk: self.sk.derive_payment_key(),
-            value: note::Value::from(value_amount),
+            value: note::Value::try_from(value_amount).expect("fixture value in range"),
             psi: NullifierTrapdoor::random(rng),
             rcm: note::CommitmentTrapdoor::random(rng),
         }
@@ -726,7 +726,7 @@ impl WalletSim {
             .collect();
 
         let bundle_plan = bundle::Plan::new(spend_plans, output_plans);
-        let sighash = mock_sighash(bundle_plan.commitment());
+        let sighash = mock_sighash(bundle_plan.commitment().expect("fixture commitment"));
         let unproven = bundle_plan
             .sign(&sighash, &ask, rng)
             .expect("sign autonome");

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -141,7 +141,7 @@ mod tests {
         let ak = ask.derive_auth_public();
         let note = Note {
             pk: sk.derive_payment_key(),
-            value: note::Value::from(1000u64),
+            value: note::Value::try_from(1000u64).unwrap(),
             psi: note::NullifierTrapdoor::random(rng),
             rcm: note::CommitmentTrapdoor::random(rng),
         };

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -33,7 +33,7 @@
 //! enters the polynomial accumulator. The concrete commitment scheme
 //! (e.g. Sinsemilla, Poseidon) depends on what is efficient inside
 //! Ragu circuits and is TBD.
-use core::{fmt, iter, ops};
+use core::{fmt, ops};
 
 use ff::Field as _;
 use pasta_curves::Fp;
@@ -168,12 +168,6 @@ impl Value {
         }
         Ok(Self(value))
     }
-
-    /// Returns the inner `u64`.
-    #[must_use]
-    pub const fn inner(self) -> u64 {
-        self.0
-    }
 }
 
 impl TryFrom<u64> for Value {
@@ -190,25 +184,24 @@ impl From<Value> for u64 {
     }
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "Value construction enforces NOTE_VALUE_MAX < i64::MAX"
+)]
 impl From<Value> for i64 {
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_wrap,
-        reason = "NOTE_VALUE_MAX (2.1e15) < i64::MAX (9.2e18), so wrapping cannot occur"
-    )]
     fn from(value: Value) -> Self {
-        value.0 as Self
+        Self::try_from(value.0).expect("Value invariant guarantees it fits in i64")
     }
 }
 
 /// Signed sum of note values across actions.
 ///
 /// Spends contribute positive values, outputs contribute negative.
-/// The valid range is `-(max * action_count)..=(max * action_count)`,
-/// but `i128` provides ample headroom for any realistic bundle.
+/// Uses `i128` internally to provide additional headroom while accumulating
+/// values. Checked arithmetic still reports overflow, and conversion to the
+/// wire-format `i64` fails if the final balance is out of range.
 ///
-/// Use [`ValueSum::to_i64`] to convert to the wire-format `i64`
-/// for `value_balance`, which checks the result fits.
+/// Use `i64::try_from(sum)` to narrow to the wire-format `i64`.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ValueSum(i128);
 
@@ -226,11 +219,13 @@ impl fmt::Display for BalanceError {
 impl ValueSum {
     /// The zero sum (identity for addition).
     pub const ZERO: Self = Self(0);
+}
 
-    /// Convert to `i64` for the wire format, or error if the sum
-    /// does not fit.
-    pub fn to_i64(self) -> Result<i64, BalanceError> {
-        i64::try_from(self.0).map_err(|_err| BalanceError)
+impl TryFrom<ValueSum> for i64 {
+    type Error = BalanceError;
+
+    fn try_from(sum: ValueSum) -> Result<Self, Self::Error> {
+        Self::try_from(sum.0).map_err(|_err| BalanceError)
     }
 }
 
@@ -253,12 +248,6 @@ impl ops::Sub<Value> for ValueSum {
             .checked_sub(i128::from(rhs.0))
             .map(Self)
             .ok_or(BalanceError)
-    }
-}
-
-impl iter::Sum<Value> for Result<ValueSum, BalanceError> {
-    fn sum<I: Iterator<Item = Value>>(mut iter: I) -> Self {
-        iter.try_fold(ValueSum::ZERO, |sum, val| sum + val)
     }
 }
 
@@ -485,9 +474,9 @@ mod tests {
 
         let sum = (ValueSum::ZERO + va).unwrap();
         let total = (sum + vb).unwrap();
-        assert_eq!(total.to_i64().unwrap(), 300);
+        assert_eq!(i64::try_from(total).unwrap(), 300);
 
         let diff = (ValueSum::ZERO - va).unwrap();
-        assert_eq!(diff.to_i64().unwrap(), -100);
+        assert_eq!(i64::try_from(diff).unwrap(), -100);
     }
 }

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -210,7 +210,6 @@ impl ops::Sub<Value> for ValueSum {
     }
 }
 
-
 impl Note {
     /// Computes the note commitment `cm`.
     ///

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -138,6 +138,7 @@ pub struct Value(pub(crate) u64);
 /// Error returned when a note value is out of the valid range
 /// `1..=NOTE_VALUE_MAX`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ValueError {
     /// The value was zero.
     Zero,
@@ -200,15 +201,6 @@ impl From<Value> for i64 {
     }
 }
 
-/// The sign of a [`ValueSum`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Sign {
-    /// The value is positive (spends).
-    Positive,
-    /// The value is negative (outputs).
-    Negative,
-}
-
 /// Signed sum of note values across actions.
 ///
 /// Spends contribute positive values, outputs contribute negative.
@@ -240,43 +232,31 @@ impl ValueSum {
     pub fn to_i64(self) -> Result<i64, BalanceError> {
         i64::try_from(self.0).map_err(|_err| BalanceError)
     }
-
-    /// Decompose into unsigned magnitude and sign.
-    ///
-    /// Zero is reported as `(0, Sign::Positive)`.
-    #[must_use]
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation,
-        reason = "ValueSum range is bounded by NOTE_VALUE_MAX * action_count, which fits u64"
-    )]
-    pub const fn magnitude_sign(self) -> (u64, Sign) {
-        if self.0 < 0 {
-            ((-self.0) as u64, Sign::Negative)
-        } else {
-            (self.0 as u64, Sign::Positive)
-        }
-    }
 }
 
 impl ops::Add<Value> for ValueSum {
-    type Output = Option<Self>;
+    type Output = Result<Self, BalanceError>;
 
     fn add(self, rhs: Value) -> Self::Output {
-        self.0.checked_add(i128::from(rhs.0)).map(Self)
+        self.0
+            .checked_add(i128::from(rhs.0))
+            .map(Self)
+            .ok_or(BalanceError)
     }
 }
 
 impl ops::Sub<Value> for ValueSum {
-    type Output = Option<Self>;
+    type Output = Result<Self, BalanceError>;
 
     fn sub(self, rhs: Value) -> Self::Output {
-        self.0.checked_sub(i128::from(rhs.0)).map(Self)
+        self.0
+            .checked_sub(i128::from(rhs.0))
+            .map(Self)
+            .ok_or(BalanceError)
     }
 }
 
-impl iter::Sum<Value> for Option<ValueSum> {
+impl iter::Sum<Value> for Result<ValueSum, BalanceError> {
     fn sum<I: Iterator<Item = Value>>(mut iter: I) -> Self {
         iter.try_fold(ValueSum::ZERO, |sum, val| sum + val)
     }
@@ -412,7 +392,7 @@ mod tests {
     /// NOTE_VALUE_MAX must be accepted (boundary is inclusive).
     #[test]
     fn value_accepts_max() {
-        assert!(Value::try_from(NOTE_VALUE_MAX).is_ok());
+        Value::try_from(NOTE_VALUE_MAX).unwrap();
     }
 
     /// Anything above NOTE_VALUE_MAX must be rejected.
@@ -504,33 +484,10 @@ mod tests {
         let vb = Value::try_from(200u64).unwrap();
 
         let sum = (ValueSum::ZERO + va).unwrap();
-        let sum = (sum + vb).unwrap();
-        assert_eq!(sum.to_i64().unwrap(), 300);
+        let total = (sum + vb).unwrap();
+        assert_eq!(total.to_i64().unwrap(), 300);
 
         let diff = (ValueSum::ZERO - va).unwrap();
         assert_eq!(diff.to_i64().unwrap(), -100);
-    }
-
-    #[test]
-    fn magnitude_sign_positive() {
-        let sum = (ValueSum::ZERO + Value::try_from(42u64).unwrap()).unwrap();
-        let (mag, sign) = sum.magnitude_sign();
-        assert_eq!(mag, 42);
-        assert_eq!(sign, Sign::Positive);
-    }
-
-    #[test]
-    fn magnitude_sign_negative() {
-        let sum = (ValueSum::ZERO - Value::try_from(42u64).unwrap()).unwrap();
-        let (mag, sign) = sum.magnitude_sign();
-        assert_eq!(mag, 42);
-        assert_eq!(sign, Sign::Negative);
-    }
-
-    #[test]
-    fn magnitude_sign_zero() {
-        let (mag, sign) = ValueSum::ZERO.magnitude_sign();
-        assert_eq!(mag, 0);
-        assert_eq!(sign, Sign::Positive);
     }
 }

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -105,11 +105,13 @@ pub struct Note {
 ///
 /// Use [`Value::try_from`] or [`Value::new`] for fallible construction.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Into)]
-#[expect(
-    clippy::field_scoped_visibility_modifiers,
-    reason = "test helpers use crate-internal construction to bypass the API check"
-)]
-pub struct Value(pub(crate) u64);
+pub struct Value(u64);
+
+impl Value {
+    /// The forbidden zero value.
+    #[cfg(test)]
+    pub(crate) const ZERO: Self = Self(0);
+}
 
 /// Error returned when a note value is out of the valid range
 /// `1..=NOTE_VALUE_MAX`.

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -33,7 +33,6 @@
 //! enters the polynomial accumulator. The concrete commitment scheme
 //! (e.g. Sinsemilla, Poseidon) depends on what is efficient inside
 //! Ragu circuits and is TBD.
-use core::ops;
 
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, Into, PartialEq};
 use ff::Field as _;
@@ -155,58 +154,6 @@ impl TryFrom<u64> for Value {
 impl From<Value> for i64 {
     fn from(value: Value) -> Self {
         Self::try_from(value.0).expect("Value invariant guarantees it fits in i64")
-    }
-}
-
-/// Signed sum of note values across actions.
-///
-/// Spends contribute positive values, outputs contribute negative.
-/// Uses `i128` internally to provide additional headroom while accumulating
-/// values. Checked arithmetic still reports overflow, and conversion to the
-/// wire-format `i64` fails if the final balance is out of range.
-///
-/// Use `i64::try_from(sum)` to narrow to the wire-format `i64`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct ValueSum(i128);
-
-/// Error returned when a [`ValueSum`] operation overflows the
-/// representable range.
-#[derive(Clone, Copy, Debug, Display, Error, PartialEq, Eq)]
-#[display("value balance overflow")]
-pub struct BalanceError;
-
-impl ValueSum {
-    /// The zero sum (identity for addition).
-    pub const ZERO: Self = Self(0);
-}
-
-impl TryFrom<ValueSum> for i64 {
-    type Error = BalanceError;
-
-    fn try_from(sum: ValueSum) -> Result<Self, Self::Error> {
-        Self::try_from(sum.0).map_err(|_err| BalanceError)
-    }
-}
-
-impl ops::Add<Value> for ValueSum {
-    type Output = Result<Self, BalanceError>;
-
-    fn add(self, rhs: Value) -> Self::Output {
-        self.0
-            .checked_add(i128::from(rhs.0))
-            .map(Self)
-            .ok_or(BalanceError)
-    }
-}
-
-impl ops::Sub<Value> for ValueSum {
-    type Output = Result<Self, BalanceError>;
-
-    fn sub(self, rhs: Value) -> Self::Output {
-        self.0
-            .checked_sub(i128::from(rhs.0))
-            .map(Self)
-            .ok_or(BalanceError)
     }
 }
 
@@ -376,18 +323,5 @@ mod tests {
         assert!(dbg.contains("Nullifier"), "must name the type");
         assert!(!dbg.contains("BEEF"), "must not leak field element");
         assert!(!dbg.contains("48879"), "must not leak decimal value");
-    }
-
-    #[test]
-    fn value_sum_checked_arithmetic() {
-        let va = Value::try_from(100u64).unwrap();
-        let vb = Value::try_from(200u64).unwrap();
-
-        let sum = (ValueSum::ZERO + va).unwrap();
-        let total = (sum + vb).unwrap();
-        assert_eq!(i64::try_from(total).unwrap(), 300);
-
-        let diff = (ValueSum::ZERO - va).unwrap();
-        assert_eq!(i64::try_from(diff).unwrap(), -100);
     }
 }

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -124,11 +124,10 @@ pub enum ValueError {
     Overflow,
 }
 
-impl Value {
-    /// Checked constructor.
-    ///
-    /// Returns `Err` if `value` is zero or exceeds `NOTE_VALUE_MAX`.
-    pub const fn new(value: u64) -> Result<Self, ValueError> {
+impl TryFrom<u64> for Value {
+    type Error = ValueError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
         if value == 0 {
             return Err(ValueError::Zero);
         }
@@ -136,14 +135,6 @@ impl Value {
             return Err(ValueError::Overflow);
         }
         Ok(Self(value))
-    }
-}
-
-impl TryFrom<u64> for Value {
-    type Error = ValueError;
-
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        Self::new(value)
     }
 }
 

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -33,7 +33,7 @@
 //! enters the polynomial accumulator. The concrete commitment scheme
 //! (e.g. Sinsemilla, Poseidon) depends on what is efficient inside
 //! Ragu circuits and is TBD.
-use core::fmt;
+use core::{fmt, iter, ops};
 
 use ff::Field as _;
 use pasta_curves::Fp;
@@ -122,40 +122,163 @@ pub struct Note {
 /// A note value in zatoshis. Non-zero and no greater than 2.1e15.
 ///
 /// Zero-valued notes are forbidden by construction: a zero-value action
-/// carries no economic meaning. The newtype enforces the invariant at
-/// `Value::from` (panics on zero and on overflow). Each PCD step that
-/// witnesses a `Note` *independently* rechecks `value != 0` — the
-/// compiler cannot prove the invariant from inside the circuit, and a
-/// compiled proof system sees only raw field elements without the
-/// Rust-level newtype protection.
-#[derive(Clone, Copy, Debug)]
+/// carries no economic meaning. Each PCD step that witnesses a `Note`
+/// *independently* rechecks `value != 0` — the compiler cannot prove the
+/// invariant from inside the circuit, and a compiled proof system sees
+/// only raw field elements without the Rust-level newtype protection.
+///
+/// Use [`Value::try_from`] or [`Value::new`] for fallible construction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[expect(
     clippy::field_scoped_visibility_modifiers,
     reason = "test helpers use crate-internal construction to bypass the API check"
 )]
 pub struct Value(pub(crate) u64);
 
-impl From<u64> for Value {
-    fn from(value: u64) -> Self {
-        assert!(value > 0, "note value must be non-zero");
-        assert!(
-            value <= NOTE_VALUE_MAX,
-            "note value must not exceed maximum"
-        );
-        Self(value)
+/// Error returned when a note value is out of the valid range
+/// `1..=NOTE_VALUE_MAX`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ValueError {
+    /// The value was zero.
+    Zero,
+    /// The value exceeds the maximum note value (2.1e15 zatoshis).
+    Overflow,
+}
+
+impl fmt::Display for ValueError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            | Self::Zero => f.write_str("note value must be non-zero"),
+            | Self::Overflow => f.write_str("note value must not exceed maximum"),
+        }
     }
 }
 
-#[expect(clippy::expect_used, reason = "specified behavior")]
-impl From<Value> for i64 {
-    fn from(value: Value) -> Self {
-        Self::try_from(value.0).expect("note value should fit in i64 (max 2.1e15 < i64::MAX)")
+impl Value {
+    /// Checked constructor.
+    ///
+    /// Returns `Err` if `value` is zero or exceeds `NOTE_VALUE_MAX`.
+    pub const fn new(value: u64) -> Result<Self, ValueError> {
+        if value == 0 {
+            return Err(ValueError::Zero);
+        }
+        if value > NOTE_VALUE_MAX {
+            return Err(ValueError::Overflow);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the inner `u64`.
+    #[must_use]
+    pub const fn inner(self) -> u64 {
+        self.0
+    }
+}
+
+impl TryFrom<u64> for Value {
+    type Error = ValueError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::new(value)
     }
 }
 
 impl From<Value> for u64 {
     fn from(value: Value) -> Self {
         value.0
+    }
+}
+
+impl From<Value> for i64 {
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_possible_wrap,
+        reason = "NOTE_VALUE_MAX (2.1e15) < i64::MAX (9.2e18), so wrapping cannot occur"
+    )]
+    fn from(value: Value) -> Self {
+        value.0 as Self
+    }
+}
+
+/// The sign of a [`ValueSum`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Sign {
+    /// The value is positive (spends).
+    Positive,
+    /// The value is negative (outputs).
+    Negative,
+}
+
+/// Signed sum of note values across actions.
+///
+/// Spends contribute positive values, outputs contribute negative.
+/// The valid range is `-(max * action_count)..=(max * action_count)`,
+/// but `i128` provides ample headroom for any realistic bundle.
+///
+/// Use [`ValueSum::to_i64`] to convert to the wire-format `i64`
+/// for `value_balance`, which checks the result fits.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ValueSum(i128);
+
+/// Error returned when a [`ValueSum`] operation overflows the
+/// representable range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BalanceError;
+
+impl fmt::Display for BalanceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("value balance overflow")
+    }
+}
+
+impl ValueSum {
+    /// The zero sum (identity for addition).
+    pub const ZERO: Self = Self(0);
+
+    /// Convert to `i64` for the wire format, or error if the sum
+    /// does not fit.
+    pub fn to_i64(self) -> Result<i64, BalanceError> {
+        i64::try_from(self.0).map_err(|_err| BalanceError)
+    }
+
+    /// Decompose into unsigned magnitude and sign.
+    ///
+    /// Zero is reported as `(0, Sign::Positive)`.
+    #[must_use]
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        reason = "ValueSum range is bounded by NOTE_VALUE_MAX * action_count, which fits u64"
+    )]
+    pub const fn magnitude_sign(self) -> (u64, Sign) {
+        if self.0 < 0 {
+            ((-self.0) as u64, Sign::Negative)
+        } else {
+            (self.0 as u64, Sign::Positive)
+        }
+    }
+}
+
+impl ops::Add<Value> for ValueSum {
+    type Output = Option<Self>;
+
+    fn add(self, rhs: Value) -> Self::Output {
+        self.0.checked_add(i128::from(rhs.0)).map(Self)
+    }
+}
+
+impl ops::Sub<Value> for ValueSum {
+    type Output = Option<Self>;
+
+    fn sub(self, rhs: Value) -> Self::Output {
+        self.0.checked_sub(i128::from(rhs.0)).map(Self)
+    }
+}
+
+impl iter::Sum<Value> for Option<ValueSum> {
+    fn sum<I: Iterator<Item = Value>>(mut iter: I) -> Self {
+        iter.try_fold(ValueSum::ZERO, |sum, val| sum + val)
     }
 }
 
@@ -289,21 +412,22 @@ mod tests {
     /// NOTE_VALUE_MAX must be accepted (boundary is inclusive).
     #[test]
     fn value_accepts_max() {
-        let _val: Value = Value::from(NOTE_VALUE_MAX);
+        assert!(Value::try_from(NOTE_VALUE_MAX).is_ok());
     }
 
     /// Anything above NOTE_VALUE_MAX must be rejected.
     #[test]
-    #[should_panic(expected = "note value must not exceed maximum")]
     fn value_rejects_overflow() {
-        let _val: Value = Value::from(NOTE_VALUE_MAX + 1);
+        assert_eq!(
+            Value::try_from(NOTE_VALUE_MAX + 1),
+            Err(ValueError::Overflow)
+        );
     }
 
     /// Zero must be rejected — notes carry economic value.
     #[test]
-    #[should_panic(expected = "note value must be non-zero")]
     fn value_rejects_zero() {
-        let _val: Value = Value::from(0u64);
+        assert_eq!(Value::try_from(0u64), Err(ValueError::Zero));
     }
 
     /// Different trapdoors produce different commitments.
@@ -315,13 +439,13 @@ mod tests {
 
         let note1 = Note {
             pk,
-            value: Value::from(100u64),
+            value: Value::try_from(100u64).unwrap(),
             psi,
             rcm: CommitmentTrapdoor::random(rng),
         };
         let note2 = Note {
             pk,
-            value: Value::from(100u64),
+            value: Value::try_from(100u64).unwrap(),
             psi,
             rcm: CommitmentTrapdoor::random(rng),
         };
@@ -338,7 +462,7 @@ mod tests {
         let nk = sk.derive_nullifier_private();
         let note = Note {
             pk: sk.derive_payment_key(),
-            value: Value::from(100u64),
+            value: Value::try_from(100u64).unwrap(),
             psi: NullifierTrapdoor::random(rng),
             rcm: CommitmentTrapdoor::random(rng),
         };
@@ -372,5 +496,41 @@ mod tests {
         assert!(dbg.contains("Nullifier"), "must name the type");
         assert!(!dbg.contains("BEEF"), "must not leak field element");
         assert!(!dbg.contains("48879"), "must not leak decimal value");
+    }
+
+    #[test]
+    fn value_sum_checked_arithmetic() {
+        let va = Value::try_from(100u64).unwrap();
+        let vb = Value::try_from(200u64).unwrap();
+
+        let sum = (ValueSum::ZERO + va).unwrap();
+        let sum = (sum + vb).unwrap();
+        assert_eq!(sum.to_i64().unwrap(), 300);
+
+        let diff = (ValueSum::ZERO - va).unwrap();
+        assert_eq!(diff.to_i64().unwrap(), -100);
+    }
+
+    #[test]
+    fn magnitude_sign_positive() {
+        let sum = (ValueSum::ZERO + Value::try_from(42u64).unwrap()).unwrap();
+        let (mag, sign) = sum.magnitude_sign();
+        assert_eq!(mag, 42);
+        assert_eq!(sign, Sign::Positive);
+    }
+
+    #[test]
+    fn magnitude_sign_negative() {
+        let sum = (ValueSum::ZERO - Value::try_from(42u64).unwrap()).unwrap();
+        let (mag, sign) = sum.magnitude_sign();
+        assert_eq!(mag, 42);
+        assert_eq!(sign, Sign::Negative);
+    }
+
+    #[test]
+    fn magnitude_sign_zero() {
+        let (mag, sign) = ValueSum::ZERO.magnitude_sign();
+        assert_eq!(mag, 0);
+        assert_eq!(sign, Sign::Positive);
     }
 }

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -99,7 +99,7 @@ mod tests {
         let sk = private::SpendingKey::random(rng);
         let note = Note {
             pk: sk.derive_payment_key(),
-            value: note::Value::from(val),
+            value: note::Value::try_from(val).unwrap(),
             psi: note::NullifierTrapdoor::random(rng),
             rcm: note::CommitmentTrapdoor::random(rng),
         };

--- a/crates/tachyon/src/serialization/mod.rs
+++ b/crates/tachyon/src/serialization/mod.rs
@@ -17,21 +17,18 @@ pub(crate) mod compactsize;
 use crate::{reddsa, serialization::compactsize::CompactSize};
 
 pub(crate) fn read_compactsize<R: Read>(mut reader: R) -> io::Result<u64> {
-    let compact_size = CompactSize::read(&mut reader)?
-        .enforce_valid()
-        .map_err(|err| {
-            match err {
+    let compact_size =
+        CompactSize::read(&mut reader)?
+            .enforce_valid()
+            .map_err(|err| match err {
                 | compactsize::CompactSizeError::NonCanonical(_) => {
                     io::Error::new(io::ErrorKind::InvalidData, "non-canonical compact size")
                 },
-                | compactsize::CompactSizeError::ExceedsMaximum(_) => {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "compact size exceeds consensus maximum",
-                    )
-                },
-            }
-        })?;
+                | compactsize::CompactSizeError::ExceedsMaximum(_) => io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "compact size exceeds consensus maximum",
+                ),
+            })?;
     Ok(compact_size.into())
 }
 

--- a/crates/tachyon/src/serialization/mod.rs
+++ b/crates/tachyon/src/serialization/mod.rs
@@ -17,18 +17,21 @@ pub(crate) mod compactsize;
 use crate::{reddsa, serialization::compactsize::CompactSize};
 
 pub(crate) fn read_compactsize<R: Read>(mut reader: R) -> io::Result<u64> {
-    let compact_size =
-        CompactSize::read(&mut reader)?
-            .enforce_valid()
-            .map_err(|err| match err {
+    let compact_size = CompactSize::read(&mut reader)?
+        .enforce_valid()
+        .map_err(|err| {
+            match err {
                 | compactsize::CompactSizeError::NonCanonical(_) => {
                     io::Error::new(io::ErrorKind::InvalidData, "non-canonical compact size")
                 },
-                | compactsize::CompactSizeError::ExceedsMaximum(_) => io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "compact size exceeds consensus maximum",
-                ),
-            })?;
+                | compactsize::CompactSizeError::ExceedsMaximum(_) => {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "compact size exceeds consensus maximum",
+                    )
+                },
+            }
+        })?;
     Ok(compact_size.into())
 }
 

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -623,7 +623,7 @@ fn step_rejects_zero_value_note() {
 
     let zero_note = Note {
         pk: user.pak.derive_payment_key(),
-        value: note::Value(0),
+        value: note::Value::ZERO,
         psi: note::NullifierTrapdoor::random(rng),
         rcm: note::CommitmentTrapdoor::random(rng),
     };
@@ -661,7 +661,7 @@ fn step_rejects_zero_value_note() {
                 rng,
                 spend::SpendBind,
                 (
-                    (note.pk, note::Value(0), note.rcm, note.psi),
+                    (note.pk, note::Value::ZERO, note.rcm, note.psi),
                     rcv,
                     alpha,
                     user.pak,

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -479,7 +479,7 @@ fn spend_bind_rejects_invalid_inputs() {
     let spend_epoch = height.epoch();
 
     let phantom = Note {
-        value: note::Value::from(999_999),
+        value: note::Value::try_from(999_999u64).expect("test value in range"),
         rcm: note::CommitmentTrapdoor::random(rng),
         ..note
     };
@@ -491,7 +491,7 @@ fn spend_bind_rejects_invalid_inputs() {
         "shared psi yields shared nullifiers"
     );
 
-    let wrong_value = note::Value::from(999_999u64);
+    let wrong_value = note::Value::try_from(999_999u64).expect("test value in range");
     assert_ne!(u64::from(wrong_value), u64::from(note.value));
 
     let cases = [
@@ -788,7 +788,7 @@ fn notes_with_shared_psi_share_nullifiers() {
     let user = WalletSim::random(rng);
     let note_a = user.random_note(rng, 500);
     let note_b = Note {
-        value: note::Value::from(700),
+        value: note::Value::try_from(700u64).expect("test value in range"),
         rcm: note::CommitmentTrapdoor::random(rng),
         ..note_a
     };
@@ -1262,7 +1262,7 @@ fn spendable_lift_rejects_wrong_cm() {
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(rng, 500);
     let phantom = Note {
-        value: note::Value::from(700),
+        value: note::Value::try_from(700u64).expect("test value in range"),
         rcm: note::CommitmentTrapdoor::random(rng),
         ..note
     };


### PR DESCRIPTION
fixes #17 
- replace From<u64> for Value with TryFrom<u64> + Value::new() checked constructor
- add ValueError enum (Zero, Overflow) for out-of-range values
- add ValueSum(i128) with checked Add<Value>/Sub<Value> returning Option
- add Sign enum and ValueSum::magnitude_sign() for decomposition
- add BalanceError and ValueSum::to_i64() for wire-format conversion
- update Plan::commitment() to return Result<[u8; 64], CommitError>
- add CommitError unifying ActionDigestError and BalanceError
- add SignError::BalanceOverflow variant for propagation
- migrate all call sites from Value::from() to Value::try_from()