### PR TITLE
Aggregation protocol ZIP

### DIFF
--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -226,8 +226,12 @@ the bundle's stamp and set the `tachyonAggregateId` field to the covering
 aggregate's `wtxid`.
 
 A stripped innocent (a former innocent aggregate) contributes no actions, but
-the stripped form still names a covering transaction: its `tachyonAggregateId`
-MUST refer to the aggregate that ultimately absorbed its stamp.
+the stripped form still names a covering transaction. Its `tachyonAggregateId`
+MUST identify a stamped transaction in the same block, and SHOULD refer to the
+aggregate that ultimately absorbed its stamp. The latter is unverifiable: a
+bundle with no actions contributes no action digests to any reconstruction, so
+a validator cannot distinguish the absorbing aggregate from any other stamped
+transaction (Step 8).
 
 ### Step 8: Block validation
 
@@ -255,7 +259,10 @@ governed by the duplicate-tachygram consensus rule of the
 2. **Adjunct association.** The `tachyonAggregateId` of every stripped bundle
 MUST identify a stamped transaction in the same block. If the referenced
 transaction is absent from the block, or bears no stamp, the validator MUST
-reject the block.
+reject the block. A stripped bundle with no actions satisfies this check
+against any stamped transaction in the block: it contributes no action digests
+to the reconstruction in item 3, so consensus attaches no further meaning to
+its reference.
 3. **Action set commitment per stamp.** The validator MUST confirm each stamp's
 `cActionsTachyon` by reconstruction: collect the action digests of the stamped
 bundle's own actions together with those of every stripped bundle that names it
@@ -409,7 +416,10 @@ mempool can identify covered autonomes by the `cActionsTachyon` check (see
 [Covered-transaction identification](#covered-transaction-identification)). This
 is inherent to the scheme: the aggregate must carry enough information for validators
 to reconstruct its header. The tachygram-set and action-digest-set commitments do not
-reveal the private contents of any covered note.
+reveal the private contents of any covered note. The `tachyonAggregateId` of a stripped
+innocent is not consensus-validated beyond naming a stamped transaction (Step 8, item 2),
+so an observer reconstructing aggregation relationships cannot rely on an actionless
+bundle's reference.
 
 **Circuit/consensus boundary.** Several security properties are enforced by consensus
 rather than fully proven inside the stamp. Double-spend prevention rests on the block-scoped

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -43,6 +43,12 @@ Open questions:
 - **Coverage-query relay message.** A reviewer proposes a `getxref`-style relay message
   that returns the bundles whose stamp references a given `wtxid`, with nodes maintaining
   a coverage graph to answer it. Whether to add such a message is undecided.
+- **Merge-input acquisition.** An aggregator selecting an existing aggregate must recover
+  the contributing actions, but contributors cannot be requested by `wtxid` because the
+  aggregate does not carry their identities. The draft's present position is that
+  aggregators index mempool data and do not attempt merges they cannot satisfy from data
+  they hold. Alternatives: a relay message requesting transactions by tachygram, or
+  aggregates carrying a list of contributing transactions. Undecided.
 - **Stripped zero-action coverage.** A stripped bundle with no actions names a covering
   aggregate that consensus does not confirm; candidate confirmation rules are an open
   question of the
@@ -184,8 +190,9 @@ so this guidance needs no enforcement (see the [Rationale](#rationale)).
 ### Step 3: Witness and PCD preparation
 
 The aggregator reconstructs each selected transaction's stamp PCD from the
-proof and data carried on that transaction itself, obtained in a single
-`MSG_WTX` getdata. Reconstruction requires no multi-stage witness fetching.
+proof and data carried on that transaction itself, which the aggregator
+already holds from mempool observation (Step 2). Reconstruction requires no
+multi-stage witness fetching.
 
 Merging is defined only over stamps bearing identical anchors. If the selected
 transactions bear unequal anchors, the aggregator first aligns them by lifting
@@ -196,16 +203,17 @@ If both selected transactions are autonomes, all necessary witness data is
 directly available on the transactions themselves.
 
 A selected transaction that is already an aggregate additionally requires the
-action digests of every transaction contributing to it. Recovering those
-contributors is
+action digests of every transaction contributing to it. The contributors
+cannot be requested from the network by `wtxid`, because the aggregate does
+not carry their identities. Recovering them from transactions the aggregator
+holds is
 [covered-transaction identification](#covered-transaction-identification): a correct and
 complete collection of action digests reproduces the action set commitment on the
 selected stamp.
 
-Aggregators typically maintain recent consensus data, cached anchor lift
-proofs, and an index of recent mempool transactions to support alignment and
-witness preparation. These are implementation concerns; this ZIP does not
-constrain them.
+Aggregators therefore maintain an index of recent mempool transactions, along
+with recent consensus data and cached anchor lift proofs, and do not attempt
+merges whose contributors they cannot recover from data they hold.
 
 ### Step 4: Aggregate construction
 

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -58,64 +58,64 @@ The term "network upgrade" is to be interpreted as described in
 [ZIP 200](https://zips.z.cash/zip-0200). The terms "Testnet" and "Mainnet" are to be
 interpreted as described in section 3.12 of the Zcash Protocol Specification.
 
-- **Tachygram.** A `byte[32]` field element ($\mathbb{F}_p$) representing either a note
-  nullifier or a note commitment. Consensus treats nullifiers and commitments
-  identically.
-- **Stamp.** A bundle trailer which may replaced with a reference to another
-  transaction. Contains a Ragu proof and some associated data necessary for
-  verification, including tachygrams.The proof establishes that the actions follow
-  the correct rules.
-- **Autonome.** A stand-alone transaction with a stamped bundle, containing a
-  proof covering only its own actions. The standard form of a user-originated
-  Tachyon transaction. An autonome may appear in a block or in the mempool.
-- **Aggregate.** A transaction with a stamped bundle, containing a merged stamp
-  that covers other transactions. More specifically, an *innocent aggregate*
-  contains no Tachyon actions of its own; and a *based aggregate* contains Tachyon
-  actions. An aggregate may appear in a block or in the mempool.
-- **Adjunct.** A transaction with a stripped bundle. Its proof has been removed
+The terms "tachygram" and "stamp" are defined by the
+[Tachyon Shielded Protocol](tachyon-shielded-protocol.md) and
+[Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIPs respectively, and
+are summarized here non-normatively. The remaining terms are defined by this ZIP.
+
+- **Tachygram.** The `byte[32]` encoding of a field element ($\mathbb{F}_p$)
+  representing either a note nullifier or a note commitment. Consensus treats
+  nullifiers and commitments identically.
+- **Stamp.** A bundle trailer carrying a Ragu proof and the data necessary to
+  verify it, including tachygrams. The proof attests that every covered action
+  satisfies the Tachyon action rules. A bundle's stamp may be replaced by a
+  reference to a covering transaction (see Adjunct).
+- **Autonome.** A stand-alone transaction with a stamped bundle, whose proof
+  covers only its own actions. The standard form of a user-originated Tachyon
+  transaction. An autonome may appear in a block or in the mempool.
+- **Aggregate.** A transaction with a stamped bundle, whose merged stamp covers
+  other transactions. An *innocent aggregate* contains no Tachyon actions of its
+  own; a *based aggregate* contains Tachyon actions. An aggregate may appear in
+  a block or in the mempool.
+- **Adjunct.** A transaction with a stripped bundle: its stamp has been removed
   and replaced by a `wtxid` reference to a covering aggregate. Adjuncts retain
-  action data, action signatures, the binding signature, and `value_balance`. An
-  adjunct should only appear in a block.
+  action data, action signatures, the binding signature, and `value_balance`.
+  An adjunct is valid only within a block.
 
 ## Abstract
 
-Tachyon shielded transactions use a recursive proof system. To reduce proof
-verification costs, recursion is used to combine many per-transaction proofs
-into a single proof covering all contributing transactions.
+Tachyon shielded transactions use a recursive proof system. Recursion allows
+many per-transaction proofs to be combined into a single proof covering all
+contributing transactions, reducing proof verification costs. This recursion
+admits a new participant role, the aggregator, without creating a new trust
+assumption.
 
-This recursion provides an opportunity to introduce a new participant role
-without creating a new trust assumption.
-
-This ZIP specifies: the aggregator protocol, a block-layout discipline under
-which miners strip redundant proofs, the semantics about effecting data and
-authorizing data that make stripping safe, and P2P rules that extend ZIP 239 to
-Tachyon's authorization-form malleability.
-
-Aggregation involves an 8-step lifecycle from transaction authorization, through
-the mempool, to block layout, and final validation. All effecting data (actions,
-value balances, action signatures, and binding signatures) remains present and
-valid when a proof is stripped.
+This ZIP specifies the aggregator protocol: an 8-step lifecycle from
+transaction authorization, through the mempool, to block layout and final
+validation. It comprises a block-layout discipline under which miners strip
+redundant proofs, the effecting-data and authorizing-data semantics that make
+stripping safe, and P2P rules extending ZIP 239 to Tachyon's
+authorization-form malleability. All effecting data (actions, value balances,
+action signatures, and binding signatures) remains present and valid when a
+proof is stripped.
 
 ## Motivation
 
-Every proof must be verified to reach consensus. Without aggregation, every
-Tachyon bundle would carry a stamp, and consensus costs would be dominated by
-stamp data and verification. By specifying an aggregation protocol, consensus
-avoids this complexity.
+Consensus requires every proof in a block to be verified. Without aggregation,
+every Tachyon bundle would carry a stamp, and consensus costs would be
+dominated by stamp data and stamp verification. Aggregation bounds that cost.
 
-A block in which a large number of Tachyon stamps are aggregated into a smaller
-number of Tachyon stamps is completely verified by that smaller number of
-stamps, while still allowing every action, signature, and balance to remain
-independently valid. In the ideal case, a single proof MAY verify all Tachyon
+A block in which a large number of Tachyon stamps have been aggregated into a
+smaller number of stamps is completely verified by that smaller number of
+stamps, while every action, signature, and balance remains independently
+verifiable. In the ideal case, a single proof verifies all Tachyon
 transactions in a block.
 
-Aggregation is RECOMMENDED, not required. A miner MAY choose to include
-completely independent non-aggregated transactions.
+Aggregation is optional. Miners remain free to include non-aggregated Tachyon
+transactions; any aggregate a block does contain must be fully backed by
+adjuncts in the same block.
 
 ## Requirements
-
-(Goals, stated without conformance keywords; the normative rules that meet them live in
-the Specification.)
 
 - Reduce per-block stamp-verification cost by allowing multiple transactions' stamps to
   be merged into one aggregate stamp.
@@ -132,7 +132,7 @@ the Specification.)
 
 ## Specification
 
-The specification is organised around the 8-step aggregation lifecycle. Each step is a
+The specification is organized around the 8-step aggregation lifecycle. Each step is a
 subsection with conformance language. Two cross-cutting concerns are specified in their own
 subsections after the lifecycle and referenced from the steps that invoke them:
 [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay), and
@@ -151,43 +151,48 @@ Aggregators observe transactions in mempool gossip (see
 
 An aggregator selects two transactions (autonomes or existing aggregates) for
 merging into a new aggregate. Selected transactions SHOULD bear disjoint
-tachygram sets.
+tachygram sets: merging combines tachygram sets, and a block containing a
+duplicate tachygram is invalid (Step 8), so an aggregate built from
+overlapping sets can never be included in a valid block.
 
-### Step 3: Prepare witnesses and PCD
+### Step 3: Witness and PCD preparation
 
-Aggregators reconstruct two stamp PCD from proofs and data available directly on
-the input transactions.
+The aggregator reconstructs each selected transaction's stamp PCD from the
+proof and data carried on that transaction.
 
-If selected transactions bear unequal anchors, aggregators MUST align stamp anchors by
-fusing with an anchor PCD that represents the difference. Aggregators are
-RECOMMENDED to maintain recent consensus data and cache anchor PCD likely to be
-relevant to anchor adjustment.
+Merging is defined only over stamps bearing identical anchors. If the selected
+transactions bear unequal anchors, the aggregator MUST first align them by
+fusing with an anchor PCD that proves the sequence from one anchor to the
+other. Aggregators SHOULD maintain recent consensus data and cache anchor PCD
+likely to be relevant to anchor alignment.
 
-If selected transactions are autonomes, all necessary witness data is directly
-available.
+If both selected transactions are autonomes, all necessary witness data is
+directly available on the transactions themselves.
 
-Any selected transaction that is already an aggregate will require additional
-action digests from all contributing transactions. Aggregators are RECOMMENDED
-to maintain an index of recent mempool transactions likely to be relevant to
-witness preparation. Recovering those contributors is
+A selected transaction that is already an aggregate additionally requires the
+action digests of every transaction contributing to it. Recovering those
+contributors is
 [covered-transaction identification](#covered-transaction-identification): a correct and
-complete collection of relevant action digests reproduces the action set commitment on the
-selected stamp.
+complete collection of action digests reproduces the action set commitment on the
+selected stamp. Aggregators SHOULD maintain an index of recent mempool
+transactions likely to be relevant to witness preparation.
 
 ### Step 4: Aggregate construction
 
-Holding two stamp PCD and an appropriate witness, the aggregator may execute a
-fuse step to prove a new stamp PCD that covers the selected transactions and all
-transactions contributing to the selected transactions.
+Holding two stamp PCD with identical anchors and the prepared witness, the
+aggregator executes a merge, proving a new stamp PCD that covers the selected
+transactions and every transaction contributing to them.
 
-The aggregator may construct a new transaction bearing the merged stamp, or
-simply update one or both of the contributing transactions.
+The aggregator MAY construct a new transaction bearing the merged stamp, or
+MAY update either contributing transaction in place, replacing its stamp with
+the merged stamp.
 
 ### Step 5: Aggregate publication
 
-Aggregators publish the aggregate transaction to the mempool. A freshly constructed
-transaction has a distinct `txid` and `wtxid`; an updated transaction keeps the same `txid`
-and produces a new `wtxid` distinct from the input it replaced. Relay follows
+The aggregator publishes the aggregate transaction to the mempool. A newly
+constructed transaction bears a new `txid` and `wtxid`; an updated transaction
+retains its `txid` and bears a new `wtxid`, distinct from the form it replaced.
+Relay follows
 [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay).
 
 ### Step 6: Miner observation and selection
@@ -206,8 +211,8 @@ Use of aggregates within a block is RECOMMENDED, not required.
 
 Miners MAY perform additional aggregation during block assembly, without
 publishing the aggregate to the mempool. The resulting aggregate is included
-directly in the miner's proposed block. The same `MergeStamp` and
-anchor-alignment rules apply.
+directly in the miner's proposed block. The merge and anchor-alignment rules
+of Steps 3 and 4 apply unchanged.
 
 A block MAY contain, in any combination:
 
@@ -215,23 +220,24 @@ A block MAY contain, in any combination:
 - zero or more Tachyon autonomes
 - zero or more Tachyon aggregates
 
-A block MUST contain a complete set of adjuncts for all included aggregates.
-For each covered adjunct the miner includes, the miner MUST strip the adjunct's
-stamp and identify the covering aggregate in the `tachyonAggregateId` field.
+A block containing an aggregate MUST also contain, as adjuncts, every
+transaction that aggregate covers. For each such adjunct, the miner MUST strip
+the bundle's stamp and set the `tachyonAggregateId` field to the covering
+aggregate's `wtxid`.
 
-A stripped innocent (a former innocent aggregate) SHOULD carry a
-`tachyonAggregateId` referring to the aggregate which ultimately absorbed its
-stamp.
+A stripped innocent (a former innocent aggregate) contributes no actions, but
+the stripped form still names a covering transaction: its `tachyonAggregateId`
+MUST refer to the aggregate that ultimately absorbed its stamp.
 
 ### Step 8: Block validation
 
 All tachygrams in a block MUST be distinct.
 
-All stripped Tachyon transactions MUST bear a `tachyonAggregateId` referring to
-the stamped transaction in the same block covering its actions.
+Every stripped Tachyon transaction MUST bear a `tachyonAggregateId` referring
+to the stamped transaction in the same block covering its actions.
 
-All stamped Tachyon transactions MUST bear a `cActionsTachyon` opening to the
-complete set of actions for all of its covered transactions in the same block.
+Every stamped Tachyon transaction MUST bear a `cActionsTachyon` opening to the
+complete set of actions of its covered transactions in the same block.
 
 All proofs in a block MUST verify.
 
@@ -246,21 +252,22 @@ cheaper checks pass:
 tachygram appears more than once. Reuse within the wider epoch window is
 governed by the duplicate-tachygram consensus rule of the
 [Tachyon Shielded Protocol](tachyon-shielded-protocol.md).
-2. **Adjunct association.** Every Tachyon transaction with a stripped bundle
-contains a `tachyonAggregateId` that MUST identify a stamped transaction in the
-same block. If no transaction is located, or the located transaction bears no
-stamp, the validator MUST reject the block.
-3. **Action set commitment per stamp.** Every stamp contains a `cActionsTachyon`
-which MUST be confirmed by reconstruction. Collect the action digests of the stamped
-bundle's own actions together with those of every stripped bundle that names it by
-`tachyonAggregateId`, form the polynomial $\prod_i (X - d_i)$ over that combined set, and
-take a single Pedersen commitment of it. If the commitment is not equal to the carried
-`cActionsTachyon`, the validator MUST reject the block.
-4. **Stamp proof verification.** Every Tachyon transaction with a stamped bundle
-contains a proof which MUST verify. Reassemble the stamp PCD from the stamp
-proof, the stamp's `anchorTachyon`, a Pedersen commitment to the stamp's
-`vTachygrams` list of tachygrams, and the confirmed `cActionsTachyon`. If a
-proof does not verify, the validator MUST reject the block.
+2. **Adjunct association.** The `tachyonAggregateId` of every stripped bundle
+MUST identify a stamped transaction in the same block. If the referenced
+transaction is absent from the block, or bears no stamp, the validator MUST
+reject the block.
+3. **Action set commitment per stamp.** The validator MUST confirm each stamp's
+`cActionsTachyon` by reconstruction: collect the action digests of the stamped
+bundle's own actions together with those of every stripped bundle that names it
+by `tachyonAggregateId`, form the polynomial $\prod_i (X - d_i)$ over that
+combined set, and take a single Pedersen commitment of it. If the reconstructed
+commitment does not equal the carried `cActionsTachyon`, the validator MUST
+reject the block.
+4. **Stamp proof verification.** Every stamped bundle's proof MUST verify. The
+validator reassembles the stamp PCD from the stamp proof, the stamp's
+`anchorTachyon`, a Pedersen commitment to the stamp's `vTachygrams` list of
+tachygrams, and the confirmed `cActionsTachyon`. If any proof does not verify,
+the validator MUST reject the block.
 
 ### Transaction identifiers and P2P relay
 
@@ -278,8 +285,9 @@ These semantics underpin publication (Step 5), observation (Steps 2 and 6), and 
   proof); a stripped bundle's trailer is the `byte[64]` covering `wtxid` (the `stampWtxid`
   of the digest contribution). The `"ZTxAuthTachyHash"` personalization is a placeholder
   pending a Tachyon amendment to ZIP 244, which specifies the normative digest algorithm.
-- A transaction's effecting data fixes its `txid`, but it can be authorized in several
-  physical forms that share that `txid` and differ only in `auth_digest`, hence in `wtxid`:
+- A transaction's effecting data fixes its `txid`, but the transaction can be authorized
+  in several physical forms that share that `txid` and differ only in `auth_digest`, hence
+  in `wtxid`:
   a wallet's autonome, an anchor-lifted or proof-rerandomized restamp, and the stripped
   adjunct a miner produces. The covering-aggregate reference an adjunct carries is a
   `wtxid`, not a `txid`, because it must pin a specific physical aggregate.
@@ -312,19 +320,20 @@ and 7).
 Tachygrams give a first pass: an aggregate's stamp publishes the tachygrams of every action
 it covers, so transactions whose tachygrams appear there are candidates. But tachygram
 matching only narrows the candidate set; it cannot confirm the set is complete. A based
-aggregate's own tachygrams are not labelled, and tachygrams do not distinguish nullifiers
+aggregate's own tachygrams are not labeled, and tachygrams do not distinguish nullifiers
 from commitments, so a near-complete collection is indistinguishable from the complete one.
 Absent a faster check, the only way to discover whether a candidate set is exactly the cover
 would be to attempt the aggregate's full proof verification, which fails only after that
-costly attempt when a transaction is missing.
+costly attempt when a transaction is missing or extra.
 
 `cActionsTachyon` is that faster check. The aggregate's stamp publishes it as a commitment
 to the action-digest set of every action the aggregate covers. A candidate set is tested by
-reconstructing the commitment from the candidate actions and matching: each action digest
-$d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$ is
-computable from public action data, so the check costs $O(n)$ polynomial arithmetic plus one
-Pedersen commitment and attempts no proof verification. A match confirms the candidate set is
-exactly the cover; a mismatch is fail-fast.
+reconstructing the commitment from the candidate actions and matching: each action digest is
+computable from the action's public data, as specified by the
+[Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, so the check costs
+$O(n)$ polynomial arithmetic plus one Pedersen commitment and attempts no proof
+verification. A match confirms the candidate set is exactly the cover; a mismatch is
+fail-fast.
 
 ## Reference implementation
 
@@ -334,7 +343,7 @@ stamp merging, stripping, and the `cActionsTachyon` coverage check) is in the
 
 ## Rationale
 
-**Lifecycle-structured specification.** Organising the Specification around the lifecycle
+**Lifecycle-structured specification.** Organizing the Specification around the lifecycle
 mirrors how participants actually move through the protocol. The two concerns that several
 steps share, transaction-identifier and relay semantics and covered-transaction
 identification, are factored into their own subsections and referenced from the steps, so no
@@ -348,9 +357,9 @@ action-digest set, reusing the commitment the proof already attests to rather th
 a signed coverage manifest or a tachygram-origin query protocol.
 
 **Aggregate limits.** Two hard limits bound an aggregate. Its tachygram vector is committed
-as a ragu polynomial, so it cannot exceed the maximum ragu polynomial size; and the
+as a Ragu polynomial, so it cannot exceed the maximum Ragu polynomial size; and the
 aggregate transaction, like any transaction, is bounded by block size. Construction is also
-shaped by parallelism: a single merge is sequential, since each `MergeStamp` consumes the
+shaped by parallelism: a chain of merges is sequential, since each merge consumes the
 previous result, but independent aggregates can be built in parallel.
 
 **`wtxid`, not `txid`, for adjunct references.** A `txid` would be ambiguous across
@@ -376,8 +385,8 @@ for Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
 **No new trust assumption.** The aggregator is not trusted. Every invariant is
 enforced either inside the Ragu PCD (circuit logic) or by consensus checks on public
 data (consensus logic). A malicious aggregator can publish an invalid aggregate, but
-validators will reject it at Step 8. A malicious miner can mis-assign adjuncts or
-omit covered transactions, but the block will fail validation.
+block validation (Step 8) rejects it. A malicious miner can mis-assign adjuncts or
+omit covered transactions, but the block fails validation.
 
 **Data availability.** Aggregation removes redundant proof bytes only. Every adjunct
 retains its action data, action signatures, binding signature, and `value_balance`;
@@ -413,13 +422,12 @@ properties.
 
 ## References
 
-- [ZIP 0: ZIP Process](https://zips.z.cash/zip-0000)
+- [Zcash Protocol Specification](https://zips.z.cash/protocol/protocol.pdf)
 - [ZIP 200: Network Upgrade Mechanism](https://zips.z.cash/zip-0200)
 - [ZIP 225: Version 5 Transaction Format](https://zips.z.cash/zip-0225)
 - [ZIP 239: Relay of Version 5 Transactions](https://zips.z.cash/zip-0239)
 - [ZIP 244: Transaction Identifier Non-Malleability](https://zips.z.cash/zip-0244)
-- [ZIP 252: Deployment of the NU5 Network Upgrade](https://zips.z.cash/zip-0252)
-- [ZIP 317: Proportional Transfer Fee Mechanism](https://zips.z.cash/zip-0317)
 - [BIP 339: WTXID-based transaction relay](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki)
 - [Tachyon Shielded Protocol](tachyon-shielded-protocol.md)
+- [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md)
 - [Tachyon Accumulator / Hash Chain](tachyon-accumulator.md)

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -11,18 +11,19 @@
   layer that aggregation preserves.
 - [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
   defines the stamped and stripped bundle wire encodings, the `tachyonBundleState` byte,
-  the `tachyonAggregateId` trailer, and the stamp trailer fields (including the
-  `cActionsTachyon` action-set indicator).
+  the `tachyonAggregateId` trailer, the stamp trailer fields (including the
+  `cActionsTachyon` action-set indicator), and the block-validity consensus rules that
+  govern how a block's stamped and stripped bundles are validated.
 - [Tachyon Accumulator / Hash Chain (#105)](https://github.com/tachyon-zcash/tachyon/issues/105)
-  defines the anchor (Poseidon hash-chain state), the per-block anchor sequence, and the
-  consensus anchor-membership rule that aggregation depends on for spend validity.
+  defines the anchor (Poseidon hash-chain state), the per-block anchor sequence, the
+  consensus anchor-membership rule that aggregation depends on for spend validity, and the
+  epoch-window duplicate-tachygram consensus rule.
 - [ZIP 239](https://zips.z.cash/zip-0239) defines `MSG_WTX`-based transaction relay by
   `wtxid = txid || auth_digest`. This ZIP extends its rationale to Tachyon's
   authorization-form malleability.
 - [ZIP 244](https://zips.z.cash/zip-0244) defines the `txid_digest` and `auth_digest`
-  trees. A Tachyon amendment to ZIP 244 (tracked separately) fixes the
-  `"ZTxAuthTachyHash"` personalization and the Tachyon digest branches; this ZIP does
-  not re-specify that algorithm.
+  trees. The [ZIP 244 update](zip-244.md) fixes the `"ZTxAuthTachyHash"` personalization
+  and the Tachyon digest branches; this ZIP does not re-specify that algorithm.
 
 ## II. Design Considerations
 
@@ -35,19 +36,17 @@ Miners are likely to vertically integrate aggregation, but a protocol is establi
 
 Open questions:
 
-- **Category.** The draft is Category 'Network', but its block-validation step defines
-  block-validity rules, which are consensus. Either this ZIP is recategorized (or
-  dual-categorized 'Consensus / Network'), or the validation rules relocate to the
-  consensus-category [bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
-  and are cited from here.
-- **Duplicate-tachygram rule ownership.** The draft cites the epoch-window
-  duplicate-tachygram rule to the
-  [Shielded Protocol ZIP (#103)](https://github.com/tachyon-zcash/tachyon/issues/103);
-  confirm it is not owned by the
-  [Accumulator ZIP (#105)](https://github.com/tachyon-zcash/tachyon/issues/105).
 - **Transaction-digest amendment.** The `"ZTxAuthTachyHash"` personalization and the
-  Tachyon `txid`/`auth_digest` branches await an amendment to ZIP 244, which may be a
-  separate update ZIP or may fold into one of the general Tachyon ZIPs.
+  Tachyon `txid`/`auth_digest` branches are specified by the
+  [ZIP 244 update](zip-244.md), conditional on the ZIP 248 registration of the extensible
+  transaction format.
+- **Coverage-query relay message.** A reviewer proposes a `getxref`-style relay message
+  that returns the bundles whose stamp references a given `wtxid`, with nodes maintaining
+  a coverage graph to answer it. Whether to add such a message is undecided.
+- **Stripped zero-action coverage.** A stripped bundle with no actions names a covering
+  aggregate that consensus does not confirm; candidate confirmation rules are an open
+  question of the
+  [bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104).
 - **Deployment.** The deployment ZIP and activation parameters are undefined; the draft's
   Deployment section points at the placeholder.
 
@@ -92,9 +91,8 @@ are summarized here non-normatively. The remaining terms are defined by this ZIP
   covers only its own actions. The standard form of a user-originated Tachyon
   transaction. An autonome may appear in a block or in the mempool.
 - **Aggregate.** A transaction with a stamped bundle, whose merged stamp covers
-  other transactions. An *innocent aggregate* contains no Tachyon actions of its
-  own; a *based aggregate* contains Tachyon actions. An aggregate may appear in
-  a block or in the mempool.
+  other transactions. An aggregate MAY contain zero or more Tachyon actions of
+  its own. An aggregate may appear in a block or in the mempool.
 - **Adjunct.** A transaction with a stripped bundle: its stamp has been removed
   and replaced by a `wtxid` reference to a covering aggregate. Adjuncts retain
   action data, action signatures, the binding signature, and `value_balance`.
@@ -104,30 +102,38 @@ are summarized here non-normatively. The remaining terms are defined by this ZIP
 
 Tachyon shielded transactions use a recursive proof system. Recursion allows
 many per-transaction proofs to be combined into a single proof covering all
-contributing transactions, reducing proof verification costs. This recursion
-admits a new participant role, the aggregator, without creating a new trust
-assumption.
+contributing transactions, reducing proof verification cost, on-chain
+footprint, and per-stamp syncing cost. This recursion admits a new participant
+role, the aggregator, without creating a new trust assumption.
 
 This ZIP specifies the aggregator protocol: an 8-step lifecycle from
 transaction authorization, through the mempool, to block layout and final
-validation. It comprises a block-layout discipline under which miners strip
-redundant proofs, the effecting-data and authorizing-data semantics that make
-stripping safe, and P2P rules extending ZIP 239 to Tachyon's
-authorization-form malleability. All effecting data (actions, value balances,
-action signatures, and binding signatures) remains present and valid when a
-proof is stripped.
+validation. It comprises a block-layout discipline under which miners replace a
+covered bundle's proof with a reference to a covering transaction, the
+effecting-data and authorizing-data semantics that make stripping safe, and P2P
+rules extending ZIP 239 to Tachyon's authorization-form malleability.
+Aggregation affects only the authorization-proof mechanism: every bundle's
+effecting data (actions, value balances, action signatures, and binding
+signatures) remains present when its proof is stripped, and the
+binding-signature balance check and transaction authorization remain unchanged
+and per-bundle.
 
 ## Motivation
 
-Consensus requires every proof in a block to be verified. Without aggregation,
-every Tachyon bundle would carry a stamp, and consensus costs would be
-dominated by stamp data and stamp verification. Aggregation bounds that cost.
+Consensus requires every bundle to be verified. Naively, every Tachyon bundle
+carries its own proof, and consensus cost is dominated by proof size and proof
+verification. Aggregation amortizes that cost: it reduces the proof
+verification a validator performs, the on-chain footprint the proofs occupy,
+and the per-stamp cost of syncing the chain.
 
-A block in which a large number of Tachyon stamps have been aggregated into a
-smaller number of stamps is completely verified by that smaller number of
-stamps, while every action, signature, and balance remains independently
-verifiable. In the ideal case, a single proof verifies all Tachyon
-transactions in a block.
+The proof system permits public aggregation of already-published proofs, so the
+aggregator is a permissionless, conceptual role that any participant may take,
+not a designated prover. A block in which a large number of Tachyon stamps have
+been aggregated into a smaller number of stamps is completely verified by that
+smaller number of stamps. Aggregation affects only the authorization-proof
+mechanism: the binding-signature balance check and transaction authorization
+remain unchanged and per-bundle. In the ideal case, a single proof verifies all
+Tachyon transactions in a block.
 
 Aggregation is optional. Miners remain free to include non-aggregated Tachyon
 transactions; any aggregate a block does contain must be fully backed by
@@ -137,9 +143,10 @@ adjuncts in the same block.
 
 - Reduce per-block stamp-verification cost by allowing multiple transactions' stamps to
   be merged into one aggregate stamp.
-- Preserve independent verifiability of every transaction's effecting data: action
-  digests, value balances, action signatures, and binding signatures remain checkable
-  without trusting the aggregator.
+- Confine aggregation to the authorization-proof mechanism: the binding-signature balance
+  check and transaction authorization remain unchanged and per-bundle, and every
+  transaction's effecting data (action digests, value balances, action signatures, and
+  binding signatures) remains present when its proof is stripped.
 - Preserve transaction-identifier stability: a transaction's `txid` is invariant across
   stamping, merging, and stripping.
 - Allow any participant to act as aggregator; no protocol-level exclusivity.
@@ -168,17 +175,22 @@ Aggregators observe transactions in mempool gossip (see
 [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay)).
 
 An aggregator selects two transactions (autonomes or existing aggregates) for
-merging into a new aggregate. Selected transactions SHOULD bear disjoint
-tachygram sets.
+merging into a new aggregate. Selected transactions MUST bear anchors that are
+identical or alignable by lifting (see
+[Step 3](#step-3-witness-and-pcd-preparation)). Selected transactions SHOULD bear
+disjoint tachygram sets; overlapping selections cannot yield a valid aggregate,
+so this guidance needs no enforcement (see the [Rationale](#rationale)).
 
 ### Step 3: Witness and PCD preparation
 
 The aggregator reconstructs each selected transaction's stamp PCD from the
-proof and data carried on that transaction.
+proof and data carried on that transaction itself, obtained in a single
+`MSG_WTX` getdata. Reconstruction requires no multi-stage witness fetching.
 
 Merging is defined only over stamps bearing identical anchors. If the selected
-transactions bear unequal anchors, the aggregator first aligns them by fusing
-with an anchor PCD that proves the sequence from one anchor to the other.
+transactions bear unequal anchors, the aggregator first aligns them by lifting
+the older anchor to the newer with a lift PCD that proves the anchor sequence
+between them.
 
 If both selected transactions are autonomes, all necessary witness data is
 directly available on the transactions themselves.
@@ -190,10 +202,10 @@ contributors is
 complete collection of action digests reproduces the action set commitment on the
 selected stamp.
 
-Aggregators typically maintain recent consensus data, cached anchor PCD, and
-an index of recent mempool transactions to support alignment and witness
-preparation. These are implementation concerns; this ZIP does not constrain
-them.
+Aggregators typically maintain recent consensus data, cached anchor lift
+proofs, and an index of recent mempool transactions to support alignment and
+witness preparation. These are implementation concerns; this ZIP does not
+constrain them.
 
 ### Step 4: Aggregate construction
 
@@ -243,57 +255,30 @@ transaction that aggregate covers. For each such adjunct, the miner MUST strip
 the bundle's stamp and set the `tachyonAggregateId` field to the covering
 aggregate's `wtxid`.
 
-A stripped innocent (a former innocent aggregate) contributes no actions, but
-the stripped form still names a covering transaction. Its `tachyonAggregateId`
-MUST identify a stamped transaction in the same block, and SHOULD refer to the
-aggregate that ultimately absorbed its stamp.
+A stripped bundle with no actions of its own still names a covering transaction.
+Its `tachyonAggregateId` MUST identify a stamped transaction in the same block,
+and SHOULD refer to the aggregate that ultimately absorbed its stamp.
 
 ### Step 8: Block validation
 
-The tachygrams of every stamped bundle MUST be distinct.
+Block validation closes the aggregation lifecycle: a validator confirms that
+every stamped bundle in a block is backed by the transactions it covers and that
+every proof holds. The normative consensus rules for this are specified in the
+[block-validity section of the Tachyon Bundle / Aggregate Transaction Format
+ZIP](tachyon-bundle.md#block-validity); this step describes only how those rules
+fit the lifecycle.
 
-All tachygrams in a block MUST be distinct.
+Validation covers tachygram distinctness across the block, association of each
+adjunct with the stamped transaction covering it, reconstruction of each stamp's
+action-set commitment from the actions actually present in the block, and
+verification of every proof. Reuse of a tachygram across the wider epoch window
+is a separate consensus concern owned by the [Tachyon Accumulator / Hash Chain
+ZIP](tachyon-accumulator.md#epoch-window).
 
-Every stripped Tachyon transaction MUST bear a `tachyonAggregateId` referring
-to the stamped transaction in the same block covering its actions.
-
-Every stamped Tachyon transaction MUST bear a `cActionsTachyon` opening to the
-complete set of actions of its covered transactions in the same block.
-
-All proofs in a block MUST verify.
-
-These are the aggregation-specific rules; other Tachyon consensus rules (action and binding
-signatures, value balance, and anchor membership) are base-protocol consensus, specified by
-the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) and
-[Tachyon Accumulator / Hash Chain](tachyon-accumulator.md) ZIPs, and apply unchanged. A validator
-confirms the rules above as follows, deferring the costly proof verification until the
-cheaper checks pass:
-
-1. **Tachygram uniqueness.** A block's tachygrams are the multiset union of
-the `vTachygrams` of every stamp it contains. The validator MUST reject the
-block if any tachygram appears more than once. This single scan enforces
-distinctness both within each stamp and across stamps. Reuse within the wider
-epoch window is governed by the duplicate-tachygram consensus rule of the
-[Tachyon Shielded Protocol](tachyon-shielded-protocol.md).
-2. **Adjunct association.** The `tachyonAggregateId` of every stripped bundle
-MUST identify a stamped transaction in the same block. If the referenced
-transaction is absent from the block, or bears no stamp, the validator MUST
-reject the block. A stripped bundle with no actions satisfies this check
-against any stamped transaction in the block: it contributes no action digests
-to the reconstruction in item 3, so consensus attaches no further meaning to
-its reference.
-3. **Action set commitment per stamp.** The validator MUST confirm each stamp's
-`cActionsTachyon` by reconstruction: collect the action digests of the stamped
-bundle's own actions together with those of every stripped bundle that names it
-by `tachyonAggregateId`, form the polynomial $\prod_i (X - d_i)$ over that
-combined set, and take a single Pedersen commitment of it. If the reconstructed
-commitment does not equal the carried `cActionsTachyon`, the validator MUST
-reject the block.
-4. **Stamp proof verification.** Every stamped bundle's proof MUST verify. The
-validator reassembles the stamp PCD from the stamp proof, the stamp's
-`anchorTachyon`, a Pedersen commitment to the stamp's `vTachygrams` list of
-tachygrams, and the confirmed `cActionsTachyon`. If any proof does not verify,
-the validator MUST reject the block.
+The spirit of these checks is fail-fast ordering: the cheap public-data scans
+(tachygram distinctness, adjunct association, and action-set reconstruction) run
+before the costly proof verification, so a block that violates a cheaper rule is
+rejected without any proof being verified.
 
 ### Transaction identifiers and P2P relay
 
@@ -301,7 +286,11 @@ These semantics underpin publication (Step 5), observation (Steps 2 and 6), and 
 (Step 7).
 
 **Identifiers.** A Tachyon transaction is identified by `wtxid = txid || auth_digest`
-([ZIP 239](https://zips.z.cash/zip-0239), [ZIP 244](https://zips.z.cash/zip-0244)):
+([ZIP 239](https://zips.z.cash/zip-0239), [ZIP 244](https://zips.z.cash/zip-0244)). The
+digest inputs (which fields each contribution commits to) are defined normatively by the
+[Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, and the digest
+algorithm by the [ZIP 244 update](zip-244.md); this section summarizes them
+non-normatively.
 
 - Tachyon's contribution to `txid` commits only to effecting data
   (`action_acc || value_balance`). It is stable across
@@ -310,8 +299,8 @@ These semantics underpin publication (Step 5), observation (Steps 2 and 6), and 
 - `auth_digest` commits to action signatures, the binding signature, and the stamp trailer.
   A stamped bundle's trailer is the full stamp (`cActionsTachyon`, anchor, tachygrams,
   proof); a stripped bundle's trailer is the `byte[64]` covering `wtxid` (the `stampWtxid`
-  of the digest contribution). The `"ZTxAuthTachyHash"` personalization is a placeholder
-  pending a Tachyon amendment to ZIP 244, which specifies the normative digest algorithm.
+  of the digest contribution). The `"ZTxAuthTachyHash"` personalization and the normative
+  digest algorithm are specified by the [ZIP 244 update](zip-244.md).
 - A transaction's effecting data fixes its `txid`, but the transaction can be authorized
   in several physical forms that share that `txid` and differ only in `auth_digest`, hence
   in `wtxid`:
@@ -340,13 +329,17 @@ invalid, and a node MUST NOT accept it into the mempool or relay it. The check i
 of the public list, requiring no proof verification.
 
 **Proof verification precedes relay.** A node MUST verify a stamped bundle's proof before
-accepting the transaction into its mempool or relaying it. The stamp is sufficient for
-this: the node assembles the proof header from the carried `cActionsTachyon`, the stamp's
-`anchorTachyon`, and a Pedersen commitment to its `vTachygrams`, and verifies the proof
-against that header. A wrong `cActionsTachyon` cannot pass, because the proof verifies
-only against the action-set commitment it actually attests to. Mempool acceptance
-therefore requires no covered transactions; confirming that a block's actions match the
-carried commitment is a block-validation concern (Step 8).
+accepting the transaction into its mempool or relaying it. This paragraph specifies only
+the Tachyon-proof-specific requirement; mempool acceptance also requires the standard
+checks (action and binding signature verification, balance rules, and general transaction
+validity). The stamp is sufficient for the proof check: the node assembles the proof
+header from the carried `cActionsTachyon`, the stamp's `anchorTachyon`, and a Pedersen
+commitment to its `vTachygrams`, and verifies the proof against that header. A wrong
+`cActionsTachyon` cannot pass, because the proof verifies only against the action-set
+commitment it actually attests to. A node can therefore verify a stamped aggregate's
+proof without holding any of the transactions it covers; confirming that a block's actions
+match the carried commitment is a block-validation concern (see
+[block validity](tachyon-bundle.md#block-validity)).
 
 **Stripped bundles are forbidden from the mempool.** A bundle in the stripped state
 (`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool, relayed, or published
@@ -367,7 +360,7 @@ and 7).
 
 Tachygrams give a first pass: an aggregate's stamp publishes the tachygrams of every action
 it covers, so transactions whose tachygrams appear there are candidates. But tachygram
-matching only narrows the candidate set; it cannot confirm the set is complete. A based
+matching only narrows the candidate set; it cannot confirm the set is complete. An
 aggregate's own tachygrams are not labeled, and tachygrams do not distinguish nullifiers
 from commitments, so a near-complete collection is indistinguishable from the complete one.
 Absent a faster check, the only way to discover whether a candidate set is exactly the cover
@@ -392,8 +385,8 @@ identification, are factored into their own subsections and referenced from the 
 step restates another's rules and the lifecycle reads as a sequence of actions.
 
 **Cheap coverage confirmation.** Matching previously-seen tachygrams associates an
-aggregate with the autonomes it covers, but cannot confirm the association is complete: a
-based aggregate's own tachygrams are indistinguishable from its covered autonomes'. The
+aggregate with the autonomes it covers, but cannot confirm the association is complete: an
+aggregate's own tachygrams are indistinguishable from its covered autonomes'. The
 `cActionsTachyon` indicator gives observers a fail-fast completeness check over the
 action-digest set, reusing the commitment the proof already attests to rather than adding
 a signed coverage manifest or a tachygram-origin query protocol.
@@ -401,7 +394,8 @@ a signed coverage manifest or a tachygram-origin query protocol.
 **Overlapping merges self-invalidate.** The disjoint-selection guidance of Step 2 is a
 SHOULD rather than a consensus rule because a violation cannot survive: merging stamps
 whose tachygram sets overlap produces a stamp bearing duplicate tachygrams, which no node
-accepts into its mempool and no valid block can contain (Step 8). The deeper reason is
+accepts into its mempool and no valid block can contain (see
+[block validity](tachyon-bundle.md#block-validity)). The deeper reason is
 that the merge is homomorphic over the stamps' set commitments, so the overlapping stamp
 commits to multiply-counted multiset members that no reconstruction over a block's
 distinct transactions can reproduce. The aggregator's proving work is simply wasted, so
@@ -416,8 +410,9 @@ previous result, but independent aggregates can be built in parallel.
 **Verified relay.** Requiring proof verification before relay is standard mempool
 hygiene, and aggregation sharpens it: an invalid stamp is a dead end, since a merge
 cannot produce a valid aggregate from an invalid input and no valid block can carry an
-unverifiable proof (Step 8). Aggregators would therefore hit every invalid proof
-themselves at the fuse; verifying at relay pushes that discovery to the network edge
+unverifiable proof (see [block validity](tachyon-bundle.md#block-validity)). Aggregators
+would therefore hit every invalid proof themselves at the merge; verifying at relay pushes
+that discovery to the network edge
 rather than spending bandwidth propagating transactions no aggregator can use and no
 block can include. The carried `cActionsTachyon` is what makes this check self-contained:
 the stamp supplies its own header, so relay verification needs no coverage data, and
@@ -446,43 +441,48 @@ for Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
 **No new trust assumption.** The aggregator is not trusted. Every invariant is
 enforced either inside the Ragu PCD (circuit logic) or by consensus checks on public
 data (consensus logic). A malicious aggregator can publish an invalid aggregate, but
-block validation (Step 8) rejects it. A malicious miner can mis-assign adjuncts or
-omit covered transactions, but the block fails validation.
+block validation (see [block validity](tachyon-bundle.md#block-validity)) rejects it. A
+malicious miner can mis-assign adjuncts or omit covered transactions, but the block fails
+validation.
 
 **Data availability.** Aggregation removes redundant proof bytes only. Every adjunct
 retains its action data, action signatures, binding signature, and `value_balance`;
 validators reconstruct the aggregate header from this public data. An aggregate proof
 alone is insufficient: the covered effecting data is present in the block as adjuncts,
-and Step 8 rejects any block where it is not.
+and the [block-validity rules](tachyon-bundle.md#block-validity) reject any block where it
+is not.
 
-**`cActionsTachyon` is confirmed, not trusted.** The action set is bound by the proof. Block
-validation confirms the carried `cActionsTachyon` by reconstructing the action-set commitment
-from the actions actually present in the block, rejects on any mismatch, and only then uses
-the confirmed value as the proof header. That confirmation is what ties the proof to the
-adjuncts the block carries, not to a value the prover supplies, so a wrong `cActionsTachyon`
-cannot pass and only harms its author. The carried value lets observers identify coverage
-cheaply (see [Covered-transaction identification](#covered-transaction-identification)) and
-lets relay nodes verify a stamp's proof without its covered transactions; it is
-reconstructable from visible actions, so it reveals nothing the actions do not, and for a
-based aggregate it does not expose which actions are the aggregator's own.
+**`cActionsTachyon` is confirmed, not trusted.** The action set is bound by the proof.
+Block validation (see [block validity](tachyon-bundle.md#block-validity)) confirms the
+carried `cActionsTachyon` by reconstructing the action-set commitment from the actions
+actually present in the block, rejects on any mismatch, and only then uses the confirmed
+value as the proof header. That confirmation is what ties the proof to the adjuncts the
+block carries, not to a value the prover supplies, so a wrong `cActionsTachyon` cannot pass
+and only harms its author. The carried value lets observers identify coverage cheaply (see
+[Covered-transaction identification](#covered-transaction-identification)) and lets relay
+nodes verify a stamp's proof without its covered transactions; it is reconstructable from
+visible actions, so it reveals nothing the actions do not, and for an aggregate carrying
+its own actions it does not expose which of them are the aggregator's own.
 
 **Privacy of aggregation relationships.** An observer who sees an aggregate in the
 mempool can identify covered autonomes by the `cActionsTachyon` check (see
 [Covered-transaction identification](#covered-transaction-identification)). This
 is inherent to the scheme: the aggregate must carry enough information for validators
 to reconstruct its header. The tachygram-set and action-digest-set commitments do not
-reveal the private contents of any covered note. A stripped innocent is valid against any
-claimed covering stamp (Step 8, item 2), so an observer reconstructing aggregation
-relationships cannot rely on an actionless bundle's reference.
+reveal the private contents of any covered note. A stripped bundle with no actions is
+valid against any claimed covering stamp (see
+[block validity](tachyon-bundle.md#block-validity)), so an observer reconstructing
+aggregation relationships cannot rely on an actionless bundle's reference.
 
 **Circuit/consensus boundary.** Several security properties are enforced by consensus
 rather than fully proven inside the stamp. Double-spend prevention rests on the block-scoped
-tachygram-uniqueness check (Step 8) together with the epoch-scoped tachygram-uniqueness,
-anchor membership, and spendable-lineage rules owned by the
-[Tachyon Accumulator / Hash Chain](tachyon-accumulator.md) and
-[Tachyon Shielded Protocol](tachyon-shielded-protocol.md) ZIPs. Those base-protocol rules are depended upon, not re-specified
-here, so implementers and auditors should not assume the proof alone establishes these
-properties.
+tachygram-uniqueness check (see [block validity](tachyon-bundle.md#block-validity)) together
+with the [epoch-window duplicate-tachygram](tachyon-accumulator.md#epoch-window) and
+[anchor-membership](tachyon-accumulator.md#anchor-membership) rules owned by the
+[Tachyon Accumulator / Hash Chain](tachyon-accumulator.md) ZIP and the spendable-lineage
+rules owned by the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) ZIP. Those
+base-protocol rules are depended upon, not re-specified here, so implementers and auditors
+should not assume the proof alone establishes these properties.
 
 ## Deployment
 

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -515,21 +515,6 @@ alone is insufficient: the covered effecting data is present in the block as *ad
 and the [block-validity rules](tachyon-bundle.md#block-validity) reject any block where it
 is not.
 
-### `hStampActionsTachyon` is confirmed, not trusted
-
-The action set is bound by the
-proof, which verifies only against the action-set commitment reconstructed from the
-actions themselves; the carried digest plays no role in that binding. Block validation
-(see [block validity](tachyon-bundle.md#block-validity)) confirms the carried digest
-against the actions actually present in the block and rejects on any mismatch, so the
-proof is tied to the *adjuncts* the block carries, not to a value the prover supplies,
-and a wrong `hStampActionsTachyon` cannot pass and only harms its author. The carried
-value lets observers identify coverage cheaply (see
-[Covered-transaction identification](#covered-transaction-identification)); it is
-recomputable from visible actions, so it reveals nothing the actions do not, and for
-an *aggregate* carrying its own actions it does not expose which of them are the
-aggregator's own.
-
 ### Circuit/consensus boundary
 
 Several security properties are enforced by consensus

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -91,7 +91,7 @@ which miners strip redundant proofs, the semantics about effecting data and
 authorizing data that make stripping safe, and P2P rules that extend ZIP 239 to
 Tachyon's authorization-form malleability.
 
-Aggregation involves a 10-step lifecycle from transaction authorization, through
+Aggregation involves an 8-step lifecycle from transaction authorization, through
 the mempool, to block layout, and final validation. All effecting data (actions,
 value balances, action signatures, and binding signatures) remains present and
 valid when a proof is stripped.
@@ -132,7 +132,7 @@ the Specification.)
 
 ## Specification
 
-The specification is organised around the 10-step aggregation lifecycle. Each step is a
+The specification is organised around the 8-step aggregation lifecycle. Each step is a
 subsection with conformance language. Two cross-cutting concerns are specified in their own
 subsections after the lifecycle and referenced from the steps that invoke them:
 [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay), and
@@ -200,7 +200,7 @@ transactions a candidate aggregate covers is
 vertically integrate aggregation, producing its own aggregates privately (Step 7) rather
 than sourcing them from the mempool.
 
-### Step 8: Block assembly
+### Step 7: Block assembly
 
 Use of aggregates within a block is RECOMMENDED, not required.
 
@@ -223,9 +223,9 @@ A stripped innocent (a former innocent aggregate) SHOULD carry a
 `tachyonAggregateId` referring to the aggregate which ultimately absorbed its
 stamp.
 
-### Step 9: Block validation
+### Step 8: Block validation
 
-All proofs in a block must verify.
+All tachygrams in a block MUST be distinct.
 
 All stripped Tachyon transactions MUST bear a `tachyonAggregateId` referring to
 the stamped transaction in the same block covering its actions.
@@ -233,27 +233,39 @@ the stamped transaction in the same block covering its actions.
 All stamped Tachyon transactions MUST bear a `cActionsTachyon` opening to the
 complete set of actions for all of its covered transactions in the same block.
 
-1. **Adjunct association.** Every Tachyon transaction with a stripped bundle
+All proofs in a block MUST verify.
+
+These are the aggregation-specific rules; other Tachyon consensus rules (action and binding
+signatures, value balance, and anchor membership) are base-protocol consensus, specified by
+the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) and
+[Tachyon Accumulator / Hash Chain](tachyon-accumulator.md) ZIPs, and apply unchanged. A validator
+confirms the rules above as follows, deferring the costly proof verification until the
+cheaper checks pass:
+
+1. **Tachygram uniqueness.** The validator MUST reject the block if any
+tachygram appears more than once. Reuse within the wider epoch window is
+governed by the duplicate-tachygram consensus rule of the
+[Tachyon Shielded Protocol](tachyon-shielded-protocol.md).
+2. **Adjunct association.** Every Tachyon transaction with a stripped bundle
 contains a `tachyonAggregateId` that MUST identify a stamped transaction in the
 same block. If no transaction is located, or the located transaction bears no
 stamp, the validator MUST reject the block.
-2. **Action set commitment per stamp.** Every stamp contains a `cActionsTachyon`
-which MUST be confirmed by reconstruction. Compute a Pedersen commitment to the
-action digests of each Tachyon transaction in the block. Multiply the computed
-commitment of each stamped bundle by the computed commitment of each stripped
-bundle which refers to it by `tachyonAggregateId`. If the result of this
-multiplication is not equal to `cActionsTachyon`, the validator MUST reject the
-block.
-3. **Stamp proof verification.** Every Tachyon transaction with a stamped bundle
+3. **Action set commitment per stamp.** Every stamp contains a `cActionsTachyon`
+which MUST be confirmed by reconstruction. Collect the action digests of the stamped
+bundle's own actions together with those of every stripped bundle that names it by
+`tachyonAggregateId`, form the polynomial $\prod_i (X - d_i)$ over that combined set, and
+take a single Pedersen commitment of it. If the commitment is not equal to the carried
+`cActionsTachyon`, the validator MUST reject the block.
+4. **Stamp proof verification.** Every Tachyon transaction with a stamped bundle
 contains a proof which MUST verify. Reassemble the stamp PCD from the stamp
-proof, the stamp's `anchorTachyon`, a pedersen commitment to the stamp's
+proof, the stamp's `anchorTachyon`, a Pedersen commitment to the stamp's
 `vTachygrams` list of tachygrams, and the confirmed `cActionsTachyon`. If a
 proof does not verify, the validator MUST reject the block.
 
 ### Transaction identifiers and P2P relay
 
 These semantics underpin publication (Step 5), observation (Steps 2 and 6), and stripping
-(Step 8).
+(Step 7).
 
 **Identifiers.** A Tachyon transaction is identified by `wtxid = txid || auth_digest`
 ([ZIP 239](https://zips.z.cash/zip-0239), [ZIP 244](https://zips.z.cash/zip-0244)):
@@ -274,12 +286,11 @@ These semantics underpin publication (Step 5), observation (Steps 2 and 6), and 
 - The wire byte `tachyonBundleState` (`uint8`) distinguishes forms: `0x00` no Tachyon
   bundle, `0x01` stamped, `0x02` stripped.
 
-**Relay.** Tachyon bundles are announced and fetched by `wtxid` using the `MSG_WTX` inv
-type, and nodes MUST treat distinct `wtxid`s as distinct inventory objects. `MSG_WTX` relay
-is mandatory: restamping, proof rerandomization, and stripping all change `wtxid` while
-leaving `txid` unchanged, so announcement by `txid` alone could not distinguish these forms.
-Relay policy MAY de-duplicate same-`txid` forms to avoid propagating more than one stamped
-form of a transaction.
+**Relay.** Tachyon bundles are announced and fetched by `wtxid` using the
+`MSG_WTX` inv type, and nodes MUST treat distinct `wtxid`s as distinct inventory
+objects. `MSG_WTX` relay is mandatory: restamping changes a transaction's
+`wtxid` while leaving `txid` unchanged, so announcement by `txid` alone could
+not distinguish the stamped forms a node may be offered.
 
 **Stripped bundles are forbidden from the mempool.** A bundle in the stripped state
 (`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool, relayed, or published
@@ -296,27 +307,24 @@ unambiguously even though relay only ever carried the stamped form.
 
 Identifying which transactions a stamp covers is a single primitive, used by aggregators
 preparing a merge witness (Step 3) and by miners observing and composing a block (Steps 6
-and 8).
+and 7).
 
-An aggregate's stamp publishes `cActionsTachyon`, a commitment to the action-digest set of
-every action it covers. A candidate set of transactions is tested by reconstructing that
-commitment from the candidate actions and matching: each action digest
+Tachygrams give a first pass: an aggregate's stamp publishes the tachygrams of every action
+it covers, so transactions whose tachygrams appear there are candidates. But tachygram
+matching only narrows the candidate set; it cannot confirm the set is complete. A based
+aggregate's own tachygrams are not labelled, and tachygrams do not distinguish nullifiers
+from commitments, so a near-complete collection is indistinguishable from the complete one.
+Absent a faster check, the only way to discover whether a candidate set is exactly the cover
+would be to attempt the aggregate's full proof verification, which fails only after that
+costly attempt when a transaction is missing.
+
+`cActionsTachyon` is that faster check. The aggregate's stamp publishes it as a commitment
+to the action-digest set of every action the aggregate covers. A candidate set is tested by
+reconstructing the commitment from the candidate actions and matching: each action digest
 $d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$ is
-computable from public action data, so the check is cheap ($O(n)$ polynomial arithmetic plus
-one Pedersen commitment) and needs no proof verification. A match confirms the candidate set
-is exactly the cover; a mismatch is fail-fast, signalling a missing or extra transaction.
-Coverage is taken over the action-digest set, one digest per action, not over tachygrams,
-whose count differs because a spend publishes two tachygrams.
-
-Tachygrams give a cheaper first pass: an aggregate's stamp publishes the tachygrams of every
-action it covers, so transactions whose tachygrams appear there are candidates. But a based
-aggregate's own tachygrams are not labelled and tachygrams do not distinguish nullifiers
-from commitments, so tachygram matching only narrows the candidate set; the `cActionsTachyon`
-match is what confirms it.
-
-`cActionsTachyon` is an aid for this identification, not a soundness mechanism: block
-validation reconstructs the proof header from the block's actual actions (Step 10), never
-from the carried indicator.
+computable from public action data, so the check costs $O(n)$ polynomial arithmetic plus one
+Pedersen commitment and attempts no proof verification. A match confirms the candidate set is
+exactly the cover; a mismatch is fail-fast.
 
 ## Reference implementation
 
@@ -358,9 +366,9 @@ bundle is not serializable until its covering `wtxid` is assigned, which happens
 assembly).
 
 **`MSG_WTX` relay is mandatory.** Tachyon's authorization-form malleability is the direct
-analogue of the v5 witness malleability that motivated ZIP 239: restamping, proof
-rerandomization, and stripping yield distinct `wtxid`s over one stable `txid`. Announcing
-by `txid` alone would let any of these forms shadow another in relay. Requiring `MSG_WTX`
+analogue of the v5 witness malleability that motivated ZIP 239: restamping and proof
+rerandomization yield distinct `wtxid`s over one stable `txid`, all relayable. Announcing
+by `txid` alone would let one such form shadow another in relay. Requiring `MSG_WTX`
 for Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
 
 ## Security and Privacy Implications
@@ -368,25 +376,24 @@ for Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
 **No new trust assumption.** The aggregator is not trusted. Every invariant is
 enforced either inside the Ragu PCD (circuit logic) or by consensus checks on public
 data (consensus logic). A malicious aggregator can publish an invalid aggregate, but
-validators will reject it at Step 10. A malicious miner can mis-assign adjuncts or
+validators will reject it at Step 8. A malicious miner can mis-assign adjuncts or
 omit covered transactions, but the block will fail validation.
 
 **Data availability.** Aggregation removes redundant proof bytes only. Every adjunct
 retains its action data, action signatures, binding signature, and `value_balance`;
 validators reconstruct the aggregate header from this public data. An aggregate proof
 alone is insufficient: the covered effecting data is present in the block as adjuncts,
-and Step 10 rejects any block where it is not.
+and Step 8 rejects any block where it is not.
 
-**`cActionsTachyon` is an indicator, not a binding.** The action set is bound by the proof.
-To verify, consensus commits afresh to the action digests of the actions present in the
-block and uses that reconstructed $\mathsf{action\_acc}$ as the proof header; it never
-builds the header from the carried `cActionsTachyon`. Reconstructing from the block's
-actual actions is what ties the proof to the adjuncts the block carries, not to a value the
-prover supplies. The carried indicator only lets observers identify coverage cheaply
-(see [Covered-transaction identification](#covered-transaction-identification)), and a wrong
-value harms only its author; it is reconstructable from visible
-actions, so it reveals nothing the actions do not, and for a based aggregate it does not
-expose which actions are the aggregator's own.
+**`cActionsTachyon` is confirmed, not trusted.** The action set is bound by the proof. Block
+validation confirms the carried `cActionsTachyon` by reconstructing the action-set commitment
+from the actions actually present in the block, rejects on any mismatch, and only then uses
+the confirmed value as the proof header. That confirmation is what ties the proof to the
+adjuncts the block carries, not to a value the prover supplies, so a wrong `cActionsTachyon`
+cannot pass and only harms its author. The carried value lets observers identify coverage
+cheaply (see [Covered-transaction identification](#covered-transaction-identification)); it
+is reconstructable from visible actions, so it reveals nothing the actions do not, and for a
+based aggregate it does not expose which actions are the aggregator's own.
 
 **Privacy of aggregation relationships.** An observer who sees an aggregate in the
 mempool can identify covered autonomes by the `cActionsTachyon` check (see
@@ -395,11 +402,14 @@ is inherent to the scheme: the aggregate must carry enough information for valid
 to reconstruct its header. The tachygram-set and action-digest-set commitments do not
 reveal the private contents of any covered note.
 
-**Circuit/consensus boundary.** Several security properties, notably spendable-lineage
-epoch pinning and double-spend prevention, depend on consensus checks
-(items 6 and 7 of Step 10) rather than being fully proven inside the stamp. This is
-by design and is documented explicitly so that implementers and auditors do not assume
-the proof alone establishes these properties.
+**Circuit/consensus boundary.** Several security properties are enforced by consensus
+rather than fully proven inside the stamp. Double-spend prevention rests on the block-scoped
+tachygram-uniqueness check (Step 8) together with the epoch-scoped tachygram-uniqueness,
+anchor membership, and spendable-lineage rules owned by the
+[Tachyon Accumulator / Hash Chain](tachyon-accumulator.md) and
+[Tachyon Shielded Protocol](tachyon-shielded-protocol.md) ZIPs. Those base-protocol rules are depended upon, not re-specified
+here, so implementers and auditors should not assume the proof alone establishes these
+properties.
 
 ## References
 
@@ -411,3 +421,5 @@ the proof alone establishes these properties.
 - [ZIP 252: Deployment of the NU5 Network Upgrade](https://zips.z.cash/zip-0252)
 - [ZIP 317: Proportional Transfer Fee Mechanism](https://zips.z.cash/zip-0317)
 - [BIP 339: WTXID-based transaction relay](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki)
+- [Tachyon Shielded Protocol](tachyon-shielded-protocol.md)
+- [Tachyon Accumulator / Hash Chain](tachyon-accumulator.md)

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -228,10 +228,10 @@ aggregate's `wtxid`.
 A stripped innocent (a former innocent aggregate) contributes no actions, but
 the stripped form still names a covering transaction. Its `tachyonAggregateId`
 MUST identify a stamped transaction in the same block, and SHOULD refer to the
-aggregate that ultimately absorbed its stamp. The latter is unverifiable: a
-bundle with no actions contributes no action digests to any reconstruction, so
-a validator cannot distinguish the absorbing aggregate from any other stamped
-transaction (Step 8).
+aggregate that ultimately absorbed its stamp. An actionless bundle is,
+however, valid against any claimed covering stamp: it contributes no action
+digests to any reconstruction, so the association checks of Step 8 pass for
+whichever stamped transaction it names.
 
 ### Step 8: Block validation
 
@@ -416,10 +416,9 @@ mempool can identify covered autonomes by the `cActionsTachyon` check (see
 [Covered-transaction identification](#covered-transaction-identification)). This
 is inherent to the scheme: the aggregate must carry enough information for validators
 to reconstruct its header. The tachygram-set and action-digest-set commitments do not
-reveal the private contents of any covered note. The `tachyonAggregateId` of a stripped
-innocent is not consensus-validated beyond naming a stamped transaction (Step 8, item 2),
-so an observer reconstructing aggregation relationships cannot rely on an actionless
-bundle's reference.
+reveal the private contents of any covered note. A stripped innocent is valid against any
+claimed covering stamp (Step 8, item 2), so an observer reconstructing aggregation
+relationships cannot rely on an actionless bundle's reference.
 
 **Circuit/consensus boundary.** Several security properties are enforced by consensus
 rather than fully proven inside the stamp. Double-spend prevention rests on the block-scoped

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -11,8 +11,8 @@
   layer that aggregation preserves.
 - [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
   defines the stamped and stripped bundle wire encodings, the `tachyonBundleState` byte,
-  the `tachyonAggregateId` trailer, and the serialization of the `ActionSetCommit` field
-  on the stamp that this ZIP relies on for covered-transaction identification.
+  the `tachyonAggregateId` trailer, and the stamp trailer fields (including the
+  `cActionsTachyon` action-set indicator).
 - [Tachyon Accumulator / Hash Chain (#105)](https://github.com/tachyon-zcash/tachyon/issues/105)
   defines the anchor (Poseidon hash-chain state), the per-block anchor sequence, and the
   consensus anchor-membership rule that aggregation depends on for spend validity.
@@ -48,8 +48,7 @@ The Specification is organised around the following lifecycle, distilled in
 4. Aggregators publish their own transactions to the mempool, and do not re-publish the
    autonomes they covered.
 5. Miners see transactions in the mempool.
-6. Miners identify the aggregate/autonome relationship by action-set commitment
-   (`ActionSetCommit`) match.
+6. Miners identify which autonomes each aggregate covers.
 7. Miners may perform their own aggregation privately, without publishing to the
    mempool.
 8. Miners compose their block at will, stripping stamps and assigning the covering
@@ -58,23 +57,16 @@ The Specification is organised around the following lifecycle, distilled in
 10. Block validation only passes if the appropriate adjuncts are included and properly
     assigned aggregate ids, enabling header reconstruction and verification.
 
-### Based-aggregate tachygram attribution
+### Identifying covered transactions
 
-A **based aggregate** carries its own tachyactions in addition to a merged stamp
-covering other transactions. Its stamp tachygram set is the union of the covered
-autonomes' tachygrams and the based aggregate's own tachygrams, with no in-protocol
-label distinguishing the two ([Bundles](../bundle.md)). An observer with an incomplete
-mempool view therefore cannot partition the published tachygram set, and cannot confirm
-by tachygram overlap alone that it holds every autonome that must become an adjunct.
-
-The protocol resolves this with the `ActionSetCommit` field carried on the stamp header:
-an observer reconstructs the action-digest-set commitment from visible actions and
-matches it against the aggregate's published `ActionSetCommit`, a cheap fail-fast check
-that needs no proof verification. The normative mechanism is specified in Step 6
-below; the design trade-offs and soundness/privacy arguments are folded into the
-Rationale and the Security and Privacy Implications sections. The encoding of
-`ActionSetCommit` on the stamp wire format is specified by the Tachyon Bundle / Aggregate
-Transaction Format ZIP (#104).
+A mempool observer associates an aggregate with the autonomes it covers primarily by
+matching tachygrams it has already seen against the aggregate's published tachygram set.
+Tachygram matching associates but does not confirm completeness: a based aggregate's own
+tachygrams are unlabelled and tachygrams do not distinguish nullifiers from commitments
+([Bundles](../bundle.md)), so overlap alone cannot tell an observer it holds every autonome
+an aggregate covers. The stamp trailer carries `cActionsTachyon`, an assistive action-set
+indicator that lets an observer confirm a candidate set cheaply (Step 6). It is an
+identification aid, not a soundness mechanism.
 
 ### Open questions
 
@@ -131,8 +123,8 @@ interpreted as described in section 3.12 of the Zcash Protocol Specification.
   cryptographically bound to one tachygram but does not contain it. A spend additionally
   publishes a next-epoch nullifier, so a stamp's tachygram set is not in 1:1
   correspondence with its actions. See [Bundles](../bundle.md).
-- **Stamp.** The recursive Ragu PCD proof data carried by a stamped bundle: `anchor`,
-  `tachygrams`, `proof`, and `ActionSetCommit`. The proof establishes that the
+- **Stamp.** The recursive Ragu PCD proof data carried by a stamped bundle:
+  `cActionsTachyon`, `anchor`, `tachygrams`, and `proof`. The proof establishes that the
   tachyactions follow the correct rules and that the published tachygrams and action
   digests correspond to those actions.
 - **Autonome.** A stamped bundle produced by a wallet, carrying a complete proof with
@@ -144,13 +136,15 @@ interpreted as described in section 3.12 of the Zcash Protocol Specification.
 - **Adjunct.** A stripped bundle whose stamp has been removed and replaced by a
   `tachyonAggregateId` reference to the covering aggregate. Adjuncts retain action data,
   action signatures, the binding signature, and `value_balance`.
-- **`ActionSetCommit`.** A Pedersen commitment to the action-digest-set polynomial, with
-  exactly one root per action:
-  $\mathsf{ActionSetCommit} = \mathsf{Commit}\bigl(\prod_i (X - d_i)\bigr)$, where each
-  action digest $d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$
-  is defined in [Authorization](../authorization.md). This is the same commitment the book
-  calls `action_acc`. It is a PCD header field (`StampHeader::Data` carries it), and its
-  on-wire encoding is specified by the bundle-format ZIP (#104).
+- **`cActionsTachyon`.** An assistive action-set indicator on the stamp trailer: a 32-byte
+  Pedersen commitment to the action-digest set,
+  $\mathsf{Commit}\bigl(\prod_i (X - d_i)\bigr)$, with action digest
+  $d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$
+  defined in [Authorization](../authorization.md). It is the same commitment the book
+  calls `action_acc` and that the proof attests to in its header, copied onto the trailer
+  so observers can identify covered transactions without verifying the proof (Step 6). It
+  is authorization data: it contributes to `auth_digest` and strips away with the stamp.
+  Its wire encoding is specified by the bundle-format ZIP (#104).
 - **`tachyonAggregateId`.** The wire field on a stripped bundle that replaces its stamp:
   the `byte[64]` `wtxid` of the covering aggregate (the implementation type is
   `AggregateId`). It is a `wtxid`, not a `txid`, so it pins a specific physical aggregate
@@ -173,15 +167,14 @@ dominate block-validation cost. This ZIP specifies the Tachyon aggregator protoc
 network role that merges stamps from multiple stamped transactions into a single
 aggregate stamp, and a block-layout discipline under which miners strip the now-
 redundant per-transaction stamps and replace them with a reference to the covering
-aggregate. The same effecting data — tachyactions, value balances, action signatures,
-and binding signatures — remains independently verifiable; only the proof bytes are
+aggregate. The same effecting data (tachyactions, value balances, action signatures,
+and binding signatures) remains independently verifiable; only the proof bytes are
 deduplicated. The ZIP defines the 10-step aggregation lifecycle from autonome
 publication through block validation, the transaction-identifier semantics that make
-stripping safe, the P2P relay rules that extend ZIP 239 to Tachyon's authorization-form
-malleability, and a fail-fast covered-transaction identification mechanism based on the
-`ActionSetCommit` field carried on the stamp. Aggregation introduces a new network
-participant but no new trust assumption: every invariant is enforced either inside the
-Ragu PCD or by consensus checks on public data.
+stripping safe, and the P2P relay rules that extend ZIP 239 to Tachyon's
+authorization-form malleability. Aggregation introduces a new network participant but no
+new trust assumption: every invariant is enforced either inside the Ragu PCD or by
+consensus checks on public data.
 
 ## Motivation
 
@@ -233,10 +226,10 @@ This specification applies identically to Mainnet and Testnet.
 
 ### Step 1: Publication of autonomes
 
-Wallets construct stamped bundles — **autonomes** — and broadcast them to the mempool
+Wallets construct stamped bundles (**autonomes**) and broadcast them to the mempool
 via the existing wallet RPC or P2P path. An autonome is a standard stamped transaction
-with a complete Ragu PCD proof, a serialized `ActionSetCommit`, and a distinct `wtxid`.
-Autonomes are announced and relayed by `wtxid` per Step 5.
+with a complete Ragu PCD proof and a distinct `wtxid`. Autonomes are announced and
+relayed by `wtxid` per Step 5.
 
 ### Step 2: Aggregator mempool observation
 
@@ -250,8 +243,7 @@ time.
 
 Aggregators merge stamps as follows:
 
-1. Deserialize and validate each input stamp, including its `ActionSetCommit` against
-   the input's visible actions.
+1. Deserialize and validate each input stamp.
 2. Align anchors: each input stamp is lifted to a common later anchor using `StampLift`
    over an `AnchorChain` segment whose `start` equals the stamp's current anchor. The
    merged stamp's anchor is the segment `end`.
@@ -259,8 +251,7 @@ Aggregators merge stamps as follows:
    binds the witnessed input action-digest and tachygram polynomials to the input
    header commitments, and proves the merged polynomials are the products of the input
    polynomials (multiset union by polynomial product).
-4. Serialize and compress the merged stamp. The merged stamp carries the merged
-   commitment $\mathsf{ActionSetCommit} = \mathsf{Commit}(P_{\mathsf{left}} \cdot P_{\mathsf{right}})$.
+4. Serialize and compress the merged stamp.
 
 The aggregator constructs a new stamped transaction carrying the merged stamp. For a
 **based** aggregate the transaction also carries the aggregator's own tachyactions; for
@@ -282,64 +273,58 @@ integrate aggregation and produce its own aggregates privately without publishin
 to the mempool (Step 7).
 
 P2P relay for Tachyon bundles follows [ZIP 239](https://zips.z.cash/zip-0239):
-transactions are announced and fetched by `wtxid` using the `MSG_WTX` inv type. An
-autonome, an aggregate, and an adjunct carrying the same effecting data are three
-distinct `wtxid`s and MUST be treated as distinct inventory objects.
+transactions are announced and fetched by `wtxid` using the `MSG_WTX` inv type. A single
+transaction's effecting data fixes its `txid`, but it can be authorized in several forms
+that share that `txid` and differ only in `auth_digest`: a wallet's autonome, an
+anchor-lifted or proof-rerandomized restamp, and the stripped adjunct form a miner
+produces. Each is a distinct `wtxid`, and nodes MUST treat distinct `wtxid`s as distinct
+objects.
 
-`MSG_WTX`-style relay is mandatory for Tachyon bundles. Announcing by `txid` alone
-would let a third party broadcast a covered autonome with the same `txid` as an
-aggregate and interfere with relay of the aggregate form — exactly the failure mode
-ZIP 239 was written to prevent for v5 witness malleability, extended here to Tachyon's
-authorization-form malleability (stamping, merging, and stripping all change `wtxid`
-while leaving `txid` unchanged).
+`MSG_WTX`-style relay is mandatory for Tachyon bundles: restamping, proof rerandomization,
+and stripping all change `wtxid` while leaving `txid` unchanged, so announcement by `txid`
+alone cannot distinguish these authorization forms of one transaction. See the Rationale.
 
-Because `txid` is stable across the aggregation lifecycle (it commits only to
-`action_acc || value_balance`), a wallet's submitted transaction remains identifiable
-in the mempool even after an aggregator republishes a covering aggregate. Relay policy
-MAY de-duplicate on `txid` to avoid redundant propagation of covered autonomes once a
-covering aggregate is present.
+Because `txid` is stable across a transaction's authorization forms (it commits only to
+`action_acc || value_balance`), a wallet's transaction stays identifiable by `txid` even
+when it is restamped or its proof is rerandomized. Relay policy MAY de-duplicate these
+same-`txid` forms to avoid propagating more than one stamped form of a transaction.
 
-Adjuncts are block-local. A standalone adjunct whose `tachyonAggregateId` is not present
-in the mempool or block MUST NOT be relayed as an independent transaction; adjuncts only
-appear inside blocks alongside their covering aggregate. Stripping is a miner-side
-block-assembly action (Step 8), not a relay-time transformation: the P2P network
-carries stamped bundles (autonomes and aggregates) only.
+Stripped bundles are forbidden from the mempool. A bundle in the stripped state
+(`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool, relayed, or
+published by an aggregator; it is valid only inside a block, alongside the covering
+aggregate its `tachyonAggregateId` names. Stripping is a miner-side block-assembly action
+(Step 8), not a relay-time transformation: the P2P network carries stamped bundles
+(autonomes and aggregates) only. An aggregator publishes its merged stamp as a new
+stamped aggregate; it never publishes a stripped form of a covered transaction.
 
-### Step 6: Covered-transaction identification by `ActionSetCommit`
+The mempool prohibition and `MSG_WTX` relay operate at different layers and do not
+conflict. `MSG_WTX` fixes the identifier and inventory semantics: every authorization form
+is a distinct `wtxid`. Relay policy then admits only the stamped forms; the stripped form,
+though it has a well-formed `wtxid`, is never announced, fetched, or accepted in the
+mempool. That `wtxid` is still meaningful at the block layer, where a block commits to
+each included transaction by `wtxid` ([ZIP 244](https://zips.z.cash/zip-0244)): an adjunct
+is committed under its own stripped-form `wtxid`, distinct from the autonome's. The
+non-malleability `MSG_WTX` provides is what lets a block name the stripped form
+unambiguously even though relay only ever carried the stamped form.
 
-Miners (and validating observers) identify the aggregate/autonome relationship using the
-`ActionSetCommit` field serialized on each stamp. Coverage is determined over the
-**action-digest set** — exactly one digest $d_i$ per action — not over tachygrams, whose
-count need not equal the action count (a spend publishes two tachygrams).
+### Step 6: Covered-transaction identification
 
-The aggregate's stamp publishes
-$\mathsf{ActionSetCommit} = \mathsf{Commit}(P_{\mathsf{aggregate}})$, where
-$P_{\mathsf{aggregate}} = \prod_i (X - d_i)$ ranges over the action digests of every
-action covered by the aggregate (both the based aggregate's own actions and all covered
-autonomes' actions). Each
+A mempool observer assembles a **candidate set of autonomes** for an aggregate primarily
+by matching tachygrams it has already seen: the aggregate's stamp publishes the tachygrams
+of every action it covers, so autonomes whose tachygrams appear there are candidates for
+coverage. Because a based aggregate's own tachygrams are not labelled and tachygrams do
+not distinguish nullifiers from commitments, tachygram matching narrows the candidate set
+but does not confirm it is complete.
+
+To confirm it holds the right set, the observer reconstructs the action-set commitment
+from its candidate set of autonomes, together with the based aggregate's own actions, and
+compares it to the aggregate's `cActionsTachyon` indicator. Each action digest
 $d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$ is
-computable from public action data.
-
-An observer who has seen a candidate set of autonomes confirms coverage as follows:
-
-1. For a based aggregate, compute $P_{\mathsf{own}} = \prod_j (X - d_j)$ from the
-   aggregate's own visible actions. For an innocent aggregate, $P_{\mathsf{own}}$ is the
-   empty product $1$.
-2. For each candidate autonome $k$, compute
-   $P_{\mathsf{autonome},k} = \prod_l (X - d_l)$ from its visible actions.
-3. Compute
-   $P_{\mathsf{observed}} = P_{\mathsf{own}} \cdot \prod_k P_{\mathsf{autonome},k}$.
-4. Compute $\mathsf{Commit}(P_{\mathsf{observed}})$ and compare to the aggregate's
-   published `ActionSetCommit`.
-
-Match confirms the observer holds the complete covered set. Mismatch is fail-fast: the
-observer is missing a covered autonome, has an extra one, or is matching against the
-wrong aggregate. The check is $O(n)$ polynomial arithmetic plus one Pedersen commitment;
-it does not require Ragu proof verification.
-
-This resolves the based-aggregate attribution problem without a comprehensive mempool
-index or a tachygram-origin query protocol: each action contributes exactly one root to
-the product, so the published commitment fixes the covered action multiset directly.
+computable from public action data, so the reconstruction is cheap and needs no proof
+verification. A match confirms the candidate set is exactly the aggregate's cover; a
+mismatch is fail-fast, signalling a missing or extra autonome. Coverage is taken over the
+action-digest set, one digest per action, not over tachygrams, whose count differs from
+the action count because a spend publishes two tachygrams.
 
 ### Step 7: Private miner aggregation (optional)
 
@@ -367,9 +352,9 @@ Transaction-identifier semantics under stripping:
   across stamping, merging, stripping, and re-stamping. A transaction's logical
   identity is invariant across the aggregation lifecycle.
 - `auth_digest` commits to action signatures, the binding signature, and the bundle's
-  stamp trailer. A stamped bundle's trailer is the full stamp (anchor,
-  `ActionSetCommit`, tachygrams, proof); a stripped bundle's trailer is the `byte[64]`
-  covering `wtxid` (referred to as `stampWtxid` in the digest contribution). Each
+  stamp trailer. A stamped bundle's trailer is the full stamp (`cActionsTachyon`, anchor,
+  tachygrams, proof); a stripped bundle's trailer is the `byte[64]` covering `wtxid`
+  (referred to as `stampWtxid` in the digest contribution). Each
   physical authorization form yields a distinct `auth_digest` and therefore a distinct
   `wtxid = txid || auth_digest`.
 - The covering-aggregate reference carried by an adjunct is a `wtxid`, not a `txid`,
@@ -401,30 +386,28 @@ in the block, all of the following hold:
 1. **Adjunct resolution.** Every adjunct whose `tachyonAggregateId` refers to that
    aggregate is present in the same block, and the aggregate is top-level, unstripped,
    and not further aggregated in that block.
-2. **Action-set reconstruction.** The multiset union of the action-digest sets of all
-   adjuncts covered by the aggregate, combined with the based aggregate's own
-   action-digest set (empty for an innocent aggregate), matches the aggregate stamp's
-   `ActionSetCommit`. Consensus reconstructs $\mathsf{action\_acc}$ from these visible
-   actions; the serialized `ActionSetCommit` on the stamp is advisory for this check, and
-   any mismatch between the serialized commitment and the reconstructed one is itself a
-   consensus error.
+2. **Action-set reconstruction.** Consensus reconstructs $\mathsf{action\_acc}$ from the
+   visible actions: the multiset union of the action-digest sets of all adjuncts covered
+   by the aggregate and the based aggregate's own action-digest set (empty for an innocent
+   aggregate). The reconstructed commitment is the header value used in item 4; the stamp's
+   carried `cActionsTachyon` is an assistive fail-fast indicator, not the binding.
 3. **Tachygram-set binding.** The aggregate stamp publishes the merged tachygram set
    (`vTachygrams`); adjuncts carry no tachygrams of their own. The Ragu PCD proof binds
    the tachygram-set commitment to the action-set commitment reconstructed in item 2, so
    consensus takes the tachygram set from the aggregate's stamp rather than
    reconstructing it from the adjuncts.
 4. **Stamp proof verification.** The header
-   $(\mathsf{action\_acc}, \mathsf{tachygram\_acc}, \mathsf{anchor})$ — with
+   $(\mathsf{action\_acc}, \mathsf{tachygram\_acc}, \mathsf{anchor})$, with
    $\mathsf{action\_acc}$ reconstructed in item 2, $\mathsf{tachygram\_acc}$ committed
-   from the stamp's published tachygrams, and $\mathsf{anchor}$ taken from the stamp —
+   from the stamp's published tachygrams, and $\mathsf{anchor}$ taken from the stamp,
    verifies against the Ragu PCD proof.
 5. **Signatures and value balance.** Action signatures and the binding signature verify
    against the transaction sighash, and the bundle's value commitments are consistent
    with the declared `value_balance`.
 6. **Anchor membership.** The aggregate's anchor is a member of the published per-block
    anchor sequence, as specified by the accumulator/anchor ZIP (#105).
-7. **Tachygram uniqueness.** No tachygram published in this block — in any stamp the
-   block contains — duplicates a tachygram published in the current epoch or the
+7. **Tachygram uniqueness.** No tachygram published in this block, in any stamp the
+   block contains, duplicates a tachygram published in the current epoch or the
    immediately preceding epoch, as specified by the tachygram-uniqueness consensus rule
    ([Tachygrams](../tachygrams.md)).
 
@@ -444,37 +427,26 @@ consensus checks above. This split is by design.
 
 ## Reference implementation
 
-A reference implementation of the Tachyon aggregator protocol, including the bundle
-state machine, stamp merging, stripping, and `ActionSetCommit`-based coverage
-identification, is in the `zcash_tachyon` crate under
-[`crates/tachyon/src/`](../../crates/tachyon/src/). The implementation currently uses
-`mock_ragu`, a permissive stand-in for real Ragu; the protocol semantics specified
-above describe the intended real-Ragu behaviour.
+A reference implementation of the Tachyon aggregator protocol (the bundle state machine,
+stamp merging, stripping, and the `cActionsTachyon` coverage check) is in the
+`zcash_tachyon` crate under [`crates/tachyon/src/`](../../crates/tachyon/src/). It uses
+`mock_ragu`, a permissive stand-in for real Ragu; the protocol semantics specified above
+describe the intended real-Ragu behaviour.
 
 ## Rationale
 
 **Lifecycle-structured specification.** Organising the Specification around the 10-step
-lifecycle — rather than as parallel sections for P2P, identifiers, block layout, and
-consensus rules — mirrors how participants actually move through the protocol and keeps
+lifecycle, rather than as parallel sections for P2P, identifiers, block layout, and
+consensus rules, mirrors how participants actually move through the protocol and keeps
 each rule anchored to the step where it applies. This avoids the reader having to
 cross-reference unrelated sections to understand a single participant's obligations.
 
-**`ActionSetCommit` solves based-aggregate attribution.** Tachygram-set overlap alone
-is insufficient for coverage identification when a based aggregate's own tachygrams are
-indistinguishable from covered autonomes' tachygrams. The `ActionSetCommit` field, a PCD
-header field bound by the proof, provides a cheap fail-fast check that does not require
-proof verification, a comprehensive mempool index, or a separate tachygram-origin query
-protocol. A based aggregate could alternatively declare
-which tachygrams are its own, but this would not help: the based portion's count is
-already inferable from the visible actions, and the remaining attribution problem is
-unchanged. It would also leak structure about the aggregator's own vs covered activity
-that the actions alone do not reveal.
-
-**No separate coverage manifest.** A coverage manifest (an explicit list of covered
-`wtxid`s signed by the aggregator) was considered and rejected. It would add a new
-authenticated data structure, require a new signature path, and still need to be
-checked against the stamp's action-digest set for soundness. The `ActionSetCommit`
-check reuses an existing PCD header field and an existing reconstruction path.
+**Cheap coverage confirmation.** Matching previously-seen tachygrams associates an
+aggregate with the autonomes it covers, but cannot confirm the association is complete: a
+based aggregate's own tachygrams are indistinguishable from its covered autonomes'. The
+`cActionsTachyon` indicator gives observers a fail-fast completeness check over the
+action-digest set, reusing the commitment the proof already attests to rather than adding
+a signed coverage manifest or a tachygram-origin query protocol.
 
 **`wtxid`, not `txid`, for adjunct references.** A `txid` would be ambiguous across
 the autonome/aggregate forms (they share effecting data). The `wtxid` pins a specific
@@ -483,16 +455,16 @@ reference. This is why the `tachyonAggregateId` holds a `wtxid` rather than a `t
 
 **Stripping is miner-side, not relay-time.** Stripping at relay time would force every
 relay node to understand aggregate coverage and would mix block-assembly policy with
-gossip. Keeping the P2P network carrying stamped bundles only, and restricting
-adjuncts to blocks, simplifies relay and matches the implementation (a stripped bundle
-is not serializable until its covering `wtxid` is assigned, which happens at block
+gossip. Keeping the P2P network carrying stamped bundles only, and forbidding stripped
+bundles from the mempool, simplifies relay and matches the implementation (a stripped
+bundle is not serializable until its covering `wtxid` is assigned, which happens at block
 assembly).
 
-**`MSG_WTX` relay is mandatory.** Tachyon's authorization-form malleability is the
-direct analogue of v5 witness malleability that motivated ZIP 239. Announcing by
-`txid` would let a third party broadcast a covered autonome with the same `txid` as
-an aggregate and interfere with relay of the aggregate form. Requiring `MSG_WTX` for
-Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
+**`MSG_WTX` relay is mandatory.** Tachyon's authorization-form malleability is the direct
+analogue of the v5 witness malleability that motivated ZIP 239: restamping, proof
+rerandomization, and stripping yield distinct `wtxid`s over one stable `txid`. Announcing
+by `txid` alone would let any of these forms shadow another in relay. Requiring `MSG_WTX`
+for Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
 
 ## Security and Privacy Implications
 
@@ -508,26 +480,20 @@ validators reconstruct the aggregate header from this public data. An aggregate 
 alone is insufficient: the covered effecting data is present in the block as adjuncts,
 and Step 10 rejects any block where it is not.
 
-**No new leakage from `ActionSetCommit`.** The commitment is reconstructable from visible
-actions for any self-contained bundle, so its serialized value reveals nothing the
-actions do not. For a based aggregate, the factored
-polynomial (which roots are the aggregator's own vs covered) is not recoverable from the
-commitment alone, so publishing it does not reveal which actions are the aggregator's
-own. The coverage check is also sound against the rank-from-above caveat of
-commit-equality: each $\prod_i (X - d_i)$ is monic of degree equal to the action count,
-so its top coefficient is fixed at $1$ and the commitment pins the exact action multiset
-(no shorter polynomial can share the commitment). Identity `cv`/`rk` is separately
-rejected by `ActionDigest::new`, which is a well-formedness guard ensuring every action
-has a computable digest, not part of the rank argument.
+**`cActionsTachyon` is an indicator, not a binding.** The action set is bound by the
+proof, whose header consensus reconstructs from the visible actions; the carried indicator
+only lets observers identify coverage cheaply, and a wrong value harms only its author. The
+indicator is reconstructable from visible actions, so it reveals nothing the actions do
+not, and for a based aggregate it does not expose which actions are the aggregator's own.
 
 **Privacy of aggregation relationships.** An observer who sees an aggregate in the
-mempool can identify covered autonomes by the `ActionSetCommit` check (Step 6). This
+mempool can identify covered autonomes by the `cActionsTachyon` check (Step 6). This
 is inherent to the scheme: the aggregate must carry enough information for validators
 to reconstruct its header. The tachygram-set and action-digest-set commitments do not
 reveal the private contents of any covered note.
 
-**Circuit/consensus boundary.** Several security properties — notably spendable-
-lineage epoch pinning and double-spend prevention — depend on consensus checks
+**Circuit/consensus boundary.** Several security properties, notably spendable-lineage
+epoch pinning and double-spend prevention, depend on consensus checks
 (items 6 and 7 of Step 10) rather than being fully proven inside the stamp. This is
 by design and is documented explicitly so that implementers and auditors do not assume
 the proof alone establishes these properties.

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -49,6 +49,11 @@ Open questions:
   aggregators index mempool data and do not attempt merges they cannot satisfy from data
   they hold. Alternatives: a relay message requesting transactions by tachygram, or
   aggregates carrying a list of contributing transactions. Undecided.
+- **`cActionsTachyon` commitment scheme.** The covered-transaction identification check
+  reconstructs the carried `cActionsTachyon` field. Whether that field, which serves
+  only external coordination, uses a different commitment scheme than the in-circuit
+  action-set commitment is an open question of the
+  [bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104).
 - **Cross-epoch lifting.** A stamp lift never crosses an epoch boundary, because
   a spend's published nullifiers are fixed relative to its anchor's epoch.
   Supporting them may be possible, but would change fundamental parts of the

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -6,22 +6,22 @@
 
 ## I. Dependencies
 
-- [Tachyon Shielded Protocol (#103)](https://github.com/tachyon-zcash/tachyon/issues/103)
+* [Tachyon Shielded Protocol (#103)](https://github.com/tachyon-zcash/tachyon/issues/103)
   defines the Tachyon pool, Tachyon actions, tachygrams, and the per-action authorization
   layer that aggregation preserves.
-- [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
+* [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
   defines the bundle wire encoding, the `tachyonBundleState` byte, the proof and
   pointer stamp forms (including the `hStampActionsTachyon` covered-actions digest),
   and the block-validity consensus rules that govern how a block's bundles are
   validated.
-- [Tachyon Accumulator / Hash Chain (#105)](https://github.com/tachyon-zcash/tachyon/issues/105)
+* [Tachyon Accumulator / Hash Chain (#105)](https://github.com/tachyon-zcash/tachyon/issues/105)
   defines the anchor (Poseidon hash-chain state), the per-block anchor sequence, the
   consensus anchor-membership rule that aggregation depends on for spend validity, and the
   epoch-window duplicate-tachygram consensus rule.
-- [ZIP 239](https://zips.z.cash/zip-0239) defines `MSG_WTX`-based transaction relay by
+* [ZIP 239](https://zips.z.cash/zip-0239) defines `MSG_WTX`-based transaction relay by
   `wtxid = txid || auth_digest`. This ZIP extends its rationale to Tachyon's
   authorization-form malleability.
-- [ZIP 244](https://zips.z.cash/zip-0244) defines the `txid_digest` and `auth_digest`
+* [ZIP 244](https://zips.z.cash/zip-0244) defines the `txid_digest` and `auth_digest`
   trees. The [ZIP 244 update](zip-244.md) fixes the `"ZTxAuthTachyHash"` personalization
   and the Tachyon digest branches; this ZIP does not re-specify that algorithm.
 
@@ -36,7 +36,7 @@ Miners are likely to vertically integrate aggregation, but a protocol is establi
 
 Open questions:
 
-- **Relay-protocol additions.** Relayed bundles carry no cross-references: an aggregate
+* **Relay-protocol additions.** Relayed bundles carry no cross-references: an aggregate
   does not identify its contributing transactions, and no mempool form names another by
   `wtxid`, so aggregation relationships are discoverable only by tachygram matching over
   held mempool data. An aggregator therefore cannot request an aggregate's contributors
@@ -46,20 +46,27 @@ Open questions:
   message requesting bundles by tachygram, with nodes maintaining a coverage graph to
   answer it; a list of contributing transactions carried on aggregates would serve only
   the merge-input case, at the cost of a large additional vector.
-- **Cross-epoch lifting.** A stamp lift never crosses an epoch boundary, because
+* **Cross-epoch lifting.** A stamp lift never crosses an epoch boundary, because
   a spend's published nullifiers are fixed relative to its anchor's epoch.
   Supporting them may be possible, but would change fundamental parts of the
   specification.
-- **Unequal-anchor merge.** Merging is defined only over identical anchors.
+* **Unequal-anchor merge.** Merging is defined only over identical anchors.
   Candidate relaxations: the aggregator commits to an anchor sequence covering
   the contributors, or to a multiset of contributing anchors later verifiable as
   members of a continuous valid sequence. Either is a significant refactor.
-- **Zero-action coverage.** An adjunct bundle with no actions names a covering
+* **Zero-action coverage.** An adjunct bundle with no actions names a covering
   aggregate that consensus does not confirm; candidate confirmation rules are an open
   question of the
   [bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104).
-- **Deployment.** The deployment ZIP and activation parameters are undefined; the draft's
+* **Deployment.** The deployment ZIP and activation parameters are undefined; the draft's
   Deployment section points at the placeholder.
+
+This draft stages the ZIP body below inside the Tachyon mdBook, so two conventions differ
+from a standalone ZIP and normalize on migration to `tachyon-zcash/zips`: the book reserves
+the top-level `#` heading for the page title, so the ZIP's own sections use `##` and `###`
+here and each promotes by one level (`#`, `##`) when the ZIP stands alone; and external ZIP
+and protocol references are written as full `https://zips.z.cash/` links for the book, where
+a standalone ZIP omits that prefix per the ZIP style guide.
 
 ## III. ZIP Draft
 
@@ -79,36 +86,41 @@ Discussions-To: <https://github.com/tachyon-zcash/tachyon/issues/106>
 ## Terminology
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "RECOMMENDED" in
-this document are to be interpreted as described in BCP 14 when, and only when, they
+this document are to be interpreted as described in BCP 14 [^BCP14] when, and only when, they
 appear in all capitals.
 
-The term "network upgrade" is to be interpreted as described in
-[ZIP 200](https://zips.z.cash/zip-0200). The terms "Testnet" and "Mainnet" are to be
-interpreted as described in section 3.12 of the Zcash Protocol Specification.
+The term "network upgrade" is to be interpreted as described in ZIP 200. [^zip-0200] The
+terms "Testnet" and "Mainnet" are to be interpreted as described in § 3.12 ‘Mainnet and
+Testnet’. [^protocol]
 
 The terms "tachygram" and "stamp" are defined by the
 [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) and
 [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIPs respectively, and
 are summarized here non-normatively. The remaining terms are defined by this ZIP.
 
-- **Tachygram.** The `byte[32]` encoding of a field element ($\mathbb{F}_p$)
-  representing either a note nullifier or a note commitment. Consensus treats
-  nullifiers and commitments identically.
-- **Stamp.** The final section of a bundle. Either a proof stamp, carrying a
-  Ragu proof and some supporting data, or a pointer stamp, carrying a `wtxid`
-  reference to a transaction with a proof.
-- **Autonome.** A stand-alone transaction whose bundle bears an independent
-  proof stamp covering only its own actions (an autonome bundle). The standard
-  form of a user-originated Tachyon transaction. An autonome may appear in a block
-  or in the mempool.
-- **Aggregate.** A transaction whose bundle bears a merged proof stamp covering
-  other transactions (an aggregate bundle). An aggregate MAY contain zero or more
-  Tachyon actions of its own. An aggregate may appear in a block or in the
-  mempool.
-- **Adjunct.** An abbreviated transaction that only appears within a block. An
-  adjunct's bundle has been stripped of its original stamp and now bears a pointer
-  stamp. Adjuncts retain action data, action signatures, binding signature, and
-  `valueBalanceTachyon`.
+Tachygram
+:   The `byte[32]` encoding of a field element ($\mathbb{F}_p$) representing either a note
+    nullifier or a note commitment. Consensus treats nullifiers and commitments identically.
+
+Stamp
+:   The final section of a bundle. Either a proof stamp, carrying a Ragu proof and some
+    supporting data, or a pointer stamp, carrying a `wtxid` reference to a transaction with a
+    proof.
+
+*Autonome*
+:   A stand-alone transaction whose bundle bears an independent proof stamp covering only its
+    own actions (an *autonome* bundle). The standard form of a user-originated Tachyon
+    transaction. An *autonome* may appear in a block or in the mempool.
+
+*Aggregate*
+:   A transaction whose bundle bears a merged proof stamp covering other transactions (an
+    *aggregate* bundle). An *aggregate* MAY contain zero or more Tachyon actions of its own. An
+    *aggregate* may appear in a block or in the mempool.
+
+*Adjunct*
+:   An abbreviated transaction that only appears within a block. An *adjunct*'s bundle has been
+    stripped of its original stamp and now bears a pointer stamp. *Adjuncts* retain action
+    data, action signatures, binding signature, and `valueBalanceTachyon`.
 
 ## Abstract
 
@@ -148,23 +160,23 @@ remain unchanged and per-bundle. In the ideal case, a single proof verifies all
 Tachyon transactions in a block.
 
 Aggregation is optional. Miners remain free to include non-aggregated Tachyon
-transactions; any aggregate a block does contain must be fully backed by
-adjuncts in the same block.
+transactions; any *aggregate* a block does contain must be fully backed by
+*adjuncts* in the same block.
 
 ## Requirements
 
-- Reduce per-block stamp-verification cost by allowing multiple transactions' stamps to
-  be merged into one aggregate stamp.
-- Confine aggregation to the authorization-proof mechanism: the binding-signature balance
+* Reduce per-block stamp-verification cost by allowing multiple transactions' stamps to
+  be merged into one *aggregate* stamp.
+* Confine aggregation to the authorization-proof mechanism: the binding-signature balance
   check and transaction authorization remain unchanged and per-bundle, and every
   transaction's effecting data (action digests, value balances, action signatures, and
   binding signatures) remains present when its proof is stripped.
-- Preserve transaction-identifier stability: a transaction's `txid` is invariant across
+* Preserve transaction-identifier stability: a transaction's `txid` is invariant across
   stamping, merging, and stripping.
-- Allow any participant to act as aggregator; no protocol-level exclusivity.
-- Enable a validator or miner to confirm they hold all necessary data before
+* Allow any participant to act as aggregator; no protocol-level exclusivity.
+* Enable a validator or miner to confirm they hold all necessary data before
   attempting proof verification.
-- Introduce no new trust assumption: every invariant is enforced either by proof
+* Introduce no new trust assumption: every invariant is enforced either by proof
   or by consensus rules.
 
 ## Specification
@@ -177,7 +189,7 @@ subsections after the lifecycle and referenced from the steps that invoke them:
 
 ### Step 1: Publication of autonomes
 
-Transaction authors produce complete and independently verifiable autonome
+Transaction authors produce complete and independently verifiable *autonome*
 transactions with proof stamps and broadcast them to the mempool via the
 existing wallet RPC or P2P path.
 
@@ -186,11 +198,11 @@ existing wallet RPC or P2P path.
 Aggregators observe transactions in mempool gossip (see
 [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay)).
 
-An aggregator selects two transactions (autonomes or existing aggregates) for
-merging into a new aggregate. Selected transactions MUST bear anchors that are
+An aggregator selects two transactions (*autonomes* or existing *aggregates*) for
+merging into a new *aggregate*. Selected transactions MUST bear anchors that are
 identical or alignable by lifting (see
 [Step 3](#step-3-witness-and-pcd-preparation)). Selected transactions SHOULD bear
-disjoint tachygram sets; overlapping selections cannot yield a valid aggregate,
+disjoint tachygram sets; overlapping selections cannot yield a valid *aggregate*,
 so this guidance needs no enforcement (see the [Rationale](#rationale)).
 
 ### Step 3: Witness and PCD preparation
@@ -211,12 +223,12 @@ published nullifiers relative to the epoch of its anchor (see the
 lift never crosses an epoch boundary, and stamps bearing anchors of different
 epochs cannot be aligned for merging.
 
-If both selected transactions are autonomes, all necessary witness data is
+If both selected transactions are *autonomes*, all necessary witness data is
 directly available on the transactions themselves.
 
-A selected transaction that is already an aggregate additionally requires the
+A selected transaction that is already an *aggregate* additionally requires the
 actions of every transaction contributing to it. The contributors
-cannot be requested from the network by `wtxid`, because the aggregate does
+cannot be requested from the network by `wtxid`, because the *aggregate* does
 not carry their identities. Recovering them from transactions the aggregator
 holds is
 [covered-transaction identification](#covered-transaction-identification): a correct and
@@ -239,7 +251,7 @@ the merged stamp.
 
 ### Step 5: Aggregate publication
 
-The aggregator publishes the aggregate transaction to the mempool. A newly
+The aggregator publishes the *aggregate* transaction to the mempool. A newly
 constructed transaction bears a new `txid` and `wtxid`; an updated transaction
 retains its `txid` and bears a new `wtxid`, distinct from the form it replaced.
 Relay follows
@@ -247,37 +259,37 @@ Relay follows
 
 ### Step 6: Miner observation and selection
 
-Miners observe both autonomes and aggregates in the mempool (see
+Miners observe both *autonomes* and *aggregates* in the mempool (see
 [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay)) and select
-the aggregates and the transactions they cover to include in a block. Determining which
-transactions a candidate aggregate covers is
+the *aggregates* and the transactions they cover to include in a block. Determining which
+transactions a candidate *aggregate* covers is
 [covered-transaction identification](#covered-transaction-identification). A miner MAY also
-vertically integrate aggregation, producing its own aggregates privately during block
+vertically integrate aggregation, producing its own *aggregates* privately during block
 assembly rather than sourcing them from the mempool.
 
 ### Step 7: Block assembly
 
-Use of aggregates within a block is RECOMMENDED, not required.
+Use of *aggregates* within a block is RECOMMENDED, not required.
 
 Miners MAY perform additional aggregation during block assembly, without
-publishing the aggregate to the mempool. The resulting aggregate is included
+publishing the *aggregate* to the mempool. The resulting *aggregate* is included
 directly in the miner's proposed block. The merge and anchor-alignment rules
 of Steps 3 and 4 apply unchanged.
 
 A block MAY contain, in any combination:
 
-- zero or more non-Tachyon transactions
-- zero or more Tachyon autonomes
-- zero or more Tachyon aggregates
+* zero or more non-Tachyon transactions
+* zero or more Tachyon *autonomes*
+* zero or more Tachyon *aggregates*
 
-A block containing an aggregate MUST also contain, as adjuncts, every
-transaction that aggregate covers. For each such adjunct, the miner MUST strip
+A block containing an *aggregate* MUST also contain, as *adjuncts*, every
+transaction that *aggregate* covers. For each such *adjunct*, the miner MUST strip
 the bundle's stamp and set the `tachyonAggregateId` field to the covering
-aggregate's `wtxid`.
+*aggregate*'s `wtxid`.
 
-An adjunct bundle with no actions of its own still names a covering transaction.
+An *adjunct* bundle with no actions of its own still names a covering transaction.
 Its `tachyonAggregateId` MUST identify a proof-stamped transaction in the same block,
-and SHOULD refer to the aggregate that ultimately absorbed its stamp.
+and SHOULD refer to the *aggregate* that ultimately absorbed its stamp.
 
 ### Step 8: Block validation
 
@@ -289,14 +301,14 @@ ZIP](tachyon-bundle.md#block-validity); this step describes only how those rules
 fit the lifecycle.
 
 Validation covers tachygram distinctness across the block, association of each
-adjunct with the aggregate covering it, confirmation of each stamp's
+*adjunct* with the *aggregate* covering it, confirmation of each stamp's
 covered-actions digest against the actions actually present in the block, and
 verification of every proof. Reuse of a tachygram across the wider epoch window
 is a separate consensus concern owned by the [Tachyon Accumulator / Hash Chain
 ZIP](tachyon-accumulator.md#epoch-window).
 
 The spirit of these checks is fail-fast ordering: the cheap public-data scans
-(tachygram distinctness, adjunct association, and covered-actions confirmation) run
+(tachygram distinctness, *adjunct* association, and covered-actions confirmation) run
 before the costly proof verification, so a block that violates a cheaper rule is
 rejected without any proof being verified.
 
@@ -306,28 +318,28 @@ These semantics underpin publication (Step 5), observation (Steps 2 and 6), and 
 (Step 7).
 
 **Identifiers.** A Tachyon transaction is identified by `wtxid = txid || auth_digest`
-([ZIP 239](https://zips.z.cash/zip-0239), [ZIP 244](https://zips.z.cash/zip-0244)). The
+(ZIP 239 [^zip-0239], ZIP 244 [^zip-0244]). The
 digest inputs (which fields each contribution commits to) are defined normatively by the
 [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, and the digest
 algorithm by the [ZIP 244 update](zip-244.md); this section summarizes them
 non-normatively.
 
-- Tachyon's contribution to `txid` commits only to effecting data
+* Tachyon's contribution to `txid` commits only to effecting data
   (`hActionsTachyon || valueBalanceTachyon`). It is stable across
   stamping, merging, stripping, and re-stamping, so a transaction's logical identity is
   invariant across the aggregation lifecycle.
-- `auth_digest` commits to action signatures, the binding signature, and the
+* `auth_digest` commits to action signatures, the binding signature, and the
   stamp. A proof stamp contributes a `byte[64]` stamp digest; a pointer stamp
   contributes the `byte[64]` covering `wtxid`. The
   `"ZTxAuthTachyHash"` personalization and the normative digest algorithm are
   specified by the [ZIP 244 update](zip-244.md).
-- A transaction's effecting data fixes its `txid`, but the transaction can be
+* A transaction's effecting data fixes its `txid`, but the transaction can be
   authorized in multiple forms that share that `txid` and differ only in
-  `auth_digest`, hence in `wtxid`: a wallet's autonome, an anchor-lifted or
-  proof-rerandomized restamp, and the adjunct a miner produces. The
-  covering-aggregate reference an adjunct carries is a `wtxid`, not a `txid`, to
-  pin a specific aggregate.
-- The wire byte `tachyonBundleState` (`uint8`) distinguishes forms: `0x00` no Tachyon
+  `auth_digest`, hence in `wtxid`: a wallet's *autonome*, an anchor-lifted or
+  proof-rerandomized restamp, and the *adjunct* a miner produces. The
+  covering-*aggregate* reference an *adjunct* carries is a `wtxid`, not a `txid`, to
+  pin a specific *aggregate*.
+* The wire byte `tachyonBundleState` (`uint8`) distinguishes forms: `0x00` no Tachyon
   bundle, `0x01` proof stamp, `0x02` pointer stamp.
 
 **Relay.** Tachyon bundles are announced and fetched by `wtxid` using the
@@ -337,11 +349,11 @@ objects. `MSG_WTX` relay is mandatory: restamping changes a transaction's
 not distinguish the proof-stamped forms a node may be offered.
 
 **Aggregates do not conflict with covered transactions.** Distinct authorization
-forms of one `txid` are alternative inventory, not conflicts, and an aggregate
-does not conflict with its contributing autonomes and aggregates. A node SHOULD
-retain contributing autonomes and aggregates after accepting the aggregate built
-from them: a block including the aggregate must include the covered transactions
-as adjuncts, and an aggregate might never be mined. Further mempool retention
+forms of one `txid` are alternative inventory, not conflicts, and an *aggregate*
+does not conflict with its contributing *autonomes* and *aggregates*. A node SHOULD
+retain contributing *autonomes* and *aggregates* after accepting the *aggregate* built
+from them: a block including the *aggregate* must include the covered transactions
+as *adjuncts*, and an *aggregate* might never be mined. Further mempool retention
 and eviction policy is a local implementation concern.
 
 **Duplicate tachygrams are transaction-invalid.** Tachygram distinctness applies
@@ -356,27 +368,27 @@ checks (action and binding signature verification, balance rules, and general tr
 validity). The proof check needs the covered actions: the node assembles the proof
 header from the action-set commitment over the covered actions' digests, the stamp's
 `anchorTachyon`, and a Pedersen commitment to its `vTachygrams`, and verifies the proof
-against that header. An autonome is self-contained, since its stamp covers only its own
-actions. For an aggregate covering other transactions, the node recovers the covered
+against that header. An *autonome* is self-contained, since its stamp covers only its own
+actions. For an *aggregate* covering other transactions, the node recovers the covered
 actions from mempool data it holds and confirms the recovered set against the carried
 `hStampActionsTachyon` (see
 [Covered-transaction identification](#covered-transaction-identification)) before
-assembling the header; an aggregate whose covered actions the node cannot recover
+assembling the header; an *aggregate* whose covered actions the node cannot recover
 cannot be verified, so it is not accepted or relayed. The contributing transactions
-propagate before the aggregate built from them, so a node observing gossip ordinarily
+propagate before the *aggregate* built from them, so a node observing gossip ordinarily
 holds them.
 
-**Adjunct bundles are forbidden from the mempool.** A bundle in the adjunct
+**Adjunct bundles are forbidden from the mempool.** A bundle in the *adjunct*
 state (`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool,
 relayed, or published by an aggregator; it is valid only inside a block. The P2P
-network carries proof-stamped bundles (autonomes and aggregates) only, and an
-aggregator publishes its merged stamp as a new proof-stamped aggregate rather
-than an adjunct form. This relay policy and `MSG_WTX` operate at different
+network carries proof-stamped bundles (*autonomes* and *aggregates*) only, and an
+aggregator publishes its merged stamp as a new proof-stamped *aggregate* rather
+than an *adjunct* form. This relay policy and `MSG_WTX` operate at different
 layers: `MSG_WTX` fixes the identifier and inventory semantics, while the policy
-admits only the proof-stamped forms. An adjunct form's `wtxid` is still
+admits only the proof-stamped forms. An *adjunct* form's `wtxid` is still
 meaningful at the block layer, where a block commits to each included
-transaction by `wtxid` ([ZIP 244](https://zips.z.cash/zip-0244)); that is what
-lets a block name an adjunct unambiguously even though relay only ever carried
+transaction by `wtxid` (ZIP 244 [^zip-0244]); that is what
+lets a block name an *adjunct* unambiguously even though relay only ever carried
 the proof-stamped form.
 
 ### Covered-transaction identification
@@ -385,17 +397,17 @@ Identifying which transactions a stamp covers is a single primitive, used by agg
 preparing a merge witness (Step 3) and by miners observing and composing a block (Steps 6
 and 7).
 
-Tachygrams give a first pass: an aggregate's stamp publishes the tachygrams of every action
+Tachygrams give a first pass: an *aggregate*'s stamp publishes the tachygrams of every action
 it covers, so transactions whose tachygrams appear there are candidates. But tachygram
 matching only narrows the candidate set; it cannot confirm the set is complete. An
-aggregate's own tachygrams are not labeled, and tachygrams do not distinguish nullifiers
+*aggregate*'s own tachygrams are not labeled, and tachygrams do not distinguish nullifiers
 from commitments, so a near-complete collection is indistinguishable from the complete one.
 Absent a faster check, the only way to discover whether a candidate set is exactly the cover
-would be to attempt the aggregate's full proof verification, which fails only after that
+would be to attempt the *aggregate*'s full proof verification, which fails only after that
 costly attempt when a transaction is missing or extra.
 
-`hStampActionsTachyon` is that faster check. The aggregate's stamp publishes it as the
-descriptor digest of every action the aggregate covers. A candidate set is tested by
+`hStampActionsTachyon` is that faster check. The *aggregate*'s stamp publishes it as the
+descriptor digest of every action the *aggregate* covers. A candidate set is tested by
 sorting the candidate actions' descriptors and recomputing the digest, as specified by
 the [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, so the
 check costs a sort and one BLAKE2b-256 hash and attempts no proof verification. A
@@ -403,21 +415,29 @@ match confirms the candidate set is exactly the cover; a mismatch is fail-fast.
 
 ## Rationale
 
-**Lifecycle-structured specification.** Organizing the Specification around the lifecycle
+This subsection is non-normative.
+
+### Lifecycle-structured specification
+
+Organizing the Specification around the lifecycle
 mirrors how participants actually move through the protocol. The two concerns that several
 steps share, transaction-identifier and relay semantics and covered-transaction
 identification, are factored into their own subsections and referenced from the steps, so no
 step restates another's rules and the lifecycle reads as a sequence of actions.
 
-**Cheap coverage confirmation.** Matching previously-seen tachygrams associates
-an aggregate with its contributing autonomes and aggregates, but cannot confirm
-the association is complete: an aggregate's own tachygrams are indistinguishable
+### Cheap coverage confirmation
+
+Matching previously-seen tachygrams associates
+an *aggregate* with its contributing *autonomes* and *aggregates*, but cannot confirm
+the association is complete: an *aggregate*'s own tachygrams are indistinguishable
 from its contributors'. The `hStampActionsTachyon` digest gives observers a
 fail-fast completeness check over the covered action set, at the cost of a sort
 and one hash, rather than adding a signed coverage manifest or a
 tachygram-origin query protocol.
 
-**Overlapping merges self-invalidate.** The disjoint-selection guidance of Step 2 is a
+### Overlapping merges self-invalidate
+
+The disjoint-selection guidance of Step 2 is a
 SHOULD rather than a consensus rule because a violation cannot survive: merging stamps
 whose tachygram sets overlap produces a stamp bearing duplicate tachygrams, which no node
 accepts into its mempool and no valid block can contain (see
@@ -427,83 +447,92 @@ commits to multiply-counted multiset members that no reconstruction over a block
 distinct transactions can reproduce. The aggregator's proving work is simply wasted, so
 the selection rule needs no enforcement of its own.
 
-**Aggregate limits.** Two hard limits bound an aggregate. Its tachygram vector is committed
-as a Ragu polynomial, so it cannot exceed the maximum Ragu polynomial size; and the
-aggregate transaction, like any transaction, is bounded by block size. Construction is also
-shaped by parallelism: a chain of merges is sequential, since each merge consumes the
-previous result, but independent aggregates can be built in parallel.
+### Aggregate limits
 
-**Verified relay.** Requiring proof verification before relay is standard mempool
+Two hard limits bound an *aggregate*. Its tachygram vector is committed
+as a Ragu polynomial, so it cannot exceed the maximum Ragu polynomial size; and the
+*aggregate* transaction, like any transaction, is bounded by block size. Construction is also
+shaped by parallelism: a chain of merges is sequential, since each merge consumes the
+previous result, but independent *aggregates* can be built in parallel.
+
+### Verified relay
+
+Requiring proof verification before relay is standard mempool
 hygiene, and aggregation sharpens it: an invalid stamp is a dead end, since a merge
-cannot produce a valid aggregate from an invalid input and no valid block can carry an
+cannot produce a valid *aggregate* from an invalid input and no valid block can carry an
 unverifiable proof (see [block validity](tachyon-bundle.md#block-validity)). Aggregators
 would therefore hit every invalid proof themselves at the merge; verifying at relay pushes
 that discovery to the network edge
 rather than spending bandwidth propagating transactions no aggregator can use and no
-block can include. Verifying an aggregate requires its covered actions, which a node
+block can include. Verifying an *aggregate* requires its covered actions, which a node
 recovers from mempool data it holds; the carried `hStampActionsTachyon` confirms the
 recovered set is complete before the node attempts the proof, and block validation
 later confirms the same digest against the block's actual actions.
 
-**`wtxid`, not `txid`, for adjunct references.** A `txid` would be ambiguous across
-the autonome/aggregate forms (they share effecting data). The `wtxid` pins a specific
-physical aggregate including its stamp state, which is what the adjunct needs to
+### `wtxid`, not `txid`, for *adjunct* references
+
+A `txid` would be ambiguous across
+the *autonome*/*aggregate* forms (they share effecting data). The `wtxid` pins a specific
+physical *aggregate* including its stamp state, which is what the *adjunct* needs to
 reference. This is why the `tachyonAggregateId` holds a `wtxid` rather than a `txid`.
 
-**Stripping is miner-side, not relay-time.** Stripping at relay time would force every
-relay node to understand aggregate coverage and would mix block-assembly policy with
-gossip. Keeping the P2P network carrying proof-stamped bundles only, and forbidding adjunct
-bundles from the mempool, simplifies relay and matches the implementation (an adjunct
+### Stripping is miner-side, not relay-time
+
+Stripping at relay time would force every
+relay node to understand *aggregate* coverage and would mix block-assembly policy with
+gossip. Keeping the P2P network carrying proof-stamped bundles only, and forbidding *adjunct*
+bundles from the mempool, simplifies relay and matches the implementation (an *adjunct*
 bundle is not serializable until its covering `wtxid` is assigned, which happens at block
 assembly).
 
-**`MSG_WTX` relay is mandatory.** Tachyon's authorization-form malleability is the direct
+### `MSG_WTX` relay is mandatory
+
+Tachyon's authorization-form malleability is the direct
 analogue of the v5 witness malleability that motivated ZIP 239: restamping and proof
 rerandomization yield distinct `wtxid`s over one stable `txid`, all relayable. Announcing
 by `txid` alone would let one such form shadow another in relay. Requiring `MSG_WTX`
 for Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
 
-## Security and Privacy Implications
+## Security Implications
 
-**No new trust assumption.** The aggregator is not trusted. Every invariant is
+This subsection is non-normative.
+
+### No new trust assumption
+
+The aggregator is not trusted. Every invariant is
 enforced either inside the Ragu PCD (circuit logic) or by consensus checks on public
-data (consensus logic). A malicious aggregator can publish an invalid aggregate, but
+data (consensus logic). A malicious aggregator can publish an invalid *aggregate*, but
 block validation (see [block validity](tachyon-bundle.md#block-validity)) rejects it. A
-malicious miner can mis-assign adjuncts or omit covered transactions, but the block fails
+malicious miner can mis-assign *adjuncts* or omit covered transactions, but the block fails
 validation.
 
-**Data availability.** Aggregation removes redundant proof bytes only. Every adjunct
+### Data availability
+
+Aggregation removes redundant proof bytes only. Every *adjunct*
 retains its action data, action signatures, binding signature, and `valueBalanceTachyon`;
-validators reconstruct the aggregate header from this public data. An aggregate proof
-alone is insufficient: the covered effecting data is present in the block as adjuncts,
+validators reconstruct the *aggregate* header from this public data. An *aggregate* proof
+alone is insufficient: the covered effecting data is present in the block as *adjuncts*,
 and the [block-validity rules](tachyon-bundle.md#block-validity) reject any block where it
 is not.
 
-**`hStampActionsTachyon` is confirmed, not trusted.** The action set is bound by the
+### `hStampActionsTachyon` is confirmed, not trusted
+
+The action set is bound by the
 proof, which verifies only against the action-set commitment reconstructed from the
 actions themselves; the carried digest plays no role in that binding. Block validation
 (see [block validity](tachyon-bundle.md#block-validity)) confirms the carried digest
 against the actions actually present in the block and rejects on any mismatch, so the
-proof is tied to the adjuncts the block carries, not to a value the prover supplies,
+proof is tied to the *adjuncts* the block carries, not to a value the prover supplies,
 and a wrong `hStampActionsTachyon` cannot pass and only harms its author. The carried
 value lets observers identify coverage cheaply (see
 [Covered-transaction identification](#covered-transaction-identification)); it is
 recomputable from visible actions, so it reveals nothing the actions do not, and for
-an aggregate carrying its own actions it does not expose which of them are the
+an *aggregate* carrying its own actions it does not expose which of them are the
 aggregator's own.
 
-**Privacy of aggregation relationships.** An observer who sees an aggregate in
-the mempool can identify contributing transactions by `vTachygrams` overlap and
-confirm the correct composition by recomputing `hStampActionsTachyon`
-(see [Covered-transaction identification](#covered-transaction-identification)).
-This is inherent to the scheme: the aggregate must carry enough information for
-validators to reconstruct its header. The tachygrams and the covered-actions
-digest do not reveal the private contents of any covered note. An adjunct
-bundle with no actions is valid against any claimed covering stamp (see [block
-validity](tachyon-bundle.md#block-validity)), so an observer reconstructing
-aggregation relationships cannot rely on an actionless bundle's reference.
+### Circuit/consensus boundary
 
-**Circuit/consensus boundary.** Several security properties are enforced by consensus
+Several security properties are enforced by consensus
 rather than fully proven inside the stamp. Double-spend prevention rests on the block-scoped
 tachygram-uniqueness check (see [block validity](tachyon-bundle.md#block-validity)) together
 with the [epoch-window duplicate-tachygram](tachyon-accumulator.md#epoch-window) and
@@ -512,6 +541,23 @@ with the [epoch-window duplicate-tachygram](tachyon-accumulator.md#epoch-window)
 rules owned by the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) ZIP. Those
 base-protocol rules are depended upon, not re-specified here, so implementers and auditors
 should not assume the proof alone establishes these properties.
+
+## Privacy Implications
+
+This subsection is non-normative.
+
+### Privacy of aggregation relationships
+
+An observer who sees an *aggregate* in
+the mempool can identify contributing transactions by `vTachygrams` overlap and
+confirm the correct composition by recomputing `hStampActionsTachyon`
+(see [Covered-transaction identification](#covered-transaction-identification)).
+This is inherent to the scheme: the *aggregate* must carry enough information for
+validators to reconstruct its header. The tachygrams and the covered-actions
+digest do not reveal the private contents of any covered note. An *adjunct*
+bundle with no actions is valid against any claimed covering stamp (see [block
+validity](tachyon-bundle.md#block-validity)), so an observer reconstructing
+aggregation relationships cannot rely on an actionless bundle's reference.
 
 ## Deployment
 
@@ -528,13 +574,12 @@ merging, stripping, and the `hStampActionsTachyon` coverage check) is developed 
 
 ## References
 
-- [Zcash Protocol Specification](https://zips.z.cash/protocol/protocol.pdf)
-- [ZIP 200: Network Upgrade Mechanism](https://zips.z.cash/zip-0200)
-- [ZIP 225: Version 5 Transaction Format](https://zips.z.cash/zip-0225)
-- [ZIP 239: Relay of Version 5 Transactions](https://zips.z.cash/zip-0239)
-- [ZIP 244: Transaction Identifier Non-Malleability](https://zips.z.cash/zip-0244)
-- [BIP 339: WTXID-based transaction relay](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki)
-- [Tachyon Shielded Protocol](tachyon-shielded-protocol.md)
-- [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md)
-- [Tachyon Accumulator / Hash Chain](tachyon-accumulator.md)
-- [Network Upgrade Deployment](network-upgrade-deployment.md)
+[^BCP14]: [Information on BCP 14: "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"](https://www.rfc-editor.org/info/bcp14)
+
+[^protocol]: [Zcash Protocol Specification](https://zips.z.cash/protocol/protocol.pdf)
+
+[^zip-0200]: [ZIP 200: Network Upgrade Mechanism](https://zips.z.cash/zip-0200)
+
+[^zip-0239]: [ZIP 239: Relay of Version 5 Transactions](https://zips.z.cash/zip-0239)
+
+[^zip-0244]: [ZIP 244: Transaction Identifier Non-Malleability](https://zips.z.cash/zip-0244)

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -151,9 +151,7 @@ Aggregators observe transactions in mempool gossip (see
 
 An aggregator selects two transactions (autonomes or existing aggregates) for
 merging into a new aggregate. Selected transactions SHOULD bear disjoint
-tachygram sets: merging combines tachygram sets, and a block containing a
-duplicate tachygram is invalid (Step 8), so an aggregate built from
-overlapping sets can never be included in a valid block.
+tachygram sets.
 
 ### Step 3: Witness and PCD preparation
 
@@ -161,10 +159,8 @@ The aggregator reconstructs each selected transaction's stamp PCD from the
 proof and data carried on that transaction.
 
 Merging is defined only over stamps bearing identical anchors. If the selected
-transactions bear unequal anchors, the aggregator MUST first align them by
-fusing with an anchor PCD that proves the sequence from one anchor to the
-other. Aggregators SHOULD maintain recent consensus data and cache anchor PCD
-likely to be relevant to anchor alignment.
+transactions bear unequal anchors, the aggregator first aligns them by fusing
+with an anchor PCD that proves the sequence from one anchor to the other.
 
 If both selected transactions are autonomes, all necessary witness data is
 directly available on the transactions themselves.
@@ -174,8 +170,12 @@ action digests of every transaction contributing to it. Recovering those
 contributors is
 [covered-transaction identification](#covered-transaction-identification): a correct and
 complete collection of action digests reproduces the action set commitment on the
-selected stamp. Aggregators SHOULD maintain an index of recent mempool
-transactions likely to be relevant to witness preparation.
+selected stamp.
+
+Aggregators typically maintain recent consensus data, cached anchor PCD, and
+an index of recent mempool transactions to support alignment and witness
+preparation. These are implementation concerns; this ZIP does not constrain
+them.
 
 ### Step 4: Aggregate construction
 
@@ -183,8 +183,8 @@ Holding two stamp PCD with identical anchors and the prepared witness, the
 aggregator executes a merge, proving a new stamp PCD that covers the selected
 transactions and every transaction contributing to them.
 
-The aggregator MAY construct a new transaction bearing the merged stamp, or
-MAY update either contributing transaction in place, replacing its stamp with
+The aggregator MAY carry the merged stamp on a newly constructed transaction,
+or update either contributing transaction in place, replacing its stamp with
 the merged stamp.
 
 ### Step 5: Aggregate publication
@@ -202,8 +202,8 @@ Miners observe both autonomes and aggregates in the mempool (see
 the aggregates and the transactions they cover to include in a block. Determining which
 transactions a candidate aggregate covers is
 [covered-transaction identification](#covered-transaction-identification). A miner MAY also
-vertically integrate aggregation, producing its own aggregates privately (Step 7) rather
-than sourcing them from the mempool.
+vertically integrate aggregation, producing its own aggregates privately during block
+assembly rather than sourcing them from the mempool.
 
 ### Step 7: Block assembly
 
@@ -228,12 +228,11 @@ aggregate's `wtxid`.
 A stripped innocent (a former innocent aggregate) contributes no actions, but
 the stripped form still names a covering transaction. Its `tachyonAggregateId`
 MUST identify a stamped transaction in the same block, and SHOULD refer to the
-aggregate that ultimately absorbed its stamp. An actionless bundle is,
-however, valid against any claimed covering stamp: it contributes no action
-digests to any reconstruction, so the association checks of Step 8 pass for
-whichever stamped transaction it names.
+aggregate that ultimately absorbed its stamp.
 
 ### Step 8: Block validation
+
+The tachygrams of every stamped bundle MUST be distinct.
 
 All tachygrams in a block MUST be distinct.
 
@@ -252,9 +251,11 @@ the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) and
 confirms the rules above as follows, deferring the costly proof verification until the
 cheaper checks pass:
 
-1. **Tachygram uniqueness.** The validator MUST reject the block if any
-tachygram appears more than once. Reuse within the wider epoch window is
-governed by the duplicate-tachygram consensus rule of the
+1. **Tachygram uniqueness.** A block's tachygrams are the multiset union of
+the `vTachygrams` of every stamp it contains. The validator MUST reject the
+block if any tachygram appears more than once. This single scan enforces
+distinctness both within each stamp and across stamps. Reuse within the wider
+epoch window is governed by the duplicate-tachygram consensus rule of the
 [Tachyon Shielded Protocol](tachyon-shielded-protocol.md).
 2. **Adjunct association.** The `tachyonAggregateId` of every stripped bundle
 MUST identify a stamped transaction in the same block. If the referenced
@@ -306,6 +307,20 @@ These semantics underpin publication (Step 5), observation (Steps 2 and 6), and 
 objects. `MSG_WTX` relay is mandatory: restamping changes a transaction's
 `wtxid` while leaving `txid` unchanged, so announcement by `txid` alone could
 not distinguish the stamped forms a node may be offered.
+
+**Duplicate tachygrams are transaction-invalid.** Tachygram distinctness applies at the
+transaction level: a stamped bundle whose `vTachygrams` contains a duplicate tachygram is
+invalid, and a node MUST NOT accept it into the mempool or relay it. The check is a scan
+of the public list, requiring no proof verification.
+
+**Proof verification precedes relay.** A node MUST verify a stamped bundle's proof before
+accepting the transaction into its mempool or relaying it. The stamp is sufficient for
+this: the node assembles the proof header from the carried `cActionsTachyon`, the stamp's
+`anchorTachyon`, and a Pedersen commitment to its `vTachygrams`, and verifies the proof
+against that header. A wrong `cActionsTachyon` cannot pass, because the proof verifies
+only against the action-set commitment it actually attests to. Mempool acceptance
+therefore requires no covered transactions; confirming that a block's actions match the
+carried commitment is a block-validation concern (Step 8).
 
 **Stripped bundles are forbidden from the mempool.** A bundle in the stripped state
 (`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool, relayed, or published
@@ -363,11 +378,30 @@ based aggregate's own tachygrams are indistinguishable from its covered autonome
 action-digest set, reusing the commitment the proof already attests to rather than adding
 a signed coverage manifest or a tachygram-origin query protocol.
 
+**Overlapping merges self-invalidate.** The disjoint-selection guidance of Step 2 is a
+SHOULD rather than a consensus rule because a violation cannot survive: merging stamps
+whose tachygram sets overlap produces a stamp bearing duplicate tachygrams, which no node
+accepts into its mempool and no valid block can contain (Step 8). The deeper reason is
+that the merge is homomorphic over the stamps' set commitments, so the overlapping stamp
+commits to multiply-counted multiset members that no reconstruction over a block's
+distinct transactions can reproduce. The aggregator's proving work is simply wasted, so
+the selection rule needs no enforcement of its own.
+
 **Aggregate limits.** Two hard limits bound an aggregate. Its tachygram vector is committed
 as a Ragu polynomial, so it cannot exceed the maximum Ragu polynomial size; and the
 aggregate transaction, like any transaction, is bounded by block size. Construction is also
 shaped by parallelism: a chain of merges is sequential, since each merge consumes the
 previous result, but independent aggregates can be built in parallel.
+
+**Verified relay.** Requiring proof verification before relay is standard mempool
+hygiene, and aggregation sharpens it: an invalid stamp is a dead end, since a merge
+cannot produce a valid aggregate from an invalid input and no valid block can carry an
+unverifiable proof (Step 8). Aggregators would therefore hit every invalid proof
+themselves at the fuse; verifying at relay pushes that discovery to the network edge
+rather than spending bandwidth propagating transactions no aggregator can use and no
+block can include. The carried `cActionsTachyon` is what makes this check self-contained:
+the stamp supplies its own header, so relay verification needs no coverage data, and
+block validation later confirms the same commitment against the block's actual actions.
 
 **`wtxid`, not `txid`, for adjunct references.** A `txid` would be ambiguous across
 the autonome/aggregate forms (they share effecting data). The `wtxid` pins a specific
@@ -407,8 +441,9 @@ from the actions actually present in the block, rejects on any mismatch, and onl
 the confirmed value as the proof header. That confirmation is what ties the proof to the
 adjuncts the block carries, not to a value the prover supplies, so a wrong `cActionsTachyon`
 cannot pass and only harms its author. The carried value lets observers identify coverage
-cheaply (see [Covered-transaction identification](#covered-transaction-identification)); it
-is reconstructable from visible actions, so it reveals nothing the actions do not, and for a
+cheaply (see [Covered-transaction identification](#covered-transaction-identification)) and
+lets relay nodes verify a stamp's proof without its covered transactions; it is
+reconstructable from visible actions, so it reveals nothing the actions do not, and for a
 based aggregate it does not expose which actions are the aggregator's own.
 
 **Privacy of aggregation relationships.** An observer who sees an aggregate in the

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -33,6 +33,24 @@ Miners are likely to vertically integrate aggregation, but a protocol is establi
 
 [^network-roles]: See [Network Roles](../network_roles/overview.md) for the aggregator and miner roles.
 
+Open questions:
+
+- **Category.** The draft is Category 'Network', but its block-validation step defines
+  block-validity rules, which are consensus. Either this ZIP is recategorized (or
+  dual-categorized 'Consensus / Network'), or the validation rules relocate to the
+  consensus-category [bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
+  and are cited from here.
+- **Duplicate-tachygram rule ownership.** The draft cites the epoch-window
+  duplicate-tachygram rule to the
+  [Shielded Protocol ZIP (#103)](https://github.com/tachyon-zcash/tachyon/issues/103);
+  confirm it is not owned by the
+  [Accumulator ZIP (#105)](https://github.com/tachyon-zcash/tachyon/issues/105).
+- **Transaction-digest amendment.** The `"ZTxAuthTachyHash"` personalization and the
+  Tachyon `txid`/`auth_digest` branches await an amendment to ZIP 244, which may be a
+  separate update ZIP or may fold into one of the general Tachyon ZIPs.
+- **Deployment.** The deployment ZIP and activation parameters are undefined; the draft's
+  Deployment section points at the placeholder.
+
 ## III. ZIP Draft
 
 --------------------------------------------------------------------------------

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -320,9 +320,10 @@ To confirm it holds the right set, the observer reconstructs the action-set comm
 from its candidate set of autonomes, together with the based aggregate's own actions, and
 compares it to the aggregate's `cActionsTachyon` indicator. Each action digest
 $d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$ is
-computable from public action data, so the reconstruction is cheap and needs no proof
-verification. A match confirms the candidate set is exactly the aggregate's cover; a
-mismatch is fail-fast, signalling a missing or extra autonome. Coverage is taken over the
+computable from public action data, so the reconstruction is cheap ($O(n)$ polynomial
+arithmetic plus one Pedersen commitment) and needs no proof verification. A match confirms
+the candidate set is exactly the aggregate's cover; a mismatch is fail-fast, signalling a
+missing or extra autonome, or a match against the wrong aggregate. Coverage is taken over the
 action-digest set, one digest per action, not over tachygrams, whose count differs from
 the action count because a spend publishes two tachygrams.
 

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -26,10 +26,16 @@
 
 ## II. Design Considerations
 
-**Aggregation** is the act of recursively merging per-transaction Ragu PCD *stamps into a single aggregate proof, and **aggregators** are the nodes that perform it.
-Miners are likely to vertically integrate aggregation, but a protocol is established for dedicated aggregator nodes to contribute aggregates to the mempool. See [Network Roles](../network_roles/overview.md) and [Aggregation](../aggregation.md).
+**Aggregation**[^aggregation] is the act of recursively merging per-transaction Ragu PCD stamps into a single aggregate proof, and **aggregators**[^network-roles] are the nodes that perform it.
+Miners are likely to vertically integrate aggregation, but a protocol is established for dedicated aggregator nodes to contribute aggregates to the mempool.
+
+[^aggregation]: See [Aggregation](../aggregation.md) for how stamps merge their tachygram and action sets.
+
+[^network-roles]: See [Network Roles](../network_roles/overview.md) for the aggregator and miner roles.
 
 ## III. ZIP Draft
+
+--------------------------------------------------------------------------------
 
 ```
 ZIP: <to be assigned by ZIP Editors>
@@ -126,9 +132,11 @@ the Specification.)
 
 ## Specification
 
-The specification is organised around the 10-step aggregation lifecycle. Each step is
-a subsection with conformance language. Transaction-identifier semantics and P2P relay
-rules are folded into the relevant steps rather than specified as parallel sections.
+The specification is organised around the 10-step aggregation lifecycle. Each step is a
+subsection with conformance language. Two cross-cutting concerns are specified in their own
+subsections after the lifecycle and referenced from the steps that invoke them:
+[Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay), and
+[Covered-transaction identification](#covered-transaction-identification).
 
 ### Step 1: Publication of autonomes
 
@@ -136,9 +144,10 @@ Transaction authors produce complete and independently verifiable transactions
 with stamped bundles (**autonomes**) and broadcast them to the mempool via the
 existing wallet RPC or P2P path.
 
-### Step 2: Aggregator mempool observation
+### Step 2: Aggregator observation and selection
 
-Aggregators observe transactions in mempool gossip.
+Aggregators observe transactions in mempool gossip (see
+[Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay)).
 
 An aggregator selects two transactions (autonomes or existing aggregates) for
 merging into a new aggregate. Selected transactions SHOULD bear disjoint
@@ -160,8 +169,10 @@ available.
 Any selected transaction that is already an aggregate will require additional
 action digests from all contributing transactions. Aggregators are RECOMMENDED
 to maintain an index of recent mempool transactions likely to be relevant to
-witness preparation. A correct and complete collection of relevant action
-digests will reproduce the action set commitment on the selected stamp.
+witness preparation. Recovering those contributors is
+[covered-transaction identification](#covered-transaction-identification): a correct and
+complete collection of relevant action digests reproduces the action set commitment on the
+selected stamp.
 
 ### Step 4: Aggregate construction
 
@@ -174,136 +185,43 @@ simply update one or both of the contributing transactions.
 
 ### Step 5: Aggregate publication
 
-Aggregators publish the aggregate transaction to the mempool.
+Aggregators publish the aggregate transaction to the mempool. A freshly constructed
+transaction has a distinct `txid` and `wtxid`; an updated transaction keeps the same `txid`
+and produces a new `wtxid` distinct from the input it replaced. Relay follows
+[Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay).
 
-A freshly constructed transaction obviously has a distinct `txid` and `wtxid`,
-but an updated transaction maintains the same `txid` and produces a new `wtxid`
-distinct from the original selected input.
+### Step 6: Miner observation and selection
 
-P2P relay for Tachyon bundles follows [ZIP 239](https://zips.z.cash/zip-0239):
-transactions are announced and fetched by `wtxid` using the `MSG_WTX` inv type. A single
-transaction's effecting data fixes its `txid`, but it can be authorized in several forms
-that share that `txid` and differ only in `auth_digest`: a wallet's autonome, an
-anchor-lifted or proof-rerandomized restamp, and the stripped adjunct form a miner
-produces. Each is a distinct `wtxid`, and nodes MUST treat distinct `wtxid`s as distinct
-objects.
+Miners observe both autonomes and aggregates in the mempool (see
+[Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay)) and select
+the aggregates and the transactions they cover to include in a block. Determining which
+transactions a candidate aggregate covers is
+[covered-transaction identification](#covered-transaction-identification). A miner MAY also
+vertically integrate aggregation, producing its own aggregates privately (Step 7) rather
+than sourcing them from the mempool.
 
-### Step 5: Miner mempool observation
+### Step 8: Block assembly
 
-Miners see both autonomes and aggregates in the mempool. A miner MAY also vertically
-integrate aggregation.
+Use of aggregates within a block is RECOMMENDED, not required.
 
-A miner that vertically integrates aggregation MAY produce its own aggregates
-privately without publishing them to the mempool (Step 7).
+Miners MAY perform additional aggregation during block assembly, without
+publishing the aggregate to the mempool. The resulting aggregate is included
+directly in the miner's proposed block. The same `MergeStamp` and
+anchor-alignment rules apply.
 
-`MSG_WTX`-style relay is mandatory for Tachyon bundles: restamping, proof rerandomization,
-and stripping all change `wtxid` while leaving `txid` unchanged, so announcement by `txid`
-alone cannot distinguish these authorization forms of one transaction. See the Rationale.
+A block MAY contain, in any combination:
 
-Because `txid` is stable across a transaction's authorization forms (it commits only to
-`action_acc || value_balance`), a wallet's transaction stays identifiable by `txid` even
-when it is restamped or its proof is rerandomized. Relay policy MAY de-duplicate these
-same-`txid` forms to avoid propagating more than one stamped form of a transaction.
+- zero or more non-Tachyon transactions
+- zero or more Tachyon autonomes
+- zero or more Tachyon aggregates
 
-Stripped bundles are forbidden from the mempool. A bundle in the stripped state
-(`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool, relayed, or
-published by an aggregator; it is valid only inside a block, alongside the covering
-aggregate its `tachyonAggregateId` names. Stripping is a miner-side block-assembly action
-(Step 8), not a relay-time transformation: the P2P network carries stamped bundles
-(autonomes and aggregates) only. An aggregator publishes its merged stamp as a new
-stamped aggregate; it never publishes a stripped form of a covered transaction.
+A block MUST contain a complete set of adjuncts for all included aggregates.
+For each covered adjunct the miner includes, the miner MUST strip the adjunct's
+stamp and identify the covering aggregate in the `tachyonAggregateId` field.
 
-The mempool prohibition and `MSG_WTX` relay operate at different layers and do not
-conflict. `MSG_WTX` fixes the identifier and inventory semantics: every authorization form
-is a distinct `wtxid`. Relay policy then admits only the stamped forms; the stripped form,
-though it has a well-formed `wtxid`, is never announced, fetched, or accepted in the
-mempool. That `wtxid` is still meaningful at the block layer, where a block commits to
-each included transaction by `wtxid` ([ZIP 244](https://zips.z.cash/zip-0244)): an adjunct
-is committed under its own stripped-form `wtxid`, distinct from the autonome's. The
-non-malleability `MSG_WTX` provides is what lets a block name the stripped form
-unambiguously even though relay only ever carried the stamped form.
-
-### Step 6: Covered-transaction identification
-
-A mempool observer assembles a **candidate set of autonomes** for an aggregate primarily
-by matching tachygrams it has already seen: the aggregate's stamp publishes the tachygrams
-of every action it covers, so autonomes whose tachygrams appear there are candidates for
-coverage. Because a based aggregate's own tachygrams are not labelled and tachygrams do
-not distinguish nullifiers from commitments, tachygram matching narrows the candidate set
-but does not confirm it is complete.
-
-To confirm it holds the right set, the observer reconstructs the action-set
-commitment from its candidate set of autonomes, together with the aggregate's
-own actions (none, for an innocent aggregate), and compares it to the
-aggregate's `cActionsTachyon` indicator.  Each action digest $d_i =
-\text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$
-is computable from public action data, so the reconstruction is cheap ($O(n)$
-polynomial arithmetic plus one Pedersen commitment) and needs no proof
-verification. A match confirms the candidate set is exactly the aggregate's
-cover; a mismatch is fail-fast, signalling a missing or extra autonome, or a
-match against the wrong aggregate. Coverage is taken over the action-digest set,
-one digest per action, not over tachygrams, whose count differs from the action
-count because a spend publishes two tachygrams.
-
-### Step 7: Private miner aggregation (optional)
-
-Miners MAY perform their own aggregation privately during block assembly, without
-publishing the aggregate to the mempool. The resulting aggregate is included directly
-in the miner's proposed block. The same `MergeStamp` and anchor-alignment rules apply;
-the only difference is that the aggregate is never gossiped.
-
-### Step 8: Block composition and adjunct assignment
-
-Miners compose the block at will. For each covered transaction the miner includes, the
-miner strips the stamp and assigns the covering aggregate's `wtxid` as the adjunct's
-`byte[64]` `tachyonAggregateId`. The covering aggregate MUST be included top-level in the
-same block, never stripped and never further aggregated in that block, so the `wtxid`
-referenced by adjuncts is stable and resolvable by validators in a single pass.
-
-A stripped innocent (an aggregate with no Tachyon actions) MAY carry an all-zero
-`tachyonAggregateId` if no absorbing aggregate was recorded; this is the only case where
-a zero `tachyonAggregateId` is valid. Nodes MUST reject a stripped bundle having
-non-empty actions and an all-zero `tachyonAggregateId`.
-
-Transaction-identifier semantics under stripping:
-
-- `txid` commits only to effecting data (`action_acc || value_balance`) and is stable
-  across stamping, merging, stripping, and re-stamping. A transaction's logical
-  identity is invariant across the aggregation lifecycle.
-- `auth_digest` commits to action signatures, the binding signature, and the bundle's
-  stamp trailer. A stamped bundle's trailer is the full stamp (`cActionsTachyon`, anchor,
-  tachygrams, proof); a stripped bundle's trailer is the `byte[64]` covering `wtxid`
-  (referred to as `stampWtxid` in the digest contribution). Each
-  physical authorization form yields a distinct `auth_digest` and therefore a distinct
-  `wtxid = txid || auth_digest`.
-- The covering-aggregate reference carried by an adjunct is a `wtxid`, not a `txid`,
-  because the `wtxid` pins a specific physical aggregate (authorization + stamp state).
-  A `txid` would be ambiguous across the autonome/aggregate forms.
-- The wire byte `tachyonBundleState` (`uint8`) distinguishes forms: `0x00` no Tachyon
-  bundle, `0x01` stamped, `0x02` stripped. Innocents and adjuncts share the stripped
-  layout; both end in a `byte[64]` `tachyonAggregateId`.
-
-The `"ZTxAuthTachyHash"` personalization used in the Tachyon `auth_digest` contribution
-is a placeholder pending a Tachyon amendment to ZIP 244; the normative digest
-algorithm is specified there, not in this ZIP.
-
-### Step 9: Block proposal
-
-The miner proposes a block. Aggregation is not required: a block MAY contain no aggregates
-at all, including stamped autonomes directly. A block MAY contain, in any combination:
-
-- zero or more top-level unstripped stamped bundles (autonomes included directly, and/or
-  aggregates);
-- for each transaction covered by an aggregate in the block, an adjunct carrying the
-  action data, action signatures, binding signature, `value_balance`, and the covering
-  `wtxid`;
-- any non-Tachyon transactions; and
-- the coinbase transaction, which MAY itself be a based aggregate.
-
-A block need not aggregate anything, but every aggregate it does contain MUST be fully
-backed by its covered transactions in the same block (Step 10): a miner cannot include an
-aggregate whose covered transactions are not all present, as adjuncts or as the aggregate's
-own based actions.
+A stripped innocent (a former innocent aggregate) SHOULD carry a
+`tachyonAggregateId` referring to the aggregate which ultimately absorbed its
+stamp.
 
 ### Step 10: Block validation
 
@@ -311,22 +229,21 @@ A block is validated bundle by bundle. The conditions below are written for a co
 aggregate and the adjuncts it covers; a stamped autonome included directly is the
 degenerate case, validated by the same conditions over its own actions, with item 1
 (adjunct resolution) vacuous because it has no adjuncts. Every stripped bundle (adjunct)
-MUST be covered by an aggregate in the same block. Aggregation is not required: a block MAY
-contain only autonomes, or no Tachyon bundles at all.
+MUST be covered by an aggregate in the same block.
 
 Nodes MUST reject a block containing Tachyon bundles unless, for every covering aggregate
 in the block, all of the following hold:
 
 1. **Adjunct resolution.** Every adjunct whose `tachyonAggregateId` refers to that
-   aggregate is present in the same block, and the aggregate is top-level, unstripped,
-   and not further aggregated in that block.
+   aggregate is present in the same block.
 2. **Action-set reconstruction.** Consensus assembles the action digests of the actions
    actually present in the block: those of every adjunct covered by the aggregate together
    with the aggregate's own actions (none for an innocent aggregate). It then commits to the
    polynomial $\prod_i (X - d_i)$ over that reconstructed collection of digests to obtain
    $\mathsf{action\_acc}$. This freshly reconstructed commitment, never the carried
    `cActionsTachyon`, is the header value used in item 4; the carried field is only the
-   assistive fail-fast indicator of Step 6. Reconstructing from the block's own actions is
+   assistive fail-fast indicator described under
+   [Covered-transaction identification](#covered-transaction-identification). Reconstructing from the block's own actions is
    what binds the proof to the effecting data the block actually carries: if any transaction
    the aggregate covers is absent from the block, the reconstructed $\mathsf{action\_acc}$
    cannot match the proof and the block is rejected, so an aggregate must be fully backed by
@@ -348,8 +265,7 @@ in the block, all of the following hold:
    anchor sequence, as specified by the accumulator/anchor ZIP (#105).
 7. **Tachygram uniqueness.** No tachygram published in this block, in any stamp the
    block contains, duplicates a tachygram published in the current epoch or the
-   immediately preceding epoch, as specified by the tachygram-uniqueness consensus rule
-   ([Tachygrams](../tachygrams.md)).
+   immediately preceding epoch, as specified by the tachygram-uniqueness consensus rule.
 
 The above checks split into two layers:
 
@@ -365,6 +281,74 @@ Several security properties (notably spendable-lineage epoch pinning and double-
 prevention) are intentionally not fully proven inside the stamp and depend on the
 consensus checks above. This split is by design.
 
+### Transaction identifiers and P2P relay
+
+These semantics underpin publication (Step 5), observation (Steps 2 and 6), and stripping
+(Step 8).
+
+**Identifiers.** A Tachyon transaction is identified by `wtxid = txid || auth_digest`
+([ZIP 239](https://zips.z.cash/zip-0239), [ZIP 244](https://zips.z.cash/zip-0244)):
+
+- `txid` commits only to effecting data (`action_acc || value_balance`). It is stable across
+  stamping, merging, stripping, and re-stamping, so a transaction's logical identity is
+  invariant across the aggregation lifecycle.
+- `auth_digest` commits to action signatures, the binding signature, and the stamp trailer.
+  A stamped bundle's trailer is the full stamp (`cActionsTachyon`, anchor, tachygrams,
+  proof); a stripped bundle's trailer is the `byte[64]` covering `wtxid` (the `stampWtxid`
+  of the digest contribution). The `"ZTxAuthTachyHash"` personalization is a placeholder
+  pending a Tachyon amendment to ZIP 244, which specifies the normative digest algorithm.
+- A transaction's effecting data fixes its `txid`, but it can be authorized in several
+  physical forms that share that `txid` and differ only in `auth_digest`, hence in `wtxid`:
+  a wallet's autonome, an anchor-lifted or proof-rerandomized restamp, and the stripped
+  adjunct a miner produces. The covering-aggregate reference an adjunct carries is a
+  `wtxid`, not a `txid`, because it must pin a specific physical aggregate.
+- The wire byte `tachyonBundleState` (`uint8`) distinguishes forms: `0x00` no Tachyon
+  bundle, `0x01` stamped, `0x02` stripped.
+
+**Relay.** Tachyon bundles are announced and fetched by `wtxid` using the `MSG_WTX` inv
+type, and nodes MUST treat distinct `wtxid`s as distinct inventory objects. `MSG_WTX` relay
+is mandatory: restamping, proof rerandomization, and stripping all change `wtxid` while
+leaving `txid` unchanged, so announcement by `txid` alone could not distinguish these forms.
+Relay policy MAY de-duplicate same-`txid` forms to avoid propagating more than one stamped
+form of a transaction.
+
+**Stripped bundles are forbidden from the mempool.** A bundle in the stripped state
+(`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool, relayed, or published
+by an aggregator; it is valid only inside a block. The P2P network carries stamped bundles
+(autonomes and aggregates) only, and an aggregator publishes its merged stamp as a new
+stamped aggregate rather than a stripped form. This relay policy and `MSG_WTX` operate at
+different layers: `MSG_WTX` fixes the identifier and inventory semantics, while the policy
+admits only the stamped forms. A stripped form's `wtxid` is still meaningful at the block
+layer, where a block commits to each included transaction by `wtxid`
+([ZIP 244](https://zips.z.cash/zip-0244)); that is what lets a block name an adjunct
+unambiguously even though relay only ever carried the stamped form.
+
+### Covered-transaction identification
+
+Identifying which transactions a stamp covers is a single primitive, used by aggregators
+preparing a merge witness (Step 3) and by miners observing and composing a block (Steps 6
+and 8).
+
+An aggregate's stamp publishes `cActionsTachyon`, a commitment to the action-digest set of
+every action it covers. A candidate set of transactions is tested by reconstructing that
+commitment from the candidate actions and matching: each action digest
+$d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$ is
+computable from public action data, so the check is cheap ($O(n)$ polynomial arithmetic plus
+one Pedersen commitment) and needs no proof verification. A match confirms the candidate set
+is exactly the cover; a mismatch is fail-fast, signalling a missing or extra transaction.
+Coverage is taken over the action-digest set, one digest per action, not over tachygrams,
+whose count differs because a spend publishes two tachygrams.
+
+Tachygrams give a cheaper first pass: an aggregate's stamp publishes the tachygrams of every
+action it covers, so transactions whose tachygrams appear there are candidates. But a based
+aggregate's own tachygrams are not labelled and tachygrams do not distinguish nullifiers
+from commitments, so tachygram matching only narrows the candidate set; the `cActionsTachyon`
+match is what confirms it.
+
+`cActionsTachyon` is an aid for this identification, not a soundness mechanism: block
+validation reconstructs the proof header from the block's actual actions (Step 10), never
+from the carried indicator.
+
 ## Reference implementation
 
 A reference implementation of the Tachyon aggregator protocol (the bundle state machine,
@@ -373,11 +357,11 @@ stamp merging, stripping, and the `cActionsTachyon` coverage check) is in the
 
 ## Rationale
 
-**Lifecycle-structured specification.** Organising the Specification around the 10-step
-lifecycle, rather than as parallel sections for P2P, identifiers, block layout, and
-consensus rules, mirrors how participants actually move through the protocol and keeps
-each rule anchored to the step where it applies. This avoids the reader having to
-cross-reference unrelated sections to understand a single participant's obligations.
+**Lifecycle-structured specification.** Organising the Specification around the lifecycle
+mirrors how participants actually move through the protocol. The two concerns that several
+steps share, transaction-identifier and relay semantics and covered-transaction
+identification, are factored into their own subsections and referenced from the steps, so no
+step restates another's rules and the lifecycle reads as a sequence of actions.
 
 **Cheap coverage confirmation.** Matching previously-seen tachygrams associates an
 aggregate with the autonomes it covers, but cannot confirm the association is complete: a
@@ -430,12 +414,14 @@ block and uses that reconstructed $\mathsf{action\_acc}$ as the proof header; it
 builds the header from the carried `cActionsTachyon`. Reconstructing from the block's
 actual actions is what ties the proof to the adjuncts the block carries, not to a value the
 prover supplies. The carried indicator only lets observers identify coverage cheaply
-(Step 6), and a wrong value harms only its author; it is reconstructable from visible
+(see [Covered-transaction identification](#covered-transaction-identification)), and a wrong
+value harms only its author; it is reconstructable from visible
 actions, so it reveals nothing the actions do not, and for a based aggregate it does not
 expose which actions are the aggregator's own.
 
 **Privacy of aggregation relationships.** An observer who sees an aggregate in the
-mempool can identify covered autonomes by the `cActionsTachyon` check (Step 6). This
+mempool can identify covered autonomes by the `cActionsTachyon` check (see
+[Covered-transaction identification](#covered-transaction-identification)). This
 is inherent to the scheme: the aggregate must carry enough information for validators
 to reconstruct its header. The tachygram-set and action-digest-set commitments do not
 reveal the private contents of any covered note.
@@ -456,11 +442,3 @@ the proof alone establishes these properties.
 - [ZIP 252: Deployment of the NU5 Network Upgrade](https://zips.z.cash/zip-0252)
 - [ZIP 317: Proportional Transfer Fee Mechanism](https://zips.z.cash/zip-0317)
 - [BIP 339: WTXID-based transaction relay](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki)
-- [Tachyon book: Aggregation](../aggregation.md)
-- [Tachyon book: Bundles](../bundle.md)
-- [Tachyon book: Proof Tree](../proof-tree.md)
-- [Tachyon book: Tachygrams](../tachygrams.md)
-- [Tachyon book: Anchor](../anchor.md)
-- [Tachyon book: Authorization](../authorization.md)
-- [Tachyon book: Transaction Identifiers](../transaction-identifiers.md)
-- [Tachyon book: Network Roles](../network_roles/overview.md)

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -36,19 +36,16 @@ Miners are likely to vertically integrate aggregation, but a protocol is establi
 
 Open questions:
 
-- **Transaction-digest amendment.** The `"ZTxAuthTachyHash"` personalization and the
-  Tachyon `txid`/`auth_digest` branches are specified by the
-  [ZIP 244 update](zip-244.md), conditional on the ZIP 248 registration of the extensible
-  transaction format.
-- **Coverage-query relay message.** A reviewer proposes a `getxref`-style relay message
-  that returns the bundles whose stamp references a given `wtxid`, with nodes maintaining
-  a coverage graph to answer it. Whether to add such a message is undecided.
-- **Merge-input acquisition.** An aggregator selecting an existing aggregate must recover
-  the contributing actions, but contributors cannot be requested by `wtxid` because the
-  aggregate does not carry their identities. The draft's present position is that
-  aggregators index mempool data and do not attempt merges they cannot satisfy from data
-  they hold. Alternatives: a relay message requesting transactions by tachygram, or
-  aggregates carrying a list of contributing transactions. Undecided.
+- **Relay-protocol additions.** Relayed bundles carry no cross-references: an aggregate
+  does not identify its contributing transactions, and no mempool form names another by
+  `wtxid`, so aggregation relationships are discoverable only by tachygram matching over
+  held mempool data. An aggregator therefore cannot request an aggregate's contributors
+  from the network, and a node cannot ask which aggregates cover a transaction it holds;
+  presently, aggregators index mempool data and do not attempt merges they cannot
+  satisfy from data they hold. A candidate mechanism serving both queries is a relay
+  message requesting bundles by tachygram, with nodes maintaining a coverage graph to
+  answer it; a list of contributing transactions carried on aggregates would serve only
+  the merge-input case, at the cost of a large additional vector.
 - **`cActionsTachyon` commitment scheme.** The covered-transaction identification check
   reconstructs the carried `cActionsTachyon` field. Whether that field, which serves
   only external coordination, uses a different commitment scheme than the in-circuit

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -223,63 +223,32 @@ A stripped innocent (a former innocent aggregate) SHOULD carry a
 `tachyonAggregateId` referring to the aggregate which ultimately absorbed its
 stamp.
 
-### Step 10: Block validation
+### Step 9: Block validation
 
-A block is validated bundle by bundle. The conditions below are written for a covering
-aggregate and the adjuncts it covers; a stamped autonome included directly is the
-degenerate case, validated by the same conditions over its own actions, with item 1
-(adjunct resolution) vacuous because it has no adjuncts. Every stripped bundle (adjunct)
-MUST be covered by an aggregate in the same block.
+All proofs in a block must verify.
 
-Nodes MUST reject a block containing Tachyon bundles unless, for every covering aggregate
-in the block, all of the following hold:
+All stripped Tachyon transactions MUST bear a `tachyonAggregateId` referring to
+the stamped transaction in the same block covering its actions.
 
-1. **Adjunct resolution.** Every adjunct whose `tachyonAggregateId` refers to that
-   aggregate is present in the same block.
-2. **Action-set reconstruction.** Consensus assembles the action digests of the actions
-   actually present in the block: those of every adjunct covered by the aggregate together
-   with the aggregate's own actions (none for an innocent aggregate). It then commits to the
-   polynomial $\prod_i (X - d_i)$ over that reconstructed collection of digests to obtain
-   $\mathsf{action\_acc}$. This freshly reconstructed commitment, never the carried
-   `cActionsTachyon`, is the header value used in item 4; the carried field is only the
-   assistive fail-fast indicator described under
-   [Covered-transaction identification](#covered-transaction-identification). Reconstructing from the block's own actions is
-   what binds the proof to the effecting data the block actually carries: if any transaction
-   the aggregate covers is absent from the block, the reconstructed $\mathsf{action\_acc}$
-   cannot match the proof and the block is rejected, so an aggregate must be fully backed by
-   its covered transactions in the same block.
-3. **Tachygram-set binding.** The aggregate stamp publishes the merged tachygram set
-   (`vTachygrams`); adjuncts carry no tachygrams of their own. The Ragu PCD proof binds
-   the tachygram-set commitment to the action-set commitment reconstructed in item 2, so
-   consensus takes the tachygram set from the aggregate's stamp rather than
-   reconstructing it from the adjuncts.
-4. **Stamp proof verification.** The header
-   $(\mathsf{action\_acc}, \mathsf{tachygram\_acc}, \mathsf{anchor})$, with
-   $\mathsf{action\_acc}$ reconstructed in item 2, $\mathsf{tachygram\_acc}$ committed
-   from the stamp's published tachygrams, and $\mathsf{anchor}$ taken from the stamp,
-   verifies against the Ragu PCD proof.
-5. **Signatures and value balance.** Action signatures and the binding signature verify
-   against the transaction sighash, and the bundle's value commitments are consistent
-   with the declared `value_balance`.
-6. **Anchor membership.** The aggregate's anchor is a member of the published per-block
-   anchor sequence, as specified by the accumulator/anchor ZIP (#105).
-7. **Tachygram uniqueness.** No tachygram published in this block, in any stamp the
-   block contains, duplicates a tachygram published in the current epoch or the
-   immediately preceding epoch, as specified by the tachygram-uniqueness consensus rule.
+All stamped Tachyon transactions MUST bear a `cActionsTachyon` opening to the
+complete set of actions for all of its covered transactions in the same block.
 
-The above checks split into two layers:
-
-- **Circuit-enforced (Ragu PCD):** spend/output validity, stamp header binding, anchor
-  equality after lifting, and the multiset-product merge relations. The proof attests
-  that the header was produced by a valid execution; the proof will only verify with
-  the correct header.
-- **Consensus-enforced:** canonical anchor membership and end-of-block anchor
-  progression; two-epoch tachygram non-reuse; action and binding signatures; value-
-  balance rules; and adjunct-to-aggregate resolution.
-
-Several security properties (notably spendable-lineage epoch pinning and double-spend
-prevention) are intentionally not fully proven inside the stamp and depend on the
-consensus checks above. This split is by design.
+1. **Adjunct association.** Every Tachyon transaction with a stripped bundle
+contains a `tachyonAggregateId` that MUST identify a stamped transaction in the
+same block. If no transaction is located, or the located transaction bears no
+stamp, the validator MUST reject the block.
+2. **Action set commitment per stamp.** Every stamp contains a `cActionsTachyon`
+which MUST be confirmed by reconstruction. Compute a Pedersen commitment to the
+action digests of each Tachyon transaction in the block. Multiply the computed
+commitment of each stamped bundle by the computed commitment of each stripped
+bundle which refers to it by `tachyonAggregateId`. If the result of this
+multiplication is not equal to `cActionsTachyon`, the validator MUST reject the
+block.
+3. **Stamp proof verification.** Every Tachyon transaction with a stamped bundle
+contains a proof which MUST verify. Reassemble the stamp PCD from the stamp
+proof, the stamp's `anchorTachyon`, a pedersen commitment to the stamp's
+`vTachygrams` list of tachygrams, and the confirmed `cActionsTachyon`. If a
+proof does not verify, the validator MUST reject the block.
 
 ### Transaction identifiers and P2P relay
 

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -285,7 +285,8 @@ These semantics underpin publication (Step 5), observation (Steps 2 and 6), and 
 **Identifiers.** A Tachyon transaction is identified by `wtxid = txid || auth_digest`
 ([ZIP 239](https://zips.z.cash/zip-0239), [ZIP 244](https://zips.z.cash/zip-0244)):
 
-- `txid` commits only to effecting data (`action_acc || value_balance`). It is stable across
+- Tachyon's contribution to `txid` commits only to effecting data
+  (`action_acc || value_balance`). It is stable across
   stamping, merging, stripping, and re-stamping, so a transaction's logical identity is
   invariant across the aggregation lifecycle.
 - `auth_digest` commits to action signatures, the binding signature, and the stamp trailer.
@@ -307,6 +308,13 @@ These semantics underpin publication (Step 5), observation (Steps 2 and 6), and 
 objects. `MSG_WTX` relay is mandatory: restamping changes a transaction's
 `wtxid` while leaving `txid` unchanged, so announcement by `txid` alone could
 not distinguish the stamped forms a node may be offered.
+
+**Aggregates do not conflict with covered transactions.** Distinct authorization forms of
+one `txid` are alternative inventory, not conflicts, and an aggregate does not conflict
+with the autonomes it covers. A node SHOULD retain covered autonomes after accepting a
+covering aggregate: a block including the aggregate must include the covered transactions
+as adjuncts, and the aggregate may never be mined. Further mempool retention and eviction
+policy is a local implementation concern.
 
 **Duplicate tachygrams are transaction-invalid.** Tachygram distinctness applies at the
 transaction level: a stamped bundle whose `vTachygrams` contains a duplicate tachygram is
@@ -356,12 +364,6 @@ computable from the action's public data, as specified by the
 $O(n)$ polynomial arithmetic plus one Pedersen commitment and attempts no proof
 verification. A match confirms the candidate set is exactly the cover; a mismatch is
 fail-fast.
-
-## Reference implementation
-
-A reference implementation of the Tachyon aggregator protocol (the bundle state machine,
-stamp merging, stripping, and the `cActionsTachyon` coverage check) is in the
-`zcash_tachyon` crate under [`crates/tachyon/src/`](../../crates/tachyon/src/).
 
 ## Rationale
 
@@ -464,6 +466,19 @@ anchor membership, and spendable-lineage rules owned by the
 here, so implementers and auditors should not assume the proof alone establishes these
 properties.
 
+## Deployment
+
+This ZIP is deployed with a Tachyon network upgrade. Activation parameters are specified
+by the corresponding deployment ZIP
+([Network Upgrade Deployment](network-upgrade-deployment.md)).
+
+## Reference implementation
+
+A reference implementation of the aggregator protocol (the bundle state machine, stamp
+merging, stripping, and the `cActionsTachyon` coverage check) is developed in the
+`zcash_tachyon` crate of the Tachyon repository:
+<https://github.com/tachyon-zcash/tachyon>.
+
 ## References
 
 - [Zcash Protocol Specification](https://zips.z.cash/protocol/protocol.pdf)
@@ -475,3 +490,4 @@ properties.
 - [Tachyon Shielded Protocol](tachyon-shielded-protocol.md)
 - [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md)
 - [Tachyon Accumulator / Hash Chain](tachyon-accumulator.md)
+- [Network Upgrade Deployment](network-upgrade-deployment.md)

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -10,10 +10,9 @@
   defines the Tachyon pool, Tachyon actions, tachygrams, and the per-action authorization
   layer that aggregation preserves.
 - [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
-  defines the stamped and stripped bundle wire encodings, the `tachyonBundleState` byte,
-  the `tachyonAggregateId` trailer, the stamp trailer fields (including the
-  `cActionsTachyon` action-set indicator), and the block-validity consensus rules that
-  govern how a block's stamped and stripped bundles are validated.
+  defines the bundle wire encoding, the `tachyonBundleState` byte, the proof and
+  pointer stamp forms (including the `cActionsTachyon` action-set indicator), and the
+  block-validity consensus rules that govern how a block's bundles are validated.
 - [Tachyon Accumulator / Hash Chain (#105)](https://github.com/tachyon-zcash/tachyon/issues/105)
   defines the anchor (Poseidon hash-chain state), the per-block anchor sequence, the
   consensus anchor-membership rule that aggregation depends on for spend validity, and the
@@ -59,7 +58,7 @@ Open questions:
   Candidate relaxations: the aggregator commits to an anchor sequence covering
   the contributors, or to a multiset of contributing anchors later verifiable as
   members of a continuous valid sequence. Either is a significant refactor.
-- **Stripped zero-action coverage.** A stripped bundle with no actions names a covering
+- **Zero-action coverage.** An adjunct bundle with no actions names a covering
   aggregate that consensus does not confirm; candidate confirmation rules are an open
   question of the
   [bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104).
@@ -99,20 +98,21 @@ are summarized here non-normatively. The remaining terms are defined by this ZIP
 - **Tachygram.** The `byte[32]` encoding of a field element ($\mathbb{F}_p$)
   representing either a note nullifier or a note commitment. Consensus treats
   nullifiers and commitments identically.
-- **Stamp.** A bundle trailer carrying a Ragu proof and the data necessary to
-  verify it, including tachygrams. The proof attests that every covered action
-  satisfies the Tachyon action rules. A bundle's stamp may be replaced by a
-  reference to a covering transaction (see Adjunct).
-- **Autonome.** A stand-alone transaction with a stamped bundle, whose proof
-  covers only its own actions. The standard form of a user-originated Tachyon
-  transaction. An autonome may appear in a block or in the mempool.
-- **Aggregate.** A transaction with a stamped bundle, whose merged stamp covers
-  other transactions. An aggregate MAY contain zero or more Tachyon actions of
-  its own. An aggregate may appear in a block or in the mempool.
-- **Adjunct.** A transaction with a stripped bundle: its stamp has been removed
-  and replaced by a `wtxid` reference to a covering aggregate. Adjuncts retain
-  action data, action signatures, the binding signature, and `value_balance`.
-  An adjunct is valid only within a block.
+- **Stamp.** The final section of a bundle. Either a proof stamp, carrying a
+  Ragu proof and some supporting data, or a pointer stamp, carrying a `wtxid`
+  reference to a transaction with a proof.
+- **Autonome.** A stand-alone transaction whose bundle bears an independent
+  proof stamp covering only its own actions (an autonome bundle). The standard
+  form of a user-originated Tachyon transaction. An autonome may appear in a block
+  or in the mempool.
+- **Aggregate.** A transaction whose bundle bears a merged proof stamp covering
+  other transactions (an aggregate bundle). An aggregate MAY contain zero or more
+  Tachyon actions of its own. An aggregate may appear in a block or in the
+  mempool.
+- **Adjunct.** An abbreviated transaction that only appears within a block. An
+  adjunct's bundle has been stripped of its original stamp and now bears a pointer
+  stamp. Adjuncts retain action data, action signatures, binding signature, and
+  `value_balance`.
 
 ## Abstract
 
@@ -181,8 +181,8 @@ subsections after the lifecycle and referenced from the steps that invoke them:
 
 ### Step 1: Publication of autonomes
 
-Transaction authors produce complete and independently verifiable transactions
-with stamped bundles (**autonomes**) and broadcast them to the mempool via the
+Transaction authors produce complete and independently verifiable autonome
+transactions with proof stamps and broadcast them to the mempool via the
 existing wallet RPC or P2P path.
 
 ### Step 2: Aggregator observation and selection
@@ -279,21 +279,21 @@ transaction that aggregate covers. For each such adjunct, the miner MUST strip
 the bundle's stamp and set the `tachyonAggregateId` field to the covering
 aggregate's `wtxid`.
 
-A stripped bundle with no actions of its own still names a covering transaction.
-Its `tachyonAggregateId` MUST identify a stamped transaction in the same block,
+An adjunct bundle with no actions of its own still names a covering transaction.
+Its `tachyonAggregateId` MUST identify a proof-stamped transaction in the same block,
 and SHOULD refer to the aggregate that ultimately absorbed its stamp.
 
 ### Step 8: Block validation
 
 Block validation closes the aggregation lifecycle: a validator confirms that
-every stamped bundle in a block is backed by the transactions it covers and that
+every proof stamp in a block is backed by the transactions it covers and that
 every proof holds. The normative consensus rules for this are specified in the
 [block-validity section of the Tachyon Bundle / Aggregate Transaction Format
 ZIP](tachyon-bundle.md#block-validity); this step describes only how those rules
 fit the lifecycle.
 
 Validation covers tachygram distinctness across the block, association of each
-adjunct with the stamped transaction covering it, reconstruction of each stamp's
+adjunct with the aggregate covering it, reconstruction of each stamp's
 action-set commitment from the actions actually present in the block, and
 verification of every proof. Reuse of a tachygram across the wider epoch window
 is a separate consensus concern owned by the [Tachyon Accumulator / Hash Chain
@@ -320,39 +320,41 @@ non-normatively.
   (`action_acc || value_balance`). It is stable across
   stamping, merging, stripping, and re-stamping, so a transaction's logical identity is
   invariant across the aggregation lifecycle.
-- `auth_digest` commits to action signatures, the binding signature, and the stamp trailer.
-  A stamped bundle's trailer is the full stamp (`cActionsTachyon`, anchor, tachygrams,
-  proof); a stripped bundle's trailer is the `byte[64]` covering `wtxid` (the `stampWtxid`
-  of the digest contribution). The `"ZTxAuthTachyHash"` personalization and the normative
-  digest algorithm are specified by the [ZIP 244 update](zip-244.md).
-- A transaction's effecting data fixes its `txid`, but the transaction can be authorized
-  in several physical forms that share that `txid` and differ only in `auth_digest`, hence
-  in `wtxid`:
-  a wallet's autonome, an anchor-lifted or proof-rerandomized restamp, and the stripped
-  adjunct a miner produces. The covering-aggregate reference an adjunct carries is a
-  `wtxid`, not a `txid`, because it must pin a specific physical aggregate.
+- `auth_digest` commits to action signatures, the binding signature, and the
+  stamp.  A proof stamp provides a `byte[64]` digest of its entire contents
+  (`cActionsTachyon`, anchor, tachygrams, proof); a pointer stamp provides the
+  `byte[64]` covering `wtxid`. The
+  `"ZTxAuthTachyHash"` personalization and the normative digest algorithm are
+  specified by the [ZIP 244 update](zip-244.md).
+- A transaction's effecting data fixes its `txid`, but the transaction can be
+  authorized in multiple forms that share that `txid` and differ only in
+  `auth_digest`, hence in `wtxid`: a wallet's autonome, an anchor-lifted or
+  proof-rerandomized restamp, and the adjunct a miner produces. The
+  covering-aggregate reference an adjunct carries is a `wtxid`, not a `txid`, to
+  pin a specific aggregate.
 - The wire byte `tachyonBundleState` (`uint8`) distinguishes forms: `0x00` no Tachyon
-  bundle, `0x01` stamped, `0x02` stripped.
+  bundle, `0x01` proof stamp, `0x02` pointer stamp.
 
 **Relay.** Tachyon bundles are announced and fetched by `wtxid` using the
 `MSG_WTX` inv type, and nodes MUST treat distinct `wtxid`s as distinct inventory
 objects. `MSG_WTX` relay is mandatory: restamping changes a transaction's
 `wtxid` while leaving `txid` unchanged, so announcement by `txid` alone could
-not distinguish the stamped forms a node may be offered.
+not distinguish the proof-stamped forms a node may be offered.
 
-**Aggregates do not conflict with covered transactions.** Distinct authorization forms of
-one `txid` are alternative inventory, not conflicts, and an aggregate does not conflict
-with the autonomes it covers. A node SHOULD retain covered autonomes after accepting a
-covering aggregate: a block including the aggregate must include the covered transactions
-as adjuncts, and the aggregate may never be mined. Further mempool retention and eviction
-policy is a local implementation concern.
+**Aggregates do not conflict with covered transactions.** Distinct authorization
+forms of one `txid` are alternative inventory, not conflicts, and an aggregate
+does not conflict with its contributing autonomes and aggregates. A node SHOULD
+retain contributing autonomes and aggregates after accepting the aggregate built
+from them: a block including the aggregate must include the covered transactions
+as adjuncts, and an aggregate might never be mined. Further mempool retention
+and eviction policy is a local implementation concern.
 
-**Duplicate tachygrams are transaction-invalid.** Tachygram distinctness applies at the
-transaction level: a stamped bundle whose `vTachygrams` contains a duplicate tachygram is
-invalid, and a node MUST NOT accept it into the mempool or relay it. The check is a scan
-of the public list, requiring no proof verification.
+**Duplicate tachygrams are transaction-invalid.** Tachygram distinctness applies
+at the transaction level: a proof stamp whose `vTachygrams` contains a duplicate
+tachygram is invalid, and a node MUST NOT accept it into the mempool or relay
+it. The check is a scan of the public list, requiring no proof verification.
 
-**Proof verification precedes relay.** A node MUST verify a stamped bundle's proof before
+**Proof verification precedes relay.** A node MUST verify a bundle's proof stamp before
 accepting the transaction into its mempool or relaying it. This paragraph specifies only
 the Tachyon-proof-specific requirement; mempool acceptance also requires the standard
 checks (action and binding signature verification, balance rules, and general transaction
@@ -360,21 +362,23 @@ validity). The stamp is sufficient for the proof check: the node assembles the p
 header from the carried `cActionsTachyon`, the stamp's `anchorTachyon`, and a Pedersen
 commitment to its `vTachygrams`, and verifies the proof against that header. A wrong
 `cActionsTachyon` cannot pass, because the proof verifies only against the action-set
-commitment it actually attests to. A node can therefore verify a stamped aggregate's
+commitment it actually attests to. A node can therefore verify an aggregate's
 proof without holding any of the transactions it covers; confirming that a block's actions
 match the carried commitment is a block-validation concern (see
 [block validity](tachyon-bundle.md#block-validity)).
 
-**Stripped bundles are forbidden from the mempool.** A bundle in the stripped state
-(`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool, relayed, or published
-by an aggregator; it is valid only inside a block. The P2P network carries stamped bundles
-(autonomes and aggregates) only, and an aggregator publishes its merged stamp as a new
-stamped aggregate rather than a stripped form. This relay policy and `MSG_WTX` operate at
-different layers: `MSG_WTX` fixes the identifier and inventory semantics, while the policy
-admits only the stamped forms. A stripped form's `wtxid` is still meaningful at the block
-layer, where a block commits to each included transaction by `wtxid`
-([ZIP 244](https://zips.z.cash/zip-0244)); that is what lets a block name an adjunct
-unambiguously even though relay only ever carried the stamped form.
+**Adjunct bundles are forbidden from the mempool.** A bundle in the adjunct
+state (`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool,
+relayed, or published by an aggregator; it is valid only inside a block. The P2P
+network carries proof-stamped bundles (autonomes and aggregates) only, and an
+aggregator publishes its merged stamp as a new proof-stamped aggregate rather
+than an adjunct form. This relay policy and `MSG_WTX` operate at different
+layers: `MSG_WTX` fixes the identifier and inventory semantics, while the policy
+admits only the proof-stamped forms. An adjunct form's `wtxid` is still
+meaningful at the block layer, where a block commits to each included
+transaction by `wtxid` ([ZIP 244](https://zips.z.cash/zip-0244)); that is what
+lets a block name an adjunct unambiguously even though relay only ever carried
+the proof-stamped form.
 
 ### Covered-transaction identification
 
@@ -408,12 +412,13 @@ steps share, transaction-identifier and relay semantics and covered-transaction
 identification, are factored into their own subsections and referenced from the steps, so no
 step restates another's rules and the lifecycle reads as a sequence of actions.
 
-**Cheap coverage confirmation.** Matching previously-seen tachygrams associates an
-aggregate with the autonomes it covers, but cannot confirm the association is complete: an
-aggregate's own tachygrams are indistinguishable from its covered autonomes'. The
-`cActionsTachyon` indicator gives observers a fail-fast completeness check over the
-action-digest set, reusing the commitment the proof already attests to rather than adding
-a signed coverage manifest or a tachygram-origin query protocol.
+**Cheap coverage confirmation.** Matching previously-seen tachygrams associates
+an aggregate with its contributing autonomes and aggregates, but cannot confirm
+the association is complete: an aggregate's own tachygrams are indistinguishable
+from its contributors'. The `cActionsTachyon` indicator gives observers a
+fail-fast completeness check over the action-digest set, reusing the commitment
+the proof already attests to rather than adding a signed coverage manifest or a
+tachygram-origin query protocol.
 
 **Overlapping merges self-invalidate.** The disjoint-selection guidance of Step 2 is a
 SHOULD rather than a consensus rule because a violation cannot survive: merging stamps
@@ -449,8 +454,8 @@ reference. This is why the `tachyonAggregateId` holds a `wtxid` rather than a `t
 
 **Stripping is miner-side, not relay-time.** Stripping at relay time would force every
 relay node to understand aggregate coverage and would mix block-assembly policy with
-gossip. Keeping the P2P network carrying stamped bundles only, and forbidding stripped
-bundles from the mempool, simplifies relay and matches the implementation (a stripped
+gossip. Keeping the P2P network carrying proof-stamped bundles only, and forbidding adjunct
+bundles from the mempool, simplifies relay and matches the implementation (an adjunct
 bundle is not serializable until its covering `wtxid` is assigned, which happens at block
 assembly).
 
@@ -488,14 +493,15 @@ nodes verify a stamp's proof without its covered transactions; it is reconstruct
 visible actions, so it reveals nothing the actions do not, and for an aggregate carrying
 its own actions it does not expose which of them are the aggregator's own.
 
-**Privacy of aggregation relationships.** An observer who sees an aggregate in the
-mempool can identify covered autonomes by the `cActionsTachyon` check (see
-[Covered-transaction identification](#covered-transaction-identification)). This
-is inherent to the scheme: the aggregate must carry enough information for validators
-to reconstruct its header. The tachygram-set and action-digest-set commitments do not
-reveal the private contents of any covered note. A stripped bundle with no actions is
-valid against any claimed covering stamp (see
-[block validity](tachyon-bundle.md#block-validity)), so an observer reconstructing
+**Privacy of aggregation relationships.** An observer who sees an aggregate in
+the mempool can identify contributing transactions by `vTachygrams` overlap and
+confirm the correct composition by confirming `cActionsTachyon` reconstruction
+(see [Covered-transaction identification](#covered-transaction-identification)).
+This is inherent to the scheme: the aggregate must carry enough information for
+validators to reconstruct its header. The tachygram-set and action-digest-set
+commitments do not reveal the private contents of any covered note. An adjunct
+bundle with no actions is valid against any claimed covering stamp (see [block
+validity](tachyon-bundle.md#block-validity)), so an observer reconstructing
 aggregation relationships cannot rely on an actionless bundle's reference.
 
 **Circuit/consensus boundary.** Several security properties are enforced by consensus

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -6,24 +6,13 @@
 
 ## I. Dependencies
 
-* [Tachyon Shielded Protocol (#103)](https://github.com/tachyon-zcash/tachyon/issues/103)
-  defines the Tachyon pool, Tachyon actions, tachygrams, and the per-action authorization
-  layer that aggregation preserves.
-* [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
-  defines the bundle wire encoding, the `tachyonBundleState` byte, the proof and
-  pointer stamp forms (including the `hStampActionsTachyon` covered-actions digest),
-  and the block-validity consensus rules that govern how a block's bundles are
-  validated.
-* [Tachyon Accumulator / Hash Chain (#105)](https://github.com/tachyon-zcash/tachyon/issues/105)
-  defines the anchor (Poseidon hash-chain state), the per-block anchor sequence, the
-  consensus anchor-membership rule that aggregation depends on for spend validity, and the
-  epoch-window duplicate-tachygram consensus rule.
-* [ZIP 239](https://zips.z.cash/zip-0239) defines `MSG_WTX`-based transaction relay by
-  `wtxid = txid || auth_digest`. This ZIP extends its rationale to Tachyon's
-  authorization-form malleability.
-* [ZIP 244](https://zips.z.cash/zip-0244) defines the `txid_digest` and `auth_digest`
-  trees. The [ZIP 244 update](zip-244.md) fixes the `"ZTxAuthTachyHash"` personalization
-  and the Tachyon digest branches; this ZIP does not re-specify that algorithm.
+* [Tachyon Shielded Protocol (#103)](https://github.com/tachyon-zcash/tachyon/issues/103) defines the Tachyon pool, Tachyon actions, tachygrams, and the per-action authorization layer that aggregation preserves.
+* [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104) defines the bundle wire encoding, the `tachyonBundleState` byte, the proof and pointer stamp forms (including the `hStampActionsTachyon` covered-actions digest), and the block-validity consensus rules that govern how a block's bundles are validated.
+* [Tachyon Accumulator / Hash Chain (#105)](https://github.com/tachyon-zcash/tachyon/issues/105) defines the anchor (Poseidon hash-chain state), the per-block anchor sequence, the consensus anchor-membership rule that aggregation depends on for spend validity, and the epoch-window duplicate-tachygram consensus rule.
+* [ZIP 239](https://zips.z.cash/zip-0239) defines `MSG_WTX`-based transaction relay by `wtxid = txid || auth_digest`.
+  This ZIP extends its rationale to Tachyon's authorization-form malleability.
+* [ZIP 244](https://zips.z.cash/zip-0244) defines the `txid_digest` and `auth_digest` trees.
+  The [ZIP 244 update](zip-244.md) fixes the `"ZTxAuthTachyHash"` personalization and the Tachyon digest branches; this ZIP does not re-specify that algorithm.
 
 ## II. Design Considerations
 
@@ -36,30 +25,16 @@ Miners are likely to vertically integrate aggregation, but a protocol is establi
 
 Open questions:
 
-* **Relay-protocol additions.** Relayed bundles carry no cross-references: an aggregate
-  does not identify its contributing transactions, and no mempool form names another by
-  `wtxid`, so aggregation relationships are discoverable only by tachygram matching over
-  held mempool data. An aggregator therefore cannot request an aggregate's contributors
-  from the network, and a node cannot ask which aggregates cover a transaction it holds;
-  presently, aggregators index mempool data and do not attempt merges they cannot
-  satisfy from data they hold. A candidate mechanism serving both queries is a relay
-  message requesting bundles by tachygram, with nodes maintaining a coverage graph to
-  answer it; a list of contributing transactions carried on aggregates would serve only
-  the merge-input case, at the cost of a large additional vector.
-* **Cross-epoch lifting.** A stamp lift never crosses an epoch boundary, because
-  a spend's published nullifiers are fixed relative to its anchor's epoch.
-  Supporting them may be possible, but would change fundamental parts of the
-  specification.
+* **Relay-protocol additions.** Relayed bundles carry no cross-references: an aggregate does not identify its contributing transactions, and no mempool form names another by `wtxid`, so aggregation relationships are discoverable only by tachygram matching over held mempool data.
+  An aggregator therefore cannot request an aggregate's contributors from the network, and a node cannot ask which aggregates cover a transaction it holds; presently, aggregators index mempool data and do not attempt merges they cannot satisfy from data they hold.
+  A candidate mechanism serving both queries is a relay message requesting bundles by tachygram, with nodes maintaining a coverage graph to answer it; a list of contributing transactions carried on aggregates would serve only the merge-input case, at the cost of a large additional vector.
+* **Cross-epoch lifting.** A stamp lift never crosses an epoch boundary, because a spend's published nullifiers are fixed relative to its anchor's epoch.
+  Supporting them may be possible, but would change fundamental parts of the specification.
 * **Unequal-anchor merge.** Merging is defined only over identical anchors.
-  Candidate relaxations: the aggregator commits to an anchor sequence covering
-  the contributors, or to a multiset of contributing anchors later verifiable as
-  members of a continuous valid sequence. Either is a significant refactor.
-* **Zero-action coverage.** An adjunct bundle with no actions names a covering
-  aggregate that consensus does not confirm; candidate confirmation rules are an open
-  question of the
-  [bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104).
-* **Deployment.** The deployment ZIP and activation parameters are undefined; the draft's
-  Deployment section points at the placeholder.
+  Candidate relaxations: the aggregator commits to an anchor sequence covering the contributors, or to a multiset of contributing anchors later verifiable as members of a continuous valid sequence.
+  Either is a significant refactor.
+* **Zero-action coverage.** An adjunct bundle with no actions names a covering aggregate that consensus does not confirm; candidate confirmation rules are an open question of the [bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104).
+* **Deployment.** The deployment ZIP and activation parameters are undefined; the draft's Deployment section points at the placeholder.
 
 This draft stages the ZIP body below inside the Tachyon mdBook, so two conventions differ
 from a standalone ZIP and normalize on migration to `tachyon-zcash/zips`: the book reserves
@@ -85,196 +60,131 @@ Discussions-To: <https://github.com/tachyon-zcash/tachyon/issues/106>
 
 ## Terminology
 
-The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "RECOMMENDED" in
-this document are to be interpreted as described in BCP 14 [^BCP14] when, and only when, they
-appear in all capitals.
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "RECOMMENDED" in this document are to be interpreted as described in BCP 14 [^BCP14] when, and only when, they appear in all capitals.
 
-The term "network upgrade" is to be interpreted as described in ZIP 200. [^zip-0200] The
-terms "Testnet" and "Mainnet" are to be interpreted as described in § 3.12 ‘Mainnet and
-Testnet’. [^protocol]
+The term "network upgrade" is to be interpreted as described in ZIP 200.[^zip-0200]
+The terms "Testnet" and "Mainnet" are to be interpreted as described in § 3.12 ‘Mainnet and Testnet’.[^protocol]
 
-The terms "tachygram" and "stamp" are defined by the
-[Tachyon Shielded Protocol](tachyon-shielded-protocol.md) and
-[Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIPs respectively, and
-are summarized here non-normatively. The remaining terms are defined by this ZIP.
+The terms "tachygram" and "stamp" are defined by the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) and [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIPs respectively, and are summarized here non-normatively.
+The remaining terms are defined by this ZIP.
 
 Tachygram
-:   The `byte[32]` encoding of a field element ($\mathbb{F}_p$) representing either a note
-    nullifier or a note commitment. Consensus treats nullifiers and commitments identically.
+:   The `byte[32]` encoding of a field element ($\mathbb{F}_p$) representing either a note nullifier or a note commitment.
+    Consensus treats nullifiers and commitments identically.
 
 Stamp
-:   The final section of a bundle. Either a proof stamp, carrying a Ragu proof and some
-    supporting data, or a pointer stamp, carrying a `wtxid` reference to a transaction with a
-    proof.
+:   The final section of a bundle.
+    Either a proof stamp, carrying a Ragu proof and some supporting data, or a pointer stamp, carrying a `wtxid` reference to a transaction with a proof.
 
 *Autonome*
-:   A stand-alone transaction whose bundle bears an independent proof stamp covering only its
-    own actions (an *autonome* bundle). The standard form of a user-originated Tachyon
-    transaction. An *autonome* may appear in a block or in the mempool.
+:   A stand-alone transaction whose bundle bears an independent proof stamp covering only its own actions (an *autonome* bundle).
+    The standard form of a user-originated Tachyon transaction.
+    An *autonome* may appear in a block or in the mempool.
 
 *Aggregate*
-:   A transaction whose bundle bears a merged proof stamp covering other transactions (an
-    *aggregate* bundle). An *aggregate* MAY contain zero or more Tachyon actions of its own. An
-    *aggregate* may appear in a block or in the mempool.
+:   A transaction whose bundle bears a merged proof stamp covering other transactions (an *aggregate* bundle).
+    An *aggregate* MAY contain zero or more Tachyon actions of its own.
+    An *aggregate* may appear in a block or in the mempool.
 
 *Adjunct*
-:   An abbreviated transaction that only appears within a block. An *adjunct*'s bundle has been
-    stripped of its original stamp and now bears a pointer stamp. *Adjuncts* retain action
-    data, action signatures, binding signature, and `valueBalanceTachyon`.
+:   An abbreviated transaction that only appears within a block.
+    An *adjunct*'s bundle has been stripped of its original stamp and now bears a pointer stamp.
+    *Adjuncts* retain action data, action signatures, binding signature, and `valueBalanceTachyon`.
 
 ## Abstract
 
-Tachyon shielded transactions use a recursive proof system. Recursion allows
-many per-transaction proofs to be combined into a single proof covering all
-contributing transactions, reducing proof verification cost, on-chain
-footprint, and per-stamp syncing cost. This recursion admits a new participant
-role, the aggregator, without creating a new trust assumption.
+Tachyon shielded transactions use a recursive proof system.
+Recursion allows many per-transaction proofs to be combined into a single proof covering all contributing transactions, reducing proof verification cost, on-chain footprint, and per-stamp syncing cost.
+This recursion admits a new participant role, the aggregator, without creating a new trust assumption.
 
-This ZIP specifies the aggregator protocol: an 8-step lifecycle from
-transaction authorization, through the mempool, to block layout and final
-validation. It comprises a block-layout discipline under which miners replace a
-covered bundle's proof with a reference to a covering transaction, the
-effecting-data and authorizing-data semantics that make stripping safe, and P2P
-rules extending ZIP 239 to Tachyon's authorization-form malleability.
-Aggregation affects only the authorization-proof mechanism: every bundle's
-effecting data (actions, value balances, action signatures, and binding
-signatures) remains present when its proof is stripped, and the
-binding-signature balance check and transaction authorization remain unchanged
-and per-bundle.
+This ZIP specifies the aggregator protocol: an 8-step lifecycle from transaction authorization, through the mempool, to block layout and final validation.
+It comprises a block-layout discipline under which miners replace a covered bundle's proof with a reference to a covering transaction, the effecting-data and authorizing-data semantics that make stripping safe, and P2P rules extending ZIP 239 to Tachyon's authorization-form malleability.
+Aggregation affects only the authorization-proof mechanism: every bundle's effecting data (actions, value balances, action signatures, and binding signatures) remains present when its proof is stripped, and the binding-signature balance check and transaction authorization remain unchanged and per-bundle.
 
 ## Motivation
 
-Consensus requires every bundle to be verified. Naively, every Tachyon bundle
-carries its own proof, and consensus cost is dominated by proof size and proof
-verification. Aggregation amortizes that cost: it reduces the proof
-verification a validator performs, the on-chain footprint the proofs occupy,
-and the per-stamp cost of syncing the chain.
+Consensus requires every bundle to be verified.
+Naively, every Tachyon bundle carries its own proof, and consensus cost is dominated by proof size and proof verification.
+Aggregation amortizes that cost: it reduces the proof verification a validator performs, the on-chain footprint the proofs occupy, and the per-stamp cost of syncing the chain.
 
-The proof system permits public aggregation of already-published proofs, so the
-aggregator is a permissionless, conceptual role that any participant may take,
-not a designated prover. A block in which a large number of Tachyon stamps have
-been aggregated into a smaller number of stamps is completely verified by that
-smaller number of stamps. Aggregation affects only the authorization-proof
-mechanism: the binding-signature balance check and transaction authorization
-remain unchanged and per-bundle. In the ideal case, a single proof verifies all
-Tachyon transactions in a block.
+The proof system permits public aggregation of already-published proofs, so the aggregator is a permissionless, conceptual role that any participant may take, not a designated prover.
+A block in which a large number of Tachyon stamps have been aggregated into a smaller number of stamps is completely verified by that smaller number of stamps.
+In the ideal case, a single proof verifies all Tachyon transactions in a block.
 
-Aggregation is optional. Miners remain free to include non-aggregated Tachyon
-transactions; any *aggregate* a block does contain must be fully backed by
-*adjuncts* in the same block.
+Aggregation is optional.
+Miners remain free to include non-aggregated Tachyon transactions; any *aggregate* a block does contain must be fully backed by *adjuncts* in the same block.
 
 ## Requirements
 
-* Reduce per-block stamp-verification cost by allowing multiple transactions' stamps to
-  be merged into one *aggregate* stamp.
-* Confine aggregation to the authorization-proof mechanism: the binding-signature balance
-  check and transaction authorization remain unchanged and per-bundle, and every
-  transaction's effecting data (action digests, value balances, action signatures, and
-  binding signatures) remains present when its proof is stripped.
-* Preserve transaction-identifier stability: a transaction's `txid` is invariant across
-  stamping, merging, and stripping.
+* Reduce per-block stamp-verification cost by allowing multiple transactions' stamps to be merged into one *aggregate* stamp.
+* Confine aggregation to the authorization-proof mechanism: the binding-signature balance check and transaction authorization remain unchanged and per-bundle, and every transaction's effecting data (action digests, value balances, action signatures, and binding signatures) remains present when its proof is stripped.
+* Preserve transaction-identifier stability: a transaction's `txid` is invariant across stamping, merging, and stripping.
 * Allow any participant to act as aggregator; no protocol-level exclusivity.
-* Enable a validator or miner to confirm they hold all necessary data before
-  attempting proof verification.
-* Introduce no new trust assumption: every invariant is enforced either by proof
-  or by consensus rules.
+* Enable a validator or miner to confirm they hold all necessary data before attempting proof verification.
+* Introduce no new trust assumption: every invariant is enforced either by proof or by consensus rules.
 
 ## Specification
 
-The specification is organized around the 8-step aggregation lifecycle. Each step is a
-subsection with conformance language. Two cross-cutting concerns are specified in their own
-subsections after the lifecycle and referenced from the steps that invoke them:
-[Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay), and
-[Covered-transaction identification](#covered-transaction-identification).
+The specification is organized around the 8-step aggregation lifecycle.
+Each step is a subsection with conformance language.
+Two cross-cutting concerns are specified in their own subsections after the lifecycle and referenced from the steps that invoke them: [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay), and [Covered-transaction identification](#covered-transaction-identification).
 
 ### Step 1: Publication of autonomes
 
-Transaction authors produce complete and independently verifiable *autonome*
-transactions with proof stamps and broadcast them to the mempool via the
-existing wallet RPC or P2P path.
+Transaction authors produce complete and independently verifiable *autonome* transactions with proof stamps and broadcast them to the mempool via the existing wallet RPC or P2P path.
 
 ### Step 2: Aggregator observation and selection
 
-Aggregators observe transactions in mempool gossip (see
-[Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay)).
+Aggregators observe transactions in mempool gossip (see [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay)).
 
-An aggregator selects two transactions (*autonomes* or existing *aggregates*) for
-merging into a new *aggregate*. Selected transactions MUST bear anchors that are
-identical or alignable by lifting (see
-[Step 3](#step-3-witness-and-pcd-preparation)). Selected transactions SHOULD bear
-disjoint tachygram sets; overlapping selections cannot yield a valid *aggregate*,
-so this guidance needs no enforcement (see the [Rationale](#rationale)).
+An aggregator selects two transactions (*autonomes* or existing *aggregates*) for merging into a new *aggregate*.
+Selected transactions MUST bear anchors that are identical or alignable by lifting (see [Step 3](#step-3-witness-and-pcd-preparation)).
+Selected transactions SHOULD bear disjoint tachygram sets; overlapping selections cannot yield a valid *aggregate*, so this guidance needs no enforcement (see [Overlapping merges self-invalidate](#overlapping-merges-self-invalidate)).
 
 ### Step 3: Witness and PCD preparation
 
-The aggregator reconstructs each selected transaction's stamp PCD from the
-proof and data carried on that transaction itself, which the aggregator
-already holds from mempool observation (Step 2). Reconstruction requires no
-multi-stage witness fetching.
+The aggregator reconstructs each selected transaction's stamp PCD from the proof and data carried on that transaction itself, which the aggregator already holds from mempool observation (Step 2).
+Reconstruction requires no multi-stage witness fetching.
 
-Merging is defined only over stamps bearing identical anchors. If the selected
-transactions bear unequal anchors, the aggregator first aligns them by lifting
-the older anchor to the newer with a lift PCD that proves the anchor sequence
-between them.
+Merging is defined only over stamps bearing identical anchors.
+If the selected transactions bear unequal anchors, the aggregator first aligns them by lifting the older anchor to the newer with a lift PCD that proves the anchor sequence between them.
 
-Lifting is confined to the anchor's epoch. A stamp's proof fixes each spend's
-published nullifiers relative to the epoch of its anchor (see the
-[Tachyon statement](tachyon-shielded-protocol.md#tachyon-statement)), so a
-lift never crosses an epoch boundary, and stamps bearing anchors of different
-epochs cannot be aligned for merging.
+Lifting is confined to the anchor's epoch.
+A stamp's proof fixes each spend's published nullifiers relative to the epoch of its anchor (see the [Tachyon statement](tachyon-shielded-protocol.md#tachyon-statement)), so a lift never crosses an epoch boundary, and stamps bearing anchors of different epochs cannot be aligned for merging.
 
-If both selected transactions are *autonomes*, all necessary witness data is
-directly available on the transactions themselves.
+If both selected transactions are *autonomes*, all necessary witness data is directly available on the transactions themselves.
 
-A selected transaction that is already an *aggregate* additionally requires the
-actions of every transaction contributing to it. The contributors
-cannot be requested from the network by `wtxid`, because the *aggregate* does
-not carry their identities. Recovering them from transactions the aggregator
-holds is
-[covered-transaction identification](#covered-transaction-identification): a correct and
-complete collection of actions reproduces the covered-actions digest on the
-selected stamp.
+A selected transaction that is already an *aggregate* additionally requires the actions of every transaction contributing to it.
+The contributors cannot be requested from the network by `wtxid`, because the *aggregate* does not carry their identities.
+Recovering them from transactions the aggregator holds is [covered-transaction identification](#covered-transaction-identification): a correct and complete collection of actions reproduces the covered-actions digest on the selected stamp.
 
-Aggregators therefore maintain an index of recent mempool transactions, along
-with recent consensus data and cached anchor lift proofs, and do not attempt
-merges whose contributors they cannot recover from data they hold.
+Aggregators therefore maintain an index of recent mempool transactions, along with recent consensus data and cached anchor lift proofs, and do not attempt merges whose contributors they cannot recover from data they hold.
 
 ### Step 4: Aggregate construction
 
-Holding two stamp PCD with identical anchors and the prepared witness, the
-aggregator executes a merge, proving a new stamp PCD that covers the selected
-transactions and every transaction contributing to them.
+Holding two stamp PCD with identical anchors and the prepared witness, the aggregator executes a merge, proving a new stamp PCD that covers the selected transactions and every transaction contributing to them.
 
-The aggregator MAY carry the merged stamp on a newly constructed transaction,
-or update either contributing transaction in place, replacing its stamp with
-the merged stamp.
+The aggregator MAY carry the merged stamp on a newly constructed transaction, or update either contributing transaction in place, replacing its stamp with the merged stamp.
 
 ### Step 5: Aggregate publication
 
-The aggregator publishes the *aggregate* transaction to the mempool. A newly
-constructed transaction bears a new `txid` and `wtxid`; an updated transaction
-retains its `txid` and bears a new `wtxid`, distinct from the form it replaced.
-Relay follows
-[Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay).
+The aggregator publishes the *aggregate* transaction to the mempool.
+A newly constructed transaction bears a new `txid` and `wtxid`; an updated transaction retains its `txid` and bears a new `wtxid`, distinct from the form it replaced.
+Relay follows [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay).
 
 ### Step 6: Miner observation and selection
 
-Miners observe both *autonomes* and *aggregates* in the mempool (see
-[Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay)) and select
-the *aggregates* and the transactions they cover to include in a block. Determining which
-transactions a candidate *aggregate* covers is
-[covered-transaction identification](#covered-transaction-identification). A miner MAY also
-vertically integrate aggregation, producing its own *aggregates* privately during block
-assembly rather than sourcing them from the mempool.
+Miners observe both *autonomes* and *aggregates* in the mempool (see [Transaction identifiers and P2P relay](#transaction-identifiers-and-p2p-relay)) and select the *aggregates* and the transactions they cover to include in a block.
+Determining which transactions a candidate *aggregate* covers is [covered-transaction identification](#covered-transaction-identification).
+A miner MAY also vertically integrate aggregation, producing its own *aggregates* privately during block assembly rather than sourcing them from the mempool.
 
 ### Step 7: Block assembly
 
 Use of *aggregates* within a block is RECOMMENDED, not required.
 
-Miners MAY perform additional aggregation during block assembly, without
-publishing the *aggregate* to the mempool. The resulting *aggregate* is included
-directly in the miner's proposed block. The merge and anchor-alignment rules
-of Steps 3 and 4 apply unchanged.
+Miners MAY perform additional aggregation during block assembly, without publishing the *aggregate* to the mempool.
+The resulting *aggregate* is included directly in the miner's proposed block.
+The merge and anchor-alignment rules of Steps 3 and 4 apply unchanged.
 
 A block MAY contain, in any combination:
 
@@ -282,136 +192,86 @@ A block MAY contain, in any combination:
 * zero or more Tachyon *autonomes*
 * zero or more Tachyon *aggregates*
 
-A block containing an *aggregate* MUST also contain, as *adjuncts*, every
-transaction that *aggregate* covers. For each such *adjunct*, the miner MUST strip
-the bundle's stamp and set the `tachyonAggregateId` field to the covering
-*aggregate*'s `wtxid`.
+A block containing an *aggregate* MUST also contain, as *adjuncts*, every transaction that *aggregate* covers.
+For each such *adjunct*, the miner MUST strip the bundle's stamp and set the `tachyonAggregateId` field to the covering *aggregate*'s `wtxid`.
 
 An *adjunct* bundle with no actions of its own still names a covering transaction.
-Its `tachyonAggregateId` MUST identify a proof-stamped transaction in the same block,
-and SHOULD refer to the *aggregate* that ultimately absorbed its stamp.
+Its `tachyonAggregateId` MUST identify a proof-stamped transaction in the same block, and SHOULD refer to the *aggregate* that ultimately absorbed its stamp.
 
 ### Step 8: Block validation
 
-Block validation closes the aggregation lifecycle: a validator confirms that
-every proof stamp in a block is backed by the transactions it covers and that
-every proof holds. The normative consensus rules for this are specified in the
-[block-validity section of the Tachyon Bundle / Aggregate Transaction Format
-ZIP](tachyon-bundle.md#block-validity); this step describes only how those rules
-fit the lifecycle.
+Block validation closes the aggregation lifecycle: a validator confirms that every proof stamp in a block is backed by the transactions it covers and that every proof holds.
+The normative consensus rules for this are specified in the [block-validity section of the Tachyon Bundle / Aggregate Transaction Format ZIP](tachyon-bundle.md#block-validity); this step describes only how those rules fit the lifecycle.
 
-Validation covers tachygram distinctness across the block, association of each
-*adjunct* with the *aggregate* covering it, confirmation of each stamp's
-covered-actions digest against the actions actually present in the block, and
-verification of every proof. Reuse of a tachygram across the wider epoch window
-is a separate consensus concern owned by the [Tachyon Accumulator / Hash Chain
-ZIP](tachyon-accumulator.md#epoch-window).
+Validation covers tachygram distinctness across the block, association of each *adjunct* with the *aggregate* covering it, confirmation of each stamp's covered-actions digest against the actions actually present in the block, and verification of every proof.
+Reuse of a tachygram across the wider epoch window is a separate consensus concern owned by the [Tachyon Accumulator / Hash Chain ZIP](tachyon-accumulator.md#epoch-window).
 
-The spirit of these checks is fail-fast ordering: the cheap public-data scans
-(tachygram distinctness, *adjunct* association, and covered-actions confirmation) run
-before the costly proof verification, so a block that violates a cheaper rule is
-rejected without any proof being verified.
+The spirit of these checks is fail-fast ordering: the cheap public-data scans (tachygram distinctness, *adjunct* association, and covered-actions confirmation) run before the costly proof verification, so a block that violates a cheaper rule is rejected without any proof being verified.
 
 ### Transaction identifiers and P2P relay
 
-These semantics underpin publication (Step 5), observation (Steps 2 and 6), and stripping
-(Step 7).
+These semantics underpin publication (Step 5), observation (Steps 2 and 6), and stripping (Step 7).
 
-**Identifiers.** A Tachyon transaction is identified by `wtxid = txid || auth_digest`
-(ZIP 239 [^zip-0239], ZIP 244 [^zip-0244]). The
-digest inputs (which fields each contribution commits to) are defined normatively by the
-[Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, and the digest
-algorithm by the [ZIP 244 update](zip-244.md); this section summarizes them
-non-normatively.
+#### Identifiers
 
-* Tachyon's contribution to `txid` commits only to effecting data
-  (`hActionsTachyon || valueBalanceTachyon`). It is stable across
-  stamping, merging, stripping, and re-stamping, so a transaction's logical identity is
-  invariant across the aggregation lifecycle.
-* `auth_digest` commits to action signatures, the binding signature, and the
-  stamp. A proof stamp contributes a `byte[64]` stamp digest; a pointer stamp
-  contributes the `byte[64]` covering `wtxid`. The
-  `"ZTxAuthTachyHash"` personalization and the normative digest algorithm are
-  specified by the [ZIP 244 update](zip-244.md).
-* A transaction's effecting data fixes its `txid`, but the transaction can be
-  authorized in multiple forms that share that `txid` and differ only in
-  `auth_digest`, hence in `wtxid`: a wallet's *autonome*, an anchor-lifted or
-  proof-rerandomized restamp, and the *adjunct* a miner produces. The
-  covering-*aggregate* reference an *adjunct* carries is a `wtxid`, not a `txid`, to
-  pin a specific *aggregate*.
-* The wire byte `tachyonBundleState` (`uint8`) distinguishes forms: `0x00` no Tachyon
-  bundle, `0x01` proof stamp, `0x02` pointer stamp.
+A Tachyon transaction is identified by `wtxid = txid || auth_digest` (ZIP 239 [^zip-0239], ZIP 244 [^zip-0244]).
+The digest inputs (which fields each contribution commits to) are defined normatively by the [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, and the digest algorithm by the [ZIP 244 update](zip-244.md); this section summarizes them non-normatively.
 
-**Relay.** Tachyon bundles are announced and fetched by `wtxid` using the
-`MSG_WTX` inv type, and nodes MUST treat distinct `wtxid`s as distinct inventory
-objects. `MSG_WTX` relay is mandatory: restamping changes a transaction's
-`wtxid` while leaving `txid` unchanged, so announcement by `txid` alone could
-not distinguish the proof-stamped forms a node may be offered.
+* Tachyon's contribution to `txid` commits only to effecting data (`hActionsTachyon || valueBalanceTachyon`).
+It is stable across stamping, merging, stripping, and re-stamping, so a transaction's logical identity is invariant across the aggregation lifecycle.
+* `auth_digest` commits to action signatures, the binding signature, and the stamp.
+A proof stamp contributes a `byte[64]` stamp digest; a pointer stamp contributes the `byte[64]` covering `wtxid`.
+The `"ZTxAuthTachyHash"` personalization and the normative digest algorithm are specified by the [ZIP 244 update](zip-244.md).
+* A transaction's effecting data fixes its `txid`, but the transaction can be authorized in multiple forms that share that `txid` and differ only in `auth_digest`, hence in `wtxid`: a wallet's *autonome*, an anchor-lifted or proof-rerandomized restamp, and the *adjunct* a miner produces.
+The covering-*aggregate* reference an *adjunct* carries is a `wtxid`, not a `txid`, to pin a specific *aggregate*.
+* The wire byte `tachyonBundleState` (`uint8`) distinguishes forms: `0x00` no Tachyon bundle, `0x01` proof stamp, `0x02` pointer stamp.
 
-**Aggregates do not conflict with covered transactions.** Distinct authorization
-forms of one `txid` are alternative inventory, not conflicts, and an *aggregate*
-does not conflict with its contributing *autonomes* and *aggregates*. A node SHOULD
-retain contributing *autonomes* and *aggregates* after accepting the *aggregate* built
-from them: a block including the *aggregate* must include the covered transactions
-as *adjuncts*, and an *aggregate* might never be mined. Further mempool retention
-and eviction policy is a local implementation concern.
+#### Relay
 
-**Duplicate tachygrams are transaction-invalid.** Tachygram distinctness applies
-at the transaction level: a proof stamp whose `vTachygrams` contains a duplicate
-tachygram is invalid, and a node MUST NOT accept it into the mempool or relay
-it. The check is a scan of the public list, requiring no proof verification.
+Tachyon bundles are announced and fetched by `wtxid` using the `MSG_WTX` inv type, and nodes MUST treat distinct `wtxid`s as distinct inventory objects.
+`MSG_WTX` relay is mandatory: restamping changes a transaction's `wtxid` while leaving `txid` unchanged, so announcement by `txid` alone could not distinguish the proof-stamped forms a node may be offered.
 
-**Proof verification precedes relay.** A node MUST verify a bundle's proof stamp before
-accepting the transaction into its mempool or relaying it. This paragraph specifies only
-the Tachyon-proof-specific requirement; mempool acceptance also requires the standard
-checks (action and binding signature verification, balance rules, and general transaction
-validity). The proof check needs the covered actions: the node assembles the proof
-header from the action-set commitment over the covered actions' digests, the stamp's
-`anchorTachyon`, and a Pedersen commitment to its `vTachygrams`, and verifies the proof
-against that header. An *autonome* is self-contained, since its stamp covers only its own
-actions. For an *aggregate* covering other transactions, the node recovers the covered
-actions from mempool data it holds and confirms the recovered set against the carried
-`hStampActionsTachyon` (see
-[Covered-transaction identification](#covered-transaction-identification)) before
-assembling the header; an *aggregate* whose covered actions the node cannot recover
-cannot be verified, so it is not accepted or relayed. The contributing transactions
-propagate before the *aggregate* built from them, so a node observing gossip ordinarily
-holds them.
+#### Aggregates do not conflict with covered transactions
 
-**Adjunct bundles are forbidden from the mempool.** A bundle in the *adjunct*
-state (`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool,
-relayed, or published by an aggregator; it is valid only inside a block. The P2P
-network carries proof-stamped bundles (*autonomes* and *aggregates*) only, and an
-aggregator publishes its merged stamp as a new proof-stamped *aggregate* rather
-than an *adjunct* form. This relay policy and `MSG_WTX` operate at different
-layers: `MSG_WTX` fixes the identifier and inventory semantics, while the policy
-admits only the proof-stamped forms. An *adjunct* form's `wtxid` is still
-meaningful at the block layer, where a block commits to each included
-transaction by `wtxid` (ZIP 244 [^zip-0244]); that is what
-lets a block name an *adjunct* unambiguously even though relay only ever carried
-the proof-stamped form.
+Distinct authorization forms of one `txid` are alternative inventory, not conflicts, and an *aggregate* does not conflict with its contributing *autonomes* and *aggregates*.
+A node SHOULD retain contributing *autonomes* and *aggregates* after accepting the *aggregate* built from them: a block including the *aggregate* must include the covered transactions as *adjuncts*, and an *aggregate* might never be mined.
+Further mempool retention and eviction policy is a local implementation concern.
+
+#### Duplicate tachygrams are transaction-invalid
+
+Tachygram distinctness applies at the transaction level: a proof stamp whose `vTachygrams` contains a duplicate tachygram is invalid, and a node MUST NOT accept it into the mempool or relay it.
+The check is a scan of the public list, requiring no proof verification.
+
+#### Proof verification precedes relay
+
+A node MUST verify a bundle's proof stamp before accepting the transaction into its mempool or relaying it.
+This paragraph specifies only the Tachyon-proof-specific requirement; mempool acceptance also requires the standard checks (action and binding signature verification, balance rules, and general transaction validity).
+The proof check needs the covered actions: the node assembles the proof header — `cStampActionsTachyon` over the covered actions' digests, the stamp's `anchorTachyon`, and `cTachygrams` — and verifies the proof against that header.
+An *autonome* is self-contained, since its stamp covers only its own actions.
+For an *aggregate* covering other transactions, the node collects the covered actions from the mempool transactions it holds and checks that set against the carried `hStampActionsTachyon` (see [Covered-transaction identification](#covered-transaction-identification)) before assembling the header.
+Without the covered actions, the *aggregate* cannot be verified.
+
+#### Adjunct bundles are forbidden from the mempool
+
+A bundle in the *adjunct* state (`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool, relayed, or published by an aggregator; it is valid only inside a block.
+The P2P network carries proof-stamped bundles (*autonomes* and *aggregates*) only, and an aggregator publishes its merged stamp as a new proof-stamped *aggregate* rather than an *adjunct* form.
+This relay policy and `MSG_WTX` operate at different layers: `MSG_WTX` fixes the identifier and inventory semantics, while the policy admits only the proof-stamped forms.
+An *adjunct* form's `wtxid` is still meaningful at the block layer, where a block commits to each included transaction by `wtxid` (ZIP 244 [^zip-0244]); that is what lets a block name an *adjunct* unambiguously even though relay only ever carried the proof-stamped form.
 
 ### Covered-transaction identification
 
-Identifying which transactions a stamp covers is a single primitive, used by aggregators
-preparing a merge witness (Step 3) and by miners observing and composing a block (Steps 6
-and 7).
+Identifying which transactions a stamp covers is a single primitive, used by aggregators preparing a merge witness (Step 3) and by miners observing and composing a block (Steps 6 and 7).
 
-Tachygrams give a first pass: an *aggregate*'s stamp publishes the tachygrams of every action
-it covers, so transactions whose tachygrams appear there are candidates. But tachygram
-matching only narrows the candidate set; it cannot confirm the set is complete. An
-*aggregate*'s own tachygrams are not labeled, and tachygrams do not distinguish nullifiers
-from commitments, so a near-complete collection is indistinguishable from the complete one.
-Absent a faster check, the only way to discover whether a candidate set is exactly the cover
-would be to attempt the *aggregate*'s full proof verification, which fails only after that
-costly attempt when a transaction is missing or extra.
+Tachygrams give a first pass: an *aggregate*'s stamp publishes the tachygrams of every action it covers, so transactions whose tachygrams appear there are candidates.
+But tachygram matching only narrows the candidate set; it cannot confirm the set is complete.
+An *aggregate*'s own tachygrams are not labeled, and tachygrams do not distinguish nullifiers from commitments, so a near-complete collection is indistinguishable from the complete one.
+Absent a faster check, the only way to discover whether a candidate set is exactly the cover would be to attempt the *aggregate*'s full proof verification, which fails only after that costly attempt when a transaction is missing or extra.
 
-`hStampActionsTachyon` is that faster check. The *aggregate*'s stamp publishes it as the
-descriptor digest of every action the *aggregate* covers. A candidate set is tested by
-sorting the candidate actions' descriptors and recomputing the digest, as specified by
-the [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, so the
-check costs a sort and one BLAKE2b-256 hash and attempts no proof verification. A
-match confirms the candidate set is exactly the cover; a mismatch is fail-fast.
+`hStampActionsTachyon` is that faster check.
+
+The *aggregate*'s stamp publishes it as the descriptor digest of every action the *aggregate* covers.
+A candidate set is tested by sorting the candidate actions' descriptors and recomputing the digest, as specified by the [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, so the check costs a sort and one BLAKE2b-256 hash and attempts no proof verification.
+A match confirms the candidate set is exactly the cover; a mismatch is fail-fast.
 
 ## Rationale
 
@@ -419,79 +279,38 @@ This subsection is non-normative.
 
 ### Lifecycle-structured specification
 
-Organizing the Specification around the lifecycle
-mirrors how participants actually move through the protocol. The two concerns that several
-steps share, transaction-identifier and relay semantics and covered-transaction
-identification, are factored into their own subsections and referenced from the steps, so no
-step restates another's rules and the lifecycle reads as a sequence of actions.
+Organizing the Specification around the lifecycle mirrors how participants actually move through the protocol.
+The two concerns that several steps share, transaction-identifier and relay semantics and covered-transaction identification, are factored into their own subsections and referenced from the steps, so no step restates another's rules and the lifecycle reads as a sequence of actions.
 
 ### Cheap coverage confirmation
 
-Matching previously-seen tachygrams associates
-an *aggregate* with its contributing *autonomes* and *aggregates*, but cannot confirm
-the association is complete: an *aggregate*'s own tachygrams are indistinguishable
-from its contributors'. The `hStampActionsTachyon` digest gives observers a
-fail-fast completeness check over the covered action set, at the cost of a sort
-and one hash, rather than adding a signed coverage manifest or a
-tachygram-origin query protocol.
+`hStampActionsTachyon` gives the fail-fast completeness check of [Covered-transaction identification](#covered-transaction-identification) at the cost of a sort and one hash, chosen rather than a signed coverage manifest or a tachygram-origin query protocol.
 
 ### Overlapping merges self-invalidate
 
-The disjoint-selection guidance of Step 2 is a
-SHOULD rather than a consensus rule because a violation cannot survive: merging stamps
-whose tachygram sets overlap produces a stamp bearing duplicate tachygrams, which no node
-accepts into its mempool and no valid block can contain (see
-[block validity](tachyon-bundle.md#block-validity)). The deeper reason is
-that the merge is homomorphic over the stamps' set commitments, so the overlapping stamp
-commits to multiply-counted multiset members that no reconstruction over a block's
-distinct transactions can reproduce. The aggregator's proving work is simply wasted, so
-the selection rule needs no enforcement of its own.
+The disjoint-selection guidance of Step 2 is a SHOULD rather than a consensus rule because a violation cannot survive: merging stamps whose tachygram sets overlap produces a stamp bearing duplicate tachygrams, which no node accepts into its mempool and no valid block can contain (see [block validity](tachyon-bundle.md#block-validity)).
+The deeper reason is that the merge is homomorphic over the stamps' multiset commitments, so the overlapping stamp commits to multiply-counted multiset members that no reconstruction over a block's distinct transactions can reproduce.
+The aggregator's proving work is simply wasted, so the selection rule needs no enforcement of its own.
 
 ### Aggregate limits
 
-Two hard limits bound an *aggregate*. Its tachygram vector is committed
-as a Ragu polynomial, so it cannot exceed the maximum Ragu polynomial size; and the
-*aggregate* transaction, like any transaction, is bounded by block size. Construction is also
-shaped by parallelism: a chain of merges is sequential, since each merge consumes the
-previous result, but independent *aggregates* can be built in parallel.
+Two hard limits bound an *aggregate*.
+Its tachygram vector is committed as a Ragu polynomial, so it cannot exceed the maximum Ragu polynomial size; and the *aggregate* transaction, like any transaction, is bounded by block size.
+Construction is also shaped by parallelism: a chain of merges is sequential, since each merge consumes the previous result, but independent *aggregates* can be built in parallel.
 
 ### Verified relay
 
-Requiring proof verification before relay is standard mempool
-hygiene, and aggregation sharpens it: an invalid stamp is a dead end, since a merge
-cannot produce a valid *aggregate* from an invalid input and no valid block can carry an
-unverifiable proof (see [block validity](tachyon-bundle.md#block-validity)). Aggregators
-would therefore hit every invalid proof themselves at the merge; verifying at relay pushes
-that discovery to the network edge
-rather than spending bandwidth propagating transactions no aggregator can use and no
-block can include. Verifying an *aggregate* requires its covered actions, which a node
-recovers from mempool data it holds; the carried `hStampActionsTachyon` confirms the
-recovered set is complete before the node attempts the proof, and block validation
-later confirms the same digest against the block's actual actions.
-
-### `wtxid`, not `txid`, for *adjunct* references
-
-A `txid` would be ambiguous across
-the *autonome*/*aggregate* forms (they share effecting data). The `wtxid` pins a specific
-physical *aggregate* including its stamp state, which is what the *adjunct* needs to
-reference. This is why the `tachyonAggregateId` holds a `wtxid` rather than a `txid`.
+Requiring proof verification before relay is standard mempool hygiene, and aggregation sharpens it: an invalid stamp is a dead end, since a merge cannot produce a valid *aggregate* from an invalid input and no valid block can carry an unverifiable proof (see [block validity](tachyon-bundle.md#block-validity)).
+Aggregators would therefore hit every invalid proof themselves at the merge; verifying at relay pushes that discovery to the network edge rather than spending bandwidth propagating transactions no aggregator can use and no block can include.
 
 ### Stripping is miner-side, not relay-time
 
-Stripping at relay time would force every
-relay node to understand *aggregate* coverage and would mix block-assembly policy with
-gossip. Keeping the P2P network carrying proof-stamped bundles only, and forbidding *adjunct*
-bundles from the mempool, simplifies relay and matches the implementation (an *adjunct*
-bundle is not serializable until its covering `wtxid` is assigned, which happens at block
-assembly).
+Stripping at relay time would force every relay node to understand *aggregate* coverage and would mix block-assembly policy with gossip.
+Keeping the P2P network carrying proof-stamped bundles only, and forbidding *adjunct* bundles from the mempool, simplifies relay and matches the implementation (an *adjunct* bundle is not serializable until its covering `wtxid` is assigned, which happens at block assembly).
 
 ### `MSG_WTX` relay is mandatory
 
-Tachyon's authorization-form malleability is the direct
-analogue of the v5 witness malleability that motivated ZIP 239: restamping and proof
-rerandomization yield distinct `wtxid`s over one stable `txid`, all relayable. Announcing
-by `txid` alone would let one such form shadow another in relay. Requiring `MSG_WTX`
-for Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
+Tachyon's authorization-form malleability is the direct analogue of the v5 witness malleability that motivated ZIP 239, and requiring `MSG_WTX` closes it for Tachyon exactly as ZIP 239 closed it for v5.
 
 ## Security Implications
 
@@ -499,33 +318,22 @@ This subsection is non-normative.
 
 ### No new trust assumption
 
-The aggregator is not trusted. Every invariant is
-enforced either inside the Ragu PCD (circuit logic) or by consensus checks on public
-data (consensus logic). A malicious aggregator can publish an invalid *aggregate*, but
-block validation (see [block validity](tachyon-bundle.md#block-validity)) rejects it. A
-malicious miner can mis-assign *adjuncts* or omit covered transactions, but the block fails
-validation.
+The aggregator is not trusted.
+Every invariant is enforced either inside the Ragu PCD (circuit logic) or by consensus checks on public data (consensus logic).
+A malicious aggregator can publish an invalid *aggregate*, but block validation (see [block validity](tachyon-bundle.md#block-validity)) rejects it.
+A malicious miner can mis-assign *adjuncts* or omit covered transactions, but the block fails validation.
 
 ### Data availability
 
-Aggregation removes redundant proof bytes only. Every *adjunct*
-retains its action data, action signatures, binding signature, and `valueBalanceTachyon`;
-validators reconstruct the *aggregate* header from this public data. An *aggregate* proof
-alone is insufficient: the covered effecting data is present in the block as *adjuncts*,
-and the [block-validity rules](tachyon-bundle.md#block-validity) reject any block where it
-is not.
+Aggregation removes redundant proof bytes only.
+Every *adjunct* retains its action data, action signatures, binding signature, and `valueBalanceTachyon`; validators reconstruct the *aggregate* header from this public data.
+An *aggregate* proof alone is insufficient: the covered effecting data is present in the block as *adjuncts*, and the [block-validity rules](tachyon-bundle.md#block-validity) reject any block where it is not.
 
 ### Circuit/consensus boundary
 
-Several security properties are enforced by consensus
-rather than fully proven inside the stamp. Double-spend prevention rests on the block-scoped
-tachygram-uniqueness check (see [block validity](tachyon-bundle.md#block-validity)) together
-with the [epoch-window duplicate-tachygram](tachyon-accumulator.md#epoch-window) and
-[anchor-membership](tachyon-accumulator.md#anchor-membership) rules owned by the
-[Tachyon Accumulator / Hash Chain](tachyon-accumulator.md) ZIP and the spendable-lineage
-rules owned by the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) ZIP. Those
-base-protocol rules are depended upon, not re-specified here, so implementers and auditors
-should not assume the proof alone establishes these properties.
+Several security properties are enforced by consensus rather than fully proven inside the stamp.
+Double-spend prevention rests on the block-scoped tachygram-uniqueness check (see [block validity](tachyon-bundle.md#block-validity)) together with the [epoch-window duplicate-tachygram](tachyon-accumulator.md#epoch-window) and [anchor-membership](tachyon-accumulator.md#anchor-membership) rules owned by the [Tachyon Accumulator / Hash Chain](tachyon-accumulator.md) ZIP and the spendable-lineage rules owned by the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) ZIP.
+Those base-protocol rules are depended upon, not re-specified here, so implementers and auditors should not assume the proof alone establishes these properties.
 
 ## Privacy Implications
 
@@ -533,29 +341,19 @@ This subsection is non-normative.
 
 ### Privacy of aggregation relationships
 
-An observer who sees an *aggregate* in
-the mempool can identify contributing transactions by `vTachygrams` overlap and
-confirm the correct composition by recomputing `hStampActionsTachyon`
-(see [Covered-transaction identification](#covered-transaction-identification)).
-This is inherent to the scheme: the *aggregate* must carry enough information for
-validators to reconstruct its header. The tachygrams and the covered-actions
-digest do not reveal the private contents of any covered note. An *adjunct*
-bundle with no actions is valid against any claimed covering stamp (see [block
-validity](tachyon-bundle.md#block-validity)), so an observer reconstructing
-aggregation relationships cannot rely on an actionless bundle's reference.
+An observer who sees an *aggregate* in the mempool can identify contributing transactions by `vTachygrams` overlap and confirm the correct composition by recomputing `hStampActionsTachyon` (see [Covered-transaction identification](#covered-transaction-identification)).
+This is inherent to the scheme: the *aggregate* must carry enough information for validators to reconstruct its header.
+The tachygrams and the covered-actions digest do not reveal the private contents of any covered note.
+An *adjunct* bundle with no actions is valid against any claimed covering stamp (see [block validity](tachyon-bundle.md#block-validity)), so an observer reconstructing aggregation relationships cannot rely on an actionless bundle's reference.
 
 ## Deployment
 
-This ZIP is deployed with a Tachyon network upgrade. Activation parameters are specified
-by the corresponding deployment ZIP
-([Network Upgrade Deployment](network-upgrade-deployment.md)).
+This ZIP is deployed with a Tachyon network upgrade.
+Activation parameters are specified by the corresponding deployment ZIP ([Network Upgrade Deployment](network-upgrade-deployment.md)).
 
 ## Reference implementation
 
-A reference implementation of the aggregator protocol (the bundle state machine, stamp
-merging, stripping, and the `hStampActionsTachyon` coverage check) is developed in the
-`zcash_tachyon` crate of the Tachyon repository:
-<https://github.com/tachyon-zcash/tachyon>.
+A reference implementation of the aggregator protocol (the bundle state machine, stamp merging, stripping, and the `hStampActionsTachyon` coverage check) is developed in the `zcash_tachyon` crate of the Tachyon repository: <https://github.com/tachyon-zcash/tachyon>.
 
 ## References
 

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -11,8 +11,9 @@
   layer that aggregation preserves.
 - [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
   defines the bundle wire encoding, the `tachyonBundleState` byte, the proof and
-  pointer stamp forms (including the `cActionsTachyon` action-set indicator), and the
-  block-validity consensus rules that govern how a block's bundles are validated.
+  pointer stamp forms (including the `hStampActionsTachyon` covered-actions digest),
+  and the block-validity consensus rules that govern how a block's bundles are
+  validated.
 - [Tachyon Accumulator / Hash Chain (#105)](https://github.com/tachyon-zcash/tachyon/issues/105)
   defines the anchor (Poseidon hash-chain state), the per-block anchor sequence, the
   consensus anchor-membership rule that aggregation depends on for spend validity, and the
@@ -45,11 +46,6 @@ Open questions:
   message requesting bundles by tachygram, with nodes maintaining a coverage graph to
   answer it; a list of contributing transactions carried on aggregates would serve only
   the merge-input case, at the cost of a large additional vector.
-- **`cActionsTachyon` commitment scheme.** The covered-transaction identification check
-  reconstructs the carried `cActionsTachyon` field. Whether that field, which serves
-  only external coordination, uses a different commitment scheme than the in-circuit
-  action-set commitment is an open question of the
-  [bundle ZIP (#104)](https://github.com/tachyon-zcash/tachyon/issues/104).
 - **Cross-epoch lifting.** A stamp lift never crosses an epoch boundary, because
   a spend's published nullifiers are fixed relative to its anchor's epoch.
   Supporting them may be possible, but would change fundamental parts of the
@@ -112,7 +108,7 @@ are summarized here non-normatively. The remaining terms are defined by this ZIP
 - **Adjunct.** An abbreviated transaction that only appears within a block. An
   adjunct's bundle has been stripped of its original stamp and now bears a pointer
   stamp. Adjuncts retain action data, action signatures, binding signature, and
-  `value_balance`.
+  `valueBalanceTachyon`.
 
 ## Abstract
 
@@ -219,12 +215,12 @@ If both selected transactions are autonomes, all necessary witness data is
 directly available on the transactions themselves.
 
 A selected transaction that is already an aggregate additionally requires the
-action digests of every transaction contributing to it. The contributors
+actions of every transaction contributing to it. The contributors
 cannot be requested from the network by `wtxid`, because the aggregate does
 not carry their identities. Recovering them from transactions the aggregator
 holds is
 [covered-transaction identification](#covered-transaction-identification): a correct and
-complete collection of action digests reproduces the action set commitment on the
+complete collection of actions reproduces the covered-actions digest on the
 selected stamp.
 
 Aggregators therefore maintain an index of recent mempool transactions, along
@@ -293,14 +289,14 @@ ZIP](tachyon-bundle.md#block-validity); this step describes only how those rules
 fit the lifecycle.
 
 Validation covers tachygram distinctness across the block, association of each
-adjunct with the aggregate covering it, reconstruction of each stamp's
-action-set commitment from the actions actually present in the block, and
+adjunct with the aggregate covering it, confirmation of each stamp's
+covered-actions digest against the actions actually present in the block, and
 verification of every proof. Reuse of a tachygram across the wider epoch window
 is a separate consensus concern owned by the [Tachyon Accumulator / Hash Chain
 ZIP](tachyon-accumulator.md#epoch-window).
 
 The spirit of these checks is fail-fast ordering: the cheap public-data scans
-(tachygram distinctness, adjunct association, and action-set reconstruction) run
+(tachygram distinctness, adjunct association, and covered-actions confirmation) run
 before the costly proof verification, so a block that violates a cheaper rule is
 rejected without any proof being verified.
 
@@ -317,13 +313,12 @@ algorithm by the [ZIP 244 update](zip-244.md); this section summarizes them
 non-normatively.
 
 - Tachyon's contribution to `txid` commits only to effecting data
-  (`action_acc || value_balance`). It is stable across
+  (`hActionsTachyon || valueBalanceTachyon`). It is stable across
   stamping, merging, stripping, and re-stamping, so a transaction's logical identity is
   invariant across the aggregation lifecycle.
 - `auth_digest` commits to action signatures, the binding signature, and the
-  stamp.  A proof stamp provides a `byte[64]` digest of its entire contents
-  (`cActionsTachyon`, anchor, tachygrams, proof); a pointer stamp provides the
-  `byte[64]` covering `wtxid`. The
+  stamp. A proof stamp contributes a `byte[64]` stamp digest; a pointer stamp
+  contributes the `byte[64]` covering `wtxid`. The
   `"ZTxAuthTachyHash"` personalization and the normative digest algorithm are
   specified by the [ZIP 244 update](zip-244.md).
 - A transaction's effecting data fixes its `txid`, but the transaction can be
@@ -358,14 +353,18 @@ it. The check is a scan of the public list, requiring no proof verification.
 accepting the transaction into its mempool or relaying it. This paragraph specifies only
 the Tachyon-proof-specific requirement; mempool acceptance also requires the standard
 checks (action and binding signature verification, balance rules, and general transaction
-validity). The stamp is sufficient for the proof check: the node assembles the proof
-header from the carried `cActionsTachyon`, the stamp's `anchorTachyon`, and a Pedersen
-commitment to its `vTachygrams`, and verifies the proof against that header. A wrong
-`cActionsTachyon` cannot pass, because the proof verifies only against the action-set
-commitment it actually attests to. A node can therefore verify an aggregate's
-proof without holding any of the transactions it covers; confirming that a block's actions
-match the carried commitment is a block-validation concern (see
-[block validity](tachyon-bundle.md#block-validity)).
+validity). The proof check needs the covered actions: the node assembles the proof
+header from the action-set commitment over the covered actions' digests, the stamp's
+`anchorTachyon`, and a Pedersen commitment to its `vTachygrams`, and verifies the proof
+against that header. An autonome is self-contained, since its stamp covers only its own
+actions. For an aggregate covering other transactions, the node recovers the covered
+actions from mempool data it holds and confirms the recovered set against the carried
+`hStampActionsTachyon` (see
+[Covered-transaction identification](#covered-transaction-identification)) before
+assembling the header; an aggregate whose covered actions the node cannot recover
+cannot be verified, so it is not accepted or relayed. The contributing transactions
+propagate before the aggregate built from them, so a node observing gossip ordinarily
+holds them.
 
 **Adjunct bundles are forbidden from the mempool.** A bundle in the adjunct
 state (`tachyonBundleState == 0x02`) MUST NOT be accepted into the mempool,
@@ -395,14 +394,12 @@ Absent a faster check, the only way to discover whether a candidate set is exact
 would be to attempt the aggregate's full proof verification, which fails only after that
 costly attempt when a transaction is missing or extra.
 
-`cActionsTachyon` is that faster check. The aggregate's stamp publishes it as a commitment
-to the action-digest set of every action the aggregate covers. A candidate set is tested by
-reconstructing the commitment from the candidate actions and matching: each action digest is
-computable from the action's public data, as specified by the
-[Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, so the check costs
-$O(n)$ polynomial arithmetic plus one Pedersen commitment and attempts no proof
-verification. A match confirms the candidate set is exactly the cover; a mismatch is
-fail-fast.
+`hStampActionsTachyon` is that faster check. The aggregate's stamp publishes it as the
+descriptor digest of every action the aggregate covers. A candidate set is tested by
+sorting the candidate actions' descriptors and recomputing the digest, as specified by
+the [Tachyon Bundle / Aggregate Transaction Format](tachyon-bundle.md) ZIP, so the
+check costs a sort and one BLAKE2b-256 hash and attempts no proof verification. A
+match confirms the candidate set is exactly the cover; a mismatch is fail-fast.
 
 ## Rationale
 
@@ -415,9 +412,9 @@ step restates another's rules and the lifecycle reads as a sequence of actions.
 **Cheap coverage confirmation.** Matching previously-seen tachygrams associates
 an aggregate with its contributing autonomes and aggregates, but cannot confirm
 the association is complete: an aggregate's own tachygrams are indistinguishable
-from its contributors'. The `cActionsTachyon` indicator gives observers a
-fail-fast completeness check over the action-digest set, reusing the commitment
-the proof already attests to rather than adding a signed coverage manifest or a
+from its contributors'. The `hStampActionsTachyon` digest gives observers a
+fail-fast completeness check over the covered action set, at the cost of a sort
+and one hash, rather than adding a signed coverage manifest or a
 tachygram-origin query protocol.
 
 **Overlapping merges self-invalidate.** The disjoint-selection guidance of Step 2 is a
@@ -443,9 +440,10 @@ unverifiable proof (see [block validity](tachyon-bundle.md#block-validity)). Agg
 would therefore hit every invalid proof themselves at the merge; verifying at relay pushes
 that discovery to the network edge
 rather than spending bandwidth propagating transactions no aggregator can use and no
-block can include. The carried `cActionsTachyon` is what makes this check self-contained:
-the stamp supplies its own header, so relay verification needs no coverage data, and
-block validation later confirms the same commitment against the block's actual actions.
+block can include. Verifying an aggregate requires its covered actions, which a node
+recovers from mempool data it holds; the carried `hStampActionsTachyon` confirms the
+recovered set is complete before the node attempts the proof, and block validation
+later confirms the same digest against the block's actual actions.
 
 **`wtxid`, not `txid`, for adjunct references.** A `txid` would be ambiguous across
 the autonome/aggregate forms (they share effecting data). The `wtxid` pins a specific
@@ -475,31 +473,32 @@ malicious miner can mis-assign adjuncts or omit covered transactions, but the bl
 validation.
 
 **Data availability.** Aggregation removes redundant proof bytes only. Every adjunct
-retains its action data, action signatures, binding signature, and `value_balance`;
+retains its action data, action signatures, binding signature, and `valueBalanceTachyon`;
 validators reconstruct the aggregate header from this public data. An aggregate proof
 alone is insufficient: the covered effecting data is present in the block as adjuncts,
 and the [block-validity rules](tachyon-bundle.md#block-validity) reject any block where it
 is not.
 
-**`cActionsTachyon` is confirmed, not trusted.** The action set is bound by the proof.
-Block validation (see [block validity](tachyon-bundle.md#block-validity)) confirms the
-carried `cActionsTachyon` by reconstructing the action-set commitment from the actions
-actually present in the block, rejects on any mismatch, and only then uses the confirmed
-value as the proof header. That confirmation is what ties the proof to the adjuncts the
-block carries, not to a value the prover supplies, so a wrong `cActionsTachyon` cannot pass
-and only harms its author. The carried value lets observers identify coverage cheaply (see
-[Covered-transaction identification](#covered-transaction-identification)) and lets relay
-nodes verify a stamp's proof without its covered transactions; it is reconstructable from
-visible actions, so it reveals nothing the actions do not, and for an aggregate carrying
-its own actions it does not expose which of them are the aggregator's own.
+**`hStampActionsTachyon` is confirmed, not trusted.** The action set is bound by the
+proof, which verifies only against the action-set commitment reconstructed from the
+actions themselves; the carried digest plays no role in that binding. Block validation
+(see [block validity](tachyon-bundle.md#block-validity)) confirms the carried digest
+against the actions actually present in the block and rejects on any mismatch, so the
+proof is tied to the adjuncts the block carries, not to a value the prover supplies,
+and a wrong `hStampActionsTachyon` cannot pass and only harms its author. The carried
+value lets observers identify coverage cheaply (see
+[Covered-transaction identification](#covered-transaction-identification)); it is
+recomputable from visible actions, so it reveals nothing the actions do not, and for
+an aggregate carrying its own actions it does not expose which of them are the
+aggregator's own.
 
 **Privacy of aggregation relationships.** An observer who sees an aggregate in
 the mempool can identify contributing transactions by `vTachygrams` overlap and
-confirm the correct composition by confirming `cActionsTachyon` reconstruction
+confirm the correct composition by recomputing `hStampActionsTachyon`
 (see [Covered-transaction identification](#covered-transaction-identification)).
 This is inherent to the scheme: the aggregate must carry enough information for
-validators to reconstruct its header. The tachygram-set and action-digest-set
-commitments do not reveal the private contents of any covered note. An adjunct
+validators to reconstruct its header. The tachygrams and the covered-actions
+digest do not reveal the private contents of any covered note. An adjunct
 bundle with no actions is valid against any claimed covering stamp (see [block
 validity](tachyon-bundle.md#block-validity)), so an observer reconstructing
 aggregation relationships cannot rely on an actionless bundle's reference.
@@ -523,7 +522,7 @@ by the corresponding deployment ZIP
 ## Reference implementation
 
 A reference implementation of the aggregator protocol (the bundle state machine, stamp
-merging, stripping, and the `cActionsTachyon` coverage check) is developed in the
+merging, stripping, and the `hStampActionsTachyon` coverage check) is developed in the
 `zcash_tachyon` crate of the Tachyon repository:
 <https://github.com/tachyon-zcash/tachyon>.
 

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -49,7 +49,7 @@ The Specification is organised around the following lifecycle, distilled in
    autonomes they covered.
 5. Miners see transactions in the mempool.
 6. Miners identify the aggregate/autonome relationship by action-set commitment
-   (`ActionSetCommit`) overlap.
+   (`ActionSetCommit`) match.
 7. Miners may perform their own aggregation privately, without publishing to the
    mempool.
 8. Miners compose their block at will, stripping stamps and assigning the covering
@@ -58,38 +58,23 @@ The Specification is organised around the following lifecycle, distilled in
 10. Block validation only passes if the appropriate adjuncts are included and properly
     assigned aggregate ids, enabling header reconstruction and verification.
 
-### Based-aggregate tachygram attribution (resolved)
+### Based-aggregate tachygram attribution
 
 A **based aggregate** carries its own tachyactions in addition to a merged stamp
-covering other transactions. Its stamp tachygram set is the union of (covered
-autonomes' tachygrams) ∪ (the based aggregate's own tachygrams). Tachygrams are opaque
-32-byte field elements with no in-protocol label distinguishing "covered" from "own",
-and each tachyaction is bound to one tachygram but does not contain it
-([Bundles](../bundle.md)). Without a coverage mechanism, an observer with an incomplete
-mempool view cannot partition the published tachygram set and cannot confirm they hold
-every autonomic that must become an adjunct.
+covering other transactions. Its stamp tachygram set is the union of the covered
+autonomes' tachygrams and the based aggregate's own tachygrams, with no in-protocol
+label distinguishing the two ([Bundles](../bundle.md)). An observer with an incomplete
+mempool view therefore cannot partition the published tachygram set, and cannot confirm
+by tachygram overlap alone that it holds every autonome that must become an adjunct.
 
-**Resolution.** The stamp serializes the `ActionSetCommit` — the Pedersen commitment to
-the action-digest-set polynomial that is already a PCD header field
-(`StampHeader::Data = (ActionSetCommit, TachygramSetCommit, Anchor)`). An observer
-computes `commit(P_own · ∏ P_autonome_i)` from the based aggregate's visible actions
-and candidate autonomes' visible actions, and compares against the published
-`ActionSetCommit`. Match confirms the observer holds the complete covered set; mismatch
-is fail-fast. This is O(n) polynomial arithmetic plus one Pedersen commitment, and does
-not require proof verification.
-
-The field strips when the stamp strips (adjuncts carry `stampWtxid` instead), so the
-covering aggregate (top-level, unstripped) retains it. Soundness is preserved:
-`ActionSetCommit` is already a public PCD header field bound by the proof; publishing
-it adds no new claim. The trailing-zeros caveat (commit-equality bounds polynomial rank
-from above, not below) does not bite in practice because `ActionDigest::new` rejects
-identity `cv`/`rk`, so the root polynomial `∏(X − d_i)` has no trailing zeros. No new
-information is leaked: the commitment is already reconstructable from visible actions
-for any self-contained bundle; for a based aggregate, the factored polynomial (which
-roots are "own" vs "covered") is not recoverable from the commitment alone.
-
-The encoding of `ActionSetCommit` on the stamp wire format is specified by the Tachyon
-Bundle / Aggregate Transaction Format ZIP (#104).
+The protocol resolves this with the `ActionSetCommit` field carried on the stamp header:
+an observer reconstructs the action-digest-set commitment from visible actions and
+matches it against the aggregate's published `ActionSetCommit`, a cheap fail-fast check
+that needs no proof verification. The normative mechanism is specified in Step 6
+below; the design trade-offs and soundness/privacy arguments are folded into the
+Rationale and the Security and Privacy Implications sections. The encoding of
+`ActionSetCommit` on the stamp wire format is specified by the Tachyon Bundle / Aggregate
+Transaction Format ZIP (#104).
 
 ### Open questions
 
@@ -138,12 +123,14 @@ The term "network upgrade" is to be interpreted as described in
 [ZIP 200](https://zips.z.cash/zip-0200). The terms "Testnet" and "Mainnet" are to be
 interpreted as described in section 3.12 of the Zcash Protocol Specification.
 
-- **Tachygram.** A 32-byte field element representing either a note nullifier or a note
-  commitment. Consensus treats nullifiers and commitments identically; one accumulator
-  handles both. See [Tachygrams](../tachygrams.md).
+- **Tachygram.** A `byte[32]` field element ($\mathbb{F}_p$) representing either a note
+  nullifier or a note commitment. Consensus treats nullifiers and commitments
+  identically; one accumulator handles both. See [Tachygrams](../tachygrams.md).
 - **Tachyaction.** An indistinguishable representation of either the creation or
-  destruction of a note. Contains `cv`, `rk`, and `sig`; is cryptographically bound to
-  one tachygram but does not contain it. See [Bundles](../bundle.md).
+  destruction of a note. Contains `cv`, `rk`, and `sig`; each tachyaction is
+  cryptographically bound to one tachygram but does not contain it. A spend additionally
+  publishes a next-epoch nullifier, so a stamp's tachygram set is not in 1:1
+  correspondence with its actions. See [Bundles](../bundle.md).
 - **Stamp.** The recursive Ragu PCD proof data carried by a stamped bundle: `anchor`,
   `tachygrams`, `proof`, and `ActionSetCommit`. The proof establishes that the
   tachyactions follow the correct rules and that the published tachygrams and action
@@ -155,20 +142,27 @@ interpreted as described in section 3.12 of the Zcash Protocol Specification.
   its own; a *based* aggregate carries its own Tachyon actions in addition to the merged
   stamp.
 - **Adjunct.** A stripped bundle whose stamp has been removed and replaced by a
-  reference to the covering aggregate's `wtxid`. Adjuncts retain action data, action
-  signatures, the binding signature, and `value_balance`.
-- **`ActionSetCommit`.** A Pedersen commitment to the action-digest-set polynomial
-  `∏_i (X − d_i)`, where `d_i = Poseidon(cv_i || rk_i)`. Already a PCD header field;
-  serialized on the stamp wire format per the bundle-format ZIP (#104).
-- **`stampWtxid`.** The 64-byte `wtxid` of the covering aggregate, carried by an adjunct
-  in place of its stripped stamp.
+  `tachyonAggregateId` reference to the covering aggregate. Adjuncts retain action data,
+  action signatures, the binding signature, and `value_balance`.
+- **`ActionSetCommit`.** A Pedersen commitment to the action-digest-set polynomial, with
+  exactly one root per action:
+  $\mathsf{ActionSetCommit} = \mathsf{Commit}\bigl(\prod_i (X - d_i)\bigr)$, where each
+  action digest $d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$
+  is defined in [Authorization](../authorization.md). This is the same commitment the book
+  calls `action_acc`. It is a PCD header field (`StampHeader::Data` carries it), and its
+  on-wire encoding is specified by the bundle-format ZIP (#104).
+- **`tachyonAggregateId`.** The wire field on a stripped bundle that replaces its stamp:
+  the `byte[64]` `wtxid` of the covering aggregate (the implementation type is
+  `AggregateId`). It is a `wtxid`, not a `txid`, so it pins a specific physical aggregate
+  including its stamp state. The `auth_digest` contribution refers to this same value as
+  `stampWtxid` (see [Transaction Identifiers](../transaction-identifiers.md)).
 - **`txid`.** The transaction identifier, committing only to effecting data. For a
   Tachyon bundle, the `txid` contribution is `action_acc || value_balance`. Stable
   across stamping, merging, and stripping.
 - **`auth_digest`.** The authorizing-data commitment. For a Tachyon bundle, commits to
   action signatures, the binding signature, and the stamp trailer. Each physical
   authorization form yields a distinct `auth_digest`.
-- **`wtxid`.** The 64-byte witnessed transaction identifier `txid || auth_digest`. The
+- **`wtxid`.** The `byte[64]` witnessed transaction identifier `txid || auth_digest`. The
   unit of physical relay per [ZIP 239](https://zips.z.cash/zip-0239).
 
 ## Abstract
@@ -204,27 +198,30 @@ strip the redundant per-transaction stamps at block-assembly time, leaving each 
 transaction as an adjunct that carries its effecting data plus a reference to the
 covering aggregate.
 
-The result is that a block containing N Tachyon transactions need only verify a small
-number of aggregate stamps rather than N independent proofs, while still allowing every
+The result is that a block containing $N$ Tachyon transactions need only verify a small
+number of aggregate stamps rather than $N$ independent proofs, while still allowing every
 action, signature, and value balance to be independently checked. This ZIP specifies
 the network behaviour, the block-layout rules, and the identification mechanism that
 makes the scheme work without a trusted aggregator.
 
 ## Requirements
 
+(Goals, stated without conformance keywords; the normative rules that meet them live in
+the Specification.)
+
 - Reduce per-block stamp-verification cost by allowing multiple transactions' stamps to
   be merged into one aggregate stamp.
 - Preserve independent verifiability of every transaction's effecting data: action
-  digests, value balances, action signatures, and binding signatures MUST remain
-  checkable without trusting the aggregator.
-- Preserve transaction-identifier stability: a transaction's `txid` MUST be invariant
-  across stamping, merging, and stripping.
+  digests, value balances, action signatures, and binding signatures remain checkable
+  without trusting the aggregator.
+- Preserve transaction-identifier stability: a transaction's `txid` is invariant across
+  stamping, merging, and stripping.
 - Allow any participant (miner or third-party) to act as aggregator; no protocol-level
   exclusivity or claim on autonomes.
 - Enable a validating observer or miner to confirm, cheaply and fail-fast, that they
-  hold every autonomic covered by an aggregate before assembling or validating a block.
-- Introduce no new trust assumption: every invariant MUST be enforced either inside the
-  Ragu PCD or by consensus checks on public data.
+  hold every autonome covered by an aggregate before assembling or validating a block.
+- Introduce no new trust assumption: every invariant is enforced either inside the Ragu
+  PCD or by consensus checks on public data.
 
 ## Specification
 
@@ -232,19 +229,21 @@ The specification is organised around the 10-step aggregation lifecycle. Each st
 a subsection with conformance language. Transaction-identifier semantics and P2P relay
 rules are folded into the relevant steps rather than specified as parallel sections.
 
+This specification applies identically to Mainnet and Testnet.
+
 ### Step 1: Publication of autonomes
 
 Wallets construct stamped bundles — **autonomes** — and broadcast them to the mempool
-via the existing wallet RPC or P2P path. An autonomic is a standard stamped transaction
+via the existing wallet RPC or P2P path. An autonome is a standard stamped transaction
 with a complete Ragu PCD proof, a serialized `ActionSetCommit`, and a distinct `wtxid`.
-Autonomes are announced and relayed by `wtxid` per step 5.
+Autonomes are announced and relayed by `wtxid` per Step 5.
 
 ### Step 2: Aggregator mempool observation
 
 Aggregators observe stamped transactions in mempool gossip. An aggregator MAY select
 any subset of autonomes (and existing aggregates) for merging. There is no protocol-
 level exclusivity or claim on autonomes: multiple aggregators MAY attempt to cover the
-same autonomic, and a miner MAY prefer one aggregate over another at block-assembly
+same autonome, and a miner MAY prefer one aggregate over another at block-assembly
 time.
 
 ### Step 3: Aggregate construction
@@ -261,7 +260,7 @@ Aggregators merge stamps as follows:
    header commitments, and proves the merged polynomials are the products of the input
    polynomials (multiset union by polynomial product).
 4. Serialize and compress the merged stamp. The merged stamp carries the merged
-   `ActionSetCommit = commit(P_left · P_right)`.
+   commitment $\mathsf{ActionSetCommit} = \mathsf{Commit}(P_{\mathsf{left}} \cdot P_{\mathsf{right}})$.
 
 The aggregator constructs a new stamped transaction carrying the merged stamp. For a
 **based** aggregate the transaction also carries the aggregator's own tachyactions; for
@@ -272,7 +271,7 @@ an **innocent** aggregate it carries no Tachyon actions.
 Aggregators publish the aggregate transaction to the mempool. Aggregators MUST NOT
 re-publish the covered autonomes; the autonome remains in the mempool independently and
 the aggregate is published alongside it. The aggregate is a new `wtxid` distinct from
-each covered autonomic's `wtxid`, because its `auth_digest` commits to a different
+each covered autonome's `wtxid`, because its `auth_digest` commits to a different
 stamp trailer (the merged stamp) even though the covered effecting data is recoverable
 from the aggregate's action-digest and tachygram sets.
 
@@ -280,15 +279,15 @@ from the aggregate's action-digest and tachygram sets.
 
 Miners see both autonomes and aggregates in the mempool. A miner MAY also vertically
 integrate aggregation and produce its own aggregates privately without publishing them
-to the mempool (step 7).
+to the mempool (Step 7).
 
 P2P relay for Tachyon bundles follows [ZIP 239](https://zips.z.cash/zip-0239):
 transactions are announced and fetched by `wtxid` using the `MSG_WTX` inv type. An
-autonomic, an aggregate, and an adjunct carrying the same effecting data are three
+autonome, an aggregate, and an adjunct carrying the same effecting data are three
 distinct `wtxid`s and MUST be treated as distinct inventory objects.
 
 `MSG_WTX`-style relay is mandatory for Tachyon bundles. Announcing by `txid` alone
-would let a third party broadcast a covered autonomic with the same `txid` as an
+would let a third party broadcast a covered autonome with the same `txid` as an
 aggregate and interfere with relay of the aggregate form — exactly the failure mode
 ZIP 239 was written to prevent for v5 witness malleability, extended here to Tachyon's
 authorization-form malleability (stamping, merging, and stripping all change `wtxid`
@@ -300,42 +299,47 @@ in the mempool even after an aggregator republishes a covering aggregate. Relay 
 MAY de-duplicate on `txid` to avoid redundant propagation of covered autonomes once a
 covering aggregate is present.
 
-Adjuncts are block-local. A standalone adjunct whose `stampWtxid` is not present in the
-mempool or block MUST NOT be relayed as an independent transaction; adjuncts only
+Adjuncts are block-local. A standalone adjunct whose `tachyonAggregateId` is not present
+in the mempool or block MUST NOT be relayed as an independent transaction; adjuncts only
 appear inside blocks alongside their covering aggregate. Stripping is a miner-side
-block-assembly action (step 8), not a relay-time transformation: the P2P network
+block-assembly action (Step 8), not a relay-time transformation: the P2P network
 carries stamped bundles (autonomes and aggregates) only.
 
 ### Step 6: Covered-transaction identification by `ActionSetCommit`
 
-Miners (and validating observers) identify the aggregate/autonome relationship using
-the `ActionSetCommit` field serialized on each stamp.
+Miners (and validating observers) identify the aggregate/autonome relationship using the
+`ActionSetCommit` field serialized on each stamp. Coverage is determined over the
+**action-digest set** — exactly one digest $d_i$ per action — not over tachygrams, whose
+count need not equal the action count (a spend publishes two tachygrams).
 
-The aggregate's stamp publishes `ActionSetCommit = commit(P_aggregate)`, where
-`P_aggregate = ∏_i (X − d_i)` over the action digests of every action covered by the
-aggregate (both the based aggregate's own actions and all covered autonomes' actions).
-Each `d_i = Poseidon(cv_i || rk_i)` is computable from public action data.
+The aggregate's stamp publishes
+$\mathsf{ActionSetCommit} = \mathsf{Commit}(P_{\mathsf{aggregate}})$, where
+$P_{\mathsf{aggregate}} = \prod_i (X - d_i)$ ranges over the action digests of every
+action covered by the aggregate (both the based aggregate's own actions and all covered
+autonomes' actions). Each
+$d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$ is
+computable from public action data.
 
 An observer who has seen a candidate set of autonomes confirms coverage as follows:
 
-1. For a based aggregate, compute `P_own = ∏ (X − d_j)` from the aggregate's own
-   visible actions. For an innocent aggregate, `P_own` is the empty product (1).
-2. For each candidate autonomic, compute `P_autonome_k = ∏ (X − d_l)` from its visible
-   actions.
-3. Compute `P_observed = P_own · ∏_k P_autonome_k`.
-4. Compute `commit(P_observed)` and compare to the aggregate's published
-   `ActionSetCommit`.
+1. For a based aggregate, compute $P_{\mathsf{own}} = \prod_j (X - d_j)$ from the
+   aggregate's own visible actions. For an innocent aggregate, $P_{\mathsf{own}}$ is the
+   empty product $1$.
+2. For each candidate autonome $k$, compute
+   $P_{\mathsf{autonome},k} = \prod_l (X - d_l)$ from its visible actions.
+3. Compute
+   $P_{\mathsf{observed}} = P_{\mathsf{own}} \cdot \prod_k P_{\mathsf{autonome},k}$.
+4. Compute $\mathsf{Commit}(P_{\mathsf{observed}})$ and compare to the aggregate's
+   published `ActionSetCommit`.
 
 Match confirms the observer holds the complete covered set. Mismatch is fail-fast: the
-observer is missing a covered autonomic, has an extra one, or is matching against the
-wrong aggregate. The check is O(n) polynomial arithmetic plus one Pedersen commitment;
+observer is missing a covered autonome, has an extra one, or is matching against the
+wrong aggregate. The check is $O(n)$ polynomial arithmetic plus one Pedersen commitment;
 it does not require Ragu proof verification.
 
-This resolves the based-aggregate attribution problem (see _Based-aggregate tachygram
-attribution (resolved)_ in section II) without a comprehensive-index assumption or a
-tachygram-origin query protocol. The cardinality of the covered set is known
-(|covered| = |stamp tachygrams| − |based actions|, since one tachygram is bound per
-action), which constrains the search, but the commitment check is what confirms it.
+This resolves the based-aggregate attribution problem without a comprehensive mempool
+index or a tachygram-origin query protocol: each action contributes exactly one root to
+the product, so the published commitment fixes the covered action multiset directly.
 
 ### Step 7: Private miner aggregation (optional)
 
@@ -348,15 +352,14 @@ the only difference is that the aggregate is never gossiped.
 
 Miners compose the block at will. For each covered transaction the miner includes, the
 miner strips the stamp and assigns the covering aggregate's `wtxid` as the adjunct's
-`tachyonAggregateId` (the 64-byte `stampWtxid` trailer). The covering aggregate MUST be
-included top-level in the same block, never stripped and never further aggregated in
-that block, so the `wtxid` referenced by adjuncts is stable and resolvable by
-validators in a single pass.
+`byte[64]` `tachyonAggregateId`. The covering aggregate MUST be included top-level in the
+same block, never stripped and never further aggregated in that block, so the `wtxid`
+referenced by adjuncts is stable and resolvable by validators in a single pass.
 
-Stripped innocents (aggregates with no Tachyon actions) MAY carry a zero `wtxid` if no
-absorbing aggregate was recorded; this is the only case where a zero
-`tachyonAggregateId` is valid. Consensus rejects a stripped bundle with non-empty
-actions and a zero `tachyonAggregateId`.
+A stripped innocent (an aggregate with no Tachyon actions) MAY carry an all-zero
+`tachyonAggregateId` if no absorbing aggregate was recorded; this is the only case where
+a zero `tachyonAggregateId` is valid. Nodes MUST reject a stripped bundle having
+non-empty actions and an all-zero `tachyonAggregateId`.
 
 Transaction-identifier semantics under stripping:
 
@@ -365,15 +368,16 @@ Transaction-identifier semantics under stripping:
   identity is invariant across the aggregation lifecycle.
 - `auth_digest` commits to action signatures, the binding signature, and the bundle's
   stamp trailer. A stamped bundle's trailer is the full stamp (anchor,
-  `ActionSetCommit`, tachygrams, proof); a stripped bundle's trailer is the 64-byte
-  `stampWtxid` of the covering aggregate. Each physical authorization form yields a
-  distinct `auth_digest` and therefore a distinct `wtxid = txid || auth_digest`.
+  `ActionSetCommit`, tachygrams, proof); a stripped bundle's trailer is the `byte[64]`
+  covering `wtxid` (referred to as `stampWtxid` in the digest contribution). Each
+  physical authorization form yields a distinct `auth_digest` and therefore a distinct
+  `wtxid = txid || auth_digest`.
 - The covering-aggregate reference carried by an adjunct is a `wtxid`, not a `txid`,
   because the `wtxid` pins a specific physical aggregate (authorization + stamp state).
   A `txid` would be ambiguous across the autonome/aggregate forms.
-- The wire byte `tachyonBundleState` distinguishes forms: `0x01` stamped, `0x02`
-  stripped. Innocents and adjuncts share the stripped layout; both end in a 64-byte
-  `tachyonAggregateId`.
+- The wire byte `tachyonBundleState` (`uint8`) distinguishes forms: `0x00` no Tachyon
+  bundle, `0x01` stamped, `0x02` stripped. Innocents and adjuncts share the stripped
+  layout; both end in a `byte[64]` `tachyonAggregateId`.
 
 The `"ZTxAuthTachyHash"` personalization used in the Tachyon `auth_digest` contribution
 is a placeholder pending a Tachyon amendment to ZIP 244; the normative digest
@@ -391,33 +395,38 @@ The miner proposes the block containing:
 
 ### Step 10: Block validation
 
-A block containing Tachyon bundles is valid only if, for every covering aggregate in
-the block:
+Nodes MUST reject a block containing Tachyon bundles unless, for every covering aggregate
+in the block, all of the following hold:
 
 1. **Adjunct resolution.** Every adjunct whose `tachyonAggregateId` refers to that
    aggregate is present in the same block, and the aggregate is top-level, unstripped,
    and not further aggregated in that block.
-2. **Action-set reconstruction.** The union of action-digest sets across all adjuncts
-   covered by the aggregate, combined with the based aggregate's own action-digest set
-   (empty for an innocent aggregate), matches the aggregate stamp's `ActionSetCommit`.
-   Consensus reconstructs the commitment from visible actions and checks it for
-   consistency; the serialized `ActionSetCommit` on the stamp is advisory for this
-   check (a mismatch between the serialized commitment and the reconstructed one is
-   itself a consensus error).
-3. **Tachygram-set reconstruction.** The union of tachygrams across all adjuncts
-   covered by the aggregate matches the aggregate stamp's tachygram set.
-4. **Stamp proof verification.** The reconstructed header
-   `(action_acc, tachygram_acc, anchor)` matches the stamp header, and the Ragu PCD
-   proof verifies against that header.
-5. **Signatures and value balance.** Action signatures and the binding signature
-   verify against the transaction sighash, and the bundle's value commitments are
-   consistent with the declared `value_balance`.
-6. **Anchor membership.** The aggregate's anchor is a member of the published per-
-   block anchor sequence, as specified by the accumulator/anchor ZIP (#105).
-7. **Tachygram uniqueness.** No tachygram published in this block (across all
-   aggregates and adjuncts) duplicates a tachygram published in the current epoch or
-   the immediately preceding epoch, as specified by the tachygram-uniqueness consensus
-   rule.
+2. **Action-set reconstruction.** The multiset union of the action-digest sets of all
+   adjuncts covered by the aggregate, combined with the based aggregate's own
+   action-digest set (empty for an innocent aggregate), matches the aggregate stamp's
+   `ActionSetCommit`. Consensus reconstructs $\mathsf{action\_acc}$ from these visible
+   actions; the serialized `ActionSetCommit` on the stamp is advisory for this check, and
+   any mismatch between the serialized commitment and the reconstructed one is itself a
+   consensus error.
+3. **Tachygram-set binding.** The aggregate stamp publishes the merged tachygram set
+   (`vTachygrams`); adjuncts carry no tachygrams of their own. The Ragu PCD proof binds
+   the tachygram-set commitment to the action-set commitment reconstructed in item 2, so
+   consensus takes the tachygram set from the aggregate's stamp rather than
+   reconstructing it from the adjuncts.
+4. **Stamp proof verification.** The header
+   $(\mathsf{action\_acc}, \mathsf{tachygram\_acc}, \mathsf{anchor})$ — with
+   $\mathsf{action\_acc}$ reconstructed in item 2, $\mathsf{tachygram\_acc}$ committed
+   from the stamp's published tachygrams, and $\mathsf{anchor}$ taken from the stamp —
+   verifies against the Ragu PCD proof.
+5. **Signatures and value balance.** Action signatures and the binding signature verify
+   against the transaction sighash, and the bundle's value commitments are consistent
+   with the declared `value_balance`.
+6. **Anchor membership.** The aggregate's anchor is a member of the published per-block
+   anchor sequence, as specified by the accumulator/anchor ZIP (#105).
+7. **Tachygram uniqueness.** No tachygram published in this block — in any stamp the
+   block contains — duplicates a tachygram published in the current epoch or the
+   immediately preceding epoch, as specified by the tachygram-uniqueness consensus rule
+   ([Tachygrams](../tachygrams.md)).
 
 The above checks split into two layers:
 
@@ -452,10 +461,10 @@ cross-reference unrelated sections to understand a single participant's obligati
 
 **`ActionSetCommit` solves based-aggregate attribution.** Tachygram-set overlap alone
 is insufficient for coverage identification when a based aggregate's own tachygrams are
-indistinguishable from covered autonomes' tachygrams. The `ActionSetCommit` field,
-already a PCD header field and already bound by the proof, provides a cheap fail-fast
-check that does not require proof verification, a comprehensive mempool index, or a
-new tachygram-origin query protocol. A based aggregate could alternatively declare
+indistinguishable from covered autonomes' tachygrams. The `ActionSetCommit` field, a PCD
+header field bound by the proof, provides a cheap fail-fast check that does not require
+proof verification, a comprehensive mempool index, or a separate tachygram-origin query
+protocol. A based aggregate could alternatively declare
 which tachygrams are its own, but this would not help: the based portion's count is
 already inferable from the visible actions, and the remaining attribution problem is
 unchanged. It would also leak structure about the aggregator's own vs covered activity
@@ -470,7 +479,7 @@ check reuses an existing PCD header field and an existing reconstruction path.
 **`wtxid`, not `txid`, for adjunct references.** A `txid` would be ambiguous across
 the autonome/aggregate forms (they share effecting data). The `wtxid` pins a specific
 physical aggregate including its stamp state, which is what the adjunct needs to
-reference. This is why adjuncts carry `stampWtxid` rather than `stampTxid`.
+reference. This is why the `tachyonAggregateId` holds a `wtxid` rather than a `txid`.
 
 **Stripping is miner-side, not relay-time.** Stripping at relay time would force every
 relay node to understand aggregate coverage and would mix block-assembly policy with
@@ -479,9 +488,9 @@ adjuncts to blocks, simplifies relay and matches the implementation (a stripped 
 is not serializable until its covering `wtxid` is assigned, which happens at block
 assembly).
 
-**MSG_WTX relay is mandatory.** Tachyon's authorization-form malleability is the
+**`MSG_WTX` relay is mandatory.** Tachyon's authorization-form malleability is the
 direct analogue of v5 witness malleability that motivated ZIP 239. Announcing by
-`txid` would let a third party broadcast a covered autonomic with the same `txid` as
+`txid` would let a third party broadcast a covered autonome with the same `txid` as
 an aggregate and interfere with relay of the aggregate form. Requiring `MSG_WTX` for
 Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
 
@@ -490,32 +499,36 @@ Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
 **No new trust assumption.** The aggregator is not trusted. Every invariant is
 enforced either inside the Ragu PCD (circuit logic) or by consensus checks on public
 data (consensus logic). A malicious aggregator can publish an invalid aggregate, but
-validators will reject it at step 10. A malicious miner can mis-assign adjuncts or
+validators will reject it at Step 10. A malicious miner can mis-assign adjuncts or
 omit covered transactions, but the block will fail validation.
 
 **Data availability.** Aggregation removes redundant proof bytes only. Every adjunct
 retains its action data, action signatures, binding signature, and `value_balance`;
 validators reconstruct the aggregate header from this public data. An aggregate proof
-alone is insufficient — the covered effecting data MUST be present in the block as
-adjuncts.
+alone is insufficient: the covered effecting data is present in the block as adjuncts,
+and Step 10 rejects any block where it is not.
 
-**No new leakage from `ActionSetCommit`.** The commitment is already reconstructable
-from visible actions for any self-contained bundle. For a based aggregate, the
-factored polynomial (which roots are the aggregator's own vs covered) is not
-recoverable from the commitment alone, so publishing it does not reveal which actions
-are the aggregator's own. The trailing-zeros caveat (commit-equality bounds
-polynomial rank from above) does not bite because `ActionDigest::new` rejects identity
-`cv`/`rk`.
+**No new leakage from `ActionSetCommit`.** The commitment is reconstructable from visible
+actions for any self-contained bundle, so its serialized value reveals nothing the
+actions do not. For a based aggregate, the factored
+polynomial (which roots are the aggregator's own vs covered) is not recoverable from the
+commitment alone, so publishing it does not reveal which actions are the aggregator's
+own. The coverage check is also sound against the rank-from-above caveat of
+commit-equality: each $\prod_i (X - d_i)$ is monic of degree equal to the action count,
+so its top coefficient is fixed at $1$ and the commitment pins the exact action multiset
+(no shorter polynomial can share the commitment). Identity `cv`/`rk` is separately
+rejected by `ActionDigest::new`, which is a well-formedness guard ensuring every action
+has a computable digest, not part of the rank argument.
 
 **Privacy of aggregation relationships.** An observer who sees an aggregate in the
-mempool can identify covered autonomes by the `ActionSetCommit` check (step 6). This
+mempool can identify covered autonomes by the `ActionSetCommit` check (Step 6). This
 is inherent to the scheme: the aggregate must carry enough information for validators
 to reconstruct its header. The tachygram-set and action-digest-set commitments do not
 reveal the private contents of any covered note.
 
 **Circuit/consensus boundary.** Several security properties — notably spendable-
 lineage epoch pinning and double-spend prevention — depend on consensus checks
-(sections 6 and 7 of step 10) rather than being fully proven inside the stamp. This is
+(items 6 and 7 of Step 10) rather than being fully proven inside the stamp. This is
 by design and is documented explicitly so that implementers and auditors do not assume
 the proof alone establishes these properties.
 

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -7,7 +7,7 @@
 ## I. Dependencies
 
 - [Tachyon Shielded Protocol (#103)](https://github.com/tachyon-zcash/tachyon/issues/103)
-  defines the Tachyon pool, tachyactions, tachygrams, and the per-action authorization
+  defines the Tachyon pool, Tachyon actions, tachygrams, and the per-action authorization
   layer that aggregation preserves.
 - [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
   defines the stamped and stripped bundle wire encodings, the `tachyonBundleState` byte,
@@ -23,74 +23,11 @@
   trees. A Tachyon amendment to ZIP 244 (tracked separately) fixes the
   `"ZTxAuthTachyHash"` personalization and the Tachyon digest branches; this ZIP does
   not re-specify that algorithm.
-- [ZIP 248](https://zips.z.cash/zip-0248) (extensible transaction format) is required
-  for registering the Tachyon bundle type on the v5 transaction format.
 
 ## II. Design Considerations
 
-### Aggregation as a network role
-
-Tachyon seeks to reduce chain costs by recursively merging per-transaction Ragu PCD
-stamps into a single aggregate proof that covers many transactions. The act of merging
-proofs is **aggregation**, and **aggregators** are the nodes that perform it. Miners
-are likely to vertically integrate aggregation, but the protocol must also work for
-third-party aggregators that publish aggregates to the mempool. See
-[Network Roles](../network_roles/overview.md) and [Aggregation](../aggregation.md).
-
-### The 10-step lifecycle
-
-The Specification is organised around the following lifecycle, distilled in
-[Aggregation](../aggregation.md):
-
-1. Autonome transactions are published to the mempool.
-2. Aggregators observe transactions in the mempool.
-3. Aggregators produce their own transactions with merged stamps.
-4. Aggregators publish their own transactions to the mempool, and do not re-publish the
-   autonomes they covered.
-5. Miners see transactions in the mempool.
-6. Miners identify which autonomes each aggregate covers.
-7. Miners may perform their own aggregation privately, without publishing to the
-   mempool.
-8. Miners compose their block at will, stripping stamps and assigning the covering
-   aggregate `wtxid` to each adjunct.
-9. The miner proposes a block.
-10. Block validation only passes if the appropriate adjuncts are included and properly
-    assigned aggregate ids, enabling header reconstruction and verification.
-
-### Identifying covered transactions
-
-A mempool observer associates an aggregate with the autonomes it covers primarily by
-matching tachygrams it has already seen against the aggregate's published tachygram set.
-Tachygram matching associates but does not confirm completeness: a based aggregate's own
-tachygrams are unlabelled and tachygrams do not distinguish nullifiers from commitments
-([Bundles](../bundle.md)), so overlap alone cannot tell an observer it holds every autonome
-an aggregate covers. The stamp trailer carries `cActionsTachyon`, an assistive action-set
-indicator that lets an observer confirm a candidate set cheaply (Step 6). It is an
-identification aid, not a soundness mechanism.
-
-### Open questions
-
-The following remain unresolved at Draft and are not normatively specified below:
-
-- **Aggregate limits.** Fan-in, recursion depth, proof size, tachygram vector size,
-  action count, and per-block aggregate count. Aggregate size is commitment-size-limited
-  before block-size-limited (on the order of thousands of actions); exact limits TBD.
-- **Anchor publication and membership.** Specified by the accumulator/anchor ZIP (#105);
-  this draft states the dependency.
-- **Fee accounting (ZIP 317).** `contribution_Tachyon` must account for logical work
-  split between adjuncts (actions) and aggregates (proofs); under discussion.
-- **Value-pool balance (ZIP 209).** `valueBalanceTachyon` turnstile integration; under
-  discussion.
-- **Block commitments (ZIP 221).** How Tachyon's end-of-block anchor enters the MMR
-  leaf; under discussion.
-- **Bundle serialization registration (ZIP 248).** Pending ZIP-248 editor consensus.
-- **P2P aggregation gossip.** Secondary objective; selection criteria (covered-
-  transaction set, size, anchor alignment) remain an open policy question. Single-
-  aggregate merge is not parallelizable, but multiple aggregates can be built in
-  parallel.
-- **`mock_ragu` vs real Ragu.** The normative text below describes the intended real
-  Ragu PCD semantics. The current Tachyon implementation uses a permissive mock; a green
-  test suite against the mock is not soundness.
+**Aggregation** is the act of recursively merging per-transaction Ragu PCD *stamps into a single aggregate proof, and **aggregators** are the nodes that perform it.
+Miners are likely to vertically integrate aggregation, but a protocol is established for dedicated aggregator nodes to contribute aggregates to the mempool. See [Network Roles](../network_roles/overview.md) and [Aggregation](../aggregation.md).
 
 ## III. ZIP Draft
 
@@ -117,85 +54,57 @@ interpreted as described in section 3.12 of the Zcash Protocol Specification.
 
 - **Tachygram.** A `byte[32]` field element ($\mathbb{F}_p$) representing either a note
   nullifier or a note commitment. Consensus treats nullifiers and commitments
-  identically; one accumulator handles both. See [Tachygrams](../tachygrams.md).
-- **Tachyaction.** An indistinguishable representation of either the creation or
-  destruction of a note. Contains `cv`, `rk`, and `sig`; each tachyaction is
-  cryptographically bound to one tachygram but does not contain it. A spend additionally
-  publishes a next-epoch nullifier, so a stamp's tachygram set is not in 1:1
-  correspondence with its actions. See [Bundles](../bundle.md).
-- **Stamp.** The recursive Ragu PCD proof data carried by a stamped bundle:
-  `cActionsTachyon`, `anchor`, `tachygrams`, and `proof`. The proof establishes that the
-  tachyactions follow the correct rules and that the published tachygrams and action
-  digests correspond to those actions.
-- **Autonome.** A stamped bundle produced by a wallet, carrying a complete proof with
-  all inputs. The standard form of a user-originated Tachyon transaction.
-- **Aggregate.** A stamped bundle produced by an aggregator, carrying a merged stamp
-  that covers multiple bundles. An *innocent* aggregate contains no Tachyon actions of
-  its own; a *based* aggregate carries its own Tachyon actions in addition to the merged
-  stamp.
-- **Adjunct.** A stripped bundle whose stamp has been removed and replaced by a
-  `tachyonAggregateId` reference to the covering aggregate. Adjuncts retain action data,
-  action signatures, the binding signature, and `value_balance`.
-- **`cActionsTachyon`.** An assistive action-set indicator on the stamp trailer: a 32-byte
-  Pedersen commitment to the action-digest set,
-  $\mathsf{Commit}\bigl(\prod_i (X - d_i)\bigr)$, with action digest
-  $d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$
-  defined in [Authorization](../authorization.md). It is the same commitment the book
-  calls `action_acc` and that the proof attests to in its header, copied onto the trailer
-  so observers can identify covered transactions without verifying the proof (Step 6). It
-  is authorization data: it contributes to `auth_digest` and strips away with the stamp.
-  Its wire encoding is specified by the bundle-format ZIP (#104).
-- **`tachyonAggregateId`.** The wire field on a stripped bundle that replaces its stamp:
-  the `byte[64]` `wtxid` of the covering aggregate (the implementation type is
-  `AggregateId`). It is a `wtxid`, not a `txid`, so it pins a specific physical aggregate
-  including its stamp state. The `auth_digest` contribution refers to this same value as
-  `stampWtxid` (see [Transaction Identifiers](../transaction-identifiers.md)).
-- **`txid`.** The transaction identifier, committing only to effecting data. For a
-  Tachyon bundle, the `txid` contribution is `action_acc || value_balance`. Stable
-  across stamping, merging, and stripping.
-- **`auth_digest`.** The authorizing-data commitment. For a Tachyon bundle, commits to
-  action signatures, the binding signature, and the stamp trailer. Each physical
-  authorization form yields a distinct `auth_digest`.
-- **`wtxid`.** The `byte[64]` witnessed transaction identifier `txid || auth_digest`. The
-  unit of physical relay per [ZIP 239](https://zips.z.cash/zip-0239).
+  identically.
+- **Stamp.** A bundle trailer which may replaced with a reference to another
+  transaction. Contains a Ragu proof and some associated data necessary for
+  verification, including tachygrams.The proof establishes that the actions follow
+  the correct rules.
+- **Autonome.** A stand-alone transaction with a stamped bundle, containing a
+  proof covering only its own actions. The standard form of a user-originated
+  Tachyon transaction. An autonome may appear in a block or in the mempool.
+- **Aggregate.** A transaction with a stamped bundle, containing a merged stamp
+  that covers other transactions. More specifically, an *innocent aggregate*
+  contains no Tachyon actions of its own; and a *based aggregate* contains Tachyon
+  actions. An aggregate may appear in a block or in the mempool.
+- **Adjunct.** A transaction with a stripped bundle. Its proof has been removed
+  and replaced by a `wtxid` reference to a covering aggregate. Adjuncts retain
+  action data, action signatures, the binding signature, and `value_balance`. An
+  adjunct should only appear in a block.
 
 ## Abstract
 
-Tachyon shielded transactions carry recursive Ragu PCD stamps whose verification cost
-is substantial. Verifying each transaction's stamp independently at consensus would
-dominate block-validation cost. This ZIP specifies the Tachyon aggregator protocol: a
-network role that merges stamps from multiple stamped transactions into a single
-aggregate stamp, and a block-layout discipline under which miners strip the now-
-redundant per-transaction stamps and replace them with a reference to the covering
-aggregate. The same effecting data (tachyactions, value balances, action signatures,
-and binding signatures) remains independently verifiable; only the proof bytes are
-deduplicated. The ZIP defines the 10-step aggregation lifecycle from autonome
-publication through block validation, the transaction-identifier semantics that make
-stripping safe, and the P2P relay rules that extend ZIP 239 to Tachyon's
-authorization-form malleability. Aggregation introduces a new network participant but no
-new trust assumption: every invariant is enforced either inside the Ragu PCD or by
-consensus checks on public data.
+Tachyon shielded transactions use a recursive proof system. To reduce proof
+verification costs, recursion is used to combine many per-transaction proofs
+into a single proof covering all contributing transactions.
+
+This recursion provides an opportunity to introduce a new participant role
+without creating a new trust assumption.
+
+This ZIP specifies: the aggregator protocol, a block-layout discipline under
+which miners strip redundant proofs, the semantics about effecting data and
+authorizing data that make stripping safe, and P2P rules that extend ZIP 239 to
+Tachyon's authorization-form malleability.
+
+Aggregation involves a 10-step lifecycle from transaction authorization, through
+the mempool, to block layout, and final validation. All effecting data (actions,
+value balances, action signatures, and binding signatures) remains present and
+valid when a proof is stripped.
 
 ## Motivation
 
-Without aggregation, every Tachyon transaction in a block carries its own Ragu PCD
-stamp, and validators must verify each stamp independently. Stamp verification is the
-dominant per-transaction cost; at scale this limits throughput and raises the barrier
-to running a validating node.
+Every proof must be verified to reach consensus. Without aggregation, every
+Tachyon bundle would carry a stamp, and consensus costs would be dominated by
+stamp data and verification. By specifying an aggregation protocol, consensus
+avoids this complexity.
 
-Ragu PCD stamps are recursively composable: two stamps at a common anchor can be merged
-into a single stamp that attests to the union of the two action-digest and tachygram
-sets. This composition is what aggregation exploits. An aggregator merges stamps off-
-chain and publishes a single aggregate transaction carrying the merged stamp; miners
-strip the redundant per-transaction stamps at block-assembly time, leaving each covered
-transaction as an adjunct that carries its effecting data plus a reference to the
-covering aggregate.
+A block in which a large number of Tachyon stamps are aggregated into a smaller
+number of Tachyon stamps is completely verified by that smaller number of
+stamps, while still allowing every action, signature, and balance to remain
+independently valid. In the ideal case, a single proof MAY verify all Tachyon
+transactions in a block.
 
-The result is that a block containing $N$ Tachyon transactions need only verify a small
-number of aggregate stamps rather than $N$ independent proofs, while still allowing every
-action, signature, and value balance to be independently checked. This ZIP specifies
-the network behaviour, the block-layout rules, and the identification mechanism that
-makes the scheme work without a trusted aggregator.
+Aggregation is RECOMMENDED, not required. A miner MAY choose to include
+completely independent non-aggregated transactions.
 
 ## Requirements
 
@@ -209,12 +118,11 @@ the Specification.)
   without trusting the aggregator.
 - Preserve transaction-identifier stability: a transaction's `txid` is invariant across
   stamping, merging, and stripping.
-- Allow any participant (miner or third-party) to act as aggregator; no protocol-level
-  exclusivity or claim on autonomes.
-- Enable a validating observer or miner to confirm, cheaply and fail-fast, that they
-  hold every autonome covered by an aggregate before assembling or validating a block.
-- Introduce no new trust assumption: every invariant is enforced either inside the Ragu
-  PCD or by consensus checks on public data.
+- Allow any participant to act as aggregator; no protocol-level exclusivity.
+- Enable a validator or miner to confirm they hold all necessary data before
+  attempting proof verification.
+- Introduce no new trust assumption: every invariant is enforced either by proof
+  or by consensus rules.
 
 ## Specification
 
@@ -222,55 +130,55 @@ The specification is organised around the 10-step aggregation lifecycle. Each st
 a subsection with conformance language. Transaction-identifier semantics and P2P relay
 rules are folded into the relevant steps rather than specified as parallel sections.
 
-This specification applies identically to Mainnet and Testnet.
-
 ### Step 1: Publication of autonomes
 
-Wallets construct stamped bundles (**autonomes**) and broadcast them to the mempool
-via the existing wallet RPC or P2P path. An autonome is a standard stamped transaction
-with a complete Ragu PCD proof and a distinct `wtxid`. Autonomes are announced and
-relayed by `wtxid` per Step 5.
+Transaction authors produce complete and independently verifiable transactions
+with stamped bundles (**autonomes**) and broadcast them to the mempool via the
+existing wallet RPC or P2P path.
 
 ### Step 2: Aggregator mempool observation
 
-Aggregators observe stamped transactions in mempool gossip. An aggregator MAY select
-any subset of autonomes (and existing aggregates) for merging. There is no protocol-
-level exclusivity or claim on autonomes: multiple aggregators MAY attempt to cover the
-same autonome, and a miner MAY prefer one aggregate over another at block-assembly
-time.
+Aggregators observe transactions in mempool gossip.
 
-### Step 3: Aggregate construction
+An aggregator selects two transactions (autonomes or existing aggregates) for
+merging into a new aggregate. Selected transactions SHOULD bear disjoint
+tachygram sets.
 
-Aggregators merge stamps as follows:
+### Step 3: Prepare witnesses and PCD
 
-1. Deserialize and validate each input stamp.
-2. Align anchors: each input stamp is lifted to a common later anchor using `StampLift`
-   over an `AnchorChain` segment whose `start` equals the stamp's current anchor. The
-   merged stamp's anchor is the segment `end`.
-3. Merge the stamps with `MergeStamp`, which constrains `left.anchor == right.anchor`,
-   binds the witnessed input action-digest and tachygram polynomials to the input
-   header commitments, and proves the merged polynomials are the products of the input
-   polynomials (multiset union by polynomial product).
-4. Serialize and compress the merged stamp.
+Aggregators reconstruct two stamp PCD from proofs and data available directly on
+the input transactions.
 
-The aggregator constructs a new stamped transaction carrying the merged stamp. For a
-**based** aggregate the transaction also carries the aggregator's own tachyactions; for
-an **innocent** aggregate it carries no Tachyon actions.
+If selected transactions bear unequal anchors, aggregators MUST align stamp anchors by
+fusing with an anchor PCD that represents the difference. Aggregators are
+RECOMMENDED to maintain recent consensus data and cache anchor PCD likely to be
+relevant to anchor adjustment.
 
-### Step 4: Aggregate publication
+If selected transactions are autonomes, all necessary witness data is directly
+available.
 
-Aggregators publish the aggregate transaction to the mempool. Aggregators MUST NOT
-re-publish the covered autonomes; the autonome remains in the mempool independently and
-the aggregate is published alongside it. The aggregate is a new `wtxid` distinct from
-each covered autonome's `wtxid`, because its `auth_digest` commits to a different
-stamp trailer (the merged stamp) even though the covered effecting data is recoverable
-from the aggregate's action-digest and tachygram sets.
+Any selected transaction that is already an aggregate will require additional
+action digests from all contributing transactions. Aggregators are RECOMMENDED
+to maintain an index of recent mempool transactions likely to be relevant to
+witness preparation. A correct and complete collection of relevant action
+digests will reproduce the action set commitment on the selected stamp.
 
-### Step 5: Miner mempool observation and P2P relay
+### Step 4: Aggregate construction
 
-Miners see both autonomes and aggregates in the mempool. A miner MAY also vertically
-integrate aggregation and produce its own aggregates privately without publishing them
-to the mempool (Step 7).
+Holding two stamp PCD and an appropriate witness, the aggregator may execute a
+fuse step to prove a new stamp PCD that covers the selected transactions and all
+transactions contributing to the selected transactions.
+
+The aggregator may construct a new transaction bearing the merged stamp, or
+simply update one or both of the contributing transactions.
+
+### Step 5: Aggregate publication
+
+Aggregators publish the aggregate transaction to the mempool.
+
+A freshly constructed transaction obviously has a distinct `txid` and `wtxid`,
+but an updated transaction maintains the same `txid` and produces a new `wtxid`
+distinct from the original selected input.
 
 P2P relay for Tachyon bundles follows [ZIP 239](https://zips.z.cash/zip-0239):
 transactions are announced and fetched by `wtxid` using the `MSG_WTX` inv type. A single
@@ -279,6 +187,14 @@ that share that `txid` and differ only in `auth_digest`: a wallet's autonome, an
 anchor-lifted or proof-rerandomized restamp, and the stripped adjunct form a miner
 produces. Each is a distinct `wtxid`, and nodes MUST treat distinct `wtxid`s as distinct
 objects.
+
+### Step 5: Miner mempool observation
+
+Miners see both autonomes and aggregates in the mempool. A miner MAY also vertically
+integrate aggregation.
+
+A miner that vertically integrates aggregation MAY produce its own aggregates
+privately without publishing them to the mempool (Step 7).
 
 `MSG_WTX`-style relay is mandatory for Tachyon bundles: restamping, proof rerandomization,
 and stripping all change `wtxid` while leaving `txid` unchanged, so announcement by `txid`
@@ -316,16 +232,18 @@ coverage. Because a based aggregate's own tachygrams are not labelled and tachyg
 not distinguish nullifiers from commitments, tachygram matching narrows the candidate set
 but does not confirm it is complete.
 
-To confirm it holds the right set, the observer reconstructs the action-set commitment
-from its candidate set of autonomes, together with the based aggregate's own actions, and
-compares it to the aggregate's `cActionsTachyon` indicator. Each action digest
-$d_i = \text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$ is
-computable from public action data, so the reconstruction is cheap ($O(n)$ polynomial
-arithmetic plus one Pedersen commitment) and needs no proof verification. A match confirms
-the candidate set is exactly the aggregate's cover; a mismatch is fail-fast, signalling a
-missing or extra autonome, or a match against the wrong aggregate. Coverage is taken over the
-action-digest set, one digest per action, not over tachygrams, whose count differs from
-the action count because a spend publishes two tachygrams.
+To confirm it holds the right set, the observer reconstructs the action-set
+commitment from its candidate set of autonomes, together with the aggregate's
+own actions (none, for an innocent aggregate), and compares it to the
+aggregate's `cActionsTachyon` indicator.  Each action digest $d_i =
+\text{Poseidon}_\texttt{Tachyon-ActionDg}(\mathsf{cv}_i \,\|\, \mathsf{rk}_i)$
+is computable from public action data, so the reconstruction is cheap ($O(n)$
+polynomial arithmetic plus one Pedersen commitment) and needs no proof
+verification. A match confirms the candidate set is exactly the aggregate's
+cover; a mismatch is fail-fast, signalling a missing or extra autonome, or a
+match against the wrong aggregate. Coverage is taken over the action-digest set,
+one digest per action, not over tachygrams, whose count differs from the action
+count because a spend publishes two tachygrams.
 
 ### Step 7: Private miner aggregation (optional)
 
@@ -371,15 +289,30 @@ algorithm is specified there, not in this ZIP.
 
 ### Step 9: Block proposal
 
-The miner proposes the block containing:
+The miner proposes a block. Aggregation is not required: a block MAY contain no aggregates
+at all, including stamped autonomes directly. A block MAY contain, in any combination:
 
-- one or more top-level unstripped aggregates;
-- for each transaction covered by an aggregate, an adjunct carrying the action data,
-  action signatures, binding signature, `value_balance`, and the covering `wtxid`;
+- zero or more top-level unstripped stamped bundles (autonomes included directly, and/or
+  aggregates);
+- for each transaction covered by an aggregate in the block, an adjunct carrying the
+  action data, action signatures, binding signature, `value_balance`, and the covering
+  `wtxid`;
 - any non-Tachyon transactions; and
 - the coinbase transaction, which MAY itself be a based aggregate.
 
+A block need not aggregate anything, but every aggregate it does contain MUST be fully
+backed by its covered transactions in the same block (Step 10): a miner cannot include an
+aggregate whose covered transactions are not all present, as adjuncts or as the aggregate's
+own based actions.
+
 ### Step 10: Block validation
+
+A block is validated bundle by bundle. The conditions below are written for a covering
+aggregate and the adjuncts it covers; a stamped autonome included directly is the
+degenerate case, validated by the same conditions over its own actions, with item 1
+(adjunct resolution) vacuous because it has no adjuncts. Every stripped bundle (adjunct)
+MUST be covered by an aggregate in the same block. Aggregation is not required: a block MAY
+contain only autonomes, or no Tachyon bundles at all.
 
 Nodes MUST reject a block containing Tachyon bundles unless, for every covering aggregate
 in the block, all of the following hold:
@@ -387,11 +320,17 @@ in the block, all of the following hold:
 1. **Adjunct resolution.** Every adjunct whose `tachyonAggregateId` refers to that
    aggregate is present in the same block, and the aggregate is top-level, unstripped,
    and not further aggregated in that block.
-2. **Action-set reconstruction.** Consensus reconstructs $\mathsf{action\_acc}$ from the
-   visible actions: the multiset union of the action-digest sets of all adjuncts covered
-   by the aggregate and the based aggregate's own action-digest set (empty for an innocent
-   aggregate). The reconstructed commitment is the header value used in item 4; the stamp's
-   carried `cActionsTachyon` is an assistive fail-fast indicator, not the binding.
+2. **Action-set reconstruction.** Consensus assembles the action digests of the actions
+   actually present in the block: those of every adjunct covered by the aggregate together
+   with the aggregate's own actions (none for an innocent aggregate). It then commits to the
+   polynomial $\prod_i (X - d_i)$ over that reconstructed collection of digests to obtain
+   $\mathsf{action\_acc}$. This freshly reconstructed commitment, never the carried
+   `cActionsTachyon`, is the header value used in item 4; the carried field is only the
+   assistive fail-fast indicator of Step 6. Reconstructing from the block's own actions is
+   what binds the proof to the effecting data the block actually carries: if any transaction
+   the aggregate covers is absent from the block, the reconstructed $\mathsf{action\_acc}$
+   cannot match the proof and the block is rejected, so an aggregate must be fully backed by
+   its covered transactions in the same block.
 3. **Tachygram-set binding.** The aggregate stamp publishes the merged tachygram set
    (`vTachygrams`); adjuncts carry no tachygrams of their own. The Ragu PCD proof binds
    the tachygram-set commitment to the action-set commitment reconstructed in item 2, so
@@ -430,9 +369,7 @@ consensus checks above. This split is by design.
 
 A reference implementation of the Tachyon aggregator protocol (the bundle state machine,
 stamp merging, stripping, and the `cActionsTachyon` coverage check) is in the
-`zcash_tachyon` crate under [`crates/tachyon/src/`](../../crates/tachyon/src/). It uses
-`mock_ragu`, a permissive stand-in for real Ragu; the protocol semantics specified above
-describe the intended real-Ragu behaviour.
+`zcash_tachyon` crate under [`crates/tachyon/src/`](../../crates/tachyon/src/).
 
 ## Rationale
 
@@ -448,6 +385,12 @@ based aggregate's own tachygrams are indistinguishable from its covered autonome
 `cActionsTachyon` indicator gives observers a fail-fast completeness check over the
 action-digest set, reusing the commitment the proof already attests to rather than adding
 a signed coverage manifest or a tachygram-origin query protocol.
+
+**Aggregate limits.** Two hard limits bound an aggregate. Its tachygram vector is committed
+as a ragu polynomial, so it cannot exceed the maximum ragu polynomial size; and the
+aggregate transaction, like any transaction, is bounded by block size. Construction is also
+shaped by parallelism: a single merge is sequential, since each `MergeStamp` consumes the
+previous result, but independent aggregates can be built in parallel.
 
 **`wtxid`, not `txid`, for adjunct references.** A `txid` would be ambiguous across
 the autonome/aggregate forms (they share effecting data). The `wtxid` pins a specific
@@ -481,11 +424,15 @@ validators reconstruct the aggregate header from this public data. An aggregate 
 alone is insufficient: the covered effecting data is present in the block as adjuncts,
 and Step 10 rejects any block where it is not.
 
-**`cActionsTachyon` is an indicator, not a binding.** The action set is bound by the
-proof, whose header consensus reconstructs from the visible actions; the carried indicator
-only lets observers identify coverage cheaply, and a wrong value harms only its author. The
-indicator is reconstructable from visible actions, so it reveals nothing the actions do
-not, and for a based aggregate it does not expose which actions are the aggregator's own.
+**`cActionsTachyon` is an indicator, not a binding.** The action set is bound by the proof.
+To verify, consensus commits afresh to the action digests of the actions present in the
+block and uses that reconstructed $\mathsf{action\_acc}$ as the proof header; it never
+builds the header from the carried `cActionsTachyon`. Reconstructing from the block's
+actual actions is what ties the proof to the adjuncts the block carries, not to a value the
+prover supplies. The carried indicator only lets observers identify coverage cheaply
+(Step 6), and a wrong value harms only its author; it is reconstructable from visible
+actions, so it reveals nothing the actions do not, and for a based aggregate it does not
+expose which actions are the aggregator's own.
 
 **Privacy of aggregation relationships.** An observer who sees an aggregate in the
 mempool can identify covered autonomes by the `cActionsTachyon` check (Step 6). This
@@ -503,11 +450,9 @@ the proof alone establishes these properties.
 
 - [ZIP 0: ZIP Process](https://zips.z.cash/zip-0000)
 - [ZIP 200: Network Upgrade Mechanism](https://zips.z.cash/zip-0200)
-- [ZIP 221: FlyClient - Consensus Layer Changes](https://zips.z.cash/zip-0221)
 - [ZIP 225: Version 5 Transaction Format](https://zips.z.cash/zip-0225)
 - [ZIP 239: Relay of Version 5 Transactions](https://zips.z.cash/zip-0239)
 - [ZIP 244: Transaction Identifier Non-Malleability](https://zips.z.cash/zip-0244)
-- [ZIP 248: Extensible Transaction Format](https://zips.z.cash/zip-0248)
 - [ZIP 252: Deployment of the NU5 Network Upgrade](https://zips.z.cash/zip-0252)
 - [ZIP 317: Proportional Transfer Fee Mechanism](https://zips.z.cash/zip-0317)
 - [BIP 339: WTXID-based transaction relay](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki)

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -6,6 +6,536 @@
 
 ## I. Dependencies
 
+- [Tachyon Shielded Protocol (#103)](https://github.com/tachyon-zcash/tachyon/issues/103)
+  defines the Tachyon pool, tachyactions, tachygrams, and the per-action authorization
+  layer that aggregation preserves.
+- [Tachyon Bundle / Aggregate Transaction Format (#104)](https://github.com/tachyon-zcash/tachyon/issues/104)
+  defines the stamped and stripped bundle wire encodings, the `tachyonBundleState` byte,
+  the `tachyonAggregateId` trailer, and the serialization of the `ActionSetCommit` field
+  on the stamp that this ZIP relies on for covered-transaction identification.
+- [Tachyon Accumulator / Hash Chain (#105)](https://github.com/tachyon-zcash/tachyon/issues/105)
+  defines the anchor (Poseidon hash-chain state), the per-block anchor sequence, and the
+  consensus anchor-membership rule that aggregation depends on for spend validity.
+- [ZIP 239](https://zips.z.cash/zip-0239) defines `MSG_WTX`-based transaction relay by
+  `wtxid = txid || auth_digest`. This ZIP extends its rationale to Tachyon's
+  authorization-form malleability.
+- [ZIP 244](https://zips.z.cash/zip-0244) defines the `txid_digest` and `auth_digest`
+  trees. A Tachyon amendment to ZIP 244 (tracked separately) fixes the
+  `"ZTxAuthTachyHash"` personalization and the Tachyon digest branches; this ZIP does
+  not re-specify that algorithm.
+- [ZIP 248](https://zips.z.cash/zip-0248) (extensible transaction format) is required
+  for registering the Tachyon bundle type on the v5 transaction format.
+
 ## II. Design Considerations
 
+### Aggregation as a network role
+
+Tachyon seeks to reduce chain costs by recursively merging per-transaction Ragu PCD
+stamps into a single aggregate proof that covers many transactions. The act of merging
+proofs is **aggregation**, and **aggregators** are the nodes that perform it. Miners
+are likely to vertically integrate aggregation, but the protocol must also work for
+third-party aggregators that publish aggregates to the mempool. See
+[Network Roles](../network_roles/overview.md) and [Aggregation](../aggregation.md).
+
+### The 10-step lifecycle
+
+The Specification is organised around the following lifecycle, distilled in
+[Aggregation](../aggregation.md):
+
+1. Autonome transactions are published to the mempool.
+2. Aggregators observe transactions in the mempool.
+3. Aggregators produce their own transactions with merged stamps.
+4. Aggregators publish their own transactions to the mempool, and do not re-publish the
+   autonomes they covered.
+5. Miners see transactions in the mempool.
+6. Miners identify the aggregate/autonome relationship by action-set commitment
+   (`ActionSetCommit`) overlap.
+7. Miners may perform their own aggregation privately, without publishing to the
+   mempool.
+8. Miners compose their block at will, stripping stamps and assigning the covering
+   aggregate `wtxid` to each adjunct.
+9. The miner proposes a block.
+10. Block validation only passes if the appropriate adjuncts are included and properly
+    assigned aggregate ids, enabling header reconstruction and verification.
+
+### Based-aggregate tachygram attribution (resolved)
+
+A **based aggregate** carries its own tachyactions in addition to a merged stamp
+covering other transactions. Its stamp tachygram set is the union of (covered
+autonomes' tachygrams) ∪ (the based aggregate's own tachygrams). Tachygrams are opaque
+32-byte field elements with no in-protocol label distinguishing "covered" from "own",
+and each tachyaction is bound to one tachygram but does not contain it
+([Bundles](../bundle.md)). Without a coverage mechanism, an observer with an incomplete
+mempool view cannot partition the published tachygram set and cannot confirm they hold
+every autonomic that must become an adjunct.
+
+**Resolution.** The stamp serializes the `ActionSetCommit` — the Pedersen commitment to
+the action-digest-set polynomial that is already a PCD header field
+(`StampHeader::Data = (ActionSetCommit, TachygramSetCommit, Anchor)`). An observer
+computes `commit(P_own · ∏ P_autonome_i)` from the based aggregate's visible actions
+and candidate autonomes' visible actions, and compares against the published
+`ActionSetCommit`. Match confirms the observer holds the complete covered set; mismatch
+is fail-fast. This is O(n) polynomial arithmetic plus one Pedersen commitment, and does
+not require proof verification.
+
+The field strips when the stamp strips (adjuncts carry `stampWtxid` instead), so the
+covering aggregate (top-level, unstripped) retains it. Soundness is preserved:
+`ActionSetCommit` is already a public PCD header field bound by the proof; publishing
+it adds no new claim. The trailing-zeros caveat (commit-equality bounds polynomial rank
+from above, not below) does not bite in practice because `ActionDigest::new` rejects
+identity `cv`/`rk`, so the root polynomial `∏(X − d_i)` has no trailing zeros. No new
+information is leaked: the commitment is already reconstructable from visible actions
+for any self-contained bundle; for a based aggregate, the factored polynomial (which
+roots are "own" vs "covered") is not recoverable from the commitment alone.
+
+The encoding of `ActionSetCommit` on the stamp wire format is specified by the Tachyon
+Bundle / Aggregate Transaction Format ZIP (#104).
+
+### Open questions
+
+The following remain unresolved at Draft and are not normatively specified below:
+
+- **Aggregate limits.** Fan-in, recursion depth, proof size, tachygram vector size,
+  action count, and per-block aggregate count. Aggregate size is commitment-size-limited
+  before block-size-limited (on the order of thousands of actions); exact limits TBD.
+- **Anchor publication and membership.** Specified by the accumulator/anchor ZIP (#105);
+  this draft states the dependency.
+- **Fee accounting (ZIP 317).** `contribution_Tachyon` must account for logical work
+  split between adjuncts (actions) and aggregates (proofs); under discussion.
+- **Value-pool balance (ZIP 209).** `valueBalanceTachyon` turnstile integration; under
+  discussion.
+- **Block commitments (ZIP 221).** How Tachyon's end-of-block anchor enters the MMR
+  leaf; under discussion.
+- **Bundle serialization registration (ZIP 248).** Pending ZIP-248 editor consensus.
+- **P2P aggregation gossip.** Secondary objective; selection criteria (covered-
+  transaction set, size, anchor alignment) remain an open policy question. Single-
+  aggregate merge is not parallelizable, but multiple aggregates can be built in
+  parallel.
+- **`mock_ragu` vs real Ragu.** The normative text below describes the intended real
+  Ragu PCD semantics. The current Tachyon implementation uses a permissive mock; a green
+  test suite against the mock is not soundness.
+
 ## III. ZIP Draft
+
+```
+ZIP: <to be assigned by ZIP Editors>
+Title: Tachyon Aggregator Protocol
+Owners: <Tachyon team>
+Status: Draft
+Category: Network
+Created: 2026-06-26
+License: MIT
+Discussions-To: <https://github.com/tachyon-zcash/tachyon/issues/106>
+```
+
+## Terminology
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "RECOMMENDED" in
+this document are to be interpreted as described in BCP 14 when, and only when, they
+appear in all capitals.
+
+The term "network upgrade" is to be interpreted as described in
+[ZIP 200](https://zips.z.cash/zip-0200). The terms "Testnet" and "Mainnet" are to be
+interpreted as described in section 3.12 of the Zcash Protocol Specification.
+
+- **Tachygram.** A 32-byte field element representing either a note nullifier or a note
+  commitment. Consensus treats nullifiers and commitments identically; one accumulator
+  handles both. See [Tachygrams](../tachygrams.md).
+- **Tachyaction.** An indistinguishable representation of either the creation or
+  destruction of a note. Contains `cv`, `rk`, and `sig`; is cryptographically bound to
+  one tachygram but does not contain it. See [Bundles](../bundle.md).
+- **Stamp.** The recursive Ragu PCD proof data carried by a stamped bundle: `anchor`,
+  `tachygrams`, `proof`, and `ActionSetCommit`. The proof establishes that the
+  tachyactions follow the correct rules and that the published tachygrams and action
+  digests correspond to those actions.
+- **Autonome.** A stamped bundle produced by a wallet, carrying a complete proof with
+  all inputs. The standard form of a user-originated Tachyon transaction.
+- **Aggregate.** A stamped bundle produced by an aggregator, carrying a merged stamp
+  that covers multiple bundles. An *innocent* aggregate contains no Tachyon actions of
+  its own; a *based* aggregate carries its own Tachyon actions in addition to the merged
+  stamp.
+- **Adjunct.** A stripped bundle whose stamp has been removed and replaced by a
+  reference to the covering aggregate's `wtxid`. Adjuncts retain action data, action
+  signatures, the binding signature, and `value_balance`.
+- **`ActionSetCommit`.** A Pedersen commitment to the action-digest-set polynomial
+  `∏_i (X − d_i)`, where `d_i = Poseidon(cv_i || rk_i)`. Already a PCD header field;
+  serialized on the stamp wire format per the bundle-format ZIP (#104).
+- **`stampWtxid`.** The 64-byte `wtxid` of the covering aggregate, carried by an adjunct
+  in place of its stripped stamp.
+- **`txid`.** The transaction identifier, committing only to effecting data. For a
+  Tachyon bundle, the `txid` contribution is `action_acc || value_balance`. Stable
+  across stamping, merging, and stripping.
+- **`auth_digest`.** The authorizing-data commitment. For a Tachyon bundle, commits to
+  action signatures, the binding signature, and the stamp trailer. Each physical
+  authorization form yields a distinct `auth_digest`.
+- **`wtxid`.** The 64-byte witnessed transaction identifier `txid || auth_digest`. The
+  unit of physical relay per [ZIP 239](https://zips.z.cash/zip-0239).
+
+## Abstract
+
+Tachyon shielded transactions carry recursive Ragu PCD stamps whose verification cost
+is substantial. Verifying each transaction's stamp independently at consensus would
+dominate block-validation cost. This ZIP specifies the Tachyon aggregator protocol: a
+network role that merges stamps from multiple stamped transactions into a single
+aggregate stamp, and a block-layout discipline under which miners strip the now-
+redundant per-transaction stamps and replace them with a reference to the covering
+aggregate. The same effecting data — tachyactions, value balances, action signatures,
+and binding signatures — remains independently verifiable; only the proof bytes are
+deduplicated. The ZIP defines the 10-step aggregation lifecycle from autonome
+publication through block validation, the transaction-identifier semantics that make
+stripping safe, the P2P relay rules that extend ZIP 239 to Tachyon's authorization-form
+malleability, and a fail-fast covered-transaction identification mechanism based on the
+`ActionSetCommit` field carried on the stamp. Aggregation introduces a new network
+participant but no new trust assumption: every invariant is enforced either inside the
+Ragu PCD or by consensus checks on public data.
+
+## Motivation
+
+Without aggregation, every Tachyon transaction in a block carries its own Ragu PCD
+stamp, and validators must verify each stamp independently. Stamp verification is the
+dominant per-transaction cost; at scale this limits throughput and raises the barrier
+to running a validating node.
+
+Ragu PCD stamps are recursively composable: two stamps at a common anchor can be merged
+into a single stamp that attests to the union of the two action-digest and tachygram
+sets. This composition is what aggregation exploits. An aggregator merges stamps off-
+chain and publishes a single aggregate transaction carrying the merged stamp; miners
+strip the redundant per-transaction stamps at block-assembly time, leaving each covered
+transaction as an adjunct that carries its effecting data plus a reference to the
+covering aggregate.
+
+The result is that a block containing N Tachyon transactions need only verify a small
+number of aggregate stamps rather than N independent proofs, while still allowing every
+action, signature, and value balance to be independently checked. This ZIP specifies
+the network behaviour, the block-layout rules, and the identification mechanism that
+makes the scheme work without a trusted aggregator.
+
+## Requirements
+
+- Reduce per-block stamp-verification cost by allowing multiple transactions' stamps to
+  be merged into one aggregate stamp.
+- Preserve independent verifiability of every transaction's effecting data: action
+  digests, value balances, action signatures, and binding signatures MUST remain
+  checkable without trusting the aggregator.
+- Preserve transaction-identifier stability: a transaction's `txid` MUST be invariant
+  across stamping, merging, and stripping.
+- Allow any participant (miner or third-party) to act as aggregator; no protocol-level
+  exclusivity or claim on autonomes.
+- Enable a validating observer or miner to confirm, cheaply and fail-fast, that they
+  hold every autonomic covered by an aggregate before assembling or validating a block.
+- Introduce no new trust assumption: every invariant MUST be enforced either inside the
+  Ragu PCD or by consensus checks on public data.
+
+## Specification
+
+The specification is organised around the 10-step aggregation lifecycle. Each step is
+a subsection with conformance language. Transaction-identifier semantics and P2P relay
+rules are folded into the relevant steps rather than specified as parallel sections.
+
+### Step 1: Publication of autonomes
+
+Wallets construct stamped bundles — **autonomes** — and broadcast them to the mempool
+via the existing wallet RPC or P2P path. An autonomic is a standard stamped transaction
+with a complete Ragu PCD proof, a serialized `ActionSetCommit`, and a distinct `wtxid`.
+Autonomes are announced and relayed by `wtxid` per step 5.
+
+### Step 2: Aggregator mempool observation
+
+Aggregators observe stamped transactions in mempool gossip. An aggregator MAY select
+any subset of autonomes (and existing aggregates) for merging. There is no protocol-
+level exclusivity or claim on autonomes: multiple aggregators MAY attempt to cover the
+same autonomic, and a miner MAY prefer one aggregate over another at block-assembly
+time.
+
+### Step 3: Aggregate construction
+
+Aggregators merge stamps as follows:
+
+1. Deserialize and validate each input stamp, including its `ActionSetCommit` against
+   the input's visible actions.
+2. Align anchors: each input stamp is lifted to a common later anchor using `StampLift`
+   over an `AnchorChain` segment whose `start` equals the stamp's current anchor. The
+   merged stamp's anchor is the segment `end`.
+3. Merge the stamps with `MergeStamp`, which constrains `left.anchor == right.anchor`,
+   binds the witnessed input action-digest and tachygram polynomials to the input
+   header commitments, and proves the merged polynomials are the products of the input
+   polynomials (multiset union by polynomial product).
+4. Serialize and compress the merged stamp. The merged stamp carries the merged
+   `ActionSetCommit = commit(P_left · P_right)`.
+
+The aggregator constructs a new stamped transaction carrying the merged stamp. For a
+**based** aggregate the transaction also carries the aggregator's own tachyactions; for
+an **innocent** aggregate it carries no Tachyon actions.
+
+### Step 4: Aggregate publication
+
+Aggregators publish the aggregate transaction to the mempool. Aggregators MUST NOT
+re-publish the covered autonomes; the autonome remains in the mempool independently and
+the aggregate is published alongside it. The aggregate is a new `wtxid` distinct from
+each covered autonomic's `wtxid`, because its `auth_digest` commits to a different
+stamp trailer (the merged stamp) even though the covered effecting data is recoverable
+from the aggregate's action-digest and tachygram sets.
+
+### Step 5: Miner mempool observation and P2P relay
+
+Miners see both autonomes and aggregates in the mempool. A miner MAY also vertically
+integrate aggregation and produce its own aggregates privately without publishing them
+to the mempool (step 7).
+
+P2P relay for Tachyon bundles follows [ZIP 239](https://zips.z.cash/zip-0239):
+transactions are announced and fetched by `wtxid` using the `MSG_WTX` inv type. An
+autonomic, an aggregate, and an adjunct carrying the same effecting data are three
+distinct `wtxid`s and MUST be treated as distinct inventory objects.
+
+`MSG_WTX`-style relay is mandatory for Tachyon bundles. Announcing by `txid` alone
+would let a third party broadcast a covered autonomic with the same `txid` as an
+aggregate and interfere with relay of the aggregate form — exactly the failure mode
+ZIP 239 was written to prevent for v5 witness malleability, extended here to Tachyon's
+authorization-form malleability (stamping, merging, and stripping all change `wtxid`
+while leaving `txid` unchanged).
+
+Because `txid` is stable across the aggregation lifecycle (it commits only to
+`action_acc || value_balance`), a wallet's submitted transaction remains identifiable
+in the mempool even after an aggregator republishes a covering aggregate. Relay policy
+MAY de-duplicate on `txid` to avoid redundant propagation of covered autonomes once a
+covering aggregate is present.
+
+Adjuncts are block-local. A standalone adjunct whose `stampWtxid` is not present in the
+mempool or block MUST NOT be relayed as an independent transaction; adjuncts only
+appear inside blocks alongside their covering aggregate. Stripping is a miner-side
+block-assembly action (step 8), not a relay-time transformation: the P2P network
+carries stamped bundles (autonomes and aggregates) only.
+
+### Step 6: Covered-transaction identification by `ActionSetCommit`
+
+Miners (and validating observers) identify the aggregate/autonome relationship using
+the `ActionSetCommit` field serialized on each stamp.
+
+The aggregate's stamp publishes `ActionSetCommit = commit(P_aggregate)`, where
+`P_aggregate = ∏_i (X − d_i)` over the action digests of every action covered by the
+aggregate (both the based aggregate's own actions and all covered autonomes' actions).
+Each `d_i = Poseidon(cv_i || rk_i)` is computable from public action data.
+
+An observer who has seen a candidate set of autonomes confirms coverage as follows:
+
+1. For a based aggregate, compute `P_own = ∏ (X − d_j)` from the aggregate's own
+   visible actions. For an innocent aggregate, `P_own` is the empty product (1).
+2. For each candidate autonomic, compute `P_autonome_k = ∏ (X − d_l)` from its visible
+   actions.
+3. Compute `P_observed = P_own · ∏_k P_autonome_k`.
+4. Compute `commit(P_observed)` and compare to the aggregate's published
+   `ActionSetCommit`.
+
+Match confirms the observer holds the complete covered set. Mismatch is fail-fast: the
+observer is missing a covered autonomic, has an extra one, or is matching against the
+wrong aggregate. The check is O(n) polynomial arithmetic plus one Pedersen commitment;
+it does not require Ragu proof verification.
+
+This resolves the based-aggregate attribution problem (see _Based-aggregate tachygram
+attribution (resolved)_ in section II) without a comprehensive-index assumption or a
+tachygram-origin query protocol. The cardinality of the covered set is known
+(|covered| = |stamp tachygrams| − |based actions|, since one tachygram is bound per
+action), which constrains the search, but the commitment check is what confirms it.
+
+### Step 7: Private miner aggregation (optional)
+
+Miners MAY perform their own aggregation privately during block assembly, without
+publishing the aggregate to the mempool. The resulting aggregate is included directly
+in the miner's proposed block. The same `MergeStamp` and anchor-alignment rules apply;
+the only difference is that the aggregate is never gossiped.
+
+### Step 8: Block composition and adjunct assignment
+
+Miners compose the block at will. For each covered transaction the miner includes, the
+miner strips the stamp and assigns the covering aggregate's `wtxid` as the adjunct's
+`tachyonAggregateId` (the 64-byte `stampWtxid` trailer). The covering aggregate MUST be
+included top-level in the same block, never stripped and never further aggregated in
+that block, so the `wtxid` referenced by adjuncts is stable and resolvable by
+validators in a single pass.
+
+Stripped innocents (aggregates with no Tachyon actions) MAY carry a zero `wtxid` if no
+absorbing aggregate was recorded; this is the only case where a zero
+`tachyonAggregateId` is valid. Consensus rejects a stripped bundle with non-empty
+actions and a zero `tachyonAggregateId`.
+
+Transaction-identifier semantics under stripping:
+
+- `txid` commits only to effecting data (`action_acc || value_balance`) and is stable
+  across stamping, merging, stripping, and re-stamping. A transaction's logical
+  identity is invariant across the aggregation lifecycle.
+- `auth_digest` commits to action signatures, the binding signature, and the bundle's
+  stamp trailer. A stamped bundle's trailer is the full stamp (anchor,
+  `ActionSetCommit`, tachygrams, proof); a stripped bundle's trailer is the 64-byte
+  `stampWtxid` of the covering aggregate. Each physical authorization form yields a
+  distinct `auth_digest` and therefore a distinct `wtxid = txid || auth_digest`.
+- The covering-aggregate reference carried by an adjunct is a `wtxid`, not a `txid`,
+  because the `wtxid` pins a specific physical aggregate (authorization + stamp state).
+  A `txid` would be ambiguous across the autonome/aggregate forms.
+- The wire byte `tachyonBundleState` distinguishes forms: `0x01` stamped, `0x02`
+  stripped. Innocents and adjuncts share the stripped layout; both end in a 64-byte
+  `tachyonAggregateId`.
+
+The `"ZTxAuthTachyHash"` personalization used in the Tachyon `auth_digest` contribution
+is a placeholder pending a Tachyon amendment to ZIP 244; the normative digest
+algorithm is specified there, not in this ZIP.
+
+### Step 9: Block proposal
+
+The miner proposes the block containing:
+
+- one or more top-level unstripped aggregates;
+- for each transaction covered by an aggregate, an adjunct carrying the action data,
+  action signatures, binding signature, `value_balance`, and the covering `wtxid`;
+- any non-Tachyon transactions; and
+- the coinbase transaction, which MAY itself be a based aggregate.
+
+### Step 10: Block validation
+
+A block containing Tachyon bundles is valid only if, for every covering aggregate in
+the block:
+
+1. **Adjunct resolution.** Every adjunct whose `tachyonAggregateId` refers to that
+   aggregate is present in the same block, and the aggregate is top-level, unstripped,
+   and not further aggregated in that block.
+2. **Action-set reconstruction.** The union of action-digest sets across all adjuncts
+   covered by the aggregate, combined with the based aggregate's own action-digest set
+   (empty for an innocent aggregate), matches the aggregate stamp's `ActionSetCommit`.
+   Consensus reconstructs the commitment from visible actions and checks it for
+   consistency; the serialized `ActionSetCommit` on the stamp is advisory for this
+   check (a mismatch between the serialized commitment and the reconstructed one is
+   itself a consensus error).
+3. **Tachygram-set reconstruction.** The union of tachygrams across all adjuncts
+   covered by the aggregate matches the aggregate stamp's tachygram set.
+4. **Stamp proof verification.** The reconstructed header
+   `(action_acc, tachygram_acc, anchor)` matches the stamp header, and the Ragu PCD
+   proof verifies against that header.
+5. **Signatures and value balance.** Action signatures and the binding signature
+   verify against the transaction sighash, and the bundle's value commitments are
+   consistent with the declared `value_balance`.
+6. **Anchor membership.** The aggregate's anchor is a member of the published per-
+   block anchor sequence, as specified by the accumulator/anchor ZIP (#105).
+7. **Tachygram uniqueness.** No tachygram published in this block (across all
+   aggregates and adjuncts) duplicates a tachygram published in the current epoch or
+   the immediately preceding epoch, as specified by the tachygram-uniqueness consensus
+   rule.
+
+The above checks split into two layers:
+
+- **Circuit-enforced (Ragu PCD):** spend/output validity, stamp header binding, anchor
+  equality after lifting, and the multiset-product merge relations. The proof attests
+  that the header was produced by a valid execution; the proof will only verify with
+  the correct header.
+- **Consensus-enforced:** canonical anchor membership and end-of-block anchor
+  progression; two-epoch tachygram non-reuse; action and binding signatures; value-
+  balance rules; and adjunct-to-aggregate resolution.
+
+Several security properties (notably spendable-lineage epoch pinning and double-spend
+prevention) are intentionally not fully proven inside the stamp and depend on the
+consensus checks above. This split is by design.
+
+## Reference implementation
+
+A reference implementation of the Tachyon aggregator protocol, including the bundle
+state machine, stamp merging, stripping, and `ActionSetCommit`-based coverage
+identification, is in the `zcash_tachyon` crate under
+[`crates/tachyon/src/`](../../crates/tachyon/src/). The implementation currently uses
+`mock_ragu`, a permissive stand-in for real Ragu; the protocol semantics specified
+above describe the intended real-Ragu behaviour.
+
+## Rationale
+
+**Lifecycle-structured specification.** Organising the Specification around the 10-step
+lifecycle — rather than as parallel sections for P2P, identifiers, block layout, and
+consensus rules — mirrors how participants actually move through the protocol and keeps
+each rule anchored to the step where it applies. This avoids the reader having to
+cross-reference unrelated sections to understand a single participant's obligations.
+
+**`ActionSetCommit` solves based-aggregate attribution.** Tachygram-set overlap alone
+is insufficient for coverage identification when a based aggregate's own tachygrams are
+indistinguishable from covered autonomes' tachygrams. The `ActionSetCommit` field,
+already a PCD header field and already bound by the proof, provides a cheap fail-fast
+check that does not require proof verification, a comprehensive mempool index, or a
+new tachygram-origin query protocol. A based aggregate could alternatively declare
+which tachygrams are its own, but this would not help: the based portion's count is
+already inferable from the visible actions, and the remaining attribution problem is
+unchanged. It would also leak structure about the aggregator's own vs covered activity
+that the actions alone do not reveal.
+
+**No separate coverage manifest.** A coverage manifest (an explicit list of covered
+`wtxid`s signed by the aggregator) was considered and rejected. It would add a new
+authenticated data structure, require a new signature path, and still need to be
+checked against the stamp's action-digest set for soundness. The `ActionSetCommit`
+check reuses an existing PCD header field and an existing reconstruction path.
+
+**`wtxid`, not `txid`, for adjunct references.** A `txid` would be ambiguous across
+the autonome/aggregate forms (they share effecting data). The `wtxid` pins a specific
+physical aggregate including its stamp state, which is what the adjunct needs to
+reference. This is why adjuncts carry `stampWtxid` rather than `stampTxid`.
+
+**Stripping is miner-side, not relay-time.** Stripping at relay time would force every
+relay node to understand aggregate coverage and would mix block-assembly policy with
+gossip. Keeping the P2P network carrying stamped bundles only, and restricting
+adjuncts to blocks, simplifies relay and matches the implementation (a stripped bundle
+is not serializable until its covering `wtxid` is assigned, which happens at block
+assembly).
+
+**MSG_WTX relay is mandatory.** Tachyon's authorization-form malleability is the
+direct analogue of v5 witness malleability that motivated ZIP 239. Announcing by
+`txid` would let a third party broadcast a covered autonomic with the same `txid` as
+an aggregate and interfere with relay of the aggregate form. Requiring `MSG_WTX` for
+Tachyon bundles closes this exactly as ZIP 239 closed it for v5.
+
+## Security and Privacy Implications
+
+**No new trust assumption.** The aggregator is not trusted. Every invariant is
+enforced either inside the Ragu PCD (circuit logic) or by consensus checks on public
+data (consensus logic). A malicious aggregator can publish an invalid aggregate, but
+validators will reject it at step 10. A malicious miner can mis-assign adjuncts or
+omit covered transactions, but the block will fail validation.
+
+**Data availability.** Aggregation removes redundant proof bytes only. Every adjunct
+retains its action data, action signatures, binding signature, and `value_balance`;
+validators reconstruct the aggregate header from this public data. An aggregate proof
+alone is insufficient — the covered effecting data MUST be present in the block as
+adjuncts.
+
+**No new leakage from `ActionSetCommit`.** The commitment is already reconstructable
+from visible actions for any self-contained bundle. For a based aggregate, the
+factored polynomial (which roots are the aggregator's own vs covered) is not
+recoverable from the commitment alone, so publishing it does not reveal which actions
+are the aggregator's own. The trailing-zeros caveat (commit-equality bounds
+polynomial rank from above) does not bite because `ActionDigest::new` rejects identity
+`cv`/`rk`.
+
+**Privacy of aggregation relationships.** An observer who sees an aggregate in the
+mempool can identify covered autonomes by the `ActionSetCommit` check (step 6). This
+is inherent to the scheme: the aggregate must carry enough information for validators
+to reconstruct its header. The tachygram-set and action-digest-set commitments do not
+reveal the private contents of any covered note.
+
+**Circuit/consensus boundary.** Several security properties — notably spendable-
+lineage epoch pinning and double-spend prevention — depend on consensus checks
+(sections 6 and 7 of step 10) rather than being fully proven inside the stamp. This is
+by design and is documented explicitly so that implementers and auditors do not assume
+the proof alone establishes these properties.
+
+## References
+
+- [ZIP 0: ZIP Process](https://zips.z.cash/zip-0000)
+- [ZIP 200: Network Upgrade Mechanism](https://zips.z.cash/zip-0200)
+- [ZIP 221: FlyClient - Consensus Layer Changes](https://zips.z.cash/zip-0221)
+- [ZIP 225: Version 5 Transaction Format](https://zips.z.cash/zip-0225)
+- [ZIP 239: Relay of Version 5 Transactions](https://zips.z.cash/zip-0239)
+- [ZIP 244: Transaction Identifier Non-Malleability](https://zips.z.cash/zip-0244)
+- [ZIP 248: Extensible Transaction Format](https://zips.z.cash/zip-0248)
+- [ZIP 252: Deployment of the NU5 Network Upgrade](https://zips.z.cash/zip-0252)
+- [ZIP 317: Proportional Transfer Fee Mechanism](https://zips.z.cash/zip-0317)
+- [BIP 339: WTXID-based transaction relay](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki)
+- [Tachyon book: Aggregation](../aggregation.md)
+- [Tachyon book: Bundles](../bundle.md)
+- [Tachyon book: Proof Tree](../proof-tree.md)
+- [Tachyon book: Tachygrams](../tachygrams.md)
+- [Tachyon book: Anchor](../anchor.md)
+- [Tachyon book: Authorization](../authorization.md)
+- [Tachyon book: Transaction Identifiers](../transaction-identifiers.md)
+- [Tachyon book: Network Roles](../network_roles/overview.md)

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -49,6 +49,14 @@ Open questions:
   aggregators index mempool data and do not attempt merges they cannot satisfy from data
   they hold. Alternatives: a relay message requesting transactions by tachygram, or
   aggregates carrying a list of contributing transactions. Undecided.
+- **Cross-epoch lifting.** A stamp lift never crosses an epoch boundary, because
+  a spend's published nullifiers are fixed relative to its anchor's epoch.
+  Supporting them may be possible, but would change fundamental parts of the
+  specification.
+- **Unequal-anchor merge.** Merging is defined only over identical anchors.
+  Candidate relaxations: the aggregator commits to an anchor sequence covering
+  the contributors, or to a multiset of contributing anchors later verifiable as
+  members of a continuous valid sequence. Either is a significant refactor.
 - **Stripped zero-action coverage.** A stripped bundle with no actions names a covering
   aggregate that consensus does not confirm; candidate confirmation rules are an open
   question of the
@@ -198,6 +206,12 @@ Merging is defined only over stamps bearing identical anchors. If the selected
 transactions bear unequal anchors, the aggregator first aligns them by lifting
 the older anchor to the newer with a lift PCD that proves the anchor sequence
 between them.
+
+Lifting is confined to the anchor's epoch. A stamp's proof fixes each spend's
+published nullifiers relative to the epoch of its anchor (see the
+[Tachyon statement](tachyon-shielded-protocol.md#tachyon-statement)), so a
+lift never crosses an epoch boundary, and stamps bearing anchors of different
+epochs cannot be aligned for merging.
 
 If both selected transactions are autonomes, all necessary witness data is
 directly available on the transactions themselves.

--- a/book/src/zips/tachyon-aggregator.md
+++ b/book/src/zips/tachyon-aggregator.md
@@ -76,6 +76,10 @@ Stamp
 :   The final section of a bundle.
     Either a proof stamp, carrying a Ragu proof and some supporting data, or a pointer stamp, carrying a `wtxid` reference to a transaction with a proof.
 
+Aggregator
+:   A participant that merges two stamps into one covering stamp and publishes the result.
+    The role is permissionless and carries no protocol-level exclusivity.
+
 *Autonome*
 :   A stand-alone transaction whose bundle bears an independent proof stamp covering only its own actions (an *autonome* bundle).
     The standard form of a user-originated Tachyon transaction.
@@ -201,7 +205,7 @@ Its `tachyonAggregateId` MUST identify a proof-stamped transaction in the same b
 ### Step 8: Block validation
 
 Block validation closes the aggregation lifecycle: a validator confirms that every proof stamp in a block is backed by the transactions it covers and that every proof holds.
-The normative consensus rules for this are specified in the [block-validity section of the Tachyon Bundle / Aggregate Transaction Format ZIP](tachyon-bundle.md#block-validity); this step describes only how those rules fit the lifecycle.
+The normative consensus rules for this are specified by [Block validity](tachyon-bundle.md#block-validity) in the Tachyon Bundle / Aggregate Transaction Format ZIP; this step describes only how those rules fit the lifecycle.
 
 Validation covers tachygram distinctness across the block, association of each *adjunct* with the *aggregate* covering it, confirmation of each stamp's covered-actions digest against the actions actually present in the block, and verification of every proof.
 Reuse of a tachygram across the wider epoch window is a separate consensus concern owned by the [Tachyon Accumulator / Hash Chain ZIP](tachyon-accumulator.md#epoch-window).
@@ -246,7 +250,8 @@ The check is a scan of the public list, requiring no proof verification.
 
 A node MUST verify a bundle's proof stamp before accepting the transaction into its mempool or relaying it.
 This paragraph specifies only the Tachyon-proof-specific requirement; mempool acceptance also requires the standard checks (action and binding signature verification, balance rules, and general transaction validity).
-The proof check needs the covered actions: the node assembles the proof header — `cStampActionsTachyon` over the covered actions' digests, the stamp's `anchorTachyon`, and `cTachygrams` — and verifies the proof against that header.
+The proof check needs the covered actions.
+The node assembles the proof header from `cStampActionsTachyon` over the covered actions' digests, the stamp's `anchorTachyon`, and `cTachygrams`, then verifies the proof against that header.
 An *autonome* is self-contained, since its stamp covers only its own actions.
 For an *aggregate* covering other transactions, the node collects the covered actions from the mempool transactions it holds and checks that set against the carried `hStampActionsTachyon` (see [Covered-transaction identification](#covered-transaction-identification)) before assembling the header.
 Without the covered actions, the *aggregate* cannot be verified.
@@ -288,19 +293,20 @@ The two concerns that several steps share, transaction-identifier and relay sema
 
 ### Overlapping merges self-invalidate
 
-The disjoint-selection guidance of Step 2 is a SHOULD rather than a consensus rule because a violation cannot survive: merging stamps whose tachygram sets overlap produces a stamp bearing duplicate tachygrams, which no node accepts into its mempool and no valid block can contain (see [block validity](tachyon-bundle.md#block-validity)).
-The deeper reason is that the merge is homomorphic over the stamps' multiset commitments, so the overlapping stamp commits to multiply-counted multiset members that no reconstruction over a block's distinct transactions can reproduce.
+The disjoint-selection guidance of Step 2 is a SHOULD rather than a consensus rule because a violation cannot survive.
+The merge proves the merged multiset polynomial to be the product of its two inputs', so an overlapping tachygram appears as a repeated root and the merged stamp commits to it twice.
+The wire format admits only distinct tachygrams in canonical order, so no publishable `vTachygrams` reconstructs that commitment, and the *aggregate* has no serialization that both parses and verifies against its own proof (see [Block validity](tachyon-bundle.md#block-validity)).
 The aggregator's proving work is simply wasted, so the selection rule needs no enforcement of its own.
 
 ### Aggregate limits
 
 Two hard limits bound an *aggregate*.
-Its tachygram vector is committed as a Ragu polynomial, so it cannot exceed the maximum Ragu polynomial size; and the *aggregate* transaction, like any transaction, is bounded by block size.
+Its tachygram vector is committed as a Ragu polynomial, one generator per coefficient, so it cannot exceed the generator count the proof system fixes; and the *aggregate* transaction, like any transaction, is bounded by block size.
 Construction is also shaped by parallelism: a chain of merges is sequential, since each merge consumes the previous result, but independent *aggregates* can be built in parallel.
 
 ### Verified relay
 
-Requiring proof verification before relay is standard mempool hygiene, and aggregation sharpens it: an invalid stamp is a dead end, since a merge cannot produce a valid *aggregate* from an invalid input and no valid block can carry an unverifiable proof (see [block validity](tachyon-bundle.md#block-validity)).
+Requiring proof verification before relay is standard mempool hygiene, and aggregation sharpens it: an invalid stamp is a dead end, since a merge cannot produce a valid *aggregate* from an invalid input and no valid block can carry an unverifiable proof (see [Block validity](tachyon-bundle.md#block-validity)).
 Aggregators would therefore hit every invalid proof themselves at the merge; verifying at relay pushes that discovery to the network edge rather than spending bandwidth propagating transactions no aggregator can use and no block can include.
 
 ### Stripping is miner-side, not relay-time
@@ -320,19 +326,19 @@ This subsection is non-normative.
 
 The aggregator is not trusted.
 Every invariant is enforced either inside the Ragu PCD (circuit logic) or by consensus checks on public data (consensus logic).
-A malicious aggregator can publish an invalid *aggregate*, but block validation (see [block validity](tachyon-bundle.md#block-validity)) rejects it.
+A malicious aggregator can publish an invalid *aggregate*, but block validation (see [Block validity](tachyon-bundle.md#block-validity)) rejects it.
 A malicious miner can mis-assign *adjuncts* or omit covered transactions, but the block fails validation.
 
 ### Data availability
 
 Aggregation removes redundant proof bytes only.
 Every *adjunct* retains its action data, action signatures, binding signature, and `valueBalanceTachyon`; validators reconstruct the *aggregate* header from this public data.
-An *aggregate* proof alone is insufficient: the covered effecting data is present in the block as *adjuncts*, and the [block-validity rules](tachyon-bundle.md#block-validity) reject any block where it is not.
+An *aggregate* proof alone is insufficient: the covered effecting data is present in the block as *adjuncts*, and [Block validity](tachyon-bundle.md#block-validity) rejects any block where it is not.
 
 ### Circuit/consensus boundary
 
 Several security properties are enforced by consensus rather than fully proven inside the stamp.
-Double-spend prevention rests on the block-scoped tachygram-uniqueness check (see [block validity](tachyon-bundle.md#block-validity)) together with the [epoch-window duplicate-tachygram](tachyon-accumulator.md#epoch-window) and [anchor-membership](tachyon-accumulator.md#anchor-membership) rules owned by the [Tachyon Accumulator / Hash Chain](tachyon-accumulator.md) ZIP and the spendable-lineage rules owned by the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) ZIP.
+Double-spend prevention rests on the block-scoped tachygram-uniqueness check (see [Block validity](tachyon-bundle.md#block-validity)) together with the [epoch-window duplicate-tachygram](tachyon-accumulator.md#epoch-window) and [anchor-membership](tachyon-accumulator.md#anchor-membership) rules owned by the [Tachyon Accumulator / Hash Chain](tachyon-accumulator.md) ZIP and the spendable-lineage rules owned by the [Tachyon Shielded Protocol](tachyon-shielded-protocol.md) ZIP.
 Those base-protocol rules are depended upon, not re-specified here, so implementers and auditors should not assume the proof alone establishes these properties.
 
 ## Privacy Implications
@@ -344,7 +350,7 @@ This subsection is non-normative.
 An observer who sees an *aggregate* in the mempool can identify contributing transactions by `vTachygrams` overlap and confirm the correct composition by recomputing `hStampActionsTachyon` (see [Covered-transaction identification](#covered-transaction-identification)).
 This is inherent to the scheme: the *aggregate* must carry enough information for validators to reconstruct its header.
 The tachygrams and the covered-actions digest do not reveal the private contents of any covered note.
-An *adjunct* bundle with no actions is valid against any claimed covering stamp (see [block validity](tachyon-bundle.md#block-validity)), so an observer reconstructing aggregation relationships cannot rely on an actionless bundle's reference.
+An *adjunct* bundle with no actions is valid against any claimed covering stamp (see [Block validity](tachyon-bundle.md#block-validity)), so an observer reconstructing aggregation relationships cannot rely on an actionless bundle's reference.
 
 ## Deployment
 


### PR DESCRIPTION
Adds the ZIP draft page for the Tachyon Aggregator Protocol #106

The draft specifies:

- An 8-step aggregation lifecycle from autonome publication through block validation,
  with block validation ordered fail-fast (tachygram uniqueness, adjunct association,
  action set commitment, then proof verification).
- Tachygram distinctness at three levels: within each stamp, across a block (as the
  multiset union of stamp `vTachygrams`), and as a mempool acceptance rule.
- Transaction identifier and relay semantics: stable `txid` across authorization forms,
  mandatory `MSG_WTX`, proof verification before relay using the stamp's own header data,
  and stripped bundles forbidden from the mempool.
- Covered-transaction identification: tachygram matching narrows candidates, and the
  `cActionsTachyon` commitment confirms completeness without proof verification.

Consensus rules not specific to aggregation (signatures, value balance, anchor
membership, epoch-window tachygram reuse) are cited to their owning ZIPs, not
re-specified. Remaining open questions (category, digest-amendment home, deployment,
duplicate-rule ownership) are called out in Design Considerations.

Please provide suggestions and amendments.