### PR TITLE
fix(bundle): restore action index in RkMismatch

### DIFF
--- a/crates/tachyon/Cargo.toml
+++ b/crates/tachyon/Cargo.toml
@@ -41,7 +41,12 @@ corez = { version = "0.1.1", default-features = false, features = [
     "alloc",
 ] }
 derive_more = { version = "~2.1", default-features = false, features = [
-    "full", # todo: use more specific features
+    "debug",
+    "display",
+    "eq",
+    "error",
+    "from",
+    "into",
 ] }
 ff = "0.13"
 group = "0.13"

--- a/crates/tachyon/Cargo.toml
+++ b/crates/tachyon/Cargo.toml
@@ -41,12 +41,7 @@ corez = { version = "0.1.1", default-features = false, features = [
     "alloc",
 ] }
 derive_more = { version = "~2.1", default-features = false, features = [
-    "debug",
-    "display",
-    "eq",
-    "error",
-    "from",
-    "into",
+    "full", # todo: use more specific features
 ] }
 ff = "0.13"
 group = "0.13"

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -227,8 +227,16 @@ pub enum SignatureError {
 #[non_exhaustive]
 pub enum SignError {
     /// The derived rk does not match the stored rk.
-    #[display("plan rk {_0:?} does not match")]
-    RkMismatch(#[error(not(source))] reddsa::VerificationKeyBytes<reddsa::ActionAuth>),
+    #[display("plan rk {rk:?} does not match at action {index}")]
+    RkMismatch {
+        /// Index of the offending action in the bundle (spends first, then
+        /// outputs).
+        #[error(not(source))]
+        index: usize,
+        /// The stored rk that did not match the derived one.
+        #[error(not(source))]
+        rk: reddsa::VerificationKeyBytes<reddsa::ActionAuth>,
+    },
     /// The number of signatures does not match the number of actions.
     #[display("expected {_0} signatures")]
     SigCountMismatch(#[error(not(source))] usize),
@@ -377,12 +385,15 @@ impl Plan {
         let n_actions = self.spends.len() + self.outputs.len();
         let mut authorized = Vec::with_capacity(n_actions);
 
-        for plan in &self.spends {
+        for (index, plan) in self.spends.iter().enumerate() {
             let cm = plan.note.commitment();
             let alpha = plan.theta.randomizer::<effect::Spend>(cm);
             let rsk = ask.derive_action_private(&alpha);
             if rsk.derive_action_public() != plan.rk {
-                return Err(SignError::RkMismatch(plan.rk.0.into()));
+                return Err(SignError::RkMismatch {
+                    index,
+                    rk: plan.rk.0.into(),
+                });
             }
             authorized.push(Action {
                 cv: plan.cv(),
@@ -391,12 +402,15 @@ impl Plan {
             });
         }
 
-        for plan in &self.outputs {
+        for (idx, plan) in self.outputs.iter().enumerate() {
             let cm = plan.note.commitment();
             let alpha = plan.theta.randomizer::<effect::Output>(cm);
             let rsk = private::ActionSigningKey::new(&alpha);
             if rsk.derive_action_public() != plan.rk {
-                return Err(SignError::RkMismatch(plan.rk.0.into()));
+                return Err(SignError::RkMismatch {
+                    index: self.spends.len() + idx,
+                    rk: plan.rk.0.into(),
+                });
             }
             authorized.push(Action {
                 cv: plan.cv(),

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -227,12 +227,12 @@ pub enum SignatureError {
 #[non_exhaustive]
 pub enum SignError {
     /// The derived rk does not match the stored rk.
-    #[display("plan rk {rk:?} does not match at action {index}")]
+    #[display("plan rk {rk:?} does not match at action {idx}")]
     RkMismatch {
         /// Index of the offending action in the bundle (spends first, then
         /// outputs).
         #[error(not(source))]
-        index: usize,
+        idx: usize,
         /// The stored rk that did not match the derived one.
         #[error(not(source))]
         rk: reddsa::VerificationKeyBytes<reddsa::ActionAuth>,
@@ -385,13 +385,13 @@ impl Plan {
         let n_actions = self.spends.len() + self.outputs.len();
         let mut authorized = Vec::with_capacity(n_actions);
 
-        for (index, plan) in self.spends.iter().enumerate() {
+        for (idx, plan) in self.spends.iter().enumerate() {
             let cm = plan.note.commitment();
             let alpha = plan.theta.randomizer::<effect::Spend>(cm);
             let rsk = ask.derive_action_private(&alpha);
             if rsk.derive_action_public() != plan.rk {
                 return Err(SignError::RkMismatch {
-                    index,
+                    idx,
                     rk: plan.rk.0.into(),
                 });
             }
@@ -408,7 +408,7 @@ impl Plan {
             let rsk = private::ActionSigningKey::new(&alpha);
             if rsk.derive_action_public() != plan.rk {
                 return Err(SignError::RkMismatch {
-                    index: self.spends.len() + idx,
+                    idx: self.spends.len() + idx,
                     rk: plan.rk.0.into(),
                 });
             }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -9,6 +9,7 @@ use super::*;
 use crate::{
     constants::EPOCH_SIZE,
     digest::blake2b::COMMIT_NO_BUNDLE,
+    entropy::ActionEntropy,
     fixtures::{
         PoolSim, WalletSim, action_digests, build_autonome, build_output_stamp, mock_sighash,
         random_action, random_block, random_block_with, shared_sk,
@@ -76,6 +77,48 @@ fn plan_commitment_matches_bundle_commitment() {
         bundle_plan.commitment().unwrap(),
         bundle.commitment().unwrap()
     );
+}
+
+#[test]
+fn sign_reports_global_action_index_on_rk_mismatch() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+
+    // A valid spend at global index 0 — derive its rk exactly as `sign` does,
+    // so it passes the spend check and signing reaches the outputs.
+    let spend = action::Plan::spend(
+        wallet.random_note(rng, 200),
+        ActionEntropy::random(rng),
+        value::CommitmentTrapdoor::random(rng),
+        |alpha| ask.derive_action_private(&alpha).derive_action_public(),
+    );
+
+    // An output at global index 1 whose rk is corrupted to a foreign key.
+    let mut output = action::Plan::output(
+        wallet.random_note(rng, 100),
+        ActionEntropy::random(rng),
+        value::CommitmentTrapdoor::random(rng),
+    );
+    let wrong_rk = action::Plan::output(
+        wallet.random_note(rng, 50),
+        ActionEntropy::random(rng),
+        value::CommitmentTrapdoor::random(rng),
+    )
+    .rk;
+    output.rk = wrong_rk;
+
+    let plan = Plan::new(alloc::vec![spend], alloc::vec![output]);
+    let sighash = mock_sighash(plan.commitment().unwrap());
+
+    let err = plan.sign(&sighash, &ask, rng).unwrap_err();
+    let SignError::RkMismatch { index, rk } = err else {
+        panic!("expected RkMismatch, got {err:?}");
+    };
+    // Global index = spends.len() (1) + output index (0): the offset is retained,
+    // and the error carries the offending rk alongside it.
+    assert_eq!(index, 1);
+    assert_eq!(rk, wrong_rk.0.into());
 }
 
 #[test]

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -112,12 +112,12 @@ fn sign_reports_global_action_index_on_rk_mismatch() {
     let sighash = mock_sighash(plan.commitment().unwrap());
 
     let err = plan.sign(&sighash, &ask, rng).unwrap_err();
-    let SignError::RkMismatch { index, rk } = err else {
+    let SignError::RkMismatch { idx, rk } = err else {
         panic!("expected RkMismatch, got {err:?}");
     };
     // Global index = spends.len() (1) + output index (0): the offset is retained,
     // and the error carries the offending rk alongside it.
-    assert_eq!(index, 1);
+    assert_eq!(idx, 1);
     assert_eq!(rk, wrong_rk.0.into());
 }
 


### PR DESCRIPTION
follow ups to #142 
- change RkMismatch to { index, rk }, preserving the offending key while restoring its global action position. Includes regression coverage for output indexing.

- Replace derive_more’s full feature with the six derives actually used.