### PR TITLE
fix rustfmt/clippy conflict

### DIFF
--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -94,10 +94,10 @@ impl BundleState {
         let mut byte = [0u8; 1];
         reader.read_exact(&mut byte)?;
         match u8::from_le_bytes(byte) {
-            | 0b0000_0000u8 => Ok(Self::NoBundle),
-            | 0b0000_0001u8 => Ok(Self::Stamped),
-            | 0b0000_0010u8 => Ok(Self::Stripped),
-            | _other => {
+            0b0000_0000u8 => Ok(Self::NoBundle),
+            0b0000_0001u8 => Ok(Self::Stamped),
+            0b0000_0010u8 => Ok(Self::Stripped),
+            _other => {
                 Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "invalid bundle state",
@@ -108,9 +108,9 @@ impl BundleState {
 
     pub(super) fn write<W: Write>(self, mut writer: W) -> io::Result<()> {
         let byte = u8::to_le_bytes(match self {
-            | Self::NoBundle => 0b0000_0000u8,
-            | Self::Stamped => 0b0000_0001u8,
-            | Self::Stripped => 0b0000_0010u8,
+            Self::NoBundle => 0b0000_0000u8,
+            Self::Stamped => 0b0000_0001u8,
+            Self::Stripped => 0b0000_0010u8,
         });
         writer.write_all(&byte)
     }
@@ -164,8 +164,8 @@ impl TryFrom<TachyonBundle> for Bundle<Stamp> {
 
     fn try_from(bundle: TachyonBundle) -> Result<Self, Self::Error> {
         match bundle {
-            | TachyonBundle::Adjunct(stripped) => Err(stripped),
-            | TachyonBundle::Stamped(stamped) => Ok(stamped),
+            TachyonBundle::Adjunct(stripped) => Err(stripped),
+            TachyonBundle::Stamped(stamped) => Ok(stamped),
         }
     }
 }
@@ -175,8 +175,8 @@ impl TryFrom<TachyonBundle> for Bundle<AggregateId> {
 
     fn try_from(bundle: TachyonBundle) -> Result<Self, Self::Error> {
         match bundle {
-            | TachyonBundle::Adjunct(stripped) => Ok(stripped),
-            | TachyonBundle::Stamped(stamped) => Err(stamped),
+            TachyonBundle::Adjunct(stripped) => Ok(stripped),
+            TachyonBundle::Stamped(stamped) => Err(stamped),
         }
     }
 }
@@ -634,8 +634,8 @@ impl TachyonBundle {
         let state = BundleState::read(&mut reader)?;
 
         Ok(match state {
-            | BundleState::NoBundle => None,
-            | BundleState::Stamped => {
+            BundleState::NoBundle => None,
+            BundleState::Stamped => {
                 let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
                 Some(Self::Stamped(Bundle {
                     actions,
@@ -644,7 +644,7 @@ impl TachyonBundle {
                     stamp: Stamp::read(&mut reader)?,
                 }))
             },
-            | BundleState::Stripped => {
+            BundleState::Stripped => {
                 let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
                 let stamp = AggregateId::read(&mut reader)?;
 
@@ -670,8 +670,8 @@ impl TachyonBundle {
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn write<W: Write>(&self, writer: W) -> io::Result<()> {
         match *self {
-            | Self::Stamped(ref stamped) => stamped.write(writer),
-            | Self::Adjunct(ref stripped) => stripped.write(writer),
+            Self::Stamped(ref stamped) => stamped.write(writer),
+            Self::Adjunct(ref stripped) => stripped.write(writer),
         }
     }
 
@@ -682,8 +682,8 @@ impl TachyonBundle {
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn auth_digest(&self) -> [u8; 64] {
         match *self {
-            | Self::Stamped(ref stamped) => stamped.auth_digest(),
-            | Self::Adjunct(ref stripped) => stripped.auth_digest(),
+            Self::Stamped(ref stamped) => stamped.auth_digest(),
+            Self::Adjunct(ref stripped) => stripped.auth_digest(),
         }
     }
 }

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -299,8 +299,8 @@ fn build_anchor_chain_inner(
                 .seed(rng, pool::EmptyBlockSeed, (state,))
                 .expect("EmptyBlockSeed");
             chain = Some(match chain.take() {
-                | None => seed,
-                | Some(left) => {
+                None => seed,
+                Some(left) => {
                     let (fused, ()) = PROOF_SYSTEM
                         .fuse(rng, pool::AnchorFuse, (), left, seed)
                         .expect("AnchorFuse");
@@ -321,8 +321,8 @@ fn build_anchor_chain_inner(
                     .seed(rng, pool::AnchorSeed, (state, *commit))
                     .expect("AnchorSeed");
                 chain = Some(match chain.take() {
-                    | None => seed,
-                    | Some(left) => {
+                    None => seed,
+                    Some(left) => {
                         let (fused, ()) = PROOF_SYSTEM
                             .fuse(rng, pool::AnchorFuse, (), left, seed)
                             .expect("AnchorFuse");
@@ -465,8 +465,8 @@ pub(crate) fn build_unspent_pcd(
                 .seed(rng, pool::EmptyBlockUnspentSeed, (state, epoch, nf))
                 .expect("EmptyBlockUnspentSeed");
             chain = Some(match chain.take() {
-                | None => seed,
-                | Some(left) => {
+                None => seed,
+                Some(left) => {
                     let (fused, ()) = PROOF_SYSTEM
                         .fuse(rng, pool::UnspentFuse, (), left, seed)
                         .expect("UnspentFuse");
@@ -479,8 +479,8 @@ pub(crate) fn build_unspent_pcd(
                 let next_state = state.next_stamp(commit);
                 let seed = build_unspent_seed_pcd(rng, state, epoch, tgs, nf);
                 chain = Some(match chain.take() {
-                    | None => seed,
-                    | Some(left) => {
+                    None => seed,
+                    Some(left) => {
                         let (fused, ()) = PROOF_SYSTEM
                             .fuse(rng, pool::UnspentFuse, (), left, seed)
                             .expect("UnspentFuse");
@@ -937,11 +937,11 @@ pub mod ggm_tools {
                 )
                 .expect("nullifier step");
             acc = Some(match acc {
-                | None => {
+                None => {
                     nfs.push(nf);
                     leaf
                 },
-                | Some(left) => {
+                Some(left) => {
                     let left_poly = NfSeqPoly::from(nfs.as_slice());
                     let right_poly = NfSeqPoly::from([nf].as_slice());
                     nfs.push(nf);
@@ -996,8 +996,8 @@ fn build_partial_multi_epoch_unspent(
         let seed = build_unspent_seed_pcd(rng, state, first_epoch, tgs, nf0);
         state = state.next_stamp(commit);
         first_segment = Some(match first_segment.take() {
-            | None => seed,
-            | Some(left) => {
+            None => seed,
+            Some(left) => {
                 let (fused, ()) = PROOF_SYSTEM
                     .fuse(rng, pool::UnspentFuse, (), left, seed)
                     .expect("UnspentFuse rest-of-block");
@@ -1009,8 +1009,8 @@ fn build_partial_multi_epoch_unspent(
     while height <= first_epoch_end {
         let segment = build_unspent_pcd(rng, pool, nf0, height..=height);
         first_segment = Some(match first_segment.take() {
-            | None => segment,
-            | Some(left) => {
+            None => segment,
+            Some(left) => {
                 let (fused, ()) = PROOF_SYSTEM
                     .fuse(rng, pool::UnspentFuse, (), left, segment)
                     .expect("UnspentFuse subsequent-block");

--- a/crates/tachyon/src/keys/ggm.rs
+++ b/crates/tachyon/src/keys/ggm.rs
@@ -231,10 +231,9 @@ pub fn cover_candidates(range: RangeInclusive<u32>) -> Vec<RangeInclusive<u32>> 
     let mut candidates: Vec<RangeInclusive<u32>> = Vec::new();
     for j in 0u8..=GGM_TREE_DEPTH {
         let alignment_bits = j * GGM_CHUNK_SIZE;
-        let s_j = match 1u32.checked_shl(u32::from(alignment_bits)) {
-            | Some(alignment) => range.start() & !(alignment - 1u32),
-            | None => 0u32,
-        };
+        let s_j = 1u32
+            .checked_shl(u32::from(alignment_bits))
+            .map_or(0u32, |alignment| range.start() & !(alignment - 1u32));
         if candidates.last().is_some_and(|prev| *prev.start() == s_j) {
             continue;
         }
@@ -253,19 +252,16 @@ fn ggm_step(node: Fp, chunk: u8) -> Fp {
 /// Recursive GGM walk: consume the top `GGM_CHUNK_SIZE` bits of `leaf` at each
 /// level, MSB-first, for `remaining` levels.
 fn ggm_walk(node: Fp, leaf: u32, remaining: u8) -> Fp {
-    match remaining.checked_sub(1) {
-        | None => node,
-        | Some(next) => {
-            let shift = next * GGM_CHUNK_SIZE;
-            let chunk_u32 = (leaf >> shift) & u32::from(GGM_CHUNK_MASK);
-            #[expect(
-                clippy::expect_used,
-                reason = "chunk bits fit in u8 because GGM_CHUNK_SIZE <= u8::BITS"
-            )]
-            let chunk = u8::try_from(chunk_u32).expect("chunk fits in u8");
-            ggm_walk(ggm_step(node, chunk), leaf, next)
-        },
-    }
+    remaining.checked_sub(1).map_or(node, |next| {
+        let shift = next * GGM_CHUNK_SIZE;
+        let chunk_u32 = (leaf >> shift) & u32::from(GGM_CHUNK_MASK);
+        #[expect(
+            clippy::expect_used,
+            reason = "chunk bits fit in u8 because GGM_CHUNK_SIZE <= u8::BITS"
+        )]
+        let chunk = u8::try_from(chunk_u32).expect("chunk fits in u8");
+        ggm_walk(ggm_step(node, chunk), leaf, next)
+    })
 }
 
 #[cfg(test)]

--- a/crates/tachyon/src/serialization/compactsize.rs
+++ b/crates/tachyon/src/serialization/compactsize.rs
@@ -105,28 +105,28 @@ impl CompactSize {
 
     pub(crate) fn enforce_canon(self) -> Result<Self, CompactSizeError> {
         match self {
-            | Self::OneByte(inner_u8) => {
+            Self::OneByte(inner_u8) => {
                 if VALID_ONE_BYTE.contains(&inner_u8.into()) {
                     Ok(self)
                 } else {
                     Err(CompactSizeError::NonCanonical(self))
                 }
             },
-            | Self::TwoBytes(inner_u16) => {
+            Self::TwoBytes(inner_u16) => {
                 if VALID_TWO_BYTES.contains(&inner_u16.into()) {
                     Ok(self)
                 } else {
                     Err(CompactSizeError::NonCanonical(self))
                 }
             },
-            | Self::FourBytes(inner_u32) => {
+            Self::FourBytes(inner_u32) => {
                 if VALID_FOUR_BYTES.contains(&inner_u32.into()) {
                     Ok(self)
                 } else {
                     Err(CompactSizeError::NonCanonical(self))
                 }
             },
-            | Self::EightBytes(inner_u64) => {
+            Self::EightBytes(inner_u64) => {
                 if VALID_EIGHT_BYTES.contains(&inner_u64) {
                     Ok(self)
                 } else {
@@ -158,18 +158,18 @@ impl CompactSize {
         reader.read_exact(&mut flag)?;
 
         Ok(match flag[0] {
-            | 0..=MAX_ONE_BYTE => Self::OneByte(flag[0]),
-            | FLAG_TWO_BYTES => {
+            0..=MAX_ONE_BYTE => Self::OneByte(flag[0]),
+            FLAG_TWO_BYTES => {
                 let mut bytes = [0u8; 2];
                 reader.read_exact(&mut bytes)?;
                 Self::TwoBytes(u16::from_le_bytes(bytes))
             },
-            | FLAG_FOUR_BYTES => {
+            FLAG_FOUR_BYTES => {
                 let mut bytes = [0u8; 4];
                 reader.read_exact(&mut bytes)?;
                 Self::FourBytes(u32::from_le_bytes(bytes))
             },
-            | FLAG_EIGHT_BYTES => {
+            FLAG_EIGHT_BYTES => {
                 let mut bytes = [0u8; 8];
                 reader.read_exact(&mut bytes)?;
                 Self::EightBytes(u64::from_le_bytes(bytes))
@@ -180,16 +180,16 @@ impl CompactSize {
     /// Write this [`CompactSize`] to `writer`.
     pub(crate) fn write<W: Write>(self, mut writer: W) -> io::Result<()> {
         match self {
-            | Self::OneByte(value) => writer.write_all(&[value]),
-            | Self::TwoBytes(value) => {
+            Self::OneByte(value) => writer.write_all(&[value]),
+            Self::TwoBytes(value) => {
                 writer.write_all(&[FLAG_TWO_BYTES])?;
                 writer.write_all(&value.to_le_bytes())
             },
-            | Self::FourBytes(value) => {
+            Self::FourBytes(value) => {
                 writer.write_all(&[FLAG_FOUR_BYTES])?;
                 writer.write_all(&value.to_le_bytes())
             },
-            | Self::EightBytes(value) => {
+            Self::EightBytes(value) => {
                 writer.write_all(&[FLAG_EIGHT_BYTES])?;
                 writer.write_all(&value.to_le_bytes())
             },
@@ -236,10 +236,10 @@ impl From<u64> for CompactSize {
 impl From<CompactSize> for u64 {
     fn from(csize: CompactSize) -> Self {
         match csize {
-            | CompactSize::OneByte(inner_u8) => Self::from(inner_u8),
-            | CompactSize::TwoBytes(inner_u16) => Self::from(inner_u16),
-            | CompactSize::FourBytes(inner_u32) => Self::from(inner_u32),
-            | CompactSize::EightBytes(inner_u64) => inner_u64,
+            CompactSize::OneByte(inner_u8) => Self::from(inner_u8),
+            CompactSize::TwoBytes(inner_u16) => Self::from(inner_u16),
+            CompactSize::FourBytes(inner_u32) => Self::from(inner_u32),
+            CompactSize::EightBytes(inner_u64) => inner_u64,
         }
     }
 }
@@ -257,10 +257,10 @@ impl TryFrom<CompactSize> for usize {
 
     fn try_from(csize: CompactSize) -> Result<Self, Self::Error> {
         match csize {
-            | CompactSize::OneByte(inner_u8) => Ok(Self::from(inner_u8)),
-            | CompactSize::TwoBytes(inner_u16) => Ok(Self::from(inner_u16)),
-            | CompactSize::FourBytes(inner_u32) => Self::try_from(inner_u32),
-            | CompactSize::EightBytes(inner_u64) => Self::try_from(inner_u64),
+            CompactSize::OneByte(inner_u8) => Ok(Self::from(inner_u8)),
+            CompactSize::TwoBytes(inner_u16) => Ok(Self::from(inner_u16)),
+            CompactSize::FourBytes(inner_u32) => Self::try_from(inner_u32),
+            CompactSize::EightBytes(inner_u64) => Self::try_from(inner_u64),
         }
     }
 }
@@ -273,10 +273,10 @@ mod tests {
 
     fn sized_value(value: &[u8]) -> Vec<u8> {
         let flag = match value.len() {
-            | 2 => [FLAG_TWO_BYTES].as_slice(),
-            | 4 => [FLAG_FOUR_BYTES].as_slice(),
-            | 8 => [FLAG_EIGHT_BYTES].as_slice(),
-            | _ => [].as_slice(),
+            2 => [FLAG_TWO_BYTES].as_slice(),
+            4 => [FLAG_FOUR_BYTES].as_slice(),
+            8 => [FLAG_EIGHT_BYTES].as_slice(),
+            _ => [].as_slice(),
         };
         [flag, value].concat()
     }

--- a/crates/tachyon/src/serialization/mod.rs
+++ b/crates/tachyon/src/serialization/mod.rs
@@ -21,10 +21,10 @@ pub(crate) fn read_compactsize<R: Read>(mut reader: R) -> io::Result<u64> {
         .enforce_valid()
         .map_err(|err| {
             match err {
-                | compactsize::CompactSizeError::NonCanonical(_) => {
+                compactsize::CompactSizeError::NonCanonical(_) => {
                     io::Error::new(io::ErrorKind::InvalidData, "non-canonical compact size")
                 },
-                | compactsize::CompactSizeError::ExceedsMaximum(_) => {
+                compactsize::CompactSizeError::ExceedsMaximum(_) => {
                     io::Error::new(
                         io::ErrorKind::InvalidData,
                         "compact size exceeds consensus maximum",

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -140,11 +140,11 @@ fn same_epoch_wrong_index_rejected_against_honest_chain() {
         )
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "SpendableInit: chain not rooted at epoch boundary"
     );
 }
@@ -260,13 +260,10 @@ fn spendable_init_rejects_tg_absent() {
         )
         .err()
         .unwrap();
-    assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
-        "SpendableInit: commitment not in set"
-    );
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(inner.to_string(), "SpendableInit: commitment not in set");
 }
 
 #[test]
@@ -287,13 +284,10 @@ fn unspent_seed_rejects_tg_present() {
         )
         .err()
         .unwrap();
-    assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
-        "UnspentSeed: found nullifier in set"
-    );
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(inner.to_string(), "UnspentSeed: found nullifier in set");
 }
 
 #[test]
@@ -314,11 +308,11 @@ fn unspent_fuse_rejects_invalid_compositions() {
             .fuse(rng, pool::UnspentFuse, (), shard_a, shard_b)
             .err()
             .unwrap();
+        let ragu::Error::InvalidWitness(inner) = err else {
+            panic!("expected InvalidWitness, got {err:?}");
+        };
         assert_eq!(
-            match err {
-                | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-                | _ => panic!("expected InvalidWitness"),
-            },
+            inner.to_string(),
             "UnspentFuse: left and right must share the same nf"
         );
     }
@@ -333,11 +327,11 @@ fn unspent_fuse_rejects_invalid_compositions() {
             .fuse(rng, pool::UnspentFuse, (), shard_a, shard_b)
             .err()
             .unwrap();
+        let ragu::Error::InvalidWitness(inner) = err else {
+            panic!("expected InvalidWitness, got {err:?}");
+        };
         assert_eq!(
-            match err {
-                | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-                | _ => panic!("expected InvalidWitness"),
-            },
+            inner.to_string(),
             "UnspentFuse: left.end must equal right.start"
         );
     }
@@ -363,13 +357,10 @@ fn anchor_chain_fuse_rejects_invalid_compositions() {
             .fuse(rng, pool::AnchorFuse, (), left, right)
             .err()
             .unwrap();
-        assert_eq!(
-            match err {
-                | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-                | _ => panic!("expected InvalidWitness"),
-            },
-            "AnchorFuse: segments not adjacent"
-        );
+        let ragu::Error::InvalidWitness(inner) = err else {
+            panic!("expected InvalidWitness, got {err:?}");
+        };
+        assert_eq!(inner.to_string(), "AnchorFuse: segments not adjacent");
     }
 
     // cross-epoch: left segment ends at epoch_0_final's anchor, right segment
@@ -394,13 +385,10 @@ fn anchor_chain_fuse_rejects_invalid_compositions() {
             .fuse(rng, pool::AnchorFuse, (), left, right)
             .err()
             .unwrap();
-        assert_eq!(
-            match err {
-                | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-                | _ => panic!("expected InvalidWitness"),
-            },
-            "AnchorFuse: segments not adjacent"
-        );
+        let ragu::Error::InvalidWitness(inner) = err else {
+            panic!("expected InvalidWitness, got {err:?}");
+        };
+        assert_eq!(inner.to_string(), "AnchorFuse: segments not adjacent");
     }
 }
 
@@ -528,14 +516,10 @@ fn spend_bind_rejects_invalid_inputs() {
             )
             .err()
             .unwrap();
-        assert_eq!(
-            match err {
-                | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-                | _ => panic!("expected InvalidWitness"),
-            },
-            expected,
-            "{label}"
-        );
+        let ragu::Error::InvalidWitness(inner) = err else {
+            panic!("expected InvalidWitness, got {err:?}");
+        };
+        assert_eq!(inner.to_string(), expected, "{label}");
     }
 }
 
@@ -558,11 +542,11 @@ fn spend_stamp_rejects_forged_next() {
         .fuse(rng, stamp::SpendStamp, (forged_next,), spend_pcd, derived)
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "SpendStamp: published scalars are not the derived leaf pair"
     );
 }
@@ -586,11 +570,11 @@ fn spend_stamp_rejects_zero_next_nullifier() {
         .fuse(rng, stamp::SpendStamp, (zero_next,), spend_pcd, derived)
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "SpendStamp: published scalars are not the derived leaf pair"
     );
 }
@@ -623,11 +607,11 @@ fn spend_stamp_rejects_identity_cv() {
         .fuse(rng, stamp::SpendStamp, (nf_next,), forged_spend, derived)
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "SpendStamp: action digest construction failed"
     );
 }
@@ -657,13 +641,10 @@ fn step_rejects_zero_value_note() {
             )
             .err()
             .unwrap();
-        assert_eq!(
-            match err {
-                | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-                | _ => panic!("expected InvalidWitness"),
-            },
-            "OutputStamp: zero-value note"
-        );
+        let ragu::Error::InvalidWitness(inner) = err else {
+            panic!("expected InvalidWitness, got {err:?}");
+        };
+        assert_eq!(inner.to_string(), "OutputStamp: zero-value note");
     }
 
     {
@@ -690,13 +671,10 @@ fn step_rejects_zero_value_note() {
             )
             .err()
             .unwrap();
-        assert_eq!(
-            match err {
-                | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-                | _ => panic!("expected InvalidWitness"),
-            },
-            "SpendBind: zero-value note"
-        );
+        let ragu::Error::InvalidWitness(inner) = err else {
+            panic!("expected InvalidWitness, got {err:?}");
+        };
+        assert_eq!(inner.to_string(), "SpendBind: zero-value note");
     }
 }
 
@@ -980,11 +958,11 @@ fn unspent_fuse_rejects_nonzero_forward_half() {
         .fuse(rng, pool::UnspentFuse, (), left, multi)
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "UnspentFuse: forwards half must stay within one epoch"
     );
 }
@@ -1037,11 +1015,11 @@ fn unspent_epoch_fuse_rejects_wrong_left_poly() {
         )
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "UnspentEpochFuse: left polynomial does not match header"
     );
 }
@@ -1064,11 +1042,11 @@ fn unspent_epoch_fuse_rejects_wrong_combined() {
         )
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "UnspentEpochFuse: combined is not the splice of the halves"
     );
 }
@@ -1108,11 +1086,11 @@ fn unspent_epoch_fuse_rejects_epoch_skip() {
         )
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "UnspentEpochFuse: right epoch must be one past left's tip"
     );
 }
@@ -1168,11 +1146,11 @@ fn verify_unspent_rejects_tip_mismatch() {
         )
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "VerifyUnspent: tip polynomial does not match present nullifier"
     );
 }
@@ -1207,11 +1185,11 @@ fn verify_unspent_rejects_elapsed_mismatch() {
         )
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "VerifyUnspent: elapsed polynomial does not match header"
     );
 }
@@ -1246,11 +1224,11 @@ fn verify_unspent_rejects_wrong_start_epoch() {
         )
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "VerifyUnspent: derived range does not start at the elapsed epoch"
     );
 }
@@ -1297,11 +1275,11 @@ fn spendable_lift_rejects_wrong_cm() {
         .fuse(rng, spendable::SpendableLift, (), spendable, verified)
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "SpendableLift: verified unspent cm does not match spendable"
     );
 }
@@ -1328,11 +1306,11 @@ fn spendable_lift_rejects_non_adjacent_unspent() {
         .fuse(rng, spendable::SpendableLift, (), spendable, verified)
         .err()
         .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
     assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
+        inner.to_string(),
         "SpendableLift: unspent not adjacent to spendable"
     );
 }
@@ -1365,13 +1343,10 @@ fn nullifier_fuse_rejects_non_contiguous() {
         )
         .err()
         .unwrap();
-    assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
-        "NullifierFuse: ranges not contiguous"
-    );
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(inner.to_string(), "NullifierFuse: ranges not contiguous");
 }
 
 #[test]
@@ -1403,11 +1378,8 @@ fn nullifier_fuse_rejects_wrong_cm() {
         )
         .err()
         .unwrap();
-    assert_eq!(
-        match err {
-            | ragu::Error::InvalidWitness(inner) => inner.to_string(),
-            | _ => panic!("expected InvalidWitness"),
-        },
-        "NullifierFuse: note commitments differ"
-    );
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(inner.to_string(), "NullifierFuse: note commitments differ");
 }

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -143,12 +143,12 @@ fn plan_prove_rejects_invalid_inputs() {
         let plan = Plan::new(two_spends(), alloc::vec![], anchor);
         let pcds = alloc::vec![bundle_b(), bundle_a()];
         let err = plan.prove(rng, &user.pak, pcds).unwrap_err();
+        let ProveError::ProofFailed(ragu::Error::InvalidWitness(inner)) = err else {
+            panic!("expected ProofFailed(InvalidWitness), got {err:?}");
+        };
         assert_eq!(
-            match err {
-                | ProveError::ProofFailed(ragu::Error::InvalidWitness(inner)) => inner.to_string(),
-                | _ => panic!("expected ProofFailed(InvalidWitness)"),
-            },
-            "SpendBind: note does not match the spendable lineage",
+            inner.to_string(),
+            "SpendBind: note does not match the spendable lineage"
         );
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,6 @@ edition = "2024"
 
 newline_style = "Unix"
 
-match_arm_leading_pipes = "Always"
 match_block_trailing_comma = true
 remove_nested_parens = true
 reorder_imports = true


### PR DESCRIPTION
The rustfmt rule `match_arm_leading_pipes = "Always"` was breaking some clippy lints, so it's now removed, and the lints are fixed.