### PR TITLE
fix: use blake2b-256 for tx identifiers

### DIFF
--- a/book/src/authorization.md
+++ b/book/src/authorization.md
@@ -75,7 +75,7 @@ The bundle commitment is a digest of the bundle's effect.
 
 $$ d_i = \text{Poseidon}_\text{Tachyon-ActionDg}(\mathsf{cv}_i \| \mathsf{rk}_i) $$
 $$ \mathsf{action\_acc} = \text{Commit}\Bigl(\prod_i \bigl(X - d_i\bigr)\Bigr) $$
-$$ \text{BLAKE2b-512}_\text{ZTxIdTachyonHash}( \mathsf{action\_acc} \| \mathsf{value\_balance}) $$
+$$ \text{BLAKE2b-256}_\text{ZTxIdTachyonHash}( \mathsf{action\_acc} \| \mathsf{value\_balance}) $$
 
 The bundle commitment hashes accumulated action digests with the value balance.
 

--- a/book/src/domain-separators.md
+++ b/book/src/domain-separators.md
@@ -1,5 +1,21 @@
 # Domain Separators
 
+## BLAKE2b-256
+
+### Transaction identifiers
+
+Digests used to commit to Tachyon bundle contents for sighash and auth digest.
+
+<!-- see 
+    https://github.com/zcash/orchard/blob/main/src/bundle/commitments.rs 
+    https://zips.z.cash/zip-0244
+-->
+
+| Purpose | Value |
+| ------- | ----- |
+| Bundle commitment | `ZTxIdTachyonHash` |
+| Bundle auth digest | `ZTxAuthTachyHash` |
+
 ## BLAKE2b-512
 
 ### Action alpha
@@ -12,20 +28,6 @@ Deterministic action randomizer for Tachyon, privately handled by transaction au
 | ------- | ----- |
 | Spend alpha | `Tachyon-Spend` |
 | Output alpha | `Tachyon-Output` |
-
-### Transaction identifiers
-
-Digests used to commit to Tachyon bundle contents for sighash and and auth digest.
-
-<!-- see 
-    https://github.com/zcash/orchard/blob/main/src/bundle/commitments.rs 
-    https://zips.z.cash/zip-0244
--->
-
-| Purpose | Value |
-| ------- | ----- |
-| Bundle commitment | `ZTxIdTachyonHash` |
-| Bundle auth digest | `ZTxAuthTachyHash` |
 
 ### PRF expansion
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -68,8 +68,9 @@ use core::ops;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, PartialEq};
+use ff::PrimeField as _;
 use group::GroupEncoding as _;
-use pasta_curves::{Eq, Fp, group::Curve as _};
+use pasta_curves::{Eq, Fp};
 use rand_core::{CryptoRng, RngCore};
 
 pub use crate::digest::blake2b::{AUTH_DIGEST_NO_BUNDLE, COMMIT_NO_BUNDLE};
@@ -294,17 +295,18 @@ impl Plan {
     ///
     /// This contributes to the transaction sighash.
     ///
-    /// $$ \mathsf{bundle\_commitment} = \text{BLAKE2b-512}(
-    /// \text{"ZTxIdTachyonHash"},\; \mathsf{action\_acc}_x \|
-    /// \mathsf{action\_acc}_y \| \mathsf{value\_balance}) $$
+    /// $$ \mathsf{bundle\_commitment} = \text{BLAKE2b-256}(
+    /// \text{"ZTxIdTachyonHash"},\;
+    /// \mathsf{encoding}(\mathsf{action\_acc}) \|
+    /// \mathsf{value\_balance}) $$
     ///
     /// where $\mathsf{action\_acc}$ is the polynomial commitment to the
     /// action digest multiset `∏(X - action_digest_i)` — order-independent
     /// by construction since the polynomial is invariant under root
-    /// permutation.
+    /// permutation — digested as its 32-byte point encoding.
     ///
     /// The stamp is excluded because it is stripped during aggregation.
-    pub fn commitment(&self) -> Result<[u8; 64], CommitError> {
+    pub fn commitment(&self) -> Result<[u8; 32], CommitError> {
         let digests: Vec<ActionDigest> = self
             .iter_actions(action::Plan::digest, action::Plan::digest)
             .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()?;
@@ -312,7 +314,7 @@ impl Plan {
         let action_commit = ActionSetPoly::from_iter(digests).commit();
 
         Ok(blake2b::bundle_commitment(
-            &Eq::from(action_commit).to_affine(),
+            &Eq::from(action_commit).to_bytes(),
             self.value_balance()?,
         ))
     }
@@ -577,9 +579,10 @@ impl Bundle<Stamp> {
 
     /// Tachyon's contribution to the transaction `auth_digest`.
     ///
-    /// Hashes action signatures, the binding signature, and the trailer.
+    /// Hashes action signatures, the binding signature, and the stamp
+    /// trailer's field encodings.
     #[must_use]
-    pub fn auth_digest(&self) -> [u8; 64] {
+    pub fn auth_digest(&self) -> [u8; 32] {
         let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig.into()).collect();
         let binding_sig: [u8; 64] = self.binding_sig.into();
 
@@ -601,7 +604,11 @@ impl Bundle<Stamp> {
             &binding_sig,
             &trailer.0,
             &trailer.1,
-            &trailer.2,
+            &trailer
+                .2
+                .iter()
+                .map(|&tg| tg.to_repr())
+                .collect::<Vec<[u8; 32]>>(),
             trailer.3.as_ref(),
         )
     }
@@ -659,10 +666,10 @@ impl Bundle<AggregateId> {
 
     /// Tachyon's contribution to the transaction `auth_digest`.
     ///
-    /// Hashes action signatures, the binding signature, and the 64-byte
-    /// `wtxid` of the covering aggregate.
+    /// Hashes action signatures, the binding signature, and the stripped
+    /// trailer: the 64-byte `wtxid` of the covering aggregate.
     #[must_use]
-    pub fn auth_digest(&self) -> [u8; 64] {
+    pub fn auth_digest(&self) -> [u8; 32] {
         let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig.into()).collect();
         let binding_sig: [u8; 64] = self.binding_sig.into();
         blake2b::stripped_auth_digest(&action_sigs, &binding_sig, &self.stamp.into())
@@ -720,7 +727,7 @@ impl TachyonBundle {
     /// `Bundle<AggregateId>`.
     #[must_use]
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
-    pub fn auth_digest(&self) -> [u8; 64] {
+    pub fn auth_digest(&self) -> [u8; 32] {
         match *self {
             Self::Stamped(ref stamped) => stamped.auth_digest(),
             Self::Adjunct(ref stripped) => stripped.auth_digest(),
@@ -730,7 +737,7 @@ impl TachyonBundle {
 
 impl<S: StampState> Bundle<S> {
     /// See [`Plan::commitment`].
-    pub fn commitment(&self) -> Result<[u8; 64], ActionDigestError> {
+    pub fn commitment(&self) -> Result<[u8; 32], ActionDigestError> {
         let action_digests = self
             .actions
             .iter()
@@ -738,7 +745,7 @@ impl<S: StampState> Bundle<S> {
             .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()?;
         let action_acc = ActionSetPoly::from_iter(action_digests).commit();
         Ok(blake2b::bundle_commitment(
-            &Eq::from(action_acc).to_affine(),
+            &Eq::from(action_acc).to_bytes(),
             self.value_balance,
         ))
     }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -589,11 +589,11 @@ impl Bundle<Stamp> {
         let trailer = {
             let action_set: [u8; 32] = Eq::from(self.stamp.action_set).to_bytes();
             let anchor: [u8; 32] = self.stamp.anchor.0.into();
-            let tachygrams: Vec<Fp> = self
+            let tachygrams: Vec<[u8; 32]> = self
                 .stamp
                 .tachygrams
                 .iter()
-                .map(|&tg| Fp::from(tg))
+                .map(|&tg| Fp::from(tg).to_repr())
                 .collect();
             let proof = self.stamp.proof.serialize();
             (action_set, anchor, tachygrams, proof)
@@ -604,11 +604,7 @@ impl Bundle<Stamp> {
             &binding_sig,
             &trailer.0,
             &trailer.1,
-            &trailer
-                .2
-                .iter()
-                .map(|&tg| tg.to_repr())
-                .collect::<Vec<[u8; 32]>>(),
+            &trailer.2,
             trailer.3.as_ref(),
         )
     }

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -123,6 +123,21 @@ pub(crate) fn bundle_commitment(action_commit: &[u8; 32], value_balance: i64) ->
 /// field encodings: the action-set commitment, the anchor, each tachygram,
 /// and the proof. Vector counts are not part of the preimage, matching the
 /// ZIP 244 auth-digest leaves.
+///
+/// Injectivity of this flat, length-free encoding is not intrinsic: it rests on
+/// two invariants enforced by the paired effecting digest and the proof system,
+/// not by this preimage.
+///
+/// - The action count is pinned by `action_acc`'s degree: the monic
+///   `∏(X - action_digest_i)` committed in `bundle_commitment` fixes the
+///   number of actions, hence the action-signature block boundary. This is the
+///   role `nActionsOrchard` plays in ZIP 244.
+/// - The proof is a compile-time fixed size (`PROOF_SIZE_COMPRESSED`), which
+///   fixes the `tachygrams || proof` boundary. Nothing on the txid side commits
+///   to the tachygram count, so the fixed proof size is load-bearing for digest
+///   injectivity, not merely wire framing: a variable-size proof would make
+///   `tachygrams || proof` ambiguous and let two distinct bundles collide on a
+///   single `wtxid`.
 pub(crate) fn stamped_auth_digest(
     action_sigs: &[[u8; 64]],
     binding_sig: &[u8; 64],

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -1,19 +1,49 @@
 //! Tachyon Blake2b digests.
 //!
-//! Each named function matches one protocol-defined hash. All use
-//! BLAKE2b-512 (64-byte output). Personalizations are 13–16 bytes;
-//! `blake2b_simd::Params::personal` accepts any length ≤ 16.
+//! Each named function matches one protocol-defined hash. Key and entropy
+//! derivation preimages use BLAKE2b-512 (64-byte output, reduced to scalars
+//! by the caller); transaction digest contributions use BLAKE2b-256
+//! (32-byte output), matching the ZIP 244 digest-tree convention.
+//! Personalizations are 13–16 bytes; `blake2b_simd::Params::personal`
+//! accepts any length ≤ 16.
 
 use blake2b_simd::Params;
-use ff::PrimeField as _;
 use lazy_static::lazy_static;
-use pasta_curves::{EqAffine, Fp, arithmetic::CurveAffine as _};
 
-fn hasher(personalization: &[u8]) -> blake2b_simd::State {
-    Params::new()
+/// BLAKE2b-256 digest for transaction digest contributions (ZIP 244 leaves).
+///
+/// `updater` feeds the preimage into the personalized state.
+fn hasher_256(personalization: &[u8], updater: impl FnOnce(&mut blake2b_simd::State)) -> [u8; 32] {
+    let mut state = Params::new()
+        .hash_length(32)
+        .personal(personalization)
+        .to_state();
+    updater(&mut state);
+
+    #[expect(clippy::expect_used, reason = "hash length is 32")]
+    state
+        .finalize()
+        .as_bytes()
+        .try_into()
+        .expect("hash length is 32")
+}
+
+/// BLAKE2b-512 digest for key and entropy derivation preimages.
+///
+/// `updater` feeds the preimage into the personalized state.
+fn hasher_512(personalization: &[u8], updater: impl FnOnce(&mut blake2b_simd::State)) -> [u8; 64] {
+    let mut state = Params::new()
         .hash_length(64)
         .personal(personalization)
-        .to_state()
+        .to_state();
+    updater(&mut state);
+
+    #[expect(clippy::expect_used, reason = "hash length is 64")]
+    state
+        .finalize()
+        .as_bytes()
+        .try_into()
+        .expect("hash length is 64")
 }
 
 const SPEND_ALPHA_PERSONALIZATION: &[u8; 13] = b"Tachyon-Spend";
@@ -24,21 +54,19 @@ const OUTPUT_ALPHA_PERSONALIZATION: &[u8; 14] = b"Tachyon-Output";
 ///
 /// Caller reduces to scalar via `Fq::from_uniform_bytes`.
 pub(crate) fn alpha_spend(theta: &[u8; 32], cm: &[u8; 32]) -> [u8; 64] {
-    *hasher(SPEND_ALPHA_PERSONALIZATION)
-        .update(theta)
-        .update(cm)
-        .finalize()
-        .as_array()
+    hasher_512(SPEND_ALPHA_PERSONALIZATION, |state| {
+        state.update(theta);
+        state.update(cm);
+    })
 }
 
 /// Output-side $\alpha$ pre-image: $\text{BLAKE2b-512}(\text{"Tachyon-Output"},
 /// \theta \| cm)$.
 pub(crate) fn alpha_output(theta: &[u8; 32], cm: &[u8; 32]) -> [u8; 64] {
-    *hasher(OUTPUT_ALPHA_PERSONALIZATION)
-        .update(theta)
-        .update(cm)
-        .finalize()
-        .as_array()
+    hasher_512(OUTPUT_ALPHA_PERSONALIZATION, |state| {
+        state.update(theta);
+        state.update(cm);
+    })
 }
 
 // See https://github.com/zcash/zcash_spec/blob/main/src/prf_expand.rs
@@ -53,11 +81,10 @@ const PRF_EXPAND_DOMAIN_NK: u8 = 0x22;
 ///
 /// TODO: return normalized Fq?
 pub(crate) fn prf_expand_ask(sk: &[u8; 32]) -> [u8; 64] {
-    *hasher(PRF_EXPAND_PERSONALIZATION)
-        .update(sk)
-        .update(&[PRF_EXPAND_DOMAIN_ASK])
-        .finalize()
-        .as_array()
+    hasher_512(PRF_EXPAND_PERSONALIZATION, |state| {
+        state.update(sk);
+        state.update(&[PRF_EXPAND_DOMAIN_ASK]);
+    })
 }
 
 /// PRF-expand to derive `nk` from a spending key. Performs no normalization.
@@ -67,11 +94,10 @@ pub(crate) fn prf_expand_ask(sk: &[u8; 32]) -> [u8; 64] {
 ///
 /// TODO: return normalized Fq?
 pub(crate) fn prf_expand_nk(sk: &[u8; 32]) -> [u8; 64] {
-    *hasher(PRF_EXPAND_PERSONALIZATION)
-        .update(sk)
-        .update(&[PRF_EXPAND_DOMAIN_NK])
-        .finalize()
-        .as_array()
+    hasher_512(PRF_EXPAND_PERSONALIZATION, |state| {
+        state.update(sk);
+        state.update(&[PRF_EXPAND_DOMAIN_NK]);
+    })
 }
 
 // See https://github.com/zcash/orchard/blob/main/src/bundle/commitments.rs
@@ -80,73 +106,61 @@ const AUTH_DIGEST_PERSONALIZATION: &[u8; 16] = b"ZTxAuthTachyHash";
 
 /// A bundle's contribution to the transaction sighash.
 ///
-/// Hashes the bundle's effecting data. The stamp is excluded because it is
+/// Hashes the bundle's effecting data: the encoding of the action-set
+/// commitment and the value balance. The stamp is excluded because it is
 /// stripped during aggregation.
 #[must_use]
-pub(crate) fn bundle_commitment(action_commit: &EqAffine, value_balance: i64) -> [u8; 64] {
-    let coords = action_commit
-        .coordinates()
-        .expect("commitment should not be the identity point");
-
-    *hasher(BUNDLE_COMMITMENT_PERSONALIZATION)
-        .update(&coords.x().to_repr())
-        .update(&coords.y().to_repr())
-        .update(&value_balance.to_le_bytes())
-        .finalize()
-        .as_array()
+pub(crate) fn bundle_commitment(action_commit: &[u8; 32], value_balance: i64) -> [u8; 32] {
+    hasher_256(BUNDLE_COMMITMENT_PERSONALIZATION, |state| {
+        state.update(action_commit);
+        state.update(&value_balance.to_le_bytes());
+    })
 }
 
 /// A stamped bundle's contribution to the transaction auth_digest.
 ///
-/// Hashes action signatures, the binding signature, and the trailer.
+/// Hashes action signatures, the binding signature, and the stamp trailer's
+/// field encodings: the action-set commitment, the anchor, each tachygram,
+/// and the proof. Vector counts are not part of the preimage, matching the
+/// ZIP 244 auth-digest leaves.
 pub(crate) fn stamped_auth_digest(
     action_sigs: &[[u8; 64]],
     binding_sig: &[u8; 64],
     action_set: &[u8; 32],
     anchor: &[u8; 32],
-    tachygrams: &[Fp],
+    tachygrams: &[[u8; 32]],
     proof: &[u8],
-) -> [u8; 64] {
-    let mut state = hasher(AUTH_DIGEST_PERSONALIZATION);
-
-    for action_sig in action_sigs {
-        state.update(action_sig);
-    }
-
-    state.update(binding_sig);
-
-    state.update(action_set);
-
-    state.update(anchor);
-
-    for tg in tachygrams {
-        state.update(&tg.to_repr());
-    }
-
-    state.update(proof);
-
-    *state.finalize().as_array()
+) -> [u8; 32] {
+    hasher_256(AUTH_DIGEST_PERSONALIZATION, |state| {
+        for sig in action_sigs {
+            state.update(sig);
+        }
+        state.update(binding_sig);
+        state.update(action_set);
+        state.update(anchor);
+        for tg in tachygrams {
+            state.update(tg);
+        }
+        state.update(proof);
+    })
 }
 
 /// A stripped bundle's contribution to the transaction auth_digest.
 ///
-/// Hashes action signatures, the binding signature, and aggregate wtxid.
+/// Hashes action signatures, the binding signature, and the stripped
+/// trailer: the 64-byte `wtxid` of the covering aggregate.
 pub(crate) fn stripped_auth_digest(
     action_sigs: &[[u8; 64]],
     binding_sig: &[u8; 64],
     wtxid: &[u8; 64],
-) -> [u8; 64] {
-    let mut state = hasher(AUTH_DIGEST_PERSONALIZATION);
-
-    for action_sig in action_sigs {
-        state.update(action_sig);
-    }
-
-    state.update(binding_sig);
-
-    state.update(wtxid);
-
-    *state.finalize().as_array()
+) -> [u8; 32] {
+    hasher_256(AUTH_DIGEST_PERSONALIZATION, |state| {
+        for sig in action_sigs {
+            state.update(sig);
+        }
+        state.update(binding_sig);
+        state.update(wtxid);
+    })
 }
 
 lazy_static! {
@@ -155,8 +169,8 @@ lazy_static! {
     /// **This is NOT the same as a stripped bundle.**
     ///
     /// **This is NOT the same as a bundle with no actions and zero balance.**
-    pub static ref COMMIT_NO_BUNDLE: [u8; 64] = {
-        *hasher(BUNDLE_COMMITMENT_PERSONALIZATION).finalize().as_array()
+    pub static ref COMMIT_NO_BUNDLE: [u8; 32] = {
+        hasher_256(BUNDLE_COMMITMENT_PERSONALIZATION, |_| {})
     };
 
     /// A non-Tachyon transaction's contribution to the transaction auth_digest.
@@ -164,7 +178,7 @@ lazy_static! {
     /// **This is NOT the same as a stripped bundle.**
     ///
     /// **This is NOT the same as a bundle with no actions and zero balance.**
-    pub static ref AUTH_DIGEST_NO_BUNDLE: [u8; 64] = {
-        *hasher(AUTH_DIGEST_PERSONALIZATION).finalize().as_array()
+    pub static ref AUTH_DIGEST_NO_BUNDLE: [u8; 32] = {
+        hasher_256(AUTH_DIGEST_PERSONALIZATION, |_| {})
     };
 }

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -42,7 +42,7 @@ use crate::{
     value, witness,
 };
 
-pub fn mock_sighash(bundle_digest: [u8; 64]) -> [u8; 32] {
+pub fn mock_sighash(bundle_digest: [u8; 32]) -> [u8; 32] {
     let hash = blake2b_simd::Params::new()
         .hash_length(32)
         .personal(b"pretend sighash")

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -49,8 +49,12 @@ pub struct Unproven;
 #[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Stripped;
 
-/// A 64-byte `wtxid` of the covering aggregate in the same block, assigned by
-/// the miner during block assembly.
+/// The 64-byte `wtxid` of the covering aggregate in the same block, assigned
+/// by the miner during block assembly.
+///
+/// A `wtxid` is `txid || auth_digest`: two 32-byte transaction digests as
+/// defined by ZIP 244, concatenated per ZIP 239 into the 64-byte identifier
+/// used for transaction relay.
 ///
 /// This uses the aggregate's wtxid (not txid) so it unambiguously pins the
 /// covering aggregate's authorization state, including stamp.


### PR DESCRIPTION
Aligns the transaction digest contributions with the ZIP 244 digest-tree
convention, checked against `orchard/src/bundle/commitments.rs` and
`librustzcash`'s `transaction/txid.rs`:

- `bundle_commitment`, `stamped_auth_digest`, and `stripped_auth_digest` are
  now BLAKE2b-256 with 32-byte outputs, matching the ZIP 244 leaves (they were
  BLAKE2b-512). The absent-bundle constants shrink to match.
- The txid contribution digests the 32-byte compressed encoding of
  `action_acc` rather than its affine coordinates. ZIP 244 digests points as
  their wire encodings; this also removes the identity-coordinates panic path.
- Auth-digest preimages remain flat field encodings with no vector counts,
  exactly the shape of the Sapling and Orchard auth leaves. Preimage shape is
  pinned by the paired effecting digest, which fixes the action count through
  `action_acc`.
- Hash-to-scalar preimages (PRF^expand, action alpha) stay BLAKE2b-512: their
  64-byte outputs feed `from_uniform_bytes` for unbiased scalar reduction, per
  protocol spec §5.4.2 and the `Zcash_ExpandSeed` convention.
- `digest/blake2b.rs` is restructured around distinct `hasher_256` /
  `hasher_512` constructors taking preimage-feeding closures, with a fully
  byte-oriented interface (tachygrams passed as encodings).
- `AggregateId` is documented as the real ZIP 239 `wtxid`:
  `txid || auth_digest`, two 32-byte ZIP 244 digests.

Book updated to match: the `authorization.md` bundle-commitment formula and
the BLAKE2b-256/512 split in `domain-separators.md`. The
`transaction-identifiers.md` formula already said BLAKE2b-256; the
implementation now agrees with it.

The `"ZTxIdTachyonHash"` / `"ZTxAuthTachyHash"` personalizations remain
placeholders pending the Tachyon amendment to ZIP 244.
