### PR TITLE
fix: same-epoch spend soundness

### DIFF
--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -12,8 +12,8 @@ Multiple parties execute the proof tree.
 ## Lifecycle
 
 A note is essentially created when the wallet runs `SpendableInit`.
-The step takes the wallet's `NullifierHeader` for the creation epoch, a pre-stamp anchor, and the tachygram set of the stamp that produced the note; it checks the note's commitment[^notes] is among those tachygrams and advances the anchor through the stamp.
-The output is a `SpendableHeader` carrying the nullifier and the post-stamp anchor.
+The step takes the wallet's `NullifierHeader` for the creation epoch and an `AnchorChain` running from the creation epoch's boundary anchor through the stamp that produced the note; it checks the note's commitment[^notes] is among that stamp's tachygrams, checks the chain roots at the epoch boundary for the nullifier's epoch, and checks the cm-stamp is the chain's final link.
+The output is a `SpendableHeader` carrying the nullifier and the post-stamp anchor; rooting the chain at the epoch boundary binds the nullifier's epoch to the consensus chain.
 
 Maintaining the spendable means advancing its anchor forward over `Unspent` segments.
 `SpendableLift` consumes one `Unspent` whose nullifier matches the spendable's and whose start matches the spendable's current anchor, producing a fresh `SpendableHeader` at the segment's end.
@@ -108,11 +108,12 @@ A fresh trapdoor per delegation makes the delegation identifier unlinkable acros
 
 `AnchorSeed`, `EmptyBlockSeed`, `UnspentSeed`, and `EmptyBlockUnspentSeed` each witness a starting anchor and prove one anchor step.
 `AnchorFuse` and `UnspentFuse` compose adjacent segments by checking endpoint equality.
-A segment ties to real chain history only when a stamp-emitting step consumes it and the resulting stamp's anchor matches a consensus-published end-of-block value.
+A segment ties to real chain history only through a consensus-published stamp whose anchor matches an end-of-block value: `StampLift` emits that stamp directly, while a segment consumed by `SpendableInit` produces a private spendable whose anchor reaches consensus only once it is spent into a stamp.
 
 ### Spendable lifecycle
 
-A spendable bootstraps at `SpendableInit`, which fuses the wallet's `NullifierHeader` with a pre-stamp anchor and the tachygram set of the stamp that produced the note, verifies the note's commitment[^notes] is among those tachygrams, and advances the anchor through that stamp.
+A spendable bootstraps at `SpendableInit`, which fuses the wallet's `NullifierHeader` with a boundary-rooted `AnchorChain` covering the creation epoch's boundary through the cm-stamp, verifies the note's commitment[^notes] is among the cm-stamp's tachygrams, requires the chain to root at the epoch boundary `next_epoch(epoch)`, and requires the cm-stamp to be the chain's final link.
+Because `next_epoch` is the only epoch-folding anchor domain and an `AnchorChain` advances only within an epoch, consensus anchor membership of the eventual spend anchor fixes which epoch boundary the chain roots at, binding the GGM leaf index to the consensus epoch.
 `SpendableLift` advances the spendable's anchor further by consuming an `Unspent` segment whose nullifier equals the spendable's and whose start matches the spendable's current anchor.
 Each `UnspentSeed` link absorbs one stamp into the anchor and proves the spendable's nullifier is absent from that stamp's tachygram set[^tachygrams]; `EmptyBlockUnspentSeed` skips the absence check (no tachygrams to scan); `UnspentFuse` requires both halves to share a nullifier and to meet at a common anchor.
 
@@ -165,7 +166,8 @@ flowchart TB
   end
 
   subgraph spendable [spendable advance]
-    w_init[/anchor, stamp_tg_set/]
+    w_init[/pre_epoch_anchor, pre_cm_anchor, stamp_tg_set/]
+    anchor_init((AnchorChain))
     s_init[SpendableInit]
     s_rfuse[RolloverFuse]
     s_rollover[SpendableRollover]
@@ -201,6 +203,7 @@ flowchart TB
   s_prefix -->|NfPrefixHeader| s_leaf_next
 
   s_leaf_old -->|NullifierHeader e-1| s_init
+  anchor_init --> s_init
   w_init --> s_init
   s_init -->|SpendableHeader| s_rollover
 
