### PR TITLE
Remove misleading commitment impls

### DIFF
--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -75,7 +75,7 @@ use crate::{
     digest::blake2b,
     keys::{private, public},
     note,
-    primitives::{ActionDigest, ActionDigestError, ActionSetCommit, Anchor, effect},
+    primitives::{ActionDigest, ActionDigestError, ActionSetPoly, Anchor, effect},
     reddsa, serialization,
     stamp::{self, AggregateId, AggregateIdError, Stamp, Stripped, Unproven},
     value,
@@ -307,7 +307,7 @@ impl Plan {
             .iter_actions(action::Plan::digest, action::Plan::digest)
             .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()?;
 
-        let action_commit = ActionSetCommit::from(digests.as_slice());
+        let action_commit = ActionSetPoly::from(digests.as_slice()).commit();
 
         Ok(blake2b::bundle_commitment(
             &Eq::from(action_commit).to_affine(),
@@ -730,7 +730,7 @@ impl<S: StampState> Bundle<S> {
             .iter()
             .map(Action::digest)
             .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()?;
-        let action_acc = ActionSetCommit::from(action_digests.as_slice());
+        let action_acc = ActionSetPoly::from(action_digests.as_slice()).commit();
         Ok(blake2b::bundle_commitment(
             &Eq::from(action_acc).to_affine(),
             self.value_balance,

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -209,7 +209,7 @@ impl PoolSim {
     pub fn stamp_commits_at(&self, height: BlockHeight) -> Vec<TachygramSetCommit> {
         self.tachygrams_at(height)
             .iter()
-            .map(|tgs| TachygramSetCommit::from(tgs.as_slice()))
+            .map(|tgs| TachygramSetPoly::from(tgs.as_slice()).commit())
             .collect()
     }
 

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -72,14 +72,16 @@ mod tests {
     use rand::{SeedableRng as _, rngs::StdRng};
 
     use super::*;
-    use crate::Tachygram;
+    use crate::{Tachygram, TachygramSetPoly};
 
     /// Folding the same stamps in the same order yields the same anchor.
     #[test]
     fn next_stamp_is_deterministic() {
         let rng = &mut StdRng::seed_from_u64(0);
-        let first = TachygramSetCommit::from([Tachygram::from(Fp::random(&mut *rng))].as_slice());
-        let second = TachygramSetCommit::from([Tachygram::from(Fp::random(&mut *rng))].as_slice());
+        let first =
+            TachygramSetPoly::from([Tachygram::from(Fp::random(&mut *rng))].as_slice()).commit();
+        let second =
+            TachygramSetPoly::from([Tachygram::from(Fp::random(&mut *rng))].as_slice()).commit();
 
         let run_one = Anchor::default().next_stamp(&first).next_stamp(&second);
         let run_two = Anchor::default().next_stamp(&first).next_stamp(&second);
@@ -90,8 +92,10 @@ mod tests {
     #[test]
     fn distinct_stamps_distinct_anchors() {
         let rng = &mut StdRng::seed_from_u64(0);
-        let first = TachygramSetCommit::from([Tachygram::from(Fp::random(&mut *rng))].as_slice());
-        let second = TachygramSetCommit::from([Tachygram::from(Fp::random(&mut *rng))].as_slice());
+        let first =
+            TachygramSetPoly::from([Tachygram::from(Fp::random(&mut *rng))].as_slice()).commit();
+        let second =
+            TachygramSetPoly::from([Tachygram::from(Fp::random(&mut *rng))].as_slice()).commit();
 
         assert_ne!(
             Anchor::default().next_stamp(&first),
@@ -103,8 +107,10 @@ mod tests {
     #[test]
     fn order_matters() {
         let rng = &mut StdRng::seed_from_u64(0);
-        let first = TachygramSetCommit::from([Tachygram::from(Fp::random(&mut *rng))].as_slice());
-        let second = TachygramSetCommit::from([Tachygram::from(Fp::random(&mut *rng))].as_slice());
+        let first =
+            TachygramSetPoly::from([Tachygram::from(Fp::random(&mut *rng))].as_slice()).commit();
+        let second =
+            TachygramSetPoly::from([Tachygram::from(Fp::random(&mut *rng))].as_slice()).commit();
 
         let forward = Anchor::default().next_stamp(&first).next_stamp(&second);
         let reverse = Anchor::default().next_stamp(&second).next_stamp(&first);
@@ -130,7 +136,8 @@ mod tests {
     #[test]
     fn next_empty_distinct_from_next_stamp() {
         let rng = &mut StdRng::seed_from_u64(0);
-        let stamp = TachygramSetCommit::from([Tachygram::from(Fp::random(&mut *rng))].as_slice());
+        let stamp =
+            TachygramSetPoly::from([Tachygram::from(Fp::random(&mut *rng))].as_slice()).commit();
         let via_empty = Anchor::default().next_empty();
         let via_stamp = Anchor::default().next_stamp(&stamp);
         assert_ne!(via_empty, via_stamp);

--- a/crates/tachyon/src/primitives/sets.rs
+++ b/crates/tachyon/src/primitives/sets.rs
@@ -7,7 +7,6 @@ use pasta_curves::{Eq, Fp};
 use ragu::Polynomial;
 
 use super::{ActionDigest, Tachygram};
-use crate::{Action, ActionDigestError};
 
 /// Pedersen commitment to a stamp's tachygram set.
 #[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
@@ -65,29 +64,5 @@ impl From<&[Tachygram]> for TachygramSetPoly {
     fn from(tgs: &[Tachygram]) -> Self {
         let roots: Vec<Fp> = tgs.iter().map(|&tg| Fp::from(tg)).collect();
         Self(Polynomial::from_roots(&roots))
-    }
-}
-
-impl From<&[ActionDigest]> for ActionSetCommit {
-    fn from(ads: &[ActionDigest]) -> Self {
-        ActionSetPoly::from(ads).commit()
-    }
-}
-
-impl TryFrom<&[Action]> for ActionSetCommit {
-    type Error = ActionDigestError;
-
-    fn try_from(actions: &[Action]) -> Result<Self, Self::Error> {
-        let ads: Vec<ActionDigest> = actions
-            .iter()
-            .map(Action::digest)
-            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()?;
-        Ok(ActionSetPoly::from(ads.as_slice()).commit())
-    }
-}
-
-impl From<&[Tachygram]> for TachygramSetCommit {
-    fn from(tgs: &[Tachygram]) -> Self {
-        TachygramSetPoly::from(tgs).commit()
     }
 }

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -30,7 +30,7 @@ use ragu::{self, proof::PROOF_SIZE_COMPRESSED};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
-    ActionSetCommit, ActionSetPoly, Note, TachygramSetCommit, TachygramSetPoly,
+    ActionSetPoly, Note, TachygramSetPoly,
     action::Action,
     effect,
     entropy::ActionRandomizer,
@@ -417,9 +417,14 @@ impl Stamp {
     ) -> Result<(), VerificationError> {
         let app = &*PROOF_SYSTEM;
 
+        let action_digests = actions
+            .iter()
+            .map(Action::digest)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(VerificationError::ActionDigest)?;
         let header = (
-            ActionSetCommit::try_from(actions).map_err(VerificationError::ActionDigest)?,
-            TachygramSetCommit::from(&*self.tachygrams),
+            ActionSetPoly::from(action_digests.as_slice()).commit(),
+            TachygramSetPoly::from(&*self.tachygrams).commit(),
             self.anchor,
         );
 

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -164,15 +164,17 @@ impl Step for NullifierStep {
         (node, depth, index, cm): <Self::Left as Header>::Data,
         _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        #[expect(clippy::expect_used, reason = "constant size")]
+        let &g0 = Pasta::host_generators(Pasta::baked())
+            .g()
+            .first()
+            .expect("at least one generator");
+
         enforce_zero(
             Fp::from(u64::from(depth)) - Fp::from(u64::from(GGM_TREE_DEPTH)),
             "NullifierStep: not at maximum depth",
         )?;
         let nf = Nullifier::from(poseidon::nullifier(node));
-        let generators = Pasta::host_generators(Pasta::baked()).g();
-
-        #[expect(clippy::expect_used, reason = "constant size")]
-        let g0 = generators.first().expect("at least one generator");
 
         let range_commit = NfSeqCommit::from(g0 * Fp::from(nf));
         Ok(((range_commit, index, index.next(), cm), ()))

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -461,6 +461,12 @@ impl Step for VerifyUnspent {
         ((elapsed, present_epoch), prev_anchor, end_anchor, present_nf, start_epoch): <Self::Left as Header>::Data,
         (range_commit, range_start, range_end, cm): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        #[expect(clippy::expect_used, reason = "constant size")]
+        let &g0 = Pasta::host_generators(Pasta::baked())
+            .g()
+            .first()
+            .expect("at least one generator");
+
         enforce_zero(
             Fp::from(range_start) - Fp::from(start_epoch),
             "VerifyUnspent: derived range does not start at the elapsed epoch",
@@ -474,11 +480,6 @@ impl Step for VerifyUnspent {
             Eq::from(elapsed),
             "VerifyUnspent: elapsed polynomial does not match header",
         )?;
-
-        let generators = Pasta::host_generators(Pasta::baked()).g();
-
-        #[expect(clippy::expect_used, reason = "constant size")]
-        let g0 = generators.first().expect("at least one generator");
 
         let present_commit = NfSeqCommit::from(g0 * Fp::from(present_nf));
         enforce_equal_point(

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -78,15 +78,17 @@ impl Step for SpendableInit {
         (chain_start, chain_end): <Self::Left as Header>::Data,
         (range_commit, range_start, range_end, cm): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        #[expect(clippy::expect_used, reason = "constant size")]
+        let &g0 = Pasta::host_generators(Pasta::baked())
+            .g()
+            .first()
+            .expect("at least one generator");
+
         // Bind `present_nf` to the single derived starting leaf `GGM(mk, epoch)`.
         enforce_zero(
             Fp::from(range_end) - (Fp::from(range_start) + Fp::ONE),
             "SpendableInit: starting range must span one epoch",
         )?;
-        let generators = Pasta::host_generators(Pasta::baked()).g();
-
-        #[expect(clippy::expect_used, reason = "constant size")]
-        let g0 = generators.first().expect("at least one generator");
 
         let present_commit = NfSeqCommit::from(g0 * Fp::from(present_nf));
         enforce_equal_point(

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -18,7 +18,7 @@ use crate::{
     entropy::ActionRandomizer,
     keys::private,
     note::{Note, Nullifier},
-    primitives::{ActionDigest, ActionSetCommit, Anchor, Tachygram, TachygramSetCommit, effect},
+    primitives::{ActionDigest, ActionSetCommit, Anchor, TachygramSetCommit, effect},
     relations::enforce_poly_product,
     value,
 };
@@ -86,6 +86,13 @@ impl Step for OutputStamp {
         _left: <Self::Left as Header>::Data,
         _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        #[expect(clippy::expect_used, reason = "constant size")]
+        let &[g0, g1] = Pasta::host_generators(Pasta::baked())
+            .g()
+            .split_first_chunk::<2>()
+            .expect("at least two generators")
+            .0;
+
         enforce_nonzero(
             Fp::from(u64::from(note.value)),
             "OutputStamp: zero-value note",
@@ -100,14 +107,20 @@ impl Step for OutputStamp {
         let action_digest = ActionDigest::new(cv, rk).map_err(|_err| {
             ragu::Error::InvalidWitness("OutputStamp: action digest construction failed".into())
         })?;
-        let tachygram = Tachygram::from(note.commitment());
 
-        let data = (
-            ActionSetCommit::from([action_digest].as_slice()),
-            TachygramSetCommit::from([tachygram].as_slice()),
-            anchor,
-        );
-        Ok((data, ()))
+        // Set commitment to one action.
+        let action_commit = {
+            let a0 = Fp::from(action_digest);
+            ActionSetCommit::from(g0 * (-a0) + g1)
+        };
+
+        // Set commitment to one note commitment.
+        let tachygram_commit = {
+            let t0 = Fp::from(note.commitment());
+            TachygramSetCommit::from(g0 * (-t0) + g1)
+        };
+
+        Ok(((action_commit, tachygram_commit, anchor), ()))
     }
 }
 
@@ -138,6 +151,13 @@ impl Step for SpendStamp {
         (cv, rk, present_nf, anchor, cm): <Self::Left as Header>::Data,
         (range_commit, range_start, range_end, range_cm): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        #[expect(clippy::expect_used, reason = "constant size")]
+        let &[g0, g1, g2] = Pasta::host_generators(Pasta::baked())
+            .g()
+            .split_first_chunk::<3>()
+            .expect("at least three generators")
+            .0;
+
         enforce_zero(
             Fp::from(range_end) - (Fp::from(range_start) + Fp::from(2u64)),
             "SpendStamp: live range must span two epochs",
@@ -148,14 +168,6 @@ impl Step for SpendStamp {
         )?;
 
         // Bind the published pair to the genuine GGM leaf pair.
-        let generators = Pasta::host_generators(Pasta::baked()).g();
-
-        #[expect(clippy::expect_used, reason = "constant size")]
-        let (g0, g1) = (
-            generators.first().expect("at least one generator"),
-            generators.get(1).expect("at least two generators"),
-        );
-
         let nf_pair_ref: Eq = g0 * Fp::from(present_nf) + g1 * Fp::from(nf_next);
         enforce_equal_point(
             Eq::from(range_commit),
@@ -177,14 +189,21 @@ impl Step for SpendStamp {
             ragu::Error::InvalidWitness("SpendStamp: action digest construction failed".into())
         })?;
 
-        let data = (
-            ActionSetCommit::from([action_digest].as_slice()),
-            TachygramSetCommit::from(
-                [Tachygram::from(present_nf), Tachygram::from(nf_next)].as_slice(),
-            ),
-            anchor,
-        );
-        Ok((data, ()))
+        // Set commitment to one action.
+        let action_commit = {
+            let a0 = Fp::from(action_digest);
+            ActionSetCommit::from(g0 * (-a0) + g1)
+        };
+
+        // Set commitment to two nullifiers.
+        let tachygram_commit = {
+            let t0 = Fp::from(present_nf);
+            let t1 = Fp::from(nf_next);
+
+            TachygramSetCommit::from(g0 * (t0 * t1) + g1 * (-(t0 + t1)) + g2)
+        };
+
+        Ok(((action_commit, tachygram_commit, anchor), ()))
     }
 }
 

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -15,7 +15,7 @@ use rand_core::{CryptoRng, RngCore};
 
 use super::{PROOF_SYSTEM, delegation, pool, spend, spendable, stamp};
 use crate::{
-    ActionSetCommit, Note, TachygramSetCommit, TachygramSetPoly,
+    ActionSetPoly, Note, TachygramSetPoly,
     constants::EPOCH_SIZE,
     entropy::ActionEntropy,
     fixtures::{
@@ -104,13 +104,14 @@ fn same_epoch_honest_spend_accepted() {
     let spend_pcd = honest_spend_bind(rng, &user, &note, spendable);
     let stamp = honest_spend_stamp(rng, &user, &note, spend_pcd, epoch);
 
-    let expected = TachygramSetCommit::from(
+    let expected = TachygramSetPoly::from(
         [
             user.nf_at(&note, epoch).into(),
             user.nf_at(&note, epoch.next()).into(),
         ]
         .as_slice(),
-    );
+    )
+    .commit();
     assert_eq!(stamp.data().1, expected, "publishes {{N_E, N_E+1}}");
     PROOF_SYSTEM
         .rerandomize(stamp, rng)
@@ -212,10 +213,9 @@ fn stamp_lift_within_epoch() {
     let note = user.random_note(rng, 200);
     let (stamp, plan) = build_output_stamp(rng, stamp_anchor, note);
 
-    let action_commit: ActionSetCommit =
-        ActionSetCommit::from([plan.digest().expect("valid plan")].as_slice());
-    let tachygram_commit: TachygramSetCommit =
-        TachygramSetCommit::from(stamp.tachygrams.as_slice());
+    let action_commit =
+        ActionSetPoly::from([plan.digest().expect("valid plan")].as_slice()).commit();
+    let tachygram_commit = TachygramSetPoly::from(stamp.tachygrams.as_slice()).commit();
 
     pool.advance(usize::try_from(EPOCH_SIZE - 2).expect("fits"), |_| {
         random_block(rng, 1, 4)
@@ -245,7 +245,7 @@ fn spendable_init_rejects_tg_absent() {
     let present_nf = user.nf_at(&note, EpochIndex(0));
     let absent_set = TachygramSetPoly::from([tg(rng)].as_slice());
     // cm-inclusion is checked first, so a dummy boundary chain suffices here.
-    let dummy_commit = TachygramSetCommit::from([tg(rng)].as_slice());
+    let dummy_commit = TachygramSetPoly::from([tg(rng)].as_slice()).commit();
     let (dummy_chain, ()) = PROOF_SYSTEM
         .seed(rng, pool::AnchorSeed, (Anchor::default(), dummy_commit))
         .expect("AnchorSeed");
@@ -296,7 +296,7 @@ fn unspent_fuse_rejects_invalid_compositions() {
     let stamps_left = vec![tg(rng)];
     let stamps_right = vec![tg(rng)];
     let start = Anchor::default();
-    let mid = start.next_stamp(&TachygramSetCommit::from(stamps_left.as_slice()));
+    let mid = start.next_stamp(&TachygramSetPoly::from(stamps_left.as_slice()).commit());
 
     // nf mismatch: contiguous states but different nfs.
     {
@@ -726,13 +726,14 @@ fn spend_after_lift_publishes_anchor_epoch_nullifiers() {
     );
 
     let stamp = honest_spend_stamp(rng, &user, &note, spend_pcd, EpochIndex(1));
-    let expected = TachygramSetCommit::from(
+    let expected = TachygramSetPoly::from(
         [
             user.nf_at(&note, EpochIndex(1)).into(),
             user.nf_at(&note, EpochIndex(2)).into(),
         ]
         .as_slice(),
-    );
+    )
+    .commit();
     assert_eq!(stamp.data().1, expected);
 }
 
@@ -750,13 +751,14 @@ fn spend_stamp_assembles_tachygrams() {
     let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd);
     let stamp_pcd = honest_spend_stamp(rng, &user, &note, spend_pcd, spend_epoch);
     let (_actions, tg_commit, _anchor) = *stamp_pcd.data();
-    let expected = TachygramSetCommit::from(
+    let expected = TachygramSetPoly::from(
         [
             Tachygram::from(user.nf_at(&note, spend_epoch)),
             Tachygram::from(user.nf_at(&note, spend_epoch.next())),
         ]
         .as_slice(),
-    );
+    )
+    .commit();
     assert_eq!(tg_commit, expected);
 }
 


### PR DESCRIPTION
Remove misleading `From`/`TryFrom` impls that skipped from slices straight to set commitments, hiding the polynomial step.

Call sites now explicitly either construct a poly or manually compute a commitment.