### PR TITLE
Use `derive_more` to reduce boilerplate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "corez"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +157,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -794,6 +826,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "visibility"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +878,7 @@ version = "0.0.0"
 dependencies = [
  "blake2b_simd",
  "corez",
+ "derive_more",
  "ff",
  "group",
  "lazy_static",

--- a/crates/tachyon/Cargo.toml
+++ b/crates/tachyon/Cargo.toml
@@ -40,6 +40,9 @@ blake2b_simd = { version = "1.0", default-features = false }
 corez = { version = "0.1.1", default-features = false, features = [
     "alloc",
 ] }
+derive_more = { version = "~2.1", default-features = false, features = [
+    "full", # todo: use more specific features
+] }
 ff = "0.13"
 group = "0.13"
 lazy_static = { version = "1", default-features = false, features = [

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -2,7 +2,7 @@
 
 use core::marker::PhantomData;
 
-use derive_more::{Debug, Eq as TotalEq, PartialEq};
+use derive_more::{Debug, Display, Eq as TotalEq, PartialEq};
 
 use crate::{
     entropy::{ActionEntropy, ActionRandomizer},
@@ -112,7 +112,8 @@ impl Action {
 }
 
 /// A spend authorization signature (RedPallas over reddsa::ActionAuth).
-#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
+#[derive(Clone, Copy, Debug, Display, PartialEq, TotalEq)]
+#[display("Signature({:?})", self.0)]
 pub struct Signature(pub(crate) reddsa::Signature<reddsa::ActionAuth>);
 
 impl From<[u8; 64]> for Signature {

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -91,7 +91,7 @@ impl<E: Effect> Plan<E> {
 /// - `cv`: Commitment to a value effect
 /// - `rk`: Public key (randomized counterpart to `rsk`)
 /// - `sig`: Signature (by single-use `rsk`) over transaction sighash
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Action {
     /// Value commitment $\mathsf{cv} = [v]\,\mathcal{V}
     /// + [\mathsf{rcv}]\,\mathcal{R}$ (EpAffine).

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -2,6 +2,8 @@
 
 use core::marker::PhantomData;
 
+use derive_more::{Debug, Eq as TotalEq, PartialEq};
+
 use crate::{
     entropy::{ActionEntropy, ActionRandomizer},
     keys::{private, public},
@@ -89,7 +91,7 @@ impl<E: Effect> Plan<E> {
 /// - `cv`: Commitment to a value effect
 /// - `rk`: Public key (randomized counterpart to `rsk`)
 /// - `sig`: Signature (by single-use `rsk`) over transaction sighash
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq)]
 pub struct Action {
     /// Value commitment $\mathsf{cv} = [v]\,\mathcal{V}
     /// + [\mathsf{rcv}]\,\mathcal{R}$ (EpAffine).
@@ -110,7 +112,7 @@ impl Action {
 }
 
 /// A spend authorization signature (RedPallas over reddsa::ActionAuth).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Signature(pub(crate) reddsa::Signature<reddsa::ActionAuth>);
 
 impl From<[u8; 64]> for Signature {

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -62,9 +62,9 @@
 //! | `tachyonAggregateId`  | 64 bytes             | wtxid of the relevant aggregate          |
 
 use alloc::vec::Vec;
-use core::{error::Error, fmt};
 
 use corez::io::{self, Read, Write};
+use derive_more::{Debug, Display, Eq as TotalEq, Error, From, PartialEq};
 use pasta_curves::{Eq, Fp, group::Curve as _};
 use rand_core::{CryptoRng, RngCore};
 
@@ -81,7 +81,7 @@ use crate::{
 
 /// The `tachyonBundleState` wire byte. See the module-level wire format
 /// documentation for its role.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 #[repr(u8)]
 enum BundleState {
     NoBundle = 0b0000_0000u8,
@@ -97,12 +97,10 @@ impl BundleState {
             | 0b0000_0000u8 => Ok(Self::NoBundle),
             | 0b0000_0001u8 => Ok(Self::Stamped),
             | 0b0000_0010u8 => Ok(Self::Stripped),
-            | _other => {
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid bundle state",
-                ))
-            },
+            | _other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid bundle state",
+            )),
         }
     }
 
@@ -129,7 +127,7 @@ pub trait StampState: sealed::Sealed {}
 impl<T: sealed::Sealed> StampState for T {}
 
 /// A Tachyon transaction bundle parameterized by stamp state `S`.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, TotalEq, PartialEq)]
 pub struct Bundle<S: StampState> {
     /// Actions (cv, rk, sig).
     pub actions: Vec<Action>,
@@ -150,25 +148,13 @@ pub struct Bundle<S: StampState> {
 /// `auth_digest`, etc. The `Unproven` and `Stripped` intermediate states are
 /// outside this enum because they have no wire representation.
 #[expect(clippy::module_name_repetitions, reason = "intentional name")]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, From)]
 pub enum TachyonBundle {
     /// A bundle with its own stamp (autonome or aggregate).
     Stamped(Bundle<Stamp>),
     /// A bundle whose stamp has been stripped; carries a reference to the
     /// covering aggregate via its [`AggregateId`].
     Adjunct(Bundle<AggregateId>),
-}
-
-impl From<Bundle<Stamp>> for TachyonBundle {
-    fn from(bundle: Bundle<Stamp>) -> Self {
-        Self::Stamped(bundle)
-    }
-}
-
-impl From<Bundle<AggregateId>> for TachyonBundle {
-    fn from(bundle: Bundle<AggregateId>) -> Self {
-        Self::Adjunct(bundle)
-    }
 }
 
 impl TryFrom<TachyonBundle> for Bundle<Stamp> {
@@ -204,28 +190,19 @@ pub enum BuildError {
 }
 
 /// Errors that can occur while signing a bundle plan.
-#[derive(Debug)]
+#[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum SignError {
     /// The derived rk does not match the stored rk at this index.
-    RkMismatch(usize),
+    #[display("plan rk {_0:?} does not match")]
+    RkMismatch(#[error(not(source))] reddsa::VerificationKeyBytes<reddsa::ActionAuth>),
     /// The number of signatures does not match the number of actions.
+    #[display("signature count mismatch")]
     SigCountMismatch,
     /// An externally-provided signature is invalid at this index.
+    #[display("invalid action signature")]
     InvalidActionSignature,
 }
-
-impl fmt::Display for SignError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            | Self::RkMismatch(idx) => write!(f, "derived rk mismatch at action {idx}"),
-            | Self::SigCountMismatch => write!(f, "signature count mismatch"),
-            | Self::InvalidActionSignature => write!(f, "invalid action signature"),
-        }
-    }
-}
-
-impl Error for SignError {}
 
 /// A complete bundle plan, awaiting authorization.
 #[derive(Clone, Debug)]
@@ -364,12 +341,12 @@ impl Plan {
         let n_actions = self.spends.len() + self.outputs.len();
         let mut authorized = Vec::with_capacity(n_actions);
 
-        for (idx, plan) in self.spends.iter().enumerate() {
+        for plan in &self.spends {
             let cm = plan.note.commitment();
             let alpha = plan.theta.randomizer::<effect::Spend>(cm);
             let rsk = ask.derive_action_private(&alpha);
             if rsk.derive_action_public() != plan.rk {
-                return Err(SignError::RkMismatch(idx));
+                return Err(SignError::RkMismatch(plan.rk.0.into()));
             }
             authorized.push(Action {
                 cv: plan.cv(),
@@ -378,12 +355,12 @@ impl Plan {
             });
         }
 
-        for (idx, plan) in self.outputs.iter().enumerate() {
+        for plan in &self.outputs {
             let cm = plan.note.commitment();
             let alpha = plan.theta.randomizer::<effect::Output>(cm);
             let rsk = private::ActionSigningKey::new(&alpha);
             if rsk.derive_action_public() != plan.rk {
-                return Err(SignError::RkMismatch(self.spends.len() + idx));
+                return Err(SignError::RkMismatch(plan.rk.0.into()));
             }
             authorized.push(Action {
                 cv: plan.cv(),
@@ -754,7 +731,7 @@ impl<S: StampState> Bundle<S> {
 /// digest computed at the transaction layer. The validator checks:
 /// $\text{BindingSig.Validate}_{\mathsf{bvk}}(\mathsf{sighash},
 ///   \text{bindingSig}) = 1$
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Signature(pub(crate) reddsa::Signature<reddsa::BindingAuth>);
 
 impl From<[u8; 64]> for Signature {

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -97,10 +97,12 @@ impl BundleState {
             | 0b0000_0000u8 => Ok(Self::NoBundle),
             | 0b0000_0001u8 => Ok(Self::Stamped),
             | 0b0000_0010u8 => Ok(Self::Stripped),
-            | _other => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "invalid bundle state",
-            )),
+            | _other => {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid bundle state",
+                ))
+            },
         }
     }
 
@@ -193,15 +195,15 @@ pub enum BuildError {
 #[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum SignError {
-    /// The derived rk does not match the stored rk at this index.
+    /// The derived rk does not match the stored rk.
     #[display("plan rk {_0:?} does not match")]
     RkMismatch(#[error(not(source))] reddsa::VerificationKeyBytes<reddsa::ActionAuth>),
     /// The number of signatures does not match the number of actions.
-    #[display("signature count mismatch")]
-    SigCountMismatch,
-    /// An externally-provided signature is invalid at this index.
-    #[display("invalid action signature")]
-    InvalidActionSignature,
+    #[display("expected {_0} signatures")]
+    SigCountMismatch(#[error(not(source))] usize),
+    /// An externally-provided signature is invalid.
+    #[display("signature {:?} does not verify", _0)]
+    InvalidActionSignature(#[error(not(source))] action::Signature),
 }
 
 /// A complete bundle plan, awaiting authorization.
@@ -392,7 +394,7 @@ impl Plan {
     ) -> Result<Bundle<Unproven>, SignError> {
         let n_actions = self.spends.len() + self.outputs.len();
         if sigs.len() != n_actions {
-            return Err(SignError::SigCountMismatch);
+            return Err(SignError::SigCountMismatch(n_actions));
         }
 
         let mut authorized = Vec::with_capacity(n_actions);
@@ -403,7 +405,7 @@ impl Plan {
 
         for ((cv, rk), sig) in all_descriptors {
             if rk.verify(sighash, &sig).is_err() {
-                return Err(SignError::InvalidActionSignature);
+                return Err(SignError::InvalidActionSignature(sig));
             }
             authorized.push(Action { cv, rk, sig });
         }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -129,7 +129,7 @@ pub trait StampState: sealed::Sealed {}
 impl<T: sealed::Sealed> StampState for T {}
 
 /// A Tachyon transaction bundle parameterized by stamp state `S`.
-#[derive(Clone, Debug, TotalEq, PartialEq)]
+#[derive(Clone, Debug, PartialEq, TotalEq)]
 pub struct Bundle<S: StampState> {
     /// Actions (cv, rk, sig).
     pub actions: Vec<Action>,

--- a/crates/tachyon/src/entropy.rs
+++ b/crates/tachyon/src/entropy.rs
@@ -4,8 +4,9 @@
 //! Combined with a note commitment it deterministically derives an
 //! [`ActionRandomizer`].
 
-use core::{any::type_name, fmt, marker::PhantomData};
+use core::{any::type_name, marker::PhantomData};
 
+use derive_more::Debug;
 use pasta_curves::Fq;
 use rand_core::{CryptoRng, RngCore};
 
@@ -25,9 +26,9 @@ use crate::{note, primitives::Effect};
 /// (possibly untrusted) device constructs the proof later using $\theta$
 /// and $\mathsf{cm}$ to recover $\alpha$
 /// ("Tachyaction at a Distance", Bowe 2025).
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[expect(clippy::module_name_repetitions, reason = "intentional name")]
-pub struct ActionEntropy(pub(crate) [u8; 32]);
+pub struct ActionEntropy(#[debug(skip)] pub(crate) [u8; 32]);
 
 impl ActionEntropy {
     /// Parse action entropy from 32 bytes.
@@ -65,26 +66,13 @@ mod sealed {
 /// - [`ActionRandomizer<Spend>`]: $\mathsf{rsk} = \mathsf{ask} + \alpha$,
 ///   $\mathsf{rk} = \mathsf{ak} + [\alpha]\,\mathcal{G}$.
 /// - [`ActionRandomizer<Output>`]: $\mathsf{rsk} = \alpha$.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
+#[debug("ActionRandomizer<{}>", type_name::<S>())]
 pub struct ActionRandomizer<S: sealed::RandomizerState>(pub(crate) Fq, pub(crate) PhantomData<S>);
 
 impl<S: sealed::RandomizerState> From<ActionRandomizer<S>> for Fq {
     fn from(randomizer: ActionRandomizer<S>) -> Self {
         randomizer.0
-    }
-}
-
-impl fmt::Debug for ActionEntropy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ActionEntropy").finish_non_exhaustive()
-    }
-}
-
-impl<S: sealed::RandomizerState> fmt::Debug for ActionRandomizer<S> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ActionRandomizer")
-            .field("state", &type_name::<S>())
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/tachyon/src/keys/ggm.rs
+++ b/crates/tachyon/src/keys/ggm.rs
@@ -10,8 +10,9 @@
 //! `GGM_ARITY^GGM_DEPTH == GGM_MAX_INDEX + 1`.
 
 use alloc::vec::Vec;
-use core::{fmt, num::NonZeroU8, ops::RangeInclusive};
+use core::{num::NonZeroU8, ops::RangeInclusive};
 
+use derive_more::{Debug, Eq as TotalEq, PartialEq};
 use pasta_curves::Fp;
 
 use crate::{constants::EPOCH_MAX, digest::poseidon, note::Nullifier, primitives::EpochIndex};
@@ -56,8 +57,8 @@ pub const GGM_TREE_DEPTH: u8 = GGM_MAX_INDEX.trailing_ones() as u8 / GGM_CHUNK_S
 ///              ├── nf = F_mk(flavor)     nullifier for a specific epoch
 ///              └── psi_t = GGM(mk, t)    prefix key for epochs e ≤ t (OSS)
 /// ```
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct NoteMasterKey(pub(crate) Fp);
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
+pub struct NoteMasterKey(#[debug(skip)] pub(crate) Fp);
 
 impl NoteMasterKey {
     /// Descend one level from the root of the GGM tree.
@@ -113,9 +114,10 @@ impl NoteMasterKey {
 /// At depth `d` there are `GGM_ARITY^d` nodes. Node `i` covers the contiguous
 /// epoch range of size `GGM_ARITY^(GGM_DEPTH - d)`. At depth
 /// `GGM_DEPTH`, a key is a leaf whose `index` equals its single epoch.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct NotePrefixedKey {
     /// GGM tree node value.
+    #[debug(skip)]
     pub(crate) inner: Fp,
     /// The number of levels already descended.
     pub(crate) depth: NonZeroU8,
@@ -263,21 +265,6 @@ fn ggm_walk(node: Fp, leaf: u32, remaining: u8) -> Fp {
             let chunk = u8::try_from(chunk_u32).expect("chunk fits in u8");
             ggm_walk(ggm_step(node, chunk), leaf, next)
         },
-    }
-}
-
-impl fmt::Debug for NoteMasterKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NoteMasterKey").finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for NotePrefixedKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NotePrefixedKey")
-            .field("depth", &self.depth)
-            .field("index", &self.index)
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -1,7 +1,6 @@
 //! Note-related keys: NullifierKey, PaymentKey.
 
-use core::fmt;
-
+use derive_more::Debug;
 use ff::PrimeField as _;
 use pasta_curves::Fp;
 
@@ -32,8 +31,8 @@ use crate::{digest::poseidon, note};
 /// `nk` alone does NOT confer spend authority — combined with `ak` it
 /// forms the proof authorizing key `pak`, enabling proof construction
 /// and nullifier derivation without signing capability.
-#[derive(Clone, Copy)]
-pub struct NullifierKey(pub(super) Fp);
+#[derive(Clone, Copy, Debug)]
+pub struct NullifierKey(#[debug(skip)] pub(super) Fp);
 
 impl NullifierKey {
     /// Derive a note's GGM master root from its nullifier trapdoor `psi`.
@@ -76,9 +75,9 @@ impl NullifierKey {
 /// note commitment. It is NOT an on-chain address; payment coordination
 /// happens out-of-band via higher-level protocols (ZIP 321 payment
 /// requests, ZIP 324 URI encapsulated payments).
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]
-pub struct PaymentKey(pub(crate) Fp);
+pub struct PaymentKey(#[debug(skip)] pub(crate) Fp);
 
 impl PaymentKey {
     /// Derive the payment key from `ak` and `nk`:
@@ -89,18 +88,6 @@ impl PaymentKey {
         let ak_bytes: [u8; 32] = ak.0.into();
         let ak_fp = Fp::from_repr(ak_bytes).expect("ak bytes should be a valid Fp");
         Self(poseidon::payment_key(ak_fp, nk.0))
-    }
-}
-
-impl fmt::Debug for NullifierKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NullifierKey").finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for PaymentKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PaymentKey").finish_non_exhaustive()
     }
 }
 

--- a/crates/tachyon/src/keys/private.rs
+++ b/crates/tachyon/src/keys/private.rs
@@ -1,7 +1,8 @@
 //! Private (signing) keys.
 
-use core::{any::type_name, fmt, marker::PhantomData};
+use core::marker::PhantomData;
 
+use derive_more::{Debug, From};
 use ff::{Field as _, FromUniformBytes as _, PrimeField as _};
 use pasta_curves::{Fp, Fq};
 use rand_core::{CryptoRng, RngCore};
@@ -34,14 +35,8 @@ use crate::{
 /// - [`derive_payment_key`](Self::derive_payment_key) → [`PaymentKey`] (`pk`)
 /// - [`derive_proof_private`](Self::derive_proof_private) →
 ///   [`ProofAuthorizingKey`] (`ak` + `nk`)
-#[derive(Clone, Copy)]
-pub struct SpendingKey([u8; 32]);
-
-impl From<[u8; 32]> for SpendingKey {
-    fn from(bytes: [u8; 32]) -> Self {
-        Self(bytes)
-    }
-}
+#[derive(Clone, Copy, Debug, From)]
+pub struct SpendingKey(#[debug(skip)] [u8; 32]);
 
 impl SpendingKey {
     /// Create a new spending key from 32 bytes of random data.
@@ -158,8 +153,8 @@ impl SpendingKey {
 /// `ask` derives [`SpendValidatingKey`](super::proof::SpendValidatingKey)
 /// (`ak`) via [`derive_auth_public`](Self::derive_auth_public) — the
 /// circuit witness that validates spend authorization.
-#[derive(Clone, Copy)]
-pub struct SpendAuthorizingKey(reddsa::SigningKey<reddsa::ActionAuth>);
+#[derive(Clone, Copy, Debug)]
+pub struct SpendAuthorizingKey(#[debug(skip)] reddsa::SigningKey<reddsa::ActionAuth>);
 
 impl SpendAuthorizingKey {
     /// Derive the spend validating (public) key: `ak = [ask]G`.
@@ -193,8 +188,11 @@ impl SpendAuthorizingKey {
 ///
 /// Both variants sign via [`sign`](Self::sign) and derive `rk` via
 /// [`derive_action_public`](Self::derive_action_public).
-#[derive(Clone, Copy)]
-pub struct ActionSigningKey<E: Effect>(reddsa::SigningKey<reddsa::ActionAuth>, PhantomData<E>);
+#[derive(Clone, Copy, Debug)]
+pub struct ActionSigningKey<E: Effect>(
+    #[debug(skip)] reddsa::SigningKey<reddsa::ActionAuth>,
+    PhantomData<E>,
+);
 
 impl<E: Effect> ActionSigningKey<E> {
     /// Sign a transaction sighash with this action key.
@@ -249,8 +247,8 @@ impl ActionSigningKey<effect::Output> {
 /// commitment (and commitments from other pools). The stamp is
 /// excluded from the bundle commitment because it is stripped during
 /// aggregation.
-#[derive(Clone, Copy)]
-pub struct BindingSigningKey(reddsa::SigningKey<reddsa::BindingAuth>);
+#[derive(Clone, Copy, Debug)]
+pub struct BindingSigningKey(#[debug(skip)] reddsa::SigningKey<reddsa::BindingAuth>);
 
 impl BindingSigningKey {
     /// Attempt to parse a binding signing key from 32 bytes.
@@ -296,32 +294,5 @@ impl From<&[value::CommitmentTrapdoor]> for BindingSigningKey {
             reddsa::SigningKey::<reddsa::BindingAuth>::try_from(sum.to_repr())
                 .expect("all Fq are valid RedPallas signing keys"),
         )
-    }
-}
-
-impl fmt::Debug for SpendingKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SpendingKey").finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for SpendAuthorizingKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SpendAuthorizingKey")
-            .finish_non_exhaustive()
-    }
-}
-
-impl<E: Effect> fmt::Debug for ActionSigningKey<E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ActionSigningKey")
-            .field("effect", &type_name::<E>())
-            .finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for BindingSigningKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BindingSigningKey").finish_non_exhaustive()
     }
 }

--- a/crates/tachyon/src/keys/proof.rs
+++ b/crates/tachyon/src/keys/proof.rs
@@ -1,6 +1,6 @@
 //! Proof-related keys: ProofAuthorizingKey.
 
-use core::fmt;
+use derive_more::Debug;
 
 use super::{
     note::{NullifierKey, PaymentKey},
@@ -25,11 +25,13 @@ use crate::{entropy::ActionRandomizer, primitives::effect, reddsa};
 /// specified.
 // TODO: add proof-construction methods (e.g., create_action_proof, create_merge_proof)
 // once the Ragu circuit API is available.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ProofAuthorizingKey {
     /// The spend validating key `ak = [ask] G`.
+    #[debug(skip)]
     pub ak: SpendValidatingKey,
     /// The nullifier deriving key.
+    #[debug(skip)]
     pub nk: NullifierKey,
 }
 
@@ -56,8 +58,10 @@ impl ProofAuthorizingKey {
 /// per-action `rk` for the proof witness. Component of
 /// [`ProofAuthorizingKey`](super::ProofAuthorizingKey) for proof authorization
 /// without spend authority.
-#[derive(Clone, Copy)]
-pub struct SpendValidatingKey(pub(crate) reddsa::VerificationKey<reddsa::ActionAuth>);
+#[derive(Clone, Copy, Debug)]
+pub struct SpendValidatingKey(
+    #[debug(skip)] pub(crate) reddsa::VerificationKey<reddsa::ActionAuth>,
+);
 
 impl SpendValidatingKey {
     /// Derive the per-action public (verification) key: $\mathsf{rk} =
@@ -80,18 +84,5 @@ impl SpendValidatingKey {
         alpha: &ActionRandomizer<effect::Spend>,
     ) -> public::ActionVerificationKey {
         public::ActionVerificationKey(self.0.randomize(&alpha.0))
-    }
-}
-
-impl fmt::Debug for ProofAuthorizingKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ProofAuthorizingKey")
-            .finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for SpendValidatingKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SpendValidatingKey").finish_non_exhaustive()
     }
 }

--- a/crates/tachyon/src/keys/public.rs
+++ b/crates/tachyon/src/keys/public.rs
@@ -46,9 +46,7 @@ impl TryFrom<[u8; 32]> for ActionVerificationKey {
     type Error = reddsa::Error;
 
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        Ok(Self(
-            reddsa::VerificationKey::<reddsa::ActionAuth>::try_from(bytes)?,
-        ))
+        reddsa::VerificationKey::<reddsa::ActionAuth>::try_from(bytes).map(Self)
     }
 }
 

--- a/crates/tachyon/src/keys/public.rs
+++ b/crates/tachyon/src/keys/public.rs
@@ -24,8 +24,10 @@ use crate::{action, action::Action, bundle, reddsa, value};
 /// This unification lets consensus treat all actions identically while
 /// the type system enforces the authority boundary at construction time.
 #[derive(Clone, Copy, Debug, Display, PartialEq)]
-#[display("ActionVerificationKey({:?})", <[u8; 32]>::from(self.0))]
+#[display("ActionVerificationKey({:?})", reddsa::VerificationKeyBytes::from(self.0))]
 pub struct ActionVerificationKey(pub(crate) reddsa::VerificationKey<reddsa::ActionAuth>);
+
+impl CoreTotalEq for ActionVerificationKey {}
 
 impl ActionVerificationKey {
     /// Verify an action signature against a transaction sighash.
@@ -33,8 +35,6 @@ impl ActionVerificationKey {
         self.0.verify(sighash, &sig.0)
     }
 }
-
-impl CoreTotalEq for ActionVerificationKey {}
 
 impl From<ActionVerificationKey> for [u8; 32] {
     fn from(avk: ActionVerificationKey) -> Self {
@@ -104,10 +104,11 @@ pub fn derive_bvk(
 ///
 /// Wraps `reddsa::VerificationKey<reddsa::BindingAuth>`, which internally
 /// stores a Pallas curve point (EpAffine, encoded as 32 compressed bytes).
-#[derive(Clone, Copy, Debug)]
-pub struct BindingVerificationKey(
-    #[debug(skip)] pub(super) reddsa::VerificationKey<reddsa::BindingAuth>,
-);
+#[derive(Clone, Copy, Debug, Display, PartialEq)]
+#[display("BindingVerificationKey({:?})", reddsa::VerificationKeyBytes::from(self.0))]
+pub struct BindingVerificationKey(pub(super) reddsa::VerificationKey<reddsa::BindingAuth>);
+
+impl CoreTotalEq for BindingVerificationKey {}
 
 impl BindingVerificationKey {
     /// Derive the binding verification key from public action data.
@@ -141,19 +142,3 @@ impl From<EpAffine> for BindingVerificationKey {
         )
     }
 }
-
-#[expect(
-    clippy::missing_trait_methods,
-    reason = "default ne/assert impls are correct"
-)]
-impl PartialEq for BindingVerificationKey {
-    fn eq(&self, other: &Self) -> bool {
-        <[u8; 32]>::from(self.0) == <[u8; 32]>::from(other.0)
-    }
-}
-
-#[expect(
-    clippy::missing_trait_methods,
-    reason = "default assert_receiver_is_total_eq is correct"
-)]
-impl Eq for BindingVerificationKey {}

--- a/crates/tachyon/src/keys/public.rs
+++ b/crates/tachyon/src/keys/public.rs
@@ -1,7 +1,8 @@
 //! Public (verification) keys.
 
-use core::fmt;
+use core::cmp::Eq as CoreTotalEq;
 
+use derive_more::{Debug, Display, PartialEq};
 use pasta_curves::{EpAffine, group::GroupEncoding as _};
 
 use crate::{action, action::Action, bundle, reddsa, value};
@@ -22,7 +23,8 @@ use crate::{action, action::Action, bundle, reddsa, value};
 ///
 /// This unification lets consensus treat all actions identically while
 /// the type system enforces the authority boundary at construction time.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, Display, PartialEq)]
+#[display("ActionVerificationKey({:?})", <[u8; 32]>::from(self.0))]
 pub struct ActionVerificationKey(pub(crate) reddsa::VerificationKey<reddsa::ActionAuth>);
 
 impl ActionVerificationKey {
@@ -32,11 +34,7 @@ impl ActionVerificationKey {
     }
 }
 
-#[expect(
-    clippy::missing_trait_methods,
-    reason = "default assert_receiver_is_total_eq is correct"
-)]
-impl Eq for ActionVerificationKey {}
+impl CoreTotalEq for ActionVerificationKey {}
 
 impl From<ActionVerificationKey> for [u8; 32] {
     fn from(avk: ActionVerificationKey) -> Self {
@@ -48,7 +46,9 @@ impl TryFrom<[u8; 32]> for ActionVerificationKey {
     type Error = reddsa::Error;
 
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        reddsa::VerificationKey::<reddsa::ActionAuth>::try_from(bytes).map(Self)
+        Ok(Self(
+            reddsa::VerificationKey::<reddsa::ActionAuth>::try_from(bytes)?,
+        ))
     }
 }
 
@@ -104,8 +104,10 @@ pub fn derive_bvk(
 ///
 /// Wraps `reddsa::VerificationKey<reddsa::BindingAuth>`, which internally
 /// stores a Pallas curve point (EpAffine, encoded as 32 compressed bytes).
-#[derive(Clone, Copy)]
-pub struct BindingVerificationKey(pub(super) reddsa::VerificationKey<reddsa::BindingAuth>);
+#[derive(Clone, Copy, Debug)]
+pub struct BindingVerificationKey(
+    #[debug(skip)] pub(super) reddsa::VerificationKey<reddsa::BindingAuth>,
+);
 
 impl BindingVerificationKey {
     /// Derive the binding verification key from public action data.
@@ -155,17 +157,3 @@ impl PartialEq for BindingVerificationKey {
     reason = "default assert_receiver_is_total_eq is correct"
 )]
 impl Eq for BindingVerificationKey {}
-
-impl fmt::Debug for ActionVerificationKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ActionVerificationKey")
-            .finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for BindingVerificationKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BindingVerificationKey")
-            .finish_non_exhaustive()
-    }
-}

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -172,7 +172,7 @@ impl Note {
 /// the value that becomes a tachygram:
 /// - For **output** operations, `cm` IS the tachygram directly.
 /// - For **spend** operations, `cm` is a private witness.
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct Commitment(#[debug(skip)] Fp);
 
 impl From<Commitment> for Tachygram {
@@ -191,7 +191,7 @@ impl From<Commitment> for Tachygram {
 /// - Don't need collision resistance (no faerie gold defense)
 /// - Have an epoch "flavor" component for sync delegation
 /// - Are prunable by validators after a window of blocks
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct Nullifier(#[debug(skip)] Fp);
 
 impl From<Nullifier> for Tachygram {

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -33,8 +33,7 @@
 //! enters the polynomial accumulator. The concrete commitment scheme
 //! (e.g. Sinsemilla, Poseidon) depends on what is efficient inside
 //! Ragu circuits and is TBD.
-use core::fmt;
-
+use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use ff::Field as _;
 use pasta_curves::Fp;
 use rand_core::{CryptoRng, RngCore};
@@ -51,9 +50,9 @@ use crate::{
 /// Used to derive the master root key: $mk = \text{KDF}(\psi, nk)$.
 /// The GGM tree PRF then evaluates $nf = F_{mk}(\text{flavor})$.
 /// Prefix keys derived from $mk$ enable range-restricted delegation.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, From, Into)]
 #[expect(clippy::field_scoped_visibility_modifiers, reason = "for internal use")]
-pub struct NullifierTrapdoor(pub(super) Fp);
+pub struct NullifierTrapdoor(#[debug(skip)] pub(super) Fp);
 
 impl NullifierTrapdoor {
     /// Generate a fresh random trapdoor.
@@ -62,41 +61,17 @@ impl NullifierTrapdoor {
     }
 }
 
-impl From<Fp> for NullifierTrapdoor {
-    fn from(fp: Fp) -> Self {
-        Self(fp)
-    }
-}
-
-impl From<NullifierTrapdoor> for Fp {
-    fn from(trapdoor: NullifierTrapdoor) -> Self {
-        trapdoor.0
-    }
-}
-
 /// Note commitment trapdoor ($rcm$) — randomness that blinds the note
 /// commitment.
 ///
 /// Can be derived from a shared secret negotiated out-of-band.
-#[derive(Clone, Copy)]
-pub struct CommitmentTrapdoor(Fp);
+#[derive(Clone, Copy, Debug, From, Into)]
+pub struct CommitmentTrapdoor(#[debug(skip)] Fp);
 
 impl CommitmentTrapdoor {
     /// Generate a fresh random trapdoor.
     pub fn random<RNG: RngCore + CryptoRng>(rng: &mut RNG) -> Self {
         Self(Fp::random(rng))
-    }
-}
-
-impl From<Fp> for CommitmentTrapdoor {
-    fn from(fp: Fp) -> Self {
-        Self(fp)
-    }
-}
-
-impl From<CommitmentTrapdoor> for Fp {
-    fn from(trapdoor: CommitmentTrapdoor) -> Self {
-        trapdoor.0
     }
 }
 
@@ -128,7 +103,7 @@ pub struct Note {
 /// compiler cannot prove the invariant from inside the circuit, and a
 /// compiled proof system sees only raw field elements without the
 /// Rust-level newtype protection.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Into)]
 #[expect(
     clippy::field_scoped_visibility_modifiers,
     reason = "test helpers use crate-internal construction to bypass the API check"
@@ -150,12 +125,6 @@ impl From<u64> for Value {
 impl From<Value> for i64 {
     fn from(value: Value) -> Self {
         Self::try_from(value.0).expect("note value should fit in i64 (max 2.1e15 < i64::MAX)")
-    }
-}
-
-impl From<Value> for u64 {
-    fn from(value: Value) -> Self {
-        value.0
     }
 }
 
@@ -203,20 +172,8 @@ impl Note {
 /// the value that becomes a tachygram:
 /// - For **output** operations, `cm` IS the tachygram directly.
 /// - For **spend** operations, `cm` is a private witness.
-#[derive(Clone, Copy, Eq, PartialEq)]
-pub struct Commitment(Fp);
-
-impl From<Fp> for Commitment {
-    fn from(fp: Fp) -> Self {
-        Self(fp)
-    }
-}
-
-impl From<Commitment> for Fp {
-    fn from(cm: Commitment) -> Self {
-        cm.0
-    }
-}
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+pub struct Commitment(#[debug(skip)] Fp);
 
 impl From<Commitment> for Tachygram {
     fn from(commitment: Commitment) -> Self {
@@ -234,48 +191,12 @@ impl From<Commitment> for Tachygram {
 /// - Don't need collision resistance (no faerie gold defense)
 /// - Have an epoch "flavor" component for sync delegation
 /// - Are prunable by validators after a window of blocks
-#[derive(Clone, Copy, Eq, PartialEq)]
-pub struct Nullifier(Fp);
-
-impl From<Fp> for Nullifier {
-    fn from(fp: Fp) -> Self {
-        Self(fp)
-    }
-}
-
-impl From<Nullifier> for Fp {
-    fn from(nf: Nullifier) -> Self {
-        nf.0
-    }
-}
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+pub struct Nullifier(#[debug(skip)] Fp);
 
 impl From<Nullifier> for Tachygram {
     fn from(nullifier: Nullifier) -> Self {
         Self::from(nullifier.0)
-    }
-}
-
-impl fmt::Debug for NullifierTrapdoor {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NullifierTrapdoor").finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for CommitmentTrapdoor {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CommitmentTrapdoor").finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for Commitment {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Commitment").finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for Nullifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Nullifier").finish_non_exhaustive()
     }
 }
 

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -1,5 +1,4 @@
-use core::{error::Error, fmt};
-
+use derive_more::{Debug, Display, Eq as TotalEq, Error, From, Into, PartialEq};
 use ff::PrimeField as _;
 use pasta_curves::{EpAffine, Fp, arithmetic::CurveAffine as _};
 
@@ -10,28 +9,19 @@ use crate::{digest::poseidon, keys::public, value};
 /// Each action produces one digest, which serves as a root in the
 /// accumulator polynomial. Multiple actions are accumulated via
 /// polynomial commitment, not on this type.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
 pub struct ActionDigest(Fp);
 
 /// Errors from action digest computation.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Display, Error)]
 pub enum ActionDigestError {
     /// The cv is the identity point, so the digest cannot be computed.
+    #[display("cv is the identity point")]
     IdentityCv,
     /// The rk is the identity point, so the digest cannot be computed.
+    #[display("rk is the identity point")]
     IdentityRk,
 }
-
-impl fmt::Display for ActionDigestError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            | Self::IdentityCv => write!(f, "cv is the identity point"),
-            | Self::IdentityRk => write!(f, "rk is the identity point"),
-        }
-    }
-}
-
-impl Error for ActionDigestError {}
 
 impl ActionDigest {
     /// Digest a single action's $(\mathsf{cv}, \mathsf{rk})$ pair.
@@ -48,19 +38,6 @@ impl ActionDigest {
             .into_option()
             .ok_or(ActionDigestError::IdentityRk)?;
         Ok(Self(poseidon::action_digest(cv_coords, rk_coords)))
-    }
-}
-
-/// Extract the inner field element (polynomial root).
-impl From<ActionDigest> for Fp {
-    fn from(digest: ActionDigest) -> Self {
-        digest.0
-    }
-}
-
-impl From<Fp> for ActionDigest {
-    fn from(fp: Fp) -> Self {
-        Self(fp)
     }
 }
 

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -9,7 +9,7 @@ use crate::{digest::poseidon, keys::public, value};
 /// Each action produces one digest, which serves as a root in the
 /// accumulator polynomial. Multiple actions are accumulated via
 /// polynomial commitment, not on this type.
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct ActionDigest(Fp);
 
 /// Errors from action digest computation.

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -18,7 +18,7 @@ use crate::{digest::poseidon, serialization};
 ///   boundary; checked against a boundary chain's root by `SpendableInit`.
 ///
 /// Opening reveals each link's role by its domain.
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct Anchor(pub Fp);
 
 impl Anchor {

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -1,4 +1,5 @@
 use corez::io::{self, Read, Write};
+use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use ff::Field as _;
 use pasta_curves::{Eq, Fp, arithmetic::CurveAffine as _, group::Curve as _};
 
@@ -17,7 +18,7 @@ use crate::{digest::poseidon, serialization};
 ///   boundary; checked against a boundary chain's root by `SpendableInit`.
 ///
 /// Opening reveals each link's role by its domain.
-#[derive(Clone, Copy, Debug, Eq)]
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
 pub struct Anchor(pub Fp);
 
 impl Anchor {
@@ -63,26 +64,6 @@ impl Default for Anchor {
     /// The genesis epoch boundary.
     fn default() -> Self {
         Self(Fp::ZERO).next_epoch(EpochIndex(0))
-    }
-}
-
-impl From<Fp> for Anchor {
-    fn from(fp: Fp) -> Self {
-        Self(fp)
-    }
-}
-
-/// Anchor's underlying `Fp` — the value used as a Poseidon input or as a
-/// polynomial root in the per-epoch blocks set.
-impl From<Anchor> for Fp {
-    fn from(anchor: Anchor) -> Self {
-        anchor.0
-    }
-}
-
-impl PartialEq<Self> for Anchor {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
     }
 }
 

--- a/crates/tachyon/src/primitives/block_height.rs
+++ b/crates/tachyon/src/primitives/block_height.rs
@@ -1,22 +1,12 @@
 use core::num::TryFromIntError;
 
+use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
+
 use crate::{constants::EPOCH_SIZE, primitives::EpochIndex};
 
 /// A block height in the pool chain.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq, Ord, PartialOrd, From, Into)]
 pub struct BlockHeight(pub u32);
-
-impl From<BlockHeight> for u32 {
-    fn from(height: BlockHeight) -> Self {
-        height.0
-    }
-}
-
-impl From<u32> for BlockHeight {
-    fn from(height: u32) -> Self {
-        Self(height)
-    }
-}
 
 impl TryFrom<BlockHeight> for usize {
     type Error = TryFromIntError;

--- a/crates/tachyon/src/primitives/block_height.rs
+++ b/crates/tachyon/src/primitives/block_height.rs
@@ -5,7 +5,7 @@ use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use crate::{constants::EPOCH_SIZE, primitives::EpochIndex};
 
 /// A block height in the pool chain.
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq, Ord, PartialOrd, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, Ord, PartialEq, PartialOrd, TotalEq)]
 pub struct BlockHeight(pub u32);
 
 impl TryFrom<BlockHeight> for usize {

--- a/crates/tachyon/src/primitives/epoch.rs
+++ b/crates/tachyon/src/primitives/epoch.rs
@@ -1,3 +1,4 @@
+use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use pasta_curves::Fp;
 
 /// A tachyon epoch — a point in the accumulator's history.
@@ -9,7 +10,7 @@ use pasta_curves::Fp;
 /// $mk = \text{KDF}(\psi, nk)$, then $nf = F_{mk}(\text{flavor})$.
 /// Different epochs produce different nullifiers for the same note,
 /// enabling range-restricted delegation via the GGM tree PRF.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, TotalEq, Ord, PartialEq, PartialOrd, From, Into)]
 pub struct EpochIndex(pub u32);
 
 impl EpochIndex {
@@ -17,18 +18,6 @@ impl EpochIndex {
     #[must_use]
     pub const fn next(self) -> Self {
         Self(self.0 + 1)
-    }
-}
-
-impl From<u32> for EpochIndex {
-    fn from(val: u32) -> Self {
-        Self(val)
-    }
-}
-
-impl From<EpochIndex> for u32 {
-    fn from(epoch: EpochIndex) -> Self {
-        epoch.0
     }
 }
 

--- a/crates/tachyon/src/primitives/epoch.rs
+++ b/crates/tachyon/src/primitives/epoch.rs
@@ -10,7 +10,7 @@ use pasta_curves::Fp;
 /// $mk = \text{KDF}(\psi, nk)$, then $nf = F_{mk}(\text{flavor})$.
 /// Different epochs produce different nullifiers for the same note,
 /// enabling range-restricted delegation via the GGM tree PRF.
-#[derive(Clone, Copy, Debug, TotalEq, Ord, PartialEq, PartialOrd, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, Ord, PartialEq, PartialOrd, TotalEq)]
 pub struct EpochIndex(pub u32);
 
 impl EpochIndex {

--- a/crates/tachyon/src/primitives/seq.rs
+++ b/crates/tachyon/src/primitives/seq.rs
@@ -1,8 +1,8 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::cmp;
 
+use derive_more::{Debug, Eq as TotalEq, PartialEq};
 use group::Group as _;
 use pasta_curves::{Eq, Fp};
 use ragu::Polynomial;
@@ -10,7 +10,7 @@ use ragu::Polynomial;
 use crate::note::Nullifier;
 
 /// Pedersen commitment to a nullifier sequence $N$.
-#[derive(Clone, Copy, Debug, cmp::Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq)]
 pub struct NfSeqCommit(Eq);
 
 /// Witness polynomial for a nullifier sequence $N$ (members encoded as

--- a/crates/tachyon/src/primitives/seq.rs
+++ b/crates/tachyon/src/primitives/seq.rs
@@ -10,7 +10,7 @@ use ragu::Polynomial;
 use crate::note::Nullifier;
 
 /// Pedersen commitment to a nullifier sequence $N$.
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct NfSeqCommit(Eq);
 
 /// Witness polynomial for a nullifier sequence $N$ (members encoded as

--- a/crates/tachyon/src/primitives/sets.rs
+++ b/crates/tachyon/src/primitives/sets.rs
@@ -10,11 +10,11 @@ use super::{ActionDigest, Tachygram};
 use crate::{Action, ActionDigestError};
 
 /// Pedersen commitment to a stamp's tachygram set.
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct TachygramSetCommit(Eq);
 
 /// Pedersen commitment to a stamp's action-digest set.
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct ActionSetCommit(Eq);
 
 /// Witness polynomial for a stamp's tachygram set (members encoded as roots).

--- a/crates/tachyon/src/primitives/sets.rs
+++ b/crates/tachyon/src/primitives/sets.rs
@@ -1,8 +1,8 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::cmp;
 
+use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use pasta_curves::{Eq, Fp};
 use ragu::Polynomial;
 
@@ -10,20 +10,20 @@ use super::{ActionDigest, Tachygram};
 use crate::{Action, ActionDigestError};
 
 /// Pedersen commitment to a stamp's tachygram set.
-#[derive(Clone, Copy, Debug, cmp::Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
 pub struct TachygramSetCommit(Eq);
 
 /// Pedersen commitment to a stamp's action-digest set.
-#[derive(Clone, Copy, Debug, cmp::Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
 pub struct ActionSetCommit(Eq);
 
 /// Witness polynomial for a stamp's tachygram set (members encoded as roots).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Into)]
 pub struct TachygramSetPoly(Polynomial);
 
 /// Witness polynomial for a stamp's action-digest set (members encoded as
 /// roots).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Into)]
 pub struct ActionSetPoly(Polynomial);
 
 impl TachygramSetPoly {
@@ -40,12 +40,6 @@ impl TachygramSetPoly {
     }
 }
 
-impl From<TachygramSetPoly> for Polynomial {
-    fn from(poly: TachygramSetPoly) -> Self {
-        poly.0
-    }
-}
-
 impl ActionSetPoly {
     /// Deterministic (untrapdoored) commitment to the set polynomial.
     #[must_use]
@@ -57,12 +51,6 @@ impl ActionSetPoly {
     #[must_use]
     pub fn eval(&self, x: Fp) -> Fp {
         self.0.eval(x)
-    }
-}
-
-impl From<ActionSetPoly> for Polynomial {
-    fn from(poly: ActionSetPoly) -> Self {
-        poly.0
     }
 }
 
@@ -101,29 +89,5 @@ impl TryFrom<&[Action]> for ActionSetCommit {
 impl From<&[Tachygram]> for TachygramSetCommit {
     fn from(tgs: &[Tachygram]) -> Self {
         TachygramSetPoly::from(tgs).commit()
-    }
-}
-
-impl From<ActionSetCommit> for Eq {
-    fn from(commit: ActionSetCommit) -> Self {
-        commit.0
-    }
-}
-
-impl From<Eq> for ActionSetCommit {
-    fn from(point: Eq) -> Self {
-        Self(point)
-    }
-}
-
-impl From<TachygramSetCommit> for Eq {
-    fn from(commit: TachygramSetCommit) -> Self {
-        commit.0
-    }
-}
-
-impl From<Eq> for TachygramSetCommit {
-    fn from(point: Eq) -> Self {
-        Self(point)
     }
 }

--- a/crates/tachyon/src/primitives/tachygram.rs
+++ b/crates/tachyon/src/primitives/tachygram.rs
@@ -15,5 +15,5 @@ use pasta_curves::Fp;
 /// Consensus rejects a published tachygram that has already appeared in
 /// any block of the current or immediately preceding epoch. See the
 /// Tachygrams book chapter for why the window spans two epochs.
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct Tachygram(Fp);

--- a/crates/tachyon/src/primitives/tachygram.rs
+++ b/crates/tachyon/src/primitives/tachygram.rs
@@ -1,3 +1,4 @@
+use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use pasta_curves::Fp;
 
 /// A tachygram is a field element ($\mathbb{F}_p$) representing either a
@@ -14,17 +15,5 @@ use pasta_curves::Fp;
 /// Consensus rejects a published tachygram that has already appeared in
 /// any block of the current or immediately preceding epoch. See the
 /// Tachygrams book chapter for why the window spans two epochs.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
 pub struct Tachygram(Fp);
-
-impl From<Fp> for Tachygram {
-    fn from(fp: Fp) -> Self {
-        Self(fp)
-    }
-}
-
-impl From<Tachygram> for Fp {
-    fn from(tg: Tachygram) -> Self {
-        tg.0
-    }
-}

--- a/crates/tachyon/src/reddsa.rs
+++ b/crates/tachyon/src/reddsa.rs
@@ -5,7 +5,7 @@
 //! names so the rest of the crate avoids direct `reddsa::orchard` imports.
 
 use ::reddsa::orchard;
-pub(crate) use ::reddsa::{Error, Signature, SigningKey, VerificationKey};
+pub(crate) use ::reddsa::{Error, Signature, SigningKey, VerificationKey, VerificationKeyBytes};
 
 /// RedPallas signature scheme for action authorization.
 ///

--- a/crates/tachyon/src/serialization/compactsize.rs
+++ b/crates/tachyon/src/serialization/compactsize.rs
@@ -9,6 +9,7 @@
 use core::{num::TryFromIntError, ops::RangeInclusive};
 
 use corez::io::{self, Read, Write};
+use derive_more::{Debug, Eq as TotalEq, PartialEq};
 
 #[derive(Debug)]
 pub(crate) enum CompactSizeError {
@@ -58,7 +59,7 @@ const VALID_EIGHT_BYTES: RangeInclusive<u64> = (u32::MAX as u64) + 1..=u64::MAX;
 /// Zcash protocol spec §7.1 (page 132): "Like other serialized fields of
 /// type compactSize, ... MUST be encoded with the minimum number of bytes
 /// ..., and other encodings MUST be rejected."
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub(crate) enum CompactSize {
     /// Single-byte form (no flag prefix), `0..=MAX_ONE_BYTE`.
     OneByte(u8),

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -18,9 +18,9 @@ extern crate alloc;
 pub mod proof;
 
 use alloc::{boxed::Box, vec::Vec};
-use core::{error::Error, fmt};
 
 use corez::io::{self, Read, Write};
+use derive_more::{Debug, Display, Eq, Error, Into, PartialEq};
 use pasta_curves::Fp;
 use proof::{
     PROOF_SYSTEM,
@@ -63,7 +63,7 @@ pub struct Stripped;
 ///
 /// This uses the aggregate's wtxid (not txid) so it unambiguously pins the
 /// covering aggregate's authorization state, including stamp.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Into)]
 pub struct AggregateId([u8; 64]);
 
 impl AggregateId {
@@ -81,22 +81,12 @@ impl AggregateId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Display, Eq, PartialEq, Error)]
 /// Errors that can occur when handling an aggregate id.
 pub enum AggregateIdError {
     /// The aggregate id is zero and refers to no aggregate.
+    #[display("aggregate id is zero and refers to no aggregate")]
     Zero,
-}
-impl Error for AggregateIdError {}
-
-impl fmt::Display for AggregateIdError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            | Self::Zero => {
-                write!(f, "aggregate id is zero and refers to no aggregate")
-            },
-        }
-    }
 }
 
 impl TryFrom<[u8; 64]> for AggregateId {
@@ -110,34 +100,19 @@ impl TryFrom<[u8; 64]> for AggregateId {
     }
 }
 
-impl From<AggregateId> for [u8; 64] {
-    fn from(aggregate_id: AggregateId) -> Self {
-        aggregate_id.0
-    }
-}
-
 /// Error during stamp verification.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display, Error)]
 pub enum VerificationError {
     /// An action's cv or rk is the identity point.
+    #[display("action digest error: {_0}")]
     ActionDigest(ActionDigestError),
     /// The proof system returned an error.
+    #[display("proof system error")]
     ProofSystem,
     /// The proof did not verify against the reconstructed header.
+    #[display("proof did not verify")]
     Disproved,
 }
-
-impl fmt::Display for VerificationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            | &Self::ActionDigest(err) => write!(f, "action digest error: {err}"),
-            | &Self::ProofSystem => write!(f, "proof system error"),
-            | &Self::Disproved => write!(f, "proof did not verify"),
-        }
-    }
-}
-
-impl Error for VerificationError {}
 
 /// Everything needed to produce a [`Stamp`].
 ///
@@ -281,36 +256,26 @@ impl Plan {
 }
 
 /// Errors that can occur while proving a stamp.
-#[derive(Debug)]
+#[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum ProveError {
     /// The plan has no actions to prove.
+    #[display("no actions to prove")]
     NoActions,
     /// Action digest construction failed (cv or rk was the identity point).
+    #[display("action digest failed: {_0}")]
     ActionDigest(ActionDigestError),
     /// Proof creation failed for an action; carries the underlying
     /// step-level error.
+    #[display("action proof failed: {_0}")]
     ProofFailed(ragu::Error),
     /// Stamp merge failed; carries the underlying step-level error.
+    #[display("stamp merge failed: {_0}")]
     MergeFailed(ragu::Error),
     /// Number of spendable PCDs doesn't match number of spends.
+    #[display("spendable PCD count mismatch")]
     SpendableMismatch,
 }
-
-impl fmt::Display for ProveError {
-    #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            | Self::NoActions => write!(f, "no actions to prove"),
-            | Self::ActionDigest(err) => write!(f, "action digest failed: {err}"),
-            | Self::ProofFailed(ref inner) => write!(f, "action proof failed: {inner}"),
-            | Self::MergeFailed(ref inner) => write!(f, "stamp merge failed: {inner}"),
-            | Self::SpendableMismatch => write!(f, "spendable PCD count mismatch"),
-        }
-    }
-}
-
-impl Error for ProveError {}
 
 /// A stamp carrying tachygrams, anchor, and proof.
 ///
@@ -320,7 +285,7 @@ impl Error for ProveError {}
 /// The PCD header `(action_acc, tachygram_acc, anchor)` is not stored here —
 /// the verifier reconstructs it from public data and passes it as the header
 /// to Ragu `verify()`.
-#[derive(Clone)]
+#[derive(Clone, derive_more::Debug)]
 pub struct Stamp {
     /// Tachygrams (nullifiers and note commitments) for data availability.
     pub tachygrams: Vec<Tachygram>,
@@ -329,17 +294,8 @@ pub struct Stamp {
     pub anchor: Anchor,
 
     /// The Ragu proof bytes.
+    #[debug(skip)]
     pub proof: ragu::Proof,
-}
-
-impl fmt::Debug for Stamp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Stamp {{ tachygrams: {:?}, anchor: {:?} }}",
-            self.tachygrams, self.anchor,
-        )
-    }
 }
 
 impl Stamp {

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -20,7 +20,7 @@ pub mod proof;
 use alloc::{boxed::Box, vec::Vec};
 
 use corez::io::{self, Read, Write};
-use derive_more::{Debug, Display, Eq, Error, Into, PartialEq};
+use derive_more::{Debug, Display, Eq as TotalEq, Error, Into, PartialEq};
 use pasta_curves::Fp;
 use proof::{
     PROOF_SYSTEM,
@@ -46,7 +46,7 @@ use crate::{
 ///
 /// This is the initial state for a newly constructed bundle.
 /// Proving produces a [`Stamp`]; stripping produces a `Bundle<Stripped>`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Unproven;
 
 /// Marker for a stripped bundle whose covering-aggregate `wtxid` has not
@@ -55,7 +55,7 @@ pub struct Unproven;
 /// Produced by [`strip()`](crate::Bundle::strip). Must transition to a
 /// `Bundle<AggregateId>` via [`assign_wtxid`](crate::Bundle::assign_wtxid)
 /// before serialization.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Stripped;
 
 /// A 64-byte `wtxid` of the covering aggregate in the same block, assigned by
@@ -63,7 +63,7 @@ pub struct Stripped;
 ///
 /// This uses the aggregate's wtxid (not txid) so it unambiguously pins the
 /// covering aggregate's authorization state, including stamp.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Into)]
+#[derive(Clone, Copy, Debug, Into, PartialEq, TotalEq)]
 pub struct AggregateId([u8; 64]);
 
 impl AggregateId {
@@ -81,7 +81,7 @@ impl AggregateId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq, Error)]
+#[derive(Clone, Copy, Debug, Display, Error, PartialEq, TotalEq)]
 /// Errors that can occur when handling an aggregate id.
 pub enum AggregateIdError {
     /// The aggregate id is zero and refers to no aggregate.
@@ -285,7 +285,7 @@ pub enum ProveError {
 /// The PCD header `(action_acc, tachygram_acc, anchor)` is not stored here —
 /// the verifier reconstructs it from public data and passes it as the header
 /// to Ragu `verify()`.
-#[derive(Clone, derive_more::Debug)]
+#[derive(Clone, Debug)]
 pub struct Stamp {
     /// Tachygrams (nullifiers and note commitments) for data availability.
     pub tachygrams: Vec<Tachygram>,

--- a/crates/tachyon/src/value.rs
+++ b/crates/tachyon/src/value.rs
@@ -98,7 +98,7 @@ impl CommitmentTrapdoor {
 /// ## Type representation
 ///
 /// An EpAffine (Pallas affine curve point, 32 compressed bytes).
-#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct Commitment(#[debug(skip)] pub(super) EpAffine);
 
 impl Commitment {

--- a/crates/tachyon/src/value.rs
+++ b/crates/tachyon/src/value.rs
@@ -3,8 +3,9 @@
 //! A value commitment hides the value transferred in an action:
 //! `cv = [v]V + [rcv]R` where `rcv` is the [`CommitmentTrapdoor`].
 
-use core::{fmt, iter, ops, ops::Neg as _};
+use core::{iter, ops, ops::Neg as _};
 
+use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use ff::Field as _;
 use lazy_static::lazy_static;
 use pasta_curves::{
@@ -45,8 +46,8 @@ lazy_static! {
 /// An $\mathbb{F}_q$ element (Pallas scalar field, 32 bytes). Lives
 /// in the scalar field because $\mathsf{rcv}$ is used as a scalar in
 /// point multiplication $[\mathsf{rcv}]\,\mathcal{R}$.
-#[derive(Clone, Copy)]
-pub struct CommitmentTrapdoor(Fq);
+#[derive(Clone, Copy, Debug, Into)]
+pub struct CommitmentTrapdoor(#[debug(skip)] Fq);
 
 impl CommitmentTrapdoor {
     /// Generate a fresh random trapdoor.
@@ -81,12 +82,6 @@ impl CommitmentTrapdoor {
     }
 }
 
-impl From<CommitmentTrapdoor> for Fq {
-    fn from(trapdoor: CommitmentTrapdoor) -> Self {
-        trapdoor.0
-    }
-}
-
 /// A value commitment for a Tachyon action.
 ///
 /// Commits to the value being transferred in an action without
@@ -103,8 +98,8 @@ impl From<CommitmentTrapdoor> for Fq {
 /// ## Type representation
 ///
 /// An EpAffine (Pallas affine curve point, 32 compressed bytes).
-#[derive(Clone, Copy, Eq, PartialEq)]
-pub struct Commitment(pub(super) EpAffine);
+#[derive(Clone, Copy, Debug, TotalEq, PartialEq, From, Into)]
+pub struct Commitment(#[debug(skip)] pub(super) EpAffine);
 
 impl Commitment {
     /// Create the value balance commitment
@@ -130,21 +125,9 @@ impl Commitment {
     }
 }
 
-impl From<Commitment> for EpAffine {
-    fn from(cv: Commitment) -> Self {
-        cv.0
-    }
-}
-
 impl From<Commitment> for [u8; 32] {
     fn from(cv: Commitment) -> Self {
         cv.0.to_bytes()
-    }
-}
-
-impl From<EpAffine> for Commitment {
-    fn from(affine: EpAffine) -> Self {
-        Self(affine)
     }
 }
 
@@ -169,18 +152,6 @@ impl iter::Sum for Commitment {
     /// commitments. Identity element is the point at infinity.
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self(EpAffine::identity()), |acc, cv| acc + cv)
-    }
-}
-
-impl fmt::Debug for CommitmentTrapdoor {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CommitmentTrapdoor").finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for Commitment {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Commitment").finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
The `derive_more` crate is already in the zebra dep tree, so this should be okay to consume.

Some public types that used to skip display of inner field will now display the inner field.