@@ -357,7 +360,7 @@ A sync-service variant substitutes `DelegateRolloverFuse` (consuming two `Delega
 | DelegateNullifierStep | DelegateNfPrefixHeader | — | — | DelegateNullifierHeader |
 | RolloverFuse | NullifierHeader | NullifierHeader | — | NullifierRolloverHeader |
 | DelegateRolloverFuse | DelegateNullifierHeader | DelegateNullifierHeader | — | NullifierRolloverHeader |
-| SpendableInit | NullifierHeader | — | anchor, stamp_tg_set | SpendableHeader |
+| SpendableInit | AnchorChain | NullifierHeader | pre_epoch_anchor, pre_cm_anchor, stamp_tg_set | SpendableHeader |
 | SpendableLift | SpendableHeader | Unspent | — | SpendableHeader |
 | SpendableRollover | SpendableHeader | NullifierRolloverHeader | — | SpendableRolloverHeader |
 | SpendableEpochLift | SpendableRolloverHeader | Unspent | — | SpendableHeader |

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -226,6 +226,18 @@ impl PoolSim {
         }
     }
 
+    /// The prior-epoch terminal anchor that folds into `epoch`'s boundary
+    /// `B_epoch = pre_epoch_anchor(epoch).next_epoch(epoch)`. This is the
+    /// single owner of the genesis convention: `Fp::ZERO` for the genesis
+    /// epoch (matching [`Anchor::default`]'s `ZERO.next_epoch(0)`),
+    /// otherwise the terminal anchor of the previous epoch's final block.
+    #[must_use]
+    pub fn pre_epoch_anchor(&self, epoch: EpochIndex) -> Anchor {
+        epoch_first_of(epoch)
+            .prev()
+            .map_or_else(|| Anchor::from(Fp::ZERO), |height| self.anchor_at(height))
+    }
+
     /// Resolve the height at which `anchor` was produced. `block.prev` already
     /// holds the anchor of the preceding block, so a single scan over the
     /// `prev` linkage suffices; only the tip anchor needs recomputing.
@@ -266,16 +278,19 @@ impl PoolSim {
     }
 }
 
-/// Build an [`AnchorChain`] covering blocks `range`, rooted at the
-/// block-start anchor of `*range.start()`.
+/// Build an [`AnchorChain`] covering blocks `range`, rooted at the block-start
+/// anchor of `*range.start()`. When `last_block_upto` is `Some(n)` the final
+/// block absorbs only its first `n` stamps (stopping the chain right after the
+/// cm-stamp); `None` absorbs every block in full.
 ///
-/// Per non-empty block: one [`AnchorSeed`] per stamp, fused via
-/// [`AnchorFuse`]. Per empty block: one [`EmptyBlockSeed`].
-/// All segments fused linearly.
-pub(crate) fn build_anchor_chain_pcd(
+/// Per non-empty block: one [`AnchorSeed`] per absorbed stamp, fused via
+/// [`AnchorFuse`]. Per empty block: one [`EmptyBlockSeed`]. All segments fused
+/// linearly.
+fn build_anchor_chain_inner(
     rng: &mut (impl RngCore + CryptoRng),
     pool: &PoolSim,
     range: RangeInclusive<BlockHeight>,
+    last_block_upto: Option<usize>,
 ) -> Pcd<pool::AnchorChain> {
     let start = *range.start();
     let end = *range.end();
@@ -303,10 +318,16 @@ pub(crate) fn build_anchor_chain_pcd(
             });
             state = next_state;
         } else {
-            for commit in commits {
-                let next_state = state.next_stamp(&commit);
+            // The final block may be truncated (cm-block prefix); others absorb all.
+            let upto = if height == end {
+                last_block_upto.unwrap_or(commits.len())
+            } else {
+                commits.len()
+            };
+            for commit in &commits[..upto] {
+                let next_state = state.next_stamp(commit);
                 let (seed, ()) = PROOF_SYSTEM
-                    .seed(rng, pool::AnchorSeed, (state, commit))
+                    .seed(rng, pool::AnchorSeed, (state, *commit))
                     .expect("AnchorSeed");
                 chain = Some(match chain.take() {
                     | None => seed,
@@ -329,16 +350,23 @@ pub(crate) fn build_anchor_chain_pcd(
     chain.expect("AnchorChain range must cover at least one block")
 }
 
-/// Build an [`AnchorChain`](pool::AnchorChain) rooted at the epoch boundary
-/// `B_E = prev_anchor_at(epoch_first)` and ending at `post_cm_anchor` — i.e.
-/// covering blocks `epoch_first..=cm_height`, with the final (cm) block
-/// truncated to its stamps `[0..=cm_idx]` so the cm-stamp is the chain's last
-/// absorbed link.
-///
-/// This is the boundary->cm segment [`spendable::SpendableInit`] consumes to pin
-/// the spendable's starting epoch. A note created first-in-epoch
-/// (`epoch_first == cm_height`, `cm_idx == 0`) yields a single-link chain, so no
-/// zero-length segment is ever needed.
+/// Build an [`AnchorChain`] covering blocks `range` in full, rooted at the
+/// block-start anchor of `*range.start()`.
+pub(crate) fn build_anchor_chain_pcd(
+    rng: &mut (impl RngCore + CryptoRng),
+    pool: &PoolSim,
+    range: RangeInclusive<BlockHeight>,
+) -> Pcd<pool::AnchorChain> {
+    build_anchor_chain_inner(rng, pool, range, None)
+}
+
+/// Build the boundary->cm segment [`spendable::SpendableInit`] consumes to pin
+/// a spendable's starting epoch: an [`AnchorChain`](pool::AnchorChain) rooted
+/// at the epoch boundary `B_E = prev_anchor_at(epoch_first)` and ending at
+/// `post_cm_anchor`, covering blocks `epoch_first..=cm_height` with the final
+/// (cm) block truncated to its stamps `[0..=cm_idx]` so the cm-stamp is the
+/// chain's last absorbed link. A note created first-in-epoch (`epoch_first ==
+/// cm_height`, `cm_idx == 0`) produces a single-link chain.
 pub(crate) fn build_anchor_chain_prefix_pcd(
     rng: &mut (impl RngCore + CryptoRng),
     pool: &PoolSim,
@@ -352,58 +380,56 @@ pub(crate) fn build_anchor_chain_prefix_pcd(
         "prefix chain is single-epoch"
     );
     assert!(epoch_first <= cm_height);
+    // The cm-block must be non-empty and `cm_idx` in range; otherwise the
+    // truncation is silently dropped and the chain would not end at the
+    // cm-stamp (surfacing only later as SpendableInit's "cm-stamp is not the
+    // chain's final link").
+    let cm_commits = pool.stamp_commits_at(cm_height);
+    assert!(
+        !cm_commits.is_empty(),
+        "cm-block at {cm_height:?} has no stamps; cm_idx is meaningless"
+    );
+    assert!(
+        cm_idx < cm_commits.len(),
+        "cm_idx {cm_idx} out of range for {}-stamp cm-block",
+        cm_commits.len()
+    );
+    build_anchor_chain_inner(rng, pool, epoch_first..=cm_height, Some(cm_idx + 1))
+}
 
-    let mut state = pool.prev_anchor_at(epoch_first);
-    let mut chain: Option<Pcd<pool::AnchorChain>> = None;
-    let mut height = epoch_first;
-    loop {
-        let commits = pool.stamp_commits_at(height);
-        if commits.is_empty() {
-            let next_state = state.next_empty();
-            let (seed, ()) = PROOF_SYSTEM
-                .seed(rng, pool::EmptyBlockSeed, (state,))
-                .expect("EmptyBlockSeed");
-            chain = Some(match chain.take() {
-                | None => seed,
-                | Some(left) => {
-                    let (fused, ()) = PROOF_SYSTEM
-                        .fuse(rng, pool::AnchorFuse, (), left, seed)
-                        .expect("AnchorFuse");
-                    fused
-                },
-            });
-            state = next_state;
-        } else {
-            // On the cm-block stop right after the cm-stamp; elsewhere absorb all.
-            let upto = if height == cm_height {
-                cm_idx + 1
-            } else {
-                commits.len()
-            };
-            for commit in &commits[..upto] {
-                let next_state = state.next_stamp(commit);
-                let (seed, ()) = PROOF_SYSTEM
-                    .seed(rng, pool::AnchorSeed, (state, *commit))
-                    .expect("AnchorSeed");
-                chain = Some(match chain.take() {
-                    | None => seed,
-                    | Some(left) => {
-                        let (fused, ()) = PROOF_SYSTEM
-                            .fuse(rng, pool::AnchorFuse, (), left, seed)
-                            .expect("AnchorFuse");
-                        fused
-                    },
-                });
-                state = next_state;
-            }
-        }
-        if height >= cm_height {
-            break;
-        }
-        height = height.next().expect("height < max");
-    }
+/// The honest [`spendable::SpendableInit`] inputs for `cm` at `height`,
+/// reconstructed from pool state: the witness `(pre_epoch_anchor,
+/// pre_cm_anchor, stamp_tg_set)` plus the boundary-rooted
+/// [`AnchorChain`](pool::AnchorChain) for the left input. Shared by
+/// [`WalletSim::spendable_init`] (which `.expect`s the fuse) and tests that
+/// drive a raw fuse to capture the `Err`.
+pub(crate) fn spendable_init_inputs(
+    rng: &mut (impl RngCore + CryptoRng),
+    pool: &PoolSim,
+    cm: note::Commitment,
+    height: BlockHeight,
+) -> (Anchor, Anchor, TachygramSetPoly, Pcd<pool::AnchorChain>) {
+    let stamps = pool.tachygrams_at(height);
+    let stamp_commits = pool.stamp_commits_at(height);
+    let cm_idx = stamps
+        .iter()
+        .position(|tgs| tgs.contains(&cm.into()))
+        .expect("cm not found in any stamp at the cm-block");
 
-    chain.expect("prefix chain covers at least the cm-stamp")
+    // Anchor immediately before the cm-stamp (the cm-block prefix fold).
+    let pre_cm_anchor = stamp_commits[..cm_idx]
+        .iter()
+        .fold(pool.prev_anchor_at(height), Anchor::next_stamp);
+
+    // Root the lineage at the epoch boundary `B_E = pre_epoch_anchor.next_epoch(E)
+    // == prev_anchor_at(epoch_first)`; the boundary->cm chain ends at
+    // post_cm_anchor.
+    let epoch = height.epoch();
+    let pre_epoch_anchor = pool.pre_epoch_anchor(epoch);
+    let chain = build_anchor_chain_prefix_pcd(rng, pool, epoch_first_of(epoch), height, cm_idx);
+    let stamp_tg_set = TachygramSetPoly::from(stamps[cm_idx].as_slice());
+
+    (pre_epoch_anchor, pre_cm_anchor, stamp_tg_set, chain)
 }
 
 pub(crate) fn build_unspent_seed_pcd(
@@ -597,44 +623,27 @@ impl WalletSim {
     ) -> Pcd<spendable::SpendableHeader> {
         let cm = note.commitment();
 
+        let (pre_epoch_anchor, pre_cm_anchor, stamp_tg_set, boundary_chain) =
+            spendable_init_inputs(rng, pool, cm, height);
+
+        let (spendable, ()) = PROOF_SYSTEM
+            .fuse(
+                rng,
+                spendable::SpendableInit,
+                (pre_epoch_anchor, pre_cm_anchor, stamp_tg_set),
+                boundary_chain,
+                nf_pcd,
+            )
+            .expect("SpendableInit");
+
+        // Rest-of-block lift: advance the spendable over the cm-block stamps
+        // after the cm-stamp so it lands on the block-final anchor.
         let stamps = pool.tachygrams_at(height);
         let stamp_commits = pool.stamp_commits_at(height);
         let cm_idx = stamps
             .iter()
             .position(|tgs| tgs.contains(&cm.into()))
             .expect("cm not found in any stamp at the cm-block");
-
-        // Anchor immediately before the cm-stamp (the cm-block prefix fold).
-        let pre_cm_anchor = stamp_commits[..cm_idx]
-            .iter()
-            .fold(pool.prev_anchor_at(height), Anchor::next_stamp);
-
-        // Root the lineage at the epoch boundary B_E. `prev_tip` is the prior
-        // epoch's terminal anchor (Fp::ZERO for the genesis epoch), so
-        // `prev_tip.next_epoch(E) == B_E == prev_anchor_at(epoch_first)`. The
-        // boundary->cm chain ends at `post_cm_anchor`.
-        let epoch = height.epoch();
-        let epoch_first = BlockHeight(epoch.0 * EPOCH_SIZE);
-        let pre_epoch_anchor = if epoch.0 == 0 {
-            Anchor::from(Fp::ZERO)
-        } else {
-            pool.anchor_at(BlockHeight(epoch_first.0 - 1))
-        };
-        let boundary_chain = build_anchor_chain_prefix_pcd(rng, pool, epoch_first, height, cm_idx);
-
-        let (spendable, ()) = PROOF_SYSTEM
-            .fuse(
-                rng,
-                spendable::SpendableInit,
-                (
-                    pre_epoch_anchor,
-                    pre_cm_anchor,
-                    TachygramSetPoly::from(stamps[cm_idx].as_slice()),
-                ),
-                boundary_chain,
-                nf_pcd,
-            )
-            .expect("SpendableInit");
 
         // If cm is the last stamp, post_cm_anchor is already the
         // block-final anchor — no rest-of-block lift needed.
@@ -894,6 +903,10 @@ fn walk_delegate_for_epoch(
         .expect("no delegate covers target_epoch")
         .clone();
     ggm_tools::walk_delegate_to_delegate_nullifier(rng, delegate, target_epoch)
+}
+
+fn epoch_first_of(epoch: EpochIndex) -> BlockHeight {
+    BlockHeight(epoch.0 * EPOCH_SIZE)
 }
 
 fn epoch_final_of(epoch: EpochIndex) -> BlockHeight {

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -11,7 +11,7 @@ use core::{cmp, iter, ops::RangeInclusive};
 
 use ff::Field as _;
 use pasta_curves::Fp;
-use ragu::{Pcd, Proof};
+use ragu::Pcd;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
@@ -329,6 +329,83 @@ pub(crate) fn build_anchor_chain_pcd(
     chain.expect("AnchorChain range must cover at least one block")
 }
 
+/// Build an [`AnchorChain`](pool::AnchorChain) rooted at the epoch boundary
+/// `B_E = prev_anchor_at(epoch_first)` and ending at `post_cm_anchor` — i.e.
+/// covering blocks `epoch_first..=cm_height`, with the final (cm) block
+/// truncated to its stamps `[0..=cm_idx]` so the cm-stamp is the chain's last
+/// absorbed link.
+///
+/// This is the boundary->cm segment [`spendable::SpendableInit`] consumes to pin
+/// the spendable's starting epoch. A note created first-in-epoch
+/// (`epoch_first == cm_height`, `cm_idx == 0`) yields a single-link chain, so no
+/// zero-length segment is ever needed.
+pub(crate) fn build_anchor_chain_prefix_pcd(
+    rng: &mut (impl RngCore + CryptoRng),
+    pool: &PoolSim,
+    epoch_first: BlockHeight,
+    cm_height: BlockHeight,
+    cm_idx: usize,
+) -> Pcd<pool::AnchorChain> {
+    assert_eq!(
+        epoch_first.epoch(),
+        cm_height.epoch(),
+        "prefix chain is single-epoch"
+    );
+    assert!(epoch_first <= cm_height);
+
+    let mut state = pool.prev_anchor_at(epoch_first);
+    let mut chain: Option<Pcd<pool::AnchorChain>> = None;
+    let mut height = epoch_first;
+    loop {
+        let commits = pool.stamp_commits_at(height);
+        if commits.is_empty() {
+            let next_state = state.next_empty();
+            let (seed, ()) = PROOF_SYSTEM
+                .seed(rng, pool::EmptyBlockSeed, (state,))
+                .expect("EmptyBlockSeed");
+            chain = Some(match chain.take() {
+                | None => seed,
+                | Some(left) => {
+                    let (fused, ()) = PROOF_SYSTEM
+                        .fuse(rng, pool::AnchorFuse, (), left, seed)
+                        .expect("AnchorFuse");
+                    fused
+                },
+            });
+            state = next_state;
+        } else {
+            // On the cm-block stop right after the cm-stamp; elsewhere absorb all.
+            let upto = if height == cm_height {
+                cm_idx + 1
+            } else {
+                commits.len()
+            };
+            for commit in &commits[..upto] {
+                let next_state = state.next_stamp(commit);
+                let (seed, ()) = PROOF_SYSTEM
+                    .seed(rng, pool::AnchorSeed, (state, *commit))
+                    .expect("AnchorSeed");
+                chain = Some(match chain.take() {
+                    | None => seed,
+                    | Some(left) => {
+                        let (fused, ()) = PROOF_SYSTEM
+                            .fuse(rng, pool::AnchorFuse, (), left, seed)
+                            .expect("AnchorFuse");
+                        fused
+                    },
+                });
+                state = next_state;
+            }
+        }
+        if height >= cm_height {
+            break;
+        }
+        height = height.next().expect("height < max");
+    }
+
+    chain.expect("prefix chain covers at least the cm-stamp")
+}
+
 pub(crate) fn build_unspent_seed_pcd(
     rng: &mut (impl RngCore + CryptoRng),
     start: Anchor,
@@ -527,20 +604,35 @@ impl WalletSim {
             .position(|tgs| tgs.contains(&cm.into()))
             .expect("cm not found in any stamp at the cm-block");
 
+        // Anchor immediately before the cm-stamp (the cm-block prefix fold).
         let pre_cm_anchor = stamp_commits[..cm_idx]
             .iter()
             .fold(pool.prev_anchor_at(height), Anchor::next_stamp);
+
+        // Root the lineage at the epoch boundary B_E. `prev_tip` is the prior
+        // epoch's terminal anchor (Fp::ZERO for the genesis epoch), so
+        // `prev_tip.next_epoch(E) == B_E == prev_anchor_at(epoch_first)`. The
+        // boundary->cm chain ends at `post_cm_anchor`.
+        let epoch = height.epoch();
+        let epoch_first = BlockHeight(epoch.0 * EPOCH_SIZE);
+        let pre_epoch_anchor = if epoch.0 == 0 {
+            Anchor::from(Fp::ZERO)
+        } else {
+            pool.anchor_at(BlockHeight(epoch_first.0 - 1))
+        };
+        let boundary_chain = build_anchor_chain_prefix_pcd(rng, pool, epoch_first, height, cm_idx);
 
         let (spendable, ()) = PROOF_SYSTEM
             .fuse(
                 rng,
                 spendable::SpendableInit,
                 (
+                    pre_epoch_anchor,
                     pre_cm_anchor,
                     TachygramSetPoly::from(stamps[cm_idx].as_slice()),
                 ),
+                boundary_chain,
                 nf_pcd,
-                Proof::trivial().carry::<()>(()),
             )
             .expect("SpendableInit");
 

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -14,7 +14,8 @@ use crate::{digest::poseidon, serialization};
 /// - [`Anchor::next_empty`] (`Tachyon-EmptyBlk`) advances through one block
 ///   that contains zero stamps, preserving per-height anchor uniqueness.
 /// - [`Anchor::next_epoch`] (`Tachyon-EpochStp`) lifts across an epoch
-///   boundary; performed by `SpendableRollover`.
+///   boundary; advanced by `SpendableRollover` and checked against a boundary
+///   chain's root by `SpendableInit`.
 ///
 /// Opening reveals each link's role by its domain.
 #[derive(Clone, Copy, Debug, Eq)]

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -28,14 +28,18 @@ use crate::{
 
 /// Anchor segment between two endpoints. Composable via [`AnchorFuse`].
 ///
-/// Direction-agnostic: `start` and `end` are both anchors. Consumed only
-/// by [`super::stamp::StampLift`] — extending a spendable's anchor must
-/// instead go through [`Unspent`] so each step proves nf-exclusion.
+/// Direction-agnostic: `start` and `end` are both anchors. Two consumers:
+/// [`super::stamp::StampLift`] advances a stamp's anchor, and
+/// [`super::spendable::SpendableInit`] consumes a boundary-rooted segment (from
+/// the epoch boundary through the cm-stamp) to pin a spendable's starting
+/// epoch. Extending an *existing* spendable's anchor must instead go through
+/// [`Unspent`] so each step proves nf-exclusion.
 ///
-/// Structurally intra-epoch because only intra-epoch [`Anchor::next_stamp`]
-/// is invoked anywhere in the [`AnchorChain`] builders — crossing an
-/// epoch boundary requires the [`Anchor::next_epoch`] domain only
-/// emitted by `SpendableRollover`.
+/// Structurally intra-epoch: the builders ([`AnchorSeed`] / [`EmptyBlockSeed`])
+/// invoke only [`Anchor::next_stamp`] / [`Anchor::next_empty`]. The
+/// [`Anchor::next_epoch`] boundary domain is never a chain link; it is produced
+/// by `SpendableRollover` and checked against a chain's `start` by
+/// [`super::spendable::SpendableInit`].
 ///
 /// The within-epoch property pairs with a consensus-side two-epoch
 /// tachygram scan that catches any tachygram already published earlier
@@ -44,8 +48,10 @@ use crate::{
 /// `start` at the seed steps ([`AnchorSeed`] / [`EmptyBlockSeed`]) has
 /// PCD lineage rooted in an unbound `start: Anchor` witness, so a
 /// standalone segment proves nothing about real coverage. Final binding
-/// closes when [`super::stamp::StampLift`] consumes the segment and the
-/// resulting stamp is accepted by consensus (anchor membership).
+/// closes through a consensus-published stamp's anchor membership:
+/// [`super::stamp::StampLift`] emits that stamp directly, while a segment
+/// consumed by [`super::spendable::SpendableInit`] binds only once the
+/// resulting (private) spendable is spent into a stamp.
 #[derive(Clone, Debug)]
 pub struct AnchorChain;
 

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -34,7 +34,7 @@ use ragu::{Header, Index, Step, Suffix};
 
 use super::{
     delegation::{DelegateNullifierHeader, NullifierHeader},
-    pool::Unspent,
+    pool::{AnchorChain, Unspent},
 };
 use crate::{
     note::Nullifier,
@@ -155,20 +155,23 @@ pub struct SpendableInit;
 
 impl Step for SpendableInit {
     type Aux<'source> = ();
-    type Left = NullifierHeader;
+    type Left = AnchorChain;
     type Output = SpendableHeader;
-    type Right = ();
-    /// `(pre_cm_anchor, stamp_tg_set)`.
-    type Witness<'source> = (Anchor, TachygramSetPoly);
+    type Right = NullifierHeader;
+    /// `(pre_epoch_anchor, pre_cm_anchor, stamp_tg_set)`. `pre_epoch_anchor` is
+    /// the prior epoch's terminal anchor (folded into the boundary);
+    /// `pre_cm_anchor` is the anchor immediately before the cm-stamp (the
+    /// chain's penultimate state).
+    type Witness<'source> = (Anchor, Anchor, TachygramSetPoly);
 
     const INDEX: Index = Index::new(13);
 
     fn witness<'source>(
         &self,
         ctx: &mut ragu::StepCtx<'_>,
-        (pre_cm_anchor, stamp_tg_set): Self::Witness<'source>,
-        (cm, nf, _epoch): <Self::Left as Header>::Data,
-        _right: <Self::Right as Header>::Data,
+        (pre_epoch_anchor, pre_cm_anchor, stamp_tg_set): Self::Witness<'source>,
+        (chain_start, chain_end): <Self::Left as Header>::Data,
+        (cm, nf, epoch): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         // Inclusion: cm ∈ set ⇔ the set polynomial vanishes at cm.
         let cm_point = Fp::from(cm);
@@ -178,7 +181,32 @@ impl Step for SpendableInit {
             return Err(ragu::Error("SpendableInit: commitment not in set"));
         }
         let stamp_commit = stamp_tg_set.commit();
+
+        // Pin the lineage's starting epoch to consensus. The boundary-rooted
+        // `AnchorChain` must root at the epoch boundary for the GGM-derived
+        // `epoch` (no longer discarded). `next_epoch` (`Tachyon-EpochStp`) is
+        // the sole epoch-folding domain and `AnchorChain` is intra-epoch by
+        // construction, so once consensus accepts the eventual spend anchor as a
+        // real epoch-E published value, collision/preimage resistance forces
+        // `epoch == E` (the same pin `SpendableRollover` applies at a crossing).
+        if chain_start != pre_epoch_anchor.next_epoch(epoch) {
+            return Err(ragu::Error(
+                "SpendableInit: chain not rooted at epoch boundary",
+            ));
+        }
+
+        // The cm-stamp is the chain's final link: `chain_end ==
+        // pre_cm_anchor.next_stamp(cm_commit)`. This ties the cm-inclusion to a
+        // real, consensus-pinned stamp and yields `post_cm_anchor` as the chain
+        // end, so a note created first-in-epoch needs only a single-link chain
+        // (`B_E -> B_E.next_stamp(cm)`) with no zero-length segment.
         let post_cm_anchor = pre_cm_anchor.next_stamp(&stamp_commit);
+        if chain_end != post_cm_anchor {
+            return Err(ragu::Error(
+                "SpendableInit: cm-stamp is not the chain's final link",
+            ));
+        }
+
         Ok(((nf, post_cm_anchor), ()))
     }
 }

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -1,28 +1,34 @@
 //! Spendable bootstrap, lift, and cross-epoch rollover.
 //!
 //! Bootstrap runs entirely on the user device. The wallet's
-//! [`NullifierHeader`] carries `(cm, nf, epoch)`; [`SpendableInit`]
-//! fuses it with a freely-witnessed `(pre_cm_anchor, stamp_tg_set)`,
-//! verifying `cm ∈ stamp_tg_set`, and emits a [`SpendableHeader`]
-//! carrying `(nf, post_cm_anchor)` — the running anchor immediately
-//! after the cm-stamp's absorption. The cm↔nf binding is structurally
-//! inherited through the [`NullifierHeader`] (GGM-bound). The wallet's
-//! epoch claim flows through `nf` itself, so no epoch alignment check
-//! is needed here.
+//! [`NullifierHeader`] carries `(cm, nf, epoch)`; [`SpendableInit`] fuses it
+//! with a boundary-rooted [`AnchorChain`] (the segment from the epoch boundary
+//! through the cm-stamp) plus a `(pre_epoch_anchor, pre_cm_anchor,
+//! stamp_tg_set)` witness. It verifies `cm ∈ stamp_tg_set`, requires the chain
+//! to root at `pre_epoch_anchor.next_epoch(epoch)`, requires the cm-stamp to be
+//! the chain's final link, and emits a [`SpendableHeader`] carrying
+//! `(nf, post_cm_anchor)`.
 //!
-//! `pre_cm_anchor` is freely witnessed at this step; the spendable
-//! reaches a real published anchor only by extending through
-//! [`SpendableLift`] over [`Unspent`] segments, which by construction
-//! prove nf-exclusion at every covered stamp. There is no path that
-//! advances a spendable's anchor without a per-stamp nf-check.
+//! Rooting the lineage at `next_epoch(epoch)` pins the GGM leaf index to the
+//! consensus epoch. The chain's `start` is
+//! `pre_epoch_anchor.next_epoch(epoch)`, which consensus anchor membership of
+//! the eventual spend anchor requires to be the real epoch boundary `B_E =
+//! (terminal of E-1).next_epoch(E)`. [`Anchor::next_epoch`] is the sole
+//! epoch-folding domain and an [`AnchorChain`] advances only within an epoch,
+//! so matching those two epoch-folded anchors forces `epoch == E`.
+//! [`SpendableRollover`] applies the same pin at a crossing.
+//!
+//! `pre_epoch_anchor` and `pre_cm_anchor` are witnessed but pinned downstream:
+//! `pre_epoch_anchor` yields a consensus-published anchor only when it is the
+//! real prior-epoch terminal, and the spendable reaches a real published anchor
+//! only by extending through [`SpendableLift`] over [`Unspent`] segments, which
+//! by construction prove nf-exclusion at every covered stamp.
 //!
 //! Sync services update spendables via lifts ([`SpendableLift`]) and
-//! cross-epoch rollovers ([`SpendableRollover`] →
-//! [`SpendableEpochLift`]). [`SpendableRollover`] is the only step that
-//! emits the [`Anchor::next_epoch`] boundary domain — it lifts the old
-//! epoch's terminal anchor into the new epoch's initial anchor, which
-//! the new-epoch [`Unspent`] then extends with ordinary per-stamp
-//! advances.
+//! cross-epoch rollovers ([`SpendableRollover`] then [`SpendableEpochLift`]).
+//! [`SpendableRollover`] lifts the old epoch's terminal anchor into the new
+//! epoch's initial anchor via the [`Anchor::next_epoch`] boundary domain, which
+//! the new-epoch [`Unspent`] then extends with ordinary per-stamp advances.
 
 extern crate alloc;
 
@@ -45,24 +51,21 @@ use crate::{
 /// encodes `(key, epoch)` via GGM determinism, so sync services can update
 /// a spendable by `nf` without knowing `delegation_id`.
 ///
-/// `anchor` at [`SpendableInit`] is computed in-circuit as
-/// `pre_cm_anchor.next_stamp(stamp_commit)`, but its PCD lineage roots
-/// in `SpendableInit`'s unbound `pre_cm_anchor: Anchor` witness.
-/// Binding on that witness closes only through subsequent
-/// [`SpendableLift`] steps over [`Unspent`] segments (each `Unspent`
-/// proves nf-exclusion at a real stamp), plus consensus anchor
-/// membership. There is no path that advances a spendable's anchor
-/// without a per-stamp nf-check.
+/// `anchor` at [`SpendableInit`] is the cm-stamp's `post_cm_anchor`, threaded
+/// from a boundary-rooted [`AnchorChain`] whose `start` is checked to equal
+/// `pre_epoch_anchor.next_epoch(epoch)`. Its PCD lineage therefore folds the
+/// GGM `epoch` at the boundary; binding closes through consensus anchor
+/// membership of the eventual spend anchor, plus the per-stamp nf-checks of any
+/// subsequent [`SpendableLift`] over [`Unspent`] segments.
 #[derive(Clone, Debug)]
 pub struct SpendableHeader;
 
 impl Header for SpendableHeader {
-    /// `(nf, anchor)`. `nf` is GGM-bound to `(note, epoch)` upstream
-    /// in [`super::delegation::NullifierHeader`]. `anchor` is computed
-    /// at [`SpendableInit`] as `pre_cm_anchor.next_stamp(stamp_commit)`
-    /// over a freely-witnessed `pre_cm_anchor`, then advanced over
-    /// [`Unspent`] segments at [`SpendableLift`] /
-    /// [`SpendableEpochLift`].
+    /// `(nf, anchor)`. `nf` is GGM-bound to `(note, epoch)` upstream in
+    /// [`super::delegation::NullifierHeader`]. `anchor` is the cm-stamp's
+    /// `post_cm_anchor`, computed at [`SpendableInit`] from a boundary-rooted
+    /// [`AnchorChain`], then advanced over [`Unspent`] segments at
+    /// [`SpendableLift`] / [`SpendableEpochLift`].
     type Data = (Nullifier, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(7);
@@ -121,10 +124,11 @@ pub struct SpendableRolloverHeader;
 
 impl Header for SpendableRolloverHeader {
     /// `(new_nf, boundary_anchor)`. `boundary_anchor` is computed at
-    /// [`SpendableRollover`] via `Anchor::next_epoch` on the
-    /// spendable's prior anchor, the only place the `Tachyon-EpochStp`
-    /// domain is invoked. The new-epoch [`Unspent`]'s `prev_anchor` is
-    /// the only way to discharge it.
+    /// [`SpendableRollover`] via `Anchor::next_epoch` on the spendable's prior
+    /// anchor. [`SpendableInit`] is the only other in-circuit caller of the
+    /// `Tachyon-EpochStp` domain (it checks a boundary chain's root rather than
+    /// advancing one). The new-epoch [`Unspent`]'s `prev_anchor` is the only
+    /// way to discharge it.
     type Data = (Nullifier, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(9);
@@ -137,19 +141,22 @@ impl Header for SpendableRolloverHeader {
     }
 }
 
-/// Bootstrap a [`SpendableHeader`] from the wallet's [`NullifierHeader`].
+/// Bootstrap a [`SpendableHeader`] from the wallet's [`NullifierHeader`] and a
+/// boundary-rooted [`AnchorChain`].
 ///
-/// Witness `(pre_cm_anchor, stamp_tg_set)`: verifies `cm ∈ stamp_tg_set`
-/// (cm comes from the left header) and emits a [`SpendableHeader`]
-/// carrying `(nf, pre_cm_anchor.next_stamp(commit))` — the running
-/// anchor immediately after the cm-stamp's absorption.
+/// Verifies `cm ∈ stamp_tg_set` (cm from the [`NullifierHeader`]), requires the
+/// chain to root at `pre_epoch_anchor.next_epoch(epoch)`, and requires the
+/// cm-stamp to be the chain's final link
+/// (`chain.end == pre_cm_anchor.next_stamp(commit)`). Emits a
+/// [`SpendableHeader`] carrying `(nf, post_cm_anchor)`.
 ///
-/// `pre_cm_anchor` is freely witnessed; the spendable reaches a real
-/// published anchor only by extending through [`SpendableLift`] over
-/// [`Unspent`] segments built from real stamps. The cm-block itself
-/// cannot contain the wallet's `nf` (`nf` is GGM-bound to `cm`), so no
-/// nf-exclusion check is needed at the cm-stamp; the wallet's epoch
-/// claim flows through `nf` (GGM-bound at the [`NullifierHeader`]).
+/// The boundary check pins the GGM leaf index to the consensus epoch: consensus
+/// anchor membership of the spend anchor requires `chain.start` to be the real
+/// epoch boundary `B_E`, and since `next_epoch` is the sole epoch-folding
+/// domain and the chain is intra-epoch, matching
+/// `pre_epoch_anchor.next_epoch(epoch)` against `B_E` forces `epoch == E`. The
+/// cm-block carries `cm`, not the wallet's `nf` (`nf` is GGM-bound to `cm`), so
+/// the cm-stamp needs no nf-exclusion check.
 #[derive(Debug)]
 pub struct SpendableInit;
 
@@ -182,12 +189,11 @@ impl Step for SpendableInit {
         }
         let stamp_commit = stamp_tg_set.commit();
 
-        // Pin the lineage's starting epoch to consensus. The boundary-rooted
-        // `AnchorChain` must root at the epoch boundary for the GGM-derived
-        // `epoch` (no longer discarded). `next_epoch` (`Tachyon-EpochStp`) is
-        // the sole epoch-folding domain and `AnchorChain` is intra-epoch by
-        // construction, so once consensus accepts the eventual spend anchor as a
-        // real epoch-E published value, collision/preimage resistance forces
+        // Pin the lineage's starting epoch to consensus. Consensus anchor
+        // membership of the eventual spend anchor requires `chain_start` to be
+        // the real epoch boundary. `next_epoch` (`Tachyon-EpochStp`) is the sole
+        // epoch-folding domain and the chain is intra-epoch, so matching
+        // `pre_epoch_anchor.next_epoch(epoch)` against that boundary forces
         // `epoch == E` (the same pin `SpendableRollover` applies at a crossing).
         if chain_start != pre_epoch_anchor.next_epoch(epoch) {
             return Err(ragu::Error(
@@ -198,8 +204,8 @@ impl Step for SpendableInit {
         // The cm-stamp is the chain's final link: `chain_end ==
         // pre_cm_anchor.next_stamp(cm_commit)`. This ties the cm-inclusion to a
         // real, consensus-pinned stamp and yields `post_cm_anchor` as the chain
-        // end, so a note created first-in-epoch needs only a single-link chain
-        // (`B_E -> B_E.next_stamp(cm)`) with no zero-length segment.
+        // end; a note created first-in-epoch produces a single-link chain
+        // (`B_E.next_stamp(cm)`).
         let post_cm_anchor = pre_cm_anchor.next_stamp(&stamp_commit);
         if chain_end != post_cm_anchor {
             return Err(ragu::Error(
@@ -317,9 +323,11 @@ impl Step for DelegateRolloverFuse {
 /// boundary_anchor)` for [`SpendableEpochLift`] to consume against a
 /// new-epoch [`Unspent`] whose `prev_anchor` equals this boundary.
 ///
-/// This is the only step in the proof tree that invokes the
-/// [`Anchor::next_epoch`] domain. `new_epoch` enters the boundary hash
-/// directly, so any tampered value diverges from the published anchor.
+/// This is the only step that *advances* a live spendable across a boundary
+/// via [`Anchor::next_epoch`]; [`SpendableInit`] also invokes that domain
+/// in-circuit, but to *check* a boundary chain's root rather than advance one.
+/// `new_epoch` enters the boundary hash directly, so any tampered value
+/// diverges from the published anchor.
 #[derive(Debug)]
 pub struct SpendableRollover;
 

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -17,11 +17,10 @@ use crate::{
     constants::EPOCH_SIZE,
     entropy::ActionEntropy,
     fixtures::{
-        PoolSim, SyncSim, WalletSim, build_anchor_chain_pcd, build_anchor_chain_prefix_pcd,
-        build_nullifier_rollover_pcd, build_output_stamp, build_unspent_pcd,
-        build_unspent_seed_pcd,
+        PoolSim, SyncSim, WalletSim, build_anchor_chain_pcd, build_nullifier_rollover_pcd,
+        build_output_stamp, build_unspent_pcd, build_unspent_seed_pcd,
         ggm_tools::{delegate_nullifier_from_master, delegate_range},
-        random_block, random_block_with, spend_witness,
+        random_block, random_block_with, spend_witness, spendable_init_inputs,
     },
     note::{self, Nullifier},
     primitives::{Anchor, BlockHeight, DelegationTrapdoor, EpochIndex, Tachygram, effect},
@@ -38,32 +37,20 @@ fn tg<RNG: RngCore + CryptoRng>(rng: &mut RNG) -> Tachygram {
     Tachygram::from(Fp::random(rng))
 }
 
-/// Drive a full same-epoch spend lineage for `note` at GGM leaf index `idx`,
-/// returning the published spend [`stamp::StampHeader`] PCD.
-///
-/// The spendable's `nf`, the [`spend::SpendBind`] pair, and the
-/// [`stamp::SpendStamp`] tie all share `idx`. After the base-case epoch pin in
-/// [`spendable::SpendableInit`], only `idx == cm_height.epoch()` bootstraps
-/// successfully — a wrong index fails the boundary check (see
-/// `same_epoch_spend_wrong_index_rejected`).
 fn same_epoch_spend_lineage(
     rng: &mut (impl RngCore + CryptoRng),
     user: &WalletSim,
     pool: &PoolSim,
     cm_height: BlockHeight,
     note: note::Note,
-    idx: u32,
 ) -> Pcd<stamp::StampHeader> {
-    let nf_for_init = user.nullifier_pcd(rng, note, EpochIndex(idx));
-    let spendable = user.spendable_init(rng, note, pool, cm_height, nf_for_init);
-
-    let (nf_now, nf_next) = user.nullifier_pair_pcd(rng, note, EpochIndex(idx));
-    let (rcv, _theta, alpha) = spend_witness(rng, &note);
+    let (spend_note, nf_now, nf_next, spendable) = user.fresh_spend(rng, pool, cm_height, note);
+    let (rcv, _theta, alpha) = spend_witness(rng, &spend_note);
     let (spend_pcd, ()) = PROOF_SYSTEM
         .fuse(
             rng,
             spend::SpendBind,
-            (rcv, alpha, user.pak, note),
+            (rcv, alpha, user.pak, spend_note),
             nf_now,
             nf_next,
         )
@@ -74,92 +61,117 @@ fn same_epoch_spend_lineage(
     stamp_pcd
 }
 
-/// After the base-case epoch pin, an honest same-epoch spend at the correct
-/// index `E` still builds and publishes its `{N_E, N_{E+1}}` pair. False-
-/// positive guard for the fix.
+fn mine_cm_in_epoch_one(
+    rng: &mut (impl RngCore + CryptoRng),
+    pool: &mut PoolSim,
+    cm: note::Commitment,
+) -> BlockHeight {
+    // Height EPOCH_SIZE is epoch 1's first block, carrying the real B_1 fold.
+    while pool.height().0 < EPOCH_SIZE {
+        pool.mine(random_block(rng, 1, 3));
+    }
+    pool.mine(random_block_with(rng, &[alloc::vec![cm]], 4));
+    let cm_height = pool.height();
+    assert_eq!(cm_height.epoch().0, 1, "cm-block is in epoch 1");
+    cm_height
+}
+
 #[test]
-fn same_epoch_spend_honest_index_stays_green() {
+fn same_epoch_honest_spend_accepted() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(rng, 500);
-    let cm = note.commitment();
+    let cm_height = mine_cm_in_epoch_one(rng, &mut pool, note.commitment());
+    let epoch = cm_height.epoch().0;
 
-    pool.mine(random_block_with(rng, &[alloc::vec![cm]], 4));
-    let cm_height = pool.height();
-    let e = cm_height.epoch().0;
-
-    let stamp = same_epoch_spend_lineage(rng, &user, &pool, cm_height, note, e);
-
+    let stamp = same_epoch_spend_lineage(rng, &user, &pool, cm_height, note);
     let expected = TachygramSetCommit::from(
         [
-            note.nullifier(&user.pak.nk, EpochIndex(e)).into(),
-            note.nullifier(&user.pak.nk, EpochIndex(e + 1)).into(),
+            note.nullifier(&user.pak.nk, EpochIndex(epoch)).into(),
+            note.nullifier(&user.pak.nk, EpochIndex(epoch + 1)).into(),
         ]
         .as_slice(),
     );
     assert_eq!(stamp.data().1, expected, "publishes {{N_E, N_E+1}}");
-
     PROOF_SYSTEM
         .rerandomize(stamp, rng)
         .expect("rerandomize honest same-epoch spend");
 }
 
-/// Regression guard for the same-epoch double-spend. A nullifier walked to the
-/// wrong index (`E + 2`) cannot bootstrap a spendable against a real epoch-`E`
-/// boundary chain: [`spendable::SpendableInit`] rejects because the chain roots
-/// at `B_E`, not `prev_tip.next_epoch(E + 2)`. Driven via a raw `fuse` so the
-/// `Err` surfaces (the `spendable_init` fixture would `.expect`).
 #[test]
-fn same_epoch_spend_wrong_index_rejected() {
+fn same_epoch_wrong_index_rejected_against_honest_chain() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(rng, 500);
-    let cm = note.commitment();
+    let cm_height = mine_cm_in_epoch_one(rng, &mut pool, note.commitment());
+    let wrong = cm_height.epoch().0 + 2;
 
-    pool.mine(random_block_with(rng, &[alloc::vec![cm]], 4));
-    let cm_height = pool.height();
-    let e = cm_height.epoch().0;
-    let wrong = e + 2;
-    assert!(wrong.abs_diff(e) >= 2);
-
-    // Reconstruct the honest epoch-E SpendableInit inputs (boundary chain rooted
-    // at B_E, real pre_cm_anchor)...
-    let stamps = pool.tachygrams_at(cm_height);
-    let stamp_commits = pool.stamp_commits_at(cm_height);
-    let cm_idx = stamps
-        .iter()
-        .position(|tgs| tgs.contains(&cm.into()))
-        .expect("cm present in cm-block");
-    let pre_cm_anchor = stamp_commits[..cm_idx]
-        .iter()
-        .fold(pool.prev_anchor_at(cm_height), Anchor::next_stamp);
-    let epoch_first = BlockHeight(e * EPOCH_SIZE);
-    let pre_epoch_anchor = if e == 0 {
-        Anchor::from(Fp::ZERO)
-    } else {
-        pool.anchor_at(BlockHeight(epoch_first.0 - 1))
-    };
-    let chain = build_anchor_chain_prefix_pcd(rng, &pool, epoch_first, cm_height, cm_idx);
-
-    // ...but feed a NullifierHeader walked to the wrong index.
+    let (pre_epoch_anchor, pre_cm_anchor, stamp_tg_set, chain) =
+        spendable_init_inputs(rng, &pool, note.commitment(), cm_height);
     let nf_wrong = user.nullifier_pcd(rng, note, EpochIndex(wrong));
     let err = PROOF_SYSTEM
         .fuse(
             rng,
             spendable::SpendableInit,
-            (
-                pre_epoch_anchor,
-                pre_cm_anchor,
-                TachygramSetPoly::from(stamps[cm_idx].as_slice()),
-            ),
+            (pre_epoch_anchor, pre_cm_anchor, stamp_tg_set),
             chain,
             nf_wrong,
         )
         .err()
         .unwrap();
     assert_eq!(err.0, "SpendableInit: chain not rooted at epoch boundary");
+}
+
+#[test]
+fn spendable_init_accepts_forged_chain() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(rng, 500);
+    let cm = note.commitment();
+    let cm_height = mine_cm_in_epoch_one(rng, &mut pool, cm);
+    let wrong = cm_height.epoch().0 + 2;
+
+    // Forge a boundary at the wrong epoch: `pre_epoch_anchor = x` (arbitrary), a
+    // chain seeded at `forged_start = x.next_epoch(wrong)` absorbing the real
+    // cm-stamp, and `pre_cm_anchor = forged_start` so `chain_end ==
+    // pre_cm_anchor.next_stamp(cm_commit)`. Both SpendableInit checks then pass.
+    let stamps = pool.tachygrams_at(cm_height);
+    let cm_idx = stamps
+        .iter()
+        .position(|tgs| tgs.contains(&cm.into()))
+        .expect("cm present in cm-block");
+    let x = Anchor::from(Fp::random(&mut *rng));
+    let forged_start = x.next_epoch(EpochIndex(wrong));
+    let cm_set = TachygramSetPoly::from(stamps[cm_idx].as_slice());
+    let cm_commit = cm_set.commit();
+    let (forged_chain, ()) = PROOF_SYSTEM
+        .seed(rng, pool::AnchorSeed, (forged_start, cm_commit))
+        .expect("AnchorSeed");
+
+    let nf_wrong = user.nullifier_pcd(rng, note, EpochIndex(wrong));
+    let (forged_spendable, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::SpendableInit,
+            (x, forged_start, cm_set),
+            forged_chain,
+            nf_wrong,
+        )
+        .expect("SpendableInit accepts the forged wrong-index chain");
+
+    // The circuit accepted, but the produced anchor is off the published sequence,
+    // so consensus anchor membership is what rejects the eventual spend.
+    let forged_anchor = forged_spendable.data().1;
+    assert_eq!(forged_anchor, forged_start.next_stamp(&cm_commit));
+    let forged_off_sequence =
+        (0..=cm_height.0).all(|height| pool.anchor_at(BlockHeight(height)) != forged_anchor);
+    assert!(
+        forged_off_sequence,
+        "forged wrong-index anchor must be absent from the published sequence"
+    );
 }
 
 #[test]
@@ -217,7 +229,8 @@ fn spend_bind_rejects_invalid_inputs() {
                 nf_pcd_l,
                 nf_pcd_r,
             )
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(
             err.0, "SpendBind: nullifiers not adjacent",
             "epochs {epoch_l:?} {epoch_r:?}"
@@ -245,7 +258,8 @@ fn spend_bind_rejects_invalid_inputs() {
                 nf_now,
                 nf_next,
             )
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "SpendBind: nullifiers not related");
     }
 
@@ -270,7 +284,8 @@ fn spend_bind_rejects_invalid_inputs() {
                 nf_now,
                 nf_next,
             )
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "SpendBind: nullifiers not related to note");
     }
 
@@ -297,7 +312,8 @@ fn spend_bind_rejects_invalid_inputs() {
                 nf_now,
                 nf_next,
             )
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "SpendBind: pak not related to note");
     }
 }
@@ -318,7 +334,8 @@ fn step_rejects_zero_value_note() {
     {
         let err = PROOF_SYSTEM
             .seed(rng, delegation::NfMasterSeed, (zero_note, user.pak))
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "NfMasterSeed: zero-value note");
     }
 
@@ -333,7 +350,8 @@ fn step_rejects_zero_value_note() {
                 stamp::OutputStamp,
                 (out_rcv, out_alpha, zero_note, out_anchor),
             )
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "OutputStamp: zero-value note");
     }
 
@@ -355,7 +373,8 @@ fn step_rejects_zero_value_note() {
                 nf_now_pcd,
                 nf_next_pcd,
             )
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "SpendBind: zero-value note");
 
         // this should also fail the commitment test
@@ -397,7 +416,8 @@ fn spend_stamp_rejects_identity_cv() {
 
     let err = PROOF_SYSTEM
         .fuse(rng, stamp::SpendStamp, (), forged_spend, spendable)
-        .err().unwrap();
+        .err()
+        .unwrap();
     assert_eq!(err.0, "SpendStamp: action digest construction failed");
 }
 
@@ -463,7 +483,8 @@ fn spendable_lift_rejects_invalid_inputs() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, spendable::SpendableLift, (), forged_spendable, unspent)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "SpendableLift: unspent not adjacent to spendable");
     }
 
@@ -496,7 +517,8 @@ fn spendable_lift_rejects_invalid_inputs() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, spendable::SpendableLift, (), spendable_a, unspent_b)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "SpendableLift: unspent does not relate to spendable");
     }
 }
@@ -539,7 +561,8 @@ fn unspent_seed_rejects_tg_present() {
 
     let err = PROOF_SYSTEM
         .seed(rng, pool::UnspentSeed, (start, containing_set, nf))
-        .err().unwrap();
+        .err()
+        .unwrap();
     assert_eq!(err.0, "UnspentSeed: found nullifier in set");
 }
 
@@ -564,7 +587,8 @@ fn delegate_rollover_fuse_rejects_invalid_inputs() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, spendable::DelegateRolloverFuse, (), nf_a, nf_b)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "DelegateRolloverFuse: nullifiers not related");
     }
 
@@ -582,7 +606,8 @@ fn delegate_rollover_fuse_rejects_invalid_inputs() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, spendable::DelegateRolloverFuse, (), nf_l, nf_r)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(
             err.0, "DelegateRolloverFuse: nullifiers not adjacent",
             "epochs {epoch_l:?} {epoch_r:?}"
@@ -617,7 +642,8 @@ fn spendable_rollover_rejects_nf_mismatch() {
             spendable_a,
             rollover_b,
         )
-        .err().unwrap();
+        .err()
+        .unwrap();
     assert_eq!(err.0, "SpendableRollover: nullifiers don't match");
 }
 
@@ -656,7 +682,8 @@ fn spendable_epoch_lift_rejects_invalid_inputs() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, spendable::SpendableEpochLift, (), rolled_a, unspent_b)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "SpendableEpochLift: nullifiers not related");
     }
 
@@ -697,7 +724,8 @@ fn spendable_epoch_lift_rejects_invalid_inputs() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, spendable::SpendableEpochLift, (), rolled_a, unspent)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(
             err.0,
             "SpendableEpochLift: unspent prev_anchor must equal rollover boundary_anchor"
@@ -719,7 +747,8 @@ fn rollover_fuse_rejects_invalid_inputs() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, spendable::RolloverFuse, (), nf_a, nf_b)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "RolloverFuse: nullifiers not related");
     }
 
@@ -734,7 +763,8 @@ fn rollover_fuse_rejects_invalid_inputs() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, spendable::RolloverFuse, (), nf_l, nf_r)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(
             err.0, "RolloverFuse: nullifiers not adjacent",
             "epochs {epoch_l:?} {epoch_r:?}"
@@ -758,7 +788,8 @@ fn unspent_fuse_rejects_invalid_compositions() {
         let shard_b = build_unspent_seed_pcd(rng, mid, &stamps_right, nf_b);
         let err = PROOF_SYSTEM
             .fuse(rng, pool::UnspentFuse, (), shard_a, shard_b)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "UnspentFuse: left and right must share the same nf");
     }
 
@@ -770,7 +801,8 @@ fn unspent_fuse_rejects_invalid_compositions() {
         let shard_b = build_unspent_seed_pcd(rng, start, &stamps_right, nf);
         let err = PROOF_SYSTEM
             .fuse(rng, pool::UnspentFuse, (), shard_a, shard_b)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "UnspentFuse: left.end must equal right.start");
     }
 }
@@ -793,7 +825,8 @@ fn anchor_chain_fuse_rejects_invalid_compositions() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, pool::AnchorFuse, (), left, right)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "AnchorFuse: segments not adjacent");
     }
 
@@ -817,7 +850,8 @@ fn anchor_chain_fuse_rejects_invalid_compositions() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, pool::AnchorFuse, (), left, right)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "AnchorFuse: segments not adjacent");
     }
 }
@@ -847,7 +881,8 @@ fn unspent_fuse_rejects_cross_pool_or_cross_epoch() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, pool::UnspentFuse, (), left, right)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "UnspentFuse: left.end must equal right.start");
     }
 
@@ -872,7 +907,8 @@ fn unspent_fuse_rejects_cross_pool_or_cross_epoch() {
 
         let err = PROOF_SYSTEM
             .fuse(rng, pool::UnspentFuse, (), left, right)
-            .err().unwrap();
+            .err()
+            .unwrap();
         assert_eq!(err.0, "UnspentFuse: left.end must equal right.start");
     }
 }

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -7,7 +7,7 @@ use alloc::vec;
 
 use ff::Field as _;
 use pasta_curves::Fp;
-use ragu::{Pcd, Proof};
+use ragu::Pcd;
 use rand::{SeedableRng as _, rngs::StdRng};
 use rand_core::{CryptoRng, RngCore};
 
@@ -17,8 +17,9 @@ use crate::{
     constants::EPOCH_SIZE,
     entropy::ActionEntropy,
     fixtures::{
-        PoolSim, SyncSim, WalletSim, build_anchor_chain_pcd, build_nullifier_rollover_pcd,
-        build_output_stamp, build_unspent_pcd, build_unspent_seed_pcd,
+        PoolSim, SyncSim, WalletSim, build_anchor_chain_pcd, build_anchor_chain_prefix_pcd,
+        build_nullifier_rollover_pcd, build_output_stamp, build_unspent_pcd,
+        build_unspent_seed_pcd,
         ggm_tools::{delegate_nullifier_from_master, delegate_range},
         random_block, random_block_with, spend_witness,
     },
@@ -37,14 +38,14 @@ fn tg<RNG: RngCore + CryptoRng>(rng: &mut RNG) -> Tachygram {
     Tachygram::from(Fp::random(rng))
 }
 
-/// Drive a full same-epoch spend lineage for `note` at a freely-chosen GGM
-/// leaf index `idx`, decoupled from the cm-block's real epoch.
+/// Drive a full same-epoch spend lineage for `note` at GGM leaf index `idx`,
+/// returning the published spend [`stamp::StampHeader`] PCD.
 ///
-/// Returns the published spend [`stamp::StampHeader`] PCD. This exercises the
-/// base-case epoch gap: [`spendable::SpendableInit`] discards the nullifier's
-/// epoch, so `idx` need not equal `cm_height.epoch()` — yet the lineage is
-/// internally consistent (the spendable's `nf`, the [`spend::SpendBind`] pair,
-/// and the [`stamp::SpendStamp`] tie all share `idx`).
+/// The spendable's `nf`, the [`spend::SpendBind`] pair, and the
+/// [`stamp::SpendStamp`] tie all share `idx`. After the base-case epoch pin in
+/// [`spendable::SpendableInit`], only `idx == cm_height.epoch()` bootstraps
+/// successfully — a wrong index fails the boundary check (see
+/// `same_epoch_spend_wrong_index_rejected`).
 fn same_epoch_spend_lineage(
     rng: &mut (impl RngCore + CryptoRng),
     user: &WalletSim,
@@ -73,67 +74,92 @@ fn same_epoch_spend_lineage(
     stamp_pcd
 }
 
-/// Demonstrates the same-epoch double-spend on the current tree: one note,
-/// created in epoch `E`, spent twice within `E` at two distinct GGM leaf
-/// indices `a`, `b` with `|a - b| >= 2`. Because [`spendable::SpendableInit`]
-/// discards the GGM epoch, both lineages are internally valid; the four
-/// published nullifiers are pairwise distinct, so the consensus two-epoch
-/// duplicate scan cannot relate them and accepts both spends.
-///
-/// This test PASSES on the unfixed tree (it is the vulnerability). After the
-/// base-case epoch pin lands, the wrong-index lineage can no longer be built;
-/// this test is then superseded by `same_epoch_spend_wrong_index_rejected`.
+/// After the base-case epoch pin, an honest same-epoch spend at the correct
+/// index `E` still builds and publishes its `{N_E, N_{E+1}}` pair. False-
+/// positive guard for the fix.
 #[test]
-fn same_epoch_double_spend_distinct_indices() {
+fn same_epoch_spend_honest_index_stays_green() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(rng, 500);
     let cm = note.commitment();
 
-    // One creation block carrying the note's cm, in epoch E.
     pool.mine(random_block_with(rng, &[alloc::vec![cm]], 4));
     let cm_height = pool.height();
     let e = cm_height.epoch().0;
 
-    // Two same-epoch lineages at distinct GGM leaf indices, |a - b| >= 2 so
-    // the published two-nullifier sets are disjoint (at |a-b|==1 the scan
-    // would relate lineage A's next-nf to lineage B's now-nf).
-    let a = e;
-    let b = e + 2;
-    assert!(b.abs_diff(a) >= 2, "indices must differ by >= 2");
+    let stamp = same_epoch_spend_lineage(rng, &user, &pool, cm_height, note, e);
 
-    let stamp_a = same_epoch_spend_lineage(rng, &user, &pool, cm_height, note, a);
-    let stamp_b = same_epoch_spend_lineage(rng, &user, &pool, cm_height, note, b);
+    let expected = TachygramSetCommit::from(
+        [
+            note.nullifier(&user.pak.nk, EpochIndex(e)).into(),
+            note.nullifier(&user.pak.nk, EpochIndex(e + 1)).into(),
+        ]
+        .as_slice(),
+    );
+    assert_eq!(stamp.data().1, expected, "publishes {{N_E, N_E+1}}");
 
-    // The four published nullifiers are pairwise distinct.
-    let nfs = [
-        note.nullifier(&user.pak.nk, EpochIndex(a)),
-        note.nullifier(&user.pak.nk, EpochIndex(a + 1)),
-        note.nullifier(&user.pak.nk, EpochIndex(b)),
-        note.nullifier(&user.pak.nk, EpochIndex(b + 1)),
-    ];
-    for i in 0..nfs.len() {
-        for j in (i + 1)..nfs.len() {
-            assert_ne!(nfs[i], nfs[j], "nullifiers {i} and {j} collide");
-        }
-    }
-
-    // Each spend publishes exactly its own disjoint two-nullifier set, so the
-    // two-epoch duplicate scan over published tachygrams finds no collision.
-    let set_a = TachygramSetCommit::from([nfs[0].into(), nfs[1].into()].as_slice());
-    let set_b = TachygramSetCommit::from([nfs[2].into(), nfs[3].into()].as_slice());
-    assert_eq!(stamp_a.data().1, set_a, "lineage A publishes {{N_a, N_a+1}}");
-    assert_eq!(stamp_b.data().1, set_b, "lineage B publishes {{N_b, N_b+1}}");
-    assert_ne!(stamp_a.data().1, stamp_b.data().1, "disjoint published sets");
-
-    // Both spends are fully valid proofs of the SAME note: a double-spend.
     PROOF_SYSTEM
-        .rerandomize(stamp_a, rng)
-        .expect("rerandomize lineage A");
-    PROOF_SYSTEM
-        .rerandomize(stamp_b, rng)
-        .expect("rerandomize lineage B");
+        .rerandomize(stamp, rng)
+        .expect("rerandomize honest same-epoch spend");
+}
+
+/// Regression guard for the same-epoch double-spend. A nullifier walked to the
+/// wrong index (`E + 2`) cannot bootstrap a spendable against a real epoch-`E`
+/// boundary chain: [`spendable::SpendableInit`] rejects because the chain roots
+/// at `B_E`, not `prev_tip.next_epoch(E + 2)`. Driven via a raw `fuse` so the
+/// `Err` surfaces (the `spendable_init` fixture would `.expect`).
+#[test]
+fn same_epoch_spend_wrong_index_rejected() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(rng, 500);
+    let cm = note.commitment();
+
+    pool.mine(random_block_with(rng, &[alloc::vec![cm]], 4));
+    let cm_height = pool.height();
+    let e = cm_height.epoch().0;
+    let wrong = e + 2;
+    assert!(wrong.abs_diff(e) >= 2);
+
+    // Reconstruct the honest epoch-E SpendableInit inputs (boundary chain rooted
+    // at B_E, real pre_cm_anchor)...
+    let stamps = pool.tachygrams_at(cm_height);
+    let stamp_commits = pool.stamp_commits_at(cm_height);
+    let cm_idx = stamps
+        .iter()
+        .position(|tgs| tgs.contains(&cm.into()))
+        .expect("cm present in cm-block");
+    let pre_cm_anchor = stamp_commits[..cm_idx]
+        .iter()
+        .fold(pool.prev_anchor_at(cm_height), Anchor::next_stamp);
+    let epoch_first = BlockHeight(e * EPOCH_SIZE);
+    let pre_epoch_anchor = if e == 0 {
+        Anchor::from(Fp::ZERO)
+    } else {
+        pool.anchor_at(BlockHeight(epoch_first.0 - 1))
+    };
+    let chain = build_anchor_chain_prefix_pcd(rng, &pool, epoch_first, cm_height, cm_idx);
+
+    // ...but feed a NullifierHeader walked to the wrong index.
+    let nf_wrong = user.nullifier_pcd(rng, note, EpochIndex(wrong));
+    let err = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spendable::SpendableInit,
+            (
+                pre_epoch_anchor,
+                pre_cm_anchor,
+                TachygramSetPoly::from(stamps[cm_idx].as_slice()),
+            ),
+            chain,
+            nf_wrong,
+        )
+        .err()
+        .unwrap();
+    assert_eq!(err.0, "SpendableInit: chain not rooted at epoch boundary");
 }
 
 #[test]
@@ -482,17 +508,22 @@ fn spendable_init_rejects_tg_absent() {
     let note = user.random_note(rng, 500);
 
     let absent_set = TachygramSetPoly::from([tg(rng)].as_slice());
-    let pre_cm_anchor = Anchor::default();
     let nf_pcd_absent = user.nullifier_pcd(rng, note, EpochIndex(0));
+    // cm-inclusion is checked first, so a dummy boundary chain suffices here.
+    let dummy_commit = TachygramSetCommit::from([tg(rng)].as_slice());
+    let (dummy_chain, ()) = PROOF_SYSTEM
+        .seed(rng, pool::AnchorSeed, (Anchor::default(), dummy_commit))
+        .expect("AnchorSeed");
     let err = PROOF_SYSTEM
         .fuse(
             rng,
             spendable::SpendableInit,
-            (pre_cm_anchor, absent_set),
+            (Anchor::default(), Anchor::default(), absent_set),
+            dummy_chain,
             nf_pcd_absent,
-            Proof::trivial().carry::<()>(()),
         )
-        .err().unwrap();
+        .err()
+        .unwrap();
     assert_eq!(err.0, "SpendableInit: commitment not in set");
 }
 

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -7,7 +7,7 @@ use alloc::vec;
 
 use ff::Field as _;
 use pasta_curves::Fp;
-use ragu::Proof;
+use ragu::{Pcd, Proof};
 use rand::{SeedableRng as _, rngs::StdRng};
 use rand_core::{CryptoRng, RngCore};
 
@@ -35,6 +35,105 @@ const NON_ADJACENT_EPOCH_PAIRS: &[(EpochIndex, EpochIndex)] = &[
 
 fn tg<RNG: RngCore + CryptoRng>(rng: &mut RNG) -> Tachygram {
     Tachygram::from(Fp::random(rng))
+}
+
+/// Drive a full same-epoch spend lineage for `note` at a freely-chosen GGM
+/// leaf index `idx`, decoupled from the cm-block's real epoch.
+///
+/// Returns the published spend [`stamp::StampHeader`] PCD. This exercises the
+/// base-case epoch gap: [`spendable::SpendableInit`] discards the nullifier's
+/// epoch, so `idx` need not equal `cm_height.epoch()` — yet the lineage is
+/// internally consistent (the spendable's `nf`, the [`spend::SpendBind`] pair,
+/// and the [`stamp::SpendStamp`] tie all share `idx`).
+fn same_epoch_spend_lineage(
+    rng: &mut (impl RngCore + CryptoRng),
+    user: &WalletSim,
+    pool: &PoolSim,
+    cm_height: BlockHeight,
+    note: note::Note,
+    idx: u32,
+) -> Pcd<stamp::StampHeader> {
+    let nf_for_init = user.nullifier_pcd(rng, note, EpochIndex(idx));
+    let spendable = user.spendable_init(rng, note, pool, cm_height, nf_for_init);
+
+    let (nf_now, nf_next) = user.nullifier_pair_pcd(rng, note, EpochIndex(idx));
+    let (rcv, _theta, alpha) = spend_witness(rng, &note);
+    let (spend_pcd, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spend::SpendBind,
+            (rcv, alpha, user.pak, note),
+            nf_now,
+            nf_next,
+        )
+        .expect("SpendBind");
+    let (stamp_pcd, ()) = PROOF_SYSTEM
+        .fuse(rng, stamp::SpendStamp, (), spend_pcd, spendable)
+        .expect("SpendStamp");
+    stamp_pcd
+}
+
+/// Demonstrates the same-epoch double-spend on the current tree: one note,
+/// created in epoch `E`, spent twice within `E` at two distinct GGM leaf
+/// indices `a`, `b` with `|a - b| >= 2`. Because [`spendable::SpendableInit`]
+/// discards the GGM epoch, both lineages are internally valid; the four
+/// published nullifiers are pairwise distinct, so the consensus two-epoch
+/// duplicate scan cannot relate them and accepts both spends.
+///
+/// This test PASSES on the unfixed tree (it is the vulnerability). After the
+/// base-case epoch pin lands, the wrong-index lineage can no longer be built;
+/// this test is then superseded by `same_epoch_spend_wrong_index_rejected`.
+#[test]
+fn same_epoch_double_spend_distinct_indices() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(rng, 500);
+    let cm = note.commitment();
+
+    // One creation block carrying the note's cm, in epoch E.
+    pool.mine(random_block_with(rng, &[alloc::vec![cm]], 4));
+    let cm_height = pool.height();
+    let e = cm_height.epoch().0;
+
+    // Two same-epoch lineages at distinct GGM leaf indices, |a - b| >= 2 so
+    // the published two-nullifier sets are disjoint (at |a-b|==1 the scan
+    // would relate lineage A's next-nf to lineage B's now-nf).
+    let a = e;
+    let b = e + 2;
+    assert!(b.abs_diff(a) >= 2, "indices must differ by >= 2");
+
+    let stamp_a = same_epoch_spend_lineage(rng, &user, &pool, cm_height, note, a);
+    let stamp_b = same_epoch_spend_lineage(rng, &user, &pool, cm_height, note, b);
+
+    // The four published nullifiers are pairwise distinct.
+    let nfs = [
+        note.nullifier(&user.pak.nk, EpochIndex(a)),
+        note.nullifier(&user.pak.nk, EpochIndex(a + 1)),
+        note.nullifier(&user.pak.nk, EpochIndex(b)),
+        note.nullifier(&user.pak.nk, EpochIndex(b + 1)),
+    ];
+    for i in 0..nfs.len() {
+        for j in (i + 1)..nfs.len() {
+            assert_ne!(nfs[i], nfs[j], "nullifiers {i} and {j} collide");
+        }
+    }
+
+    // Each spend publishes exactly its own disjoint two-nullifier set, so the
+    // two-epoch duplicate scan over published tachygrams finds no collision.
+    let set_a = TachygramSetCommit::from([nfs[0].into(), nfs[1].into()].as_slice());
+    let set_b = TachygramSetCommit::from([nfs[2].into(), nfs[3].into()].as_slice());
+    assert_eq!(stamp_a.data().1, set_a, "lineage A publishes {{N_a, N_a+1}}");
+    assert_eq!(stamp_b.data().1, set_b, "lineage B publishes {{N_b, N_b+1}}");
+    assert_ne!(stamp_a.data().1, stamp_b.data().1, "disjoint published sets");
+
+    // Both spends are fully valid proofs of the SAME note: a double-spend.
+    PROOF_SYSTEM
+        .rerandomize(stamp_a, rng)
+        .expect("rerandomize lineage A");
+    PROOF_SYSTEM
+        .rerandomize(stamp_b, rng)
+        .expect("rerandomize lineage B");
 }
 
 #[test]


### PR DESCRIPTION
`SpendableInit` accepted a freely-witnessed `pre_cm_anchor` with no constraint tying it to a specific epoch. The nullifier encodes an epoch index via the GGM leaf, but nothing in the proof forced that index to match the blockchain epoch where the note was created. A prover could walk a note to the wrong GGM epoch index and produce a valid-looking spendable proof, enabling a same-epoch spend with a mismatched nullifier.

`SpendableInit` now takes an `AnchorChain` input and a `pre_epoch_anchor` witness. This allows us to bind the epoch with `chain_start == pre_epoch_anchor.next_epoch(epoch)` and ensure the correct nullifier is derived.

### Changes

- `stamp/proof/spendable.rs` -- adds `AnchorChain` + `pre_epoch_anchor` parameters and constraints
- `stamp/proof/pool.rs` -- threads the new parameters through pool-level step construction
- `fixtures.rs` -- extends test fixtures to support the new parameters
- `stamp/proof/tests.rs` -- adds tests: honest spends at the correct epoch index pass; wrong-index attempts fail at the boundary check
- `book/src/proof-tree.md` -- documents the epoch-pin and cm-closure constraints

## Verification

- `just test` green
- `just lint` clean