### PR TITLE
refactor: structured digests

### DIFF
--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -2,6 +2,7 @@
 
 use core::{cmp, marker::PhantomData};
 
+use alloc::vec::Vec;
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, PartialEq};
 use pasta_curves::{EpAffine, group::GroupEncoding as _};
@@ -40,18 +41,9 @@ impl Descriptor {
 
     /// Write an action descriptor in the consensus wire format.
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        serialization::write_ep_affine(&mut writer, &EpAffine::from(self.cv))?;
+        serialization::write_ep_affine(&mut writer, &self.cv.into())?;
         serialization::write_action_vk(&mut writer, &self.rk.0)?;
         Ok(())
-    }
-}
-
-impl From<Descriptor> for [u8; 64] {
-    fn from(desc: Descriptor) -> Self {
-        let mut bytes = [0u8; 64];
-        bytes[..32].copy_from_slice(&EpAffine::from(desc.cv).to_bytes());
-        bytes[32..].copy_from_slice(&<[u8; 32]>::from(desc.rk));
-        bytes
     }
 }
 
@@ -66,7 +58,11 @@ impl Ord for Descriptor {
         EpAffine::from(self.cv)
             .to_bytes()
             .cmp(&EpAffine::from(other.cv).to_bytes())
-            .then(<[u8; 32]>::from(self.rk).cmp(&<[u8; 32]>::from(other.rk)))
+            .then(
+                EpAffine::from(self.rk)
+                    .to_bytes()
+                    .cmp(&EpAffine::from(other.rk).to_bytes()),
+            )
     }
 }
 
@@ -205,7 +201,7 @@ impl Ord for Action {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.descriptor()
             .cmp(&other.descriptor())
-            .then_with(|| <[u8; 64]>::from(self.sig).cmp(&<[u8; 64]>::from(other.sig)))
+            .then_with(|| <[u8; 64]>::from(self.sig.0).cmp(&<[u8; 64]>::from(other.sig.0)))
     }
 }
 
@@ -237,14 +233,23 @@ impl Signature {
     }
 }
 
-impl From<[u8; 64]> for Signature {
-    fn from(bytes: [u8; 64]) -> Self {
-        Self(reddsa::Signature::<reddsa::ActionAuth>::from(bytes))
+impl FromIterator<Descriptor> for Vec<[u8; 64]> {
+    fn from_iter<I: IntoIterator<Item = Descriptor>>(iter: I) -> Self {
+        iter.into_iter()
+            .map(|desc| {
+                let mut desc_bytes = [0u8; 64];
+                desc_bytes[0..32].copy_from_slice(&EpAffine::from(desc.cv).to_bytes());
+                desc_bytes[32..64].copy_from_slice(&EpAffine::from(desc.rk).to_bytes());
+                desc_bytes
+            })
+            .collect()
     }
 }
 
-impl From<Signature> for [u8; 64] {
-    fn from(sig: Signature) -> [u8; 64] {
-        <[u8; 64]>::from(sig.0)
+impl FromIterator<Signature> for Vec<[u8; 64]> {
+    fn from_iter<I: IntoIterator<Item = Signature>>(iter: I) -> Self {
+        iter.into_iter()
+            .map(|sig| <[u8; 64]>::from(sig.0))
+            .collect()
     }
 }

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -1,7 +1,8 @@
 //! Tachyon Action descriptions.
 
-use core::marker::PhantomData;
+use core::{cmp, marker::PhantomData};
 
+use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, PartialEq};
 
 use crate::{
@@ -9,8 +10,63 @@ use crate::{
     keys::{private, public},
     note::Note,
     primitives::{ActionDigest, ActionDigestError, Effect, effect},
-    reddsa, value,
+    reddsa, serialization, value,
 };
+
+/// The simple fields of an action, without the signature.
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
+pub struct Descriptor {
+    /// Value commitment $\mathsf{cv} = [v]\,\mathcal{V}
+    /// + [\mathsf{rcv}]\,\mathcal{R}$ (EpAffine).
+    pub cv: value::Commitment,
+
+    /// Randomized action verification key $\mathsf{rk}$ (EpAffine).
+    pub rk: public::ActionVerificationKey,
+}
+
+impl Descriptor {
+    /// Derive the action digest.
+    pub fn digest(&self) -> Result<ActionDigest, ActionDigestError> {
+        ActionDigest::new(self.cv, self.rk)
+    }
+
+    /// Read an action descriptor from the consensus wire format.
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let cv = value::Commitment(serialization::read_ep_affine(&mut reader)?);
+        let rk = public::ActionVerificationKey(serialization::read_action_vk(&mut reader)?);
+        Ok(Self { cv, rk })
+    }
+
+    /// Write an action descriptor in the consensus wire format.
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        serialization::write_ep_affine(&mut writer, &self.cv.0)?;
+        serialization::write_action_vk(&mut writer, &self.rk.0)?;
+        Ok(())
+    }
+}
+
+impl From<Descriptor> for [u8; 64] {
+    fn from(desc: Descriptor) -> Self {
+        let mut bytes = [0u8; 64];
+        bytes[..32].copy_from_slice(&<[u8; 32]>::from(desc.cv));
+        bytes[32..].copy_from_slice(&<[u8; 32]>::from(desc.rk));
+        bytes
+    }
+}
+
+impl PartialOrd for Descriptor {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Descriptor {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        <[u8; 32]>::from(self.cv)
+            .cmp(&<[u8; 32]>::from(other.cv))
+            .then(<[u8; 32]>::from(self.rk).cmp(&<[u8; 32]>::from(other.rk)))
+    }
+}
 
 /// A planned Tachyon action, not yet authorized.
 #[derive(Clone, Copy, Debug)]
@@ -84,6 +140,15 @@ impl<E: Effect> Plan<E> {
     pub fn digest(&self) -> Result<ActionDigest, ActionDigestError> {
         ActionDigest::new(self.cv(), self.rk)
     }
+
+    /// Obtain a descriptor for this planned action.
+    #[must_use]
+    pub fn descriptor(&self) -> Descriptor {
+        Descriptor {
+            cv: self.cv(),
+            rk: self.rk,
+        }
+    }
 }
 
 /// An authorized Tachyon action.
@@ -105,9 +170,49 @@ pub struct Action {
 }
 
 impl Action {
+    /// Construct an action from a descriptor and signature.
+    #[must_use]
+    pub const fn from_parts(desc: Descriptor, sig: Signature) -> Self {
+        Self {
+            cv: desc.cv,
+            rk: desc.rk,
+            sig,
+        }
+    }
+
     /// Derive the action digest.
     pub fn digest(&self) -> Result<ActionDigest, ActionDigestError> {
         ActionDigest::new(self.cv, self.rk)
+    }
+
+    /// Obtain a descriptor for this action.
+    #[must_use]
+    pub fn descriptor(&self) -> Descriptor {
+        Descriptor::from(*self)
+    }
+}
+
+impl PartialOrd for Action {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Action {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        <[u8; 32]>::from(self.cv)
+            .cmp(&<[u8; 32]>::from(other.cv))
+            .then(<[u8; 32]>::from(self.rk).cmp(&<[u8; 32]>::from(other.rk)))
+            .then(<[u8; 64]>::from(self.sig).cmp(&<[u8; 64]>::from(other.sig)))
+    }
+}
+
+impl From<Action> for Descriptor {
+    fn from(action: Action) -> Self {
+        Self {
+            cv: action.cv,
+            rk: action.rk,
+        }
     }
 }
 
@@ -115,6 +220,20 @@ impl Action {
 #[derive(Clone, Copy, Debug, Display, PartialEq, TotalEq)]
 #[display("Signature({:?})", self.0)]
 pub struct Signature(pub(crate) reddsa::Signature<reddsa::ActionAuth>);
+
+impl Signature {
+    /// Read an action signature from the consensus wire format.
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let sig = serialization::read_action_sig(&mut reader)?;
+        Ok(Self(sig))
+    }
+
+    /// Write an action signature in the consensus wire format.
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        serialization::write_action_sig(&mut writer, &self.0)?;
+        Ok(())
+    }
+}
 
 impl From<[u8; 64]> for Signature {
     fn from(bytes: [u8; 64]) -> Self {

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -200,10 +200,9 @@ impl PartialOrd for Action {
 
 impl Ord for Action {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        <[u8; 32]>::from(self.cv)
-            .cmp(&<[u8; 32]>::from(other.cv))
-            .then(<[u8; 32]>::from(self.rk).cmp(&<[u8; 32]>::from(other.rk)))
-            .then(<[u8; 64]>::from(self.sig).cmp(&<[u8; 64]>::from(other.sig)))
+        self.descriptor()
+            .cmp(&other.descriptor())
+            .then_with(|| <[u8; 64]>::from(self.sig).cmp(&<[u8; 64]>::from(other.sig)))
     }
 }
 

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -1,8 +1,8 @@
 //! Tachyon Action descriptions.
 
+use alloc::vec::Vec;
 use core::{cmp, marker::PhantomData};
 
-use alloc::vec::Vec;
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, PartialEq};
 use pasta_curves::{EpAffine, group::GroupEncoding as _};

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -126,14 +126,14 @@ impl BundleStateFlags {
 }
 
 mod sealed {
-    pub trait Sealed {}
-    impl Sealed for super::Unproven {}
-    impl Sealed for super::ProofStamp {}
-    impl Sealed for super::PointerStamp {}
+    pub trait BundleState {}
+    impl BundleState for super::Unproven {}
+    impl BundleState for super::ProofStamp {}
+    impl BundleState for super::PointerStamp {}
 }
 
 /// Sealed trait constraining stamp state types.
-pub trait StampState: sealed::Sealed {
+pub trait StampState: sealed::BundleState {
     /// The stamp's 64-byte wtxid-shaped digest: a proof stamp's
     /// `hActionsTachyon || stamp_data_digest`, or a pointer stamp's
     /// `wtxid = txid || auth_digest`.
@@ -539,7 +539,7 @@ impl Bundle<ProofStamp> {
     /// adjunct's and check it against the carried `hActionsTachyon`.
     /// Assistive, not soundness.
     #[must_use]
-    pub fn covers(&self, adjuncts: &[Bundle<PointerStamp>]) -> bool {
+    pub fn covers<T: StampState>(&self, adjuncts: &[Bundle<T>]) -> bool {
         let own_descs = self.actions.iter().map(Action::descriptor);
         let other_descs = adjuncts
             .iter()

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -147,6 +147,12 @@ pub trait StampState: BundleState {
     /// `hActionsTachyon || stamp_data_digest`, or a pointer stamp's
     /// `wtxid = txid || auth_digest`.
     fn stamp_digest(&self) -> [u8; 64];
+
+    // fn state_flags(&self) -> BundleStateFlags;
+
+    // fn read<R: Read>(mut reader: R) -> io::Result<Self>;
+
+    // fn write<W: Write>(&self, mut writer: W) -> io::Result<()>;
 }
 
 impl StampState for PointerStamp {
@@ -203,7 +209,7 @@ pub struct Bundle<S: BundleState + ?Sized> {
 /// enum because it has no wire representation.
 #[expect(clippy::module_name_repetitions, reason = "intentional name")]
 #[derive(Clone, Debug, From)]
-pub enum TachyonBundle {
+pub enum StampedBundle {
     /// A bundle with its own stamp (autonome or aggregate).
     Stamped(Bundle<ProofStamp>),
     /// A bundle whose stamp has been stripped; carries a reference to the
@@ -211,24 +217,24 @@ pub enum TachyonBundle {
     Adjunct(Bundle<PointerStamp>),
 }
 
-impl TryFrom<TachyonBundle> for Bundle<ProofStamp> {
+impl TryFrom<StampedBundle> for Bundle<ProofStamp> {
     type Error = Bundle<PointerStamp>;
 
-    fn try_from(bundle: TachyonBundle) -> Result<Self, Self::Error> {
+    fn try_from(bundle: StampedBundle) -> Result<Self, Self::Error> {
         match bundle {
-            TachyonBundle::Adjunct(stripped) => Err(stripped),
-            TachyonBundle::Stamped(stamped) => Ok(stamped),
+            StampedBundle::Adjunct(stripped) => Err(stripped),
+            StampedBundle::Stamped(stamped) => Ok(stamped),
         }
     }
 }
 
-impl TryFrom<TachyonBundle> for Bundle<PointerStamp> {
+impl TryFrom<StampedBundle> for Bundle<PointerStamp> {
     type Error = Bundle<ProofStamp>;
 
-    fn try_from(bundle: TachyonBundle) -> Result<Self, Self::Error> {
+    fn try_from(bundle: StampedBundle) -> Result<Self, Self::Error> {
         match bundle {
-            TachyonBundle::Adjunct(stripped) => Ok(stripped),
-            TachyonBundle::Stamped(stamped) => Err(stamped),
+            StampedBundle::Adjunct(stripped) => Ok(stripped),
+            StampedBundle::Stamped(stamped) => Err(stamped),
         }
     }
 }
@@ -671,7 +677,7 @@ impl Bundle<PointerStamp> {
     }
 }
 
-impl TachyonBundle {
+impl StampedBundle {
     /// Read any Tachyon bundle from the consensus wire format, dispatching
     /// on the `tachyonBundleState` byte.
     ///

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -98,6 +98,13 @@ pub enum StateByte {
     PointerStamped = 0b0000_0010u8,
 }
 
+impl From<StateByte> for u8 {
+    #[expect(clippy::as_conversions, reason = "repr u8")]
+    fn from(val: StateByte) -> Self {
+        val as Self
+    }
+}
+
 impl StateByte {
     pub(super) fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut byte = [0u8; 1];
@@ -619,7 +626,12 @@ impl<S: StampState> Bundle<S> {
         let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig).collect();
         let binding_sig: [u8; 64] = self.binding_sig.0.into();
 
-        blake2b::bundle_auth_digest(&action_sigs, &binding_sig, &self.stamp.stamp_digest())
+        blake2b::bundle_auth_digest(
+            S::state_byte().into(),
+            &action_sigs,
+            &binding_sig,
+            &self.stamp.stamp_digest(),
+        )
     }
 }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -163,11 +163,7 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     /// aggregation.
     #[must_use]
     pub fn commitment(&self) -> [u8; 32] {
-        let descriptors: Vec<[u8; 64]> = self
-            .descriptors()
-            .into_iter()
-            .map(<[u8; 64]>::from)
-            .collect();
+        let descriptors: Vec<[u8; 64]> = self.descriptors().into_iter().collect();
 
         // The bundle's actions should already be sorted by construction.
         debug_assert!(
@@ -329,11 +325,7 @@ impl Plan {
     /// Compute a digest of all the bundle's effecting data.
     /// See [`Bundle::commitment`].
     pub fn commitment(&self) -> Result<[u8; 32], CommitError> {
-        let desc_bytes: Vec<[u8; 64]> = self
-            .descriptors()
-            .into_iter()
-            .map(<[u8; 64]>::from)
-            .collect();
+        let desc_bytes: Vec<[u8; 64]> = self.descriptors().into_iter().collect();
 
         Ok(blake2b::bundle_commitment(
             &blake2b::action_descriptor_digest(&desc_bytes),
@@ -541,11 +533,7 @@ impl Bundle<ProofStamp> {
     /// owned actions and comparing to its stamp's `hStampActionsTachyon`.
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
-        let desc_bytes: Vec<[u8; 64]> = self
-            .descriptors()
-            .into_iter()
-            .map(<[u8; 64]>::from)
-            .collect();
+        let desc_bytes = self.descriptors().into_iter().collect::<Vec<[u8; 64]>>();
         blake2b::action_descriptor_digest(&desc_bytes) == self.stamp.actions
     }
 }
@@ -664,8 +652,8 @@ impl<S: StampState> Bundle<S> {
     /// digest. See [`blake2b::bundle_auth_digest`].
     #[must_use]
     pub fn auth_digest(&self) -> [u8; 32] {
-        let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig.into()).collect();
-        let binding_sig: [u8; 64] = self.binding_sig.into();
+        let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig).collect();
+        let binding_sig: [u8; 64] = self.binding_sig.0.into();
 
         blake2b::bundle_auth_digest(&action_sigs, &binding_sig, &self.stamp.stamp_digest())
     }
@@ -785,18 +773,6 @@ impl Signature {
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         serialization::write_binding_sig(&mut writer, &self.0)?;
         Ok(())
-    }
-}
-
-impl From<[u8; 64]> for Signature {
-    fn from(bytes: [u8; 64]) -> Self {
-        Self(bytes.into())
-    }
-}
-
-impl From<Signature> for [u8; 64] {
-    fn from(sig: Signature) -> Self {
-        sig.0.into()
     }
 }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -152,6 +152,7 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     /// Collect the descriptors of all actions in the bundle.
     #[must_use]
     pub fn descriptors(&self) -> Vec<action::Descriptor> {
+        // Do NOT sort here: a constructed bundle should already be canonical.
         self.actions.iter().map(Action::descriptor).collect()
     }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -3,22 +3,23 @@
 //! A bundle is parameterized by stamp state `S: StampState`.
 //! Actions are constant through state transitions; only the stamp changes.
 //!
-//! - `Bundle<Stamp>` — self-contained bundle with a stamp
-//! - `Bundle<AggregateId>` — stamp removed, references the covering aggregate
-//! - [`TachyonBundle`] — enum of stamped-or-stripped for mixed contexts
+//! - `Bundle<ProofStamp>` — self-contained bundle with a proof stamp
+//! - `Bundle<PointerStamp>` — proof stamp replaced by a pointer stamp naming
+//!   the covering aggregate
+//! - [`TachyonBundle`] — enum of the two on-wire forms for mixed contexts
 //!
 //! # Consensus wire format
 //!
 //! The first byte `tachyonBundleState` selects one of three bundle states:
 //!
-//! | value         | state       | bundle contents                       |
-//! | ------------- | ----------- | ------------------------------------- |
-//! | `0b0000_0000` | non-tachyon | no bundle                             |
-//! | `0b0000_0001` | stamped     | bundle with anchor, tachygrams, proof |
-//! | `0b0000_0010` | stripped    | bundle with aggregate's wtxid         |
-//! | `...`         | *reserved*  | *n/a*                                 |
+//! | value         | state         | bundle contents                       |
+//! | ------------- | ------------- | ------------------------------------- |
+//! | `0b0000_0000` | non-tachyon   | no bundle                             |
+//! | `0b0000_0001` | proof stamp   | bundle with anchor, tachygrams, proof |
+//! | `0b0000_0010` | pointer stamp | bundle with aggregate's wtxid         |
+//! | `...`         | *reserved*    | *n/a*                                 |
 //!
-//! Any other byte is invalid. Stripped innocents and stripped adjuncts share
+//! Any other byte is invalid. Pointer-stamped innocents and adjuncts share
 //! the same wire layout (both write `0x02` + body + a nonzero 64-byte `wtxid`
 //! naming the covering aggregate).
 //!
@@ -43,25 +44,29 @@
 //! | `vActionSigsTachyon`  | 64 * nActionsTachyon | authorization per action over tx sighash |
 //! | `bindingSigTachyon`   | 64 bytes             | binding over tx sighash                  |
 //!
-//! ### Stamp trailer
+//! ### Proof stamp
 //!
-//! When `tachyonBundleState == 1`, there is a stamp trailer.
+//! When `tachyonBundleState == 1`, the bundle carries a proof stamp.
 //!
 //! | Name                  | Format               | Description                              |
 //! | --------------------- | -------------------- | ---------------------------------------- |
-//! | `cActionsTachyon`     | 32 bytes             | action set for this proof                |
+//! | `hActionsTachyon`     | 32 bytes             | BLAKE2b digest of the covered actions    |
 //! | `anchorTachyon`       | 32 bytes             | pool state reference                     |
 //! | `nTachygrams`         | compactsize          | number of tachygrams                     |
 //! | `vTachygrams`         | 32 * nTachygrams     | tachygrams for this proof                |
 //! | `proofTachyon`        | PROOF_SIZE blob      | serialized proof of fixed size           |
 //!
-//! ## Stripped trailer
+//! ## Pointer stamp
 //!
-//! When `tachyonBundleState == 2`, there is a stripped trailer.
+//! When `tachyonBundleState == 2`, the bundle carries a pointer stamp.
 //!
 //! | Name                  | Format               | Description                              |
 //! | --------------------- | -------------------- | ---------------------------------------- |
 //! | `tachyonAggregateId`  | 64 bytes             | wtxid of the relevant aggregate          |
+//!
+//! The transaction `auth_digest` contribution commits either stamp as a
+//! 64-byte wtxid-shaped value: the pointer stamp's `wtxid` directly, or
+//! `hActionsTachyon || stamp_data_digest` for a proof stamp.
 
 use alloc::vec::Vec;
 use core::ops;
@@ -70,7 +75,7 @@ use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, PartialEq};
 use ff::PrimeField as _;
 use group::GroupEncoding as _;
-use pasta_curves::{Ep, EpAffine, Eq, Fp};
+use pasta_curves::{Eq, Fp};
 use rand_core::{CryptoRng, RngCore};
 
 pub use crate::digest::blake2b::{AUTH_DIGEST_NO_BUNDLE, COMMIT_NO_BUNDLE};
@@ -83,7 +88,6 @@ use crate::{
     primitives::{ActionDigest, ActionDigestError, Anchor, effect},
     reddsa, serialization,
     stamp::{self, PointerStamp, ProofStamp, Stripped, Unproven},
-    value,
 };
 
 /// The `tachyonBundleState` wire byte. See the module-level wire format
@@ -131,6 +135,14 @@ mod sealed {
 
 /// Sealed trait constraining stamp state types.
 pub trait StampState: sealed::Sealed {
+    /// The stamp's 64-byte wtxid-shaped digest: a proof stamp's
+    /// `hActionsTachyon || stamp_data_digest`, or a pointer stamp's
+    /// `wtxid = txid || auth_digest`.
+    ///
+    /// # Panics
+    ///
+    /// The intermediate `Unproven` and `Stripped` states have no stamp;
+    /// calling this on them panics.
     fn stamp_digest(&self) -> [u8; 64];
 }
 
@@ -154,8 +166,6 @@ impl StampState for PointerStamp {
 
 impl StampState for ProofStamp {
     fn stamp_digest(&self) -> [u8; 64] {
-        let stamp_actions: [u8; 32] = Eq::from(self.action_set).to_bytes();
-
         let stamp_data_digest: [u8; 32] = {
             let proof = self.proof.serialize();
             let anchor: [u8; 32] = self.anchor.0.into();
@@ -165,11 +175,15 @@ impl StampState for ProofStamp {
                 .map(|&tg| Fp::from(tg).to_repr())
                 .collect();
 
-            blake2b::stamp_data_digest(blake2b::stamp_proof_digest(proof), anchor, tachygrams)
+            blake2b::stamp_data_digest(
+                blake2b::stamp_proof_digest(proof.as_ref()),
+                anchor,
+                &tachygrams,
+            )
         };
 
         let mut stamp_digest = [0u8; 64];
-        stamp_digest[..32].copy_from_slice(&stamp_actions);
+        stamp_digest[..32].copy_from_slice(&self.covered_actions);
         stamp_digest[32..].copy_from_slice(&stamp_data_digest);
         stamp_digest
     }
@@ -373,7 +387,7 @@ impl Plan {
             .iter()
             .map(|plan| {
                 let alpha = plan.theta.randomizer(plan.note.commitment());
-                ((plan.cv(), plan.rk), (alpha, plan.note, plan.rcv))
+                (plan.descriptor(), (alpha, plan.note, plan.rcv))
             })
             .collect();
 
@@ -382,7 +396,7 @@ impl Plan {
             .iter()
             .map(|plan| {
                 let alpha = plan.theta.randomizer(plan.note.commitment());
-                ((plan.cv(), plan.rk), (alpha, plan.note, plan.rcv))
+                (plan.descriptor(), (alpha, plan.note, plan.rcv))
             })
             .collect();
 
@@ -478,14 +492,14 @@ impl Plan {
         let mut authorized = Vec::with_capacity(n_actions);
 
         let all_descriptors = self
-            .iter_actions(|plan| (plan.cv(), plan.rk), |plan| (plan.cv(), plan.rk))
+            .iter_actions(action::Plan::descriptor, action::Plan::descriptor)
             .zip(sigs);
 
-        for ((cv, rk), sig) in all_descriptors {
-            if rk.verify(sighash, &sig).is_err() {
+        for (desc, sig) in all_descriptors {
+            if desc.rk.verify(sighash, &sig).is_err() {
                 return Err(SignError::InvalidActionSignature(sig));
             }
-            authorized.push(Action { cv, rk, sig });
+            authorized.push(Action::from_parts(desc, sig));
         }
 
         let bsk = self.derive_bsk_private();
@@ -555,25 +569,23 @@ impl Bundle<ProofStamp> {
         )
     }
 
-    /// Confirm published coverage without verifying the proof: reconstruct the
-    /// action-set commitment from this bundle's actions plus every adjunct's
-    /// and check it against the carried `cActionsTachyon`. Assistive, not
-    /// soundness.
-    pub fn covers<T: StampState>(
-        &self,
-        associates: &[Bundle<T>],
-    ) -> Result<bool, ActionDigestError> {
-        let associate_actions = associates.iter().flat_map(|adjunct| adjunct.actions.iter());
+    /// Confirm published coverage without verifying the proof: reconstruct
+    /// the covered-actions digest from this bundle's actions plus every
+    /// adjunct's and check it against the carried `hActionsTachyon`.
+    /// Assistive, not soundness.
+    #[must_use]
+    pub fn covers(&self, adjuncts: &[Bundle<PointerStamp>]) -> bool {
+        let own_descs = self.actions.iter().map(Action::descriptor);
+        let other_descs = adjuncts
+            .iter()
+            .flat_map(|adjunct| adjunct.actions.iter())
+            .map(Action::descriptor);
 
-        let cover_actions = self.actions.iter().chain(associate_actions);
-
-        let cover_digests = cover_actions
-            .map(Action::digest)
-            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()?;
-
-        let cover_set = cover_digests.into_iter().collect::<ActionSetPoly>();
-
-        Ok(cover_set.commit() == self.stamp.action_set)
+        self.stamp.covers(
+            &own_descs
+                .chain(other_descs)
+                .collect::<Vec<action::Descriptor>>(),
+        )
     }
 
     /// Read a stamped bundle from the consensus wire format.
@@ -621,34 +633,14 @@ impl Bundle<ProofStamp> {
 
     /// Tachyon's contribution to the transaction `auth_digest`.
     ///
-    /// Hashes action signatures, the binding signature, and the stamp
-    /// trailer's field encodings.
+    /// Commits the action signatures, the binding signature, and the proof
+    /// stamp's digest. See [`blake2b::auth_digest`].
     #[must_use]
     pub fn auth_digest(&self) -> [u8; 32] {
         let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig.into()).collect();
         let binding_sig: [u8; 64] = self.binding_sig.into();
 
-        let trailer = {
-            let action_set: [u8; 32] = Eq::from(self.stamp.action_set).to_bytes();
-            let anchor: [u8; 32] = self.stamp.anchor.0.into();
-            let tachygrams: Vec<[u8; 32]> = self
-                .stamp
-                .tachygrams
-                .iter()
-                .map(|&tg| Fp::from(tg).to_repr())
-                .collect();
-            let proof = self.stamp.proof.serialize();
-            (action_set, anchor, tachygrams, proof)
-        };
-
-        blake2b::stamped_auth_digest(
-            &action_sigs,
-            &binding_sig,
-            &trailer.0,
-            &trailer.1,
-            &trailer.2,
-            trailer.3.as_ref(),
-        )
+        blake2b::auth_digest(&action_sigs, &binding_sig, &self.stamp.stamp_digest())
     }
 }
 
@@ -704,13 +696,14 @@ impl Bundle<PointerStamp> {
 
     /// Tachyon's contribution to the transaction `auth_digest`.
     ///
-    /// Hashes action signatures, the binding signature, and the stripped
-    /// trailer: the 64-byte `wtxid` of the covering aggregate.
+    /// Commits the action signatures, the binding signature, and the
+    /// pointer stamp's digest. See [`blake2b::auth_digest`].
     #[must_use]
     pub fn auth_digest(&self) -> [u8; 32] {
         let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig.into()).collect();
         let binding_sig: [u8; 64] = self.binding_sig.into();
-        blake2b::stripped_auth_digest(&action_sigs, &binding_sig, &self.stamp.into())
+
+        blake2b::auth_digest(&action_sigs, &binding_sig, &self.stamp.stamp_digest())
     }
 }
 
@@ -878,6 +871,20 @@ impl ops::Sub<note::Value> for ValueBalance {
 #[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Signature(pub(crate) reddsa::Signature<reddsa::BindingAuth>);
 
+impl Signature {
+    /// Read a binding signature from the consensus wire format.
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let sig = serialization::read_binding_sig(&mut reader)?;
+        Ok(Self(sig))
+    }
+
+    /// Write a binding signature to the consensus wire format.
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        serialization::write_binding_sig(&mut writer, &self.0)?;
+        Ok(())
+    }
+}
+
 impl From<[u8; 64]> for Signature {
     fn from(bytes: [u8; 64]) -> Self {
         Self(bytes.into())
@@ -905,26 +912,23 @@ fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, i64, Sig
             )
         })?;
 
-    let mut descriptors = Vec::with_capacity(n_actions);
+    let mut descriptors: Vec<action::Descriptor> = Vec::with_capacity(n_actions);
     for _ in 0..n_actions {
-        let cv = value::Commitment(serialization::read_ep_affine(&mut reader)?);
-        let rk = public::ActionVerificationKey(serialization::read_action_vk(&mut reader)?);
-        descriptors.push((cv, rk));
+        descriptors.push(action::Descriptor::read(&mut reader)?);
     }
 
     let mut signatures = Vec::with_capacity(n_actions);
     for _ in 0..n_actions {
-        let sig = action::Signature(serialization::read_action_sig(&mut reader)?);
-        signatures.push(sig);
+        signatures.push(action::Signature::read(&mut reader)?);
     }
 
     let actions = descriptors
         .iter()
         .zip(signatures.iter())
-        .map(|(&(cv, rk), &sig)| Action { cv, rk, sig })
+        .map(|(&desc, &sig)| Action::from_parts(desc, sig))
         .collect();
 
-    let binding_sig = Signature(serialization::read_binding_sig(&mut reader)?);
+    let binding_sig = Signature::read(&mut reader)?;
 
     Ok((actions, value_balance, binding_sig))
 }
@@ -949,8 +953,7 @@ fn write_bundle_body<W: Write>(
         })?,
     )?;
     for action in actions {
-        serialization::write_ep_affine(&mut writer, &action.cv.0)?;
-        serialization::write_action_vk(&mut writer, &action.rk.0)?;
+        action.descriptor().write(&mut writer)?;
     }
     for action in actions {
         serialization::write_action_sig(&mut writer, &action.sig.0)?;

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -456,7 +456,7 @@ impl Bundle<Unproven> {
 }
 
 impl Bundle<ProofStamp> {
-    /// Replace the stamp with a wtixd pointer to a covering aggregate.
+    /// Replace the stamp with a wtxid pointer to a covering aggregate.
     #[must_use]
     pub fn strip(self, wtxid: PointerStamp) -> Bundle<PointerStamp> {
         Bundle {
@@ -632,8 +632,7 @@ impl<S: StampState> Bundle<S> {
     }
 }
 
-/// A Tachyon bundle in any of its on-wire states: absent, stamped, or stripped.
-/// Provided for consumers to switch over any form.
+/// A Tachyon bundle in one of its valid wire states.
 ///
 /// The `Unproven` intermediate state is outside this enum because it has no
 /// wire representation.
@@ -642,10 +641,9 @@ impl<S: StampState> Bundle<S> {
 pub enum TachyonBundle {
     /// No bundle.
     NoBundle,
-    /// A bundle with its own stamp (autonome or aggregate).
+    /// A bundle with its own proof (autonome or aggregate).
     Proven(Bundle<ProofStamp>),
-    /// A bundle whose stamp has been stripped; carries a reference to the
-    /// covering aggregate via its [`PointerStamp`].
+    /// A bundle with no internal proof (adjunct).
     Adjunct(Bundle<PointerStamp>),
 }
 
@@ -668,53 +666,47 @@ impl TachyonBundle {
 
     /// Write any Tachyon bundle in the consensus wire format, dispatching on
     /// the variant.
-    #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn write<W: Write>(&self, writer: W) -> io::Result<()> {
+        #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
         match *self {
             Self::NoBundle => StateByte::NoBundle.write(writer),
             Self::Proven(ref stamped) => stamped.write(writer),
-            Self::Adjunct(ref stripped) => stripped.write(writer),
+            Self::Adjunct(ref stamped) => stamped.write(writer),
         }
     }
 
     /// Tachyon's contribution to the transaction `auth_digest`, dispatching
-    /// on the variant. See [`Bundle::auth_digest`].
+    /// on the variant.
     #[must_use]
-    #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn auth_digest(&self) -> [u8; 32] {
+        #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
         match *self {
             Self::NoBundle => *blake2b::AUTH_DIGEST_NO_BUNDLE,
             Self::Proven(ref stamped) => stamped.auth_digest(),
-            Self::Adjunct(ref stripped) => stripped.auth_digest(),
+            Self::Adjunct(ref stamped) => stamped.auth_digest(),
         }
     }
 
-    /// Tachyon's contribution to the transaction sighash (txid side).
-    ///
-    /// Dispatches on the variant to [`Bundle::commitment`], which commits the
-    /// owned actions' descriptors and the value balance; a `NoBundle`
-    /// contributes the fixed `COMMIT_NO_BUNDLE` sentinel. The stamp and the
-    /// signatures are excluded (they belong to the `auth_digest`).
+    /// Tachyon's contribution to the transaction sighash, dispatching on the
+    /// variant.
     #[must_use]
-    #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn commitment(&self) -> [u8; 32] {
+        #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
         match *self {
             Self::NoBundle => *blake2b::COMMIT_NO_BUNDLE,
             Self::Proven(ref stamped) => stamped.commitment(),
-            Self::Adjunct(ref stripped) => stripped.commitment(),
+            Self::Adjunct(ref stamped) => stamped.commitment(),
         }
     }
 
-    /// Check if this bundle is an aggregate, by computing the digest of its
-    /// owned actions and comparing to its stamp's `hStampActionsTachyon` if
-    /// present.
+    /// Check if this bundle is an aggregate.
     #[must_use]
-    #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn is_aggregate(&self) -> bool {
+        #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
         match *self {
             Self::NoBundle => false,
             Self::Proven(ref stamped) => stamped.is_aggregate(),
-            Self::Adjunct(ref _stripped) => false,
+            Self::Adjunct(ref _stamped) => false,
         }
     }
 }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -73,17 +73,14 @@ use core::ops;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, IsVariant, PartialEq, TryInto};
-use group::GroupEncoding as _;
-use pasta_curves::Eq;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
-    ActionSetPoly,
     action::{self, Action},
     digest::blake2b,
     keys::{private, public},
     note,
-    primitives::{ActionDigest, ActionDigestError, Anchor, effect},
+    primitives::{ActionDigestError, Anchor, effect},
     reddsa, serialization,
     stamp::{self, PointerStamp, ProofStamp, StampState, Unproven},
 };
@@ -117,12 +114,8 @@ impl StateByte {
     }
 
     pub(super) fn write<W: Write>(self, mut writer: W) -> io::Result<()> {
-        let byte = match self {
-            Self::NoBundle => 0b0000_0000u8,
-            Self::ProofStamped => 0b0000_0001u8,
-            Self::PointerStamped => 0b0000_0010u8,
-        };
-        writer.write_all(&byte.to_le_bytes())
+        #[expect(clippy::as_conversions, reason = "repr u8")]
+        writer.write_all(&(self as u8).to_le_bytes())
     }
 }
 
@@ -137,9 +130,7 @@ mod sealed {
 #[expect(clippy::module_name_repetitions, reason = "intentional name")]
 pub trait BundleState: sealed::Sealed {}
 
-impl BundleState for Unproven {}
-impl BundleState for ProofStamp {}
-impl BundleState for PointerStamp {}
+impl<T: sealed::Sealed> BundleState for T {}
 
 /// A Tachyon transaction bundle parameterized by bundle state `S`.
 #[derive(Clone, Debug, PartialEq, TotalEq)]
@@ -157,22 +148,57 @@ pub struct Bundle<S: BundleState + ?Sized> {
     pub stamp: S,
 }
 
-/// A Tachyon bundle in any of its on-wire states: absent, stamped, or
-/// stripped.
-///
-/// Used where code accepts any form — reading from the wire, dispatching
-/// `auth_digest`, etc. The `Unproven` intermediate state is outside this
-/// enum because it has no wire representation.
-#[expect(clippy::module_name_repetitions, reason = "intentional name")]
-#[derive(Clone, Debug, From, IsVariant, TryInto)]
-pub enum TachyonBundle {
-    /// No bundle.
-    NoBundle,
-    /// A bundle with its own stamp (autonome or aggregate).
-    Proven(Bundle<ProofStamp>),
-    /// A bundle whose stamp has been stripped; carries a reference to the
-    /// covering aggregate via its [`PointerStamp`].
-    Adjunct(Bundle<PointerStamp>),
+impl<S: BundleState + ?Sized> Bundle<S> {
+    /// Collect the descriptors of all actions in the bundle.
+    #[must_use]
+    pub fn descriptors(&self) -> Vec<action::Descriptor> {
+        self.actions.iter().map(Action::descriptor).collect()
+    }
+
+    /// Digest the bundle's effecting data.
+    ///
+    /// This contributes to the transaction sighash. The stamp is excluded
+    /// because it is considered authorizing data, and is malleable during
+    /// aggregation.
+    #[must_use]
+    pub fn commitment(&self) -> [u8; 32] {
+        let descriptors: Vec<[u8; 64]> = self
+            .descriptors()
+            .into_iter()
+            .map(<[u8; 64]>::from)
+            .collect();
+
+        // The bundle's actions should already be sorted by construction.
+        debug_assert!(
+            descriptors.is_sorted(),
+            "bundle actions must be canonically sorted"
+        );
+
+        blake2b::bundle_commitment(
+            &blake2b::action_descriptor_digest(&descriptors),
+            self.value_balance,
+        )
+    }
+
+    /// Verify the bundle's binding signature and all action signatures.
+    pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), SignatureError> {
+        // 1. Derive bvk from public data (validator-side, §4.14)
+        let bvk = public::BindingVerificationKey::derive(&self.actions, self.value_balance);
+
+        // 2. Verify binding signature
+        bvk.verify(sighash, &self.binding_sig)
+            .map_err(|_err| SignatureError::Binding(self.binding_sig))?;
+
+        // 3. Verify each action signature against the SAME sighash
+        for action in &self.actions {
+            action
+                .rk
+                .verify(sighash, &action.sig)
+                .map_err(|_err| SignatureError::Action(action.sig))?;
+        }
+
+        Ok(())
+    }
 }
 
 /// Errors during bundle construction.
@@ -262,6 +288,16 @@ impl Plan {
         spend_transform.chain(output_transform)
     }
 
+    /// Collect and sort the descriptors of all actions in the plan.
+    #[must_use]
+    pub fn descriptors(&self) -> Vec<action::Descriptor> {
+        let mut desc = self
+            .iter_actions(action::Plan::descriptor, action::Plan::descriptor)
+            .collect::<Vec<action::Descriptor>>();
+        desc.sort_unstable();
+        desc
+    }
+
     /// Derive value_balance from note values.
     ///
     /// $\mathsf{v\_balance} = \sum_i v_{\text{spend},i} - \sum_j
@@ -281,29 +317,16 @@ impl Plan {
     }
 
     /// Compute a digest of all the bundle's effecting data.
-    ///
-    /// This contributes to the transaction sighash.
-    ///
-    /// $$ \mathsf{bundle\_commitment} = \text{BLAKE2b-256}(
-    /// \text{"ZTxIdTachyonHash"},\;
-    /// \mathsf{encoding}(\mathsf{action\_acc}) \|
-    /// \mathsf{value\_balance}) $$
-    ///
-    /// where $\mathsf{action\_acc}$ is the polynomial commitment to the
-    /// action digest multiset `∏(X - action_digest_i)` — order-independent
-    /// by construction since the polynomial is invariant under root
-    /// permutation — digested as its 32-byte point encoding.
-    ///
-    /// The stamp is excluded because it is stripped during aggregation.
+    /// See [`Bundle::commitment`].
     pub fn commitment(&self) -> Result<[u8; 32], CommitError> {
-        let digests: Vec<ActionDigest> = self
-            .iter_actions(action::Plan::digest, action::Plan::digest)
-            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()?;
-
-        let action_commit = ActionSetPoly::from_iter(digests).commit();
+        let desc_bytes: Vec<[u8; 64]> = self
+            .descriptors()
+            .into_iter()
+            .map(<[u8; 64]>::from)
+            .collect();
 
         Ok(blake2b::bundle_commitment(
-            &Eq::from(action_commit).to_bytes(),
+            &blake2b::action_descriptor_digest(&desc_bytes),
             self.value_balance()?,
         ))
     }
@@ -353,7 +376,8 @@ impl Plan {
     /// For each action, independently derives alpha from theta + note
     /// commitment, verifies the derived rk matches, and signs. Also
     /// derives the binding signing key from rcvs and signs the binding
-    /// signature.
+    /// signature. The resulting actions are canonically sorted so that the
+    /// bundle matches its commitment's descriptor order.
     ///
     /// The result is a `Bundle<Unproven>` — combine with a [`ProofStamp`]
     /// via [`Bundle::stamp`] to produce a `Bundle<ProofStamp>`.
@@ -394,6 +418,8 @@ impl Plan {
             });
         }
 
+        authorized.sort_unstable();
+
         let bsk = self.derive_bsk_private();
         let binding_sig = bsk.sign(rng, sighash);
 
@@ -407,33 +433,34 @@ impl Plan {
         })
     }
 
-    /// Apply externally-produced signatures (e.g. from FROST).
+    /// Apply externally-produced signatures.
     ///
     /// Validates each signature against the action's rk and the sighash.
-    /// Derives cv from each plan and produces the binding signature.
+    /// Derives cv from each plan and produces the binding signature. The
+    /// resulting actions are canonically sorted; each signature stays paired
+    /// with its descriptor, so sorting preserves the pairing.
     pub fn apply_signatures<RNG: RngCore + CryptoRng>(
         &self,
+        rng: &mut RNG,
         sighash: &[u8; 32],
         sigs: Vec<action::Signature>,
-        rng: &mut RNG,
     ) -> Result<Bundle<Unproven>, SignError> {
         let n_actions = self.spends.len() + self.outputs.len();
         if sigs.len() != n_actions {
             return Err(SignError::SigCountMismatch(n_actions));
         }
 
-        let mut authorized = Vec::with_capacity(n_actions);
-
-        let all_descriptors = self
-            .iter_actions(action::Plan::descriptor, action::Plan::descriptor)
-            .zip(sigs);
-
-        for (desc, sig) in all_descriptors {
-            if desc.rk.verify(sighash, &sig).is_err() {
-                return Err(SignError::InvalidActionSignature(sig));
-            }
-            authorized.push(Action::from_parts(desc, sig));
-        }
+        let authorized = self
+            .descriptors()
+            .into_iter()
+            .zip(sigs)
+            .map(|(desc, sig)| {
+                desc.rk
+                    .verify(sighash, &sig)
+                    .map_err(|_err| SignError::InvalidActionSignature(sig))?;
+                Ok(Action::from_parts(desc, sig))
+            })
+            .collect::<Result<Vec<Action>, SignError>>()?;
 
         let bsk = self.derive_bsk_private();
         let binding_sig = bsk.sign(rng, sighash);
@@ -463,7 +490,7 @@ impl Bundle<Unproven> {
 }
 
 impl Bundle<ProofStamp> {
-    /// Produce an adjunct bundle with a pointer to a covering aggregate.
+    /// Replace the stamp with a wtixd pointer to a covering aggregate.
     #[must_use]
     pub fn strip(self, wtxid: PointerStamp) -> Bundle<PointerStamp> {
         Bundle {
@@ -493,13 +520,24 @@ impl Bundle<ProofStamp> {
                 .collect::<Vec<action::Descriptor>>(),
         )
     }
+
+    /// Check if this bundle is an aggregate, by computing the digest of its
+    /// owned actions and comparing to its stamp's `hActionsTachyon`.
+    #[must_use]
+    pub fn is_aggregate(&self) -> bool {
+        let desc_bytes: Vec<[u8; 64]> = self
+            .descriptors()
+            .into_iter()
+            .map(<[u8; 64]>::from)
+            .collect();
+        blake2b::action_descriptor_digest(&desc_bytes) == self.stamp.covered_actions
+    }
 }
 
 impl<S: StampState> Bundle<S> {
-    /// Read a bundle in state `S` from the consensus wire format.
+    /// Read a stamped bundle in state `S` from the consensus wire format.
     ///
-    /// Expects the `tachyonBundleState` byte for `S`. See the module-level
-    /// wire format documentation.
+    /// See the module-level wire format documentation.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let head = StateByte::read(&mut reader)?;
 
@@ -522,6 +560,10 @@ impl<S: StampState> Bundle<S> {
             vb_bytes
         });
 
+        // `n_actions` is attacker-controlled up to MAX_COMPACT_SIZE (2^25), so
+        // do not pre-allocate vector capacity. vector reads are ASSUMED to hit
+        // invalid data or EOF before significant problems occur.
+        // TODO: assert a reasonable maximum, to allow pre-allocation?
         let n_actions =
             usize::try_from(serialization::read_compactsize(&mut reader)?).map_err(|_err| {
                 io::Error::new(
@@ -530,20 +572,27 @@ impl<S: StampState> Bundle<S> {
                 )
             })?;
 
-        let mut descriptors: Vec<action::Descriptor> = Vec::with_capacity(n_actions);
+        let mut descriptors: Vec<action::Descriptor> = Vec::new();
         for _ in 0..n_actions {
             descriptors.push(action::Descriptor::read(&mut reader)?);
         }
 
-        let mut signatures = Vec::with_capacity(n_actions);
+        if !descriptors.is_sorted() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "actions are not canonically sorted",
+            ));
+        }
+
+        let mut signatures: Vec<action::Signature> = Vec::new();
         for _ in 0..n_actions {
             signatures.push(action::Signature::read(&mut reader)?);
         }
 
-        let actions = descriptors
-            .iter()
-            .zip(signatures.iter())
-            .map(|(&desc, &sig)| Action::from_parts(desc, sig))
+        let actions: Vec<Action> = descriptors
+            .into_iter()
+            .zip(signatures)
+            .map(|(desc, sig)| Action::from_parts(desc, sig))
             .collect();
 
         let binding_sig = Signature::read(&mut reader)?;
@@ -587,15 +636,51 @@ impl<S: StampState> Bundle<S> {
 
     /// Tachyon's contribution to the transaction `auth_digest`.
     ///
-    /// Commits the action signatures, the binding signature, and the
-    /// stamp's digest. See [`blake2b::auth_digest`].
+    /// Commits the action descriptor digest, the action signatures, the
+    /// binding signature, and the stamp's digest. See
+    /// [`blake2b::bundle_auth_digest`].
     #[must_use]
     pub fn auth_digest(&self) -> [u8; 32] {
+        let descriptors: Vec<[u8; 64]> = self
+            .descriptors()
+            .into_iter()
+            .map(<[u8; 64]>::from)
+            .collect();
+
+        // The bundle's actions should already be sorted by construction.
+        debug_assert!(
+            descriptors.is_sorted(),
+            "bundle actions must be canonically sorted"
+        );
+        let action_digest = blake2b::action_descriptor_digest(&descriptors);
+
         let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig.into()).collect();
         let binding_sig: [u8; 64] = self.binding_sig.into();
 
-        blake2b::auth_digest(&action_sigs, &binding_sig, &self.stamp.stamp_digest())
+        blake2b::bundle_auth_digest(
+            &action_digest,
+            &action_sigs,
+            &binding_sig,
+            &self.stamp.stamp_digest(),
+        )
     }
+}
+
+/// A Tachyon bundle in any of its on-wire states: absent, stamped, or stripped.
+/// Provided for consumers to switch over any form.
+///
+/// The `Unproven` intermediate state is outside this enum because it has no
+/// wire representation.
+#[expect(clippy::module_name_repetitions, reason = "intentional name")]
+#[derive(Clone, Debug, From, IsVariant, TryInto)]
+pub enum TachyonBundle {
+    /// No bundle.
+    NoBundle,
+    /// A bundle with its own stamp (autonome or aggregate).
+    Proven(Bundle<ProofStamp>),
+    /// A bundle whose stamp has been stripped; carries a reference to the
+    /// covering aggregate via its [`PointerStamp`].
+    Adjunct(Bundle<PointerStamp>),
 }
 
 impl TachyonBundle {
@@ -638,53 +723,32 @@ impl TachyonBundle {
         }
     }
 
-    /// Tachyon's contribution to the transaction `commitment`.
+    /// Tachyon's contribution to the transaction sighash (txid side).
     ///
-    /// Commits the action signatures, the binding signature, and the
-    /// stamp's digest. See [`blake2b::bundle_commitment`].
+    /// Dispatches on the variant to [`Bundle::commitment`], which commits the
+    /// owned actions' descriptors and the value balance; a `NoBundle`
+    /// contributes the fixed `COMMIT_NO_BUNDLE` sentinel. The stamp and the
+    /// signatures are excluded (they belong to the `auth_digest`).
+    #[must_use]
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
-    pub fn commitment(&self) -> Result<[u8; 32], ActionDigestError> {
+    pub fn commitment(&self) -> [u8; 32] {
         match *self {
-            Self::NoBundle => Ok(*blake2b::COMMIT_NO_BUNDLE),
+            Self::NoBundle => *blake2b::COMMIT_NO_BUNDLE,
             Self::Proven(ref stamped) => stamped.commitment(),
             Self::Adjunct(ref stripped) => stripped.commitment(),
         }
     }
-}
 
-impl<S: BundleState + ?Sized> Bundle<S> {
-    /// See [`Plan::commitment`].
-    pub fn commitment(&self) -> Result<[u8; 32], ActionDigestError> {
-        let action_digests = self
-            .actions
-            .iter()
-            .map(Action::digest)
-            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()?;
-        let action_acc = ActionSetPoly::from_iter(action_digests).commit();
-        Ok(blake2b::bundle_commitment(
-            &Eq::from(action_acc).to_bytes(),
-            self.value_balance,
-        ))
-    }
-
-    /// Verify the bundle's binding signature and all action signatures.
-    pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), SignatureError> {
-        // 1. Derive bvk from public data (validator-side, §4.14)
-        let bvk = public::BindingVerificationKey::derive(&self.actions, self.value_balance);
-
-        // 2. Verify binding signature
-        bvk.verify(sighash, &self.binding_sig)
-            .map_err(|_err| SignatureError::Binding(self.binding_sig))?;
-
-        // 3. Verify each action signature against the SAME sighash
-        for action in &self.actions {
-            action
-                .rk
-                .verify(sighash, &action.sig)
-                .map_err(|_err| SignatureError::Action(action.sig))?;
+    /// Check if this bundle is an aggregate, by computing the digest of its
+    /// owned actions and comparing to its stamp's `hActionsTachyon` if present.
+    #[must_use]
+    #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
+    pub fn is_aggregate(&self) -> bool {
+        match *self {
+            Self::NoBundle => false,
+            Self::Proven(ref stamped) => stamped.is_aggregate(),
+            Self::Adjunct(ref _stripped) => false,
         }
-
-        Ok(())
     }
 }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -82,7 +82,7 @@ use crate::{
     note,
     primitives::{ActionDigest, ActionDigestError, Anchor, effect},
     reddsa, serialization,
-    stamp::{self, AggregateId, Stamp, Stripped, Unproven},
+    stamp::{self, PointerStamp, ProofStamp, Stripped, Unproven},
     value,
 };
 
@@ -90,20 +90,20 @@ use crate::{
 /// documentation for its role.
 #[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 #[repr(u8)]
-enum BundleState {
+enum BundleStateFlags {
     NoBundle = 0b0000_0000u8,
-    Stamped = 0b0000_0001u8,
-    Stripped = 0b0000_0010u8,
+    ProofStamped = 0b0000_0001u8,
+    PointerStamped = 0b0000_0010u8,
 }
 
-impl BundleState {
+impl BundleStateFlags {
     pub(super) fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut byte = [0u8; 1];
         reader.read_exact(&mut byte)?;
         match u8::from_le_bytes(byte) {
             0b0000_0000u8 => Ok(Self::NoBundle),
-            0b0000_0001u8 => Ok(Self::Stamped),
-            0b0000_0010u8 => Ok(Self::Stripped),
+            0b0000_0001u8 => Ok(Self::ProofStamped),
+            0b0000_0010u8 => Ok(Self::PointerStamped),
             _other => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "invalid bundle state",
@@ -114,8 +114,8 @@ impl BundleState {
     pub(super) fn write<W: Write>(self, mut writer: W) -> io::Result<()> {
         let byte = u8::to_le_bytes(match self {
             Self::NoBundle => 0b0000_0000u8,
-            Self::Stamped => 0b0000_0001u8,
-            Self::Stripped => 0b0000_0010u8,
+            Self::ProofStamped => 0b0000_0001u8,
+            Self::PointerStamped => 0b0000_0010u8,
         });
         writer.write_all(&byte)
     }
@@ -124,9 +124,9 @@ impl BundleState {
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::Unproven {}
-    impl Sealed for super::Stamp {}
-    impl Sealed for super::AggregateId {}
+    impl Sealed for super::ProofStamp {}
     impl Sealed for super::Stripped {}
+    impl Sealed for super::PointerStamp {}
 }
 
 /// Sealed trait constraining stamp state types.
@@ -158,14 +158,14 @@ pub struct Bundle<S: StampState> {
 #[derive(Clone, Debug, From)]
 pub enum TachyonBundle {
     /// A bundle with its own stamp (autonome or aggregate).
-    Stamped(Bundle<Stamp>),
+    Stamped(Bundle<ProofStamp>),
     /// A bundle whose stamp has been stripped; carries a reference to the
     /// covering aggregate via its [`AggregateId`].
-    Adjunct(Bundle<AggregateId>),
+    Adjunct(Bundle<PointerStamp>),
 }
 
-impl TryFrom<TachyonBundle> for Bundle<Stamp> {
-    type Error = Bundle<AggregateId>;
+impl TryFrom<TachyonBundle> for Bundle<ProofStamp> {
+    type Error = Bundle<PointerStamp>;
 
     fn try_from(bundle: TachyonBundle) -> Result<Self, Self::Error> {
         match bundle {
@@ -175,8 +175,8 @@ impl TryFrom<TachyonBundle> for Bundle<Stamp> {
     }
 }
 
-impl TryFrom<TachyonBundle> for Bundle<AggregateId> {
-    type Error = Bundle<Stamp>;
+impl TryFrom<TachyonBundle> for Bundle<PointerStamp> {
+    type Error = Bundle<ProofStamp>;
 
     fn try_from(bundle: TachyonBundle) -> Result<Self, Self::Error> {
         match bundle {
@@ -463,7 +463,7 @@ impl Plan {
 impl Bundle<Unproven> {
     /// Attach a stamp, producing a `Bundle<Stamp>`.
     #[must_use]
-    pub fn stamp(self, stamp: Stamp) -> Bundle<Stamp> {
+    pub fn stamp(self, stamp: ProofStamp) -> Bundle<ProofStamp> {
         Bundle {
             actions: self.actions,
             value_balance: self.value_balance,
@@ -482,7 +482,7 @@ impl Bundle<Stripped> {
     /// `wtxid` is an already-validated nonzero [`AggregateId`], so every
     /// stripped bundle (innocent or adjunct) names a covering aggregate.
     #[must_use]
-    pub fn assign_wtxid(self, wtxid: AggregateId) -> Bundle<AggregateId> {
+    pub fn assign_wtxid(self, wtxid: PointerStamp) -> Bundle<PointerStamp> {
         Bundle {
             actions: self.actions,
             value_balance: self.value_balance,
@@ -492,7 +492,7 @@ impl Bundle<Stripped> {
     }
 }
 
-impl Bundle<Stamp> {
+impl Bundle<ProofStamp> {
     /// Strips the stamp, producing an unassigned bundle and the extracted
     /// stamp.
     ///
@@ -501,7 +501,7 @@ impl Bundle<Stamp> {
     /// before it can be serialized. The stamp should be merged into an
     /// aggregate.
     #[must_use]
-    pub fn strip(self) -> (Bundle<Stripped>, Stamp) {
+    pub fn strip(self) -> (Bundle<Stripped>, ProofStamp) {
         (
             Bundle {
                 actions: self.actions,
@@ -539,9 +539,9 @@ impl Bundle<Stamp> {
     /// Expects `tachyonBundleState == 0x01`. See the module-level wire format
     /// documentation.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
-        let head = BundleState::read(&mut reader)?;
+        let head = BundleStateFlags::read(&mut reader)?;
 
-        if head != BundleState::Stamped {
+        if head != BundleStateFlags::ProofStamped {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "stamped bundle requires tachyonBundleState 0x01",
@@ -551,7 +551,7 @@ impl Bundle<Stamp> {
         let (actions, value_balance, binding_sig): (Vec<Action>, i64, Signature) =
             read_bundle_body(&mut reader)?;
 
-        let stamp = Stamp::read(&mut reader)?;
+        let stamp = ProofStamp::read(&mut reader)?;
 
         Ok(Self {
             actions,
@@ -563,7 +563,7 @@ impl Bundle<Stamp> {
 
     /// Write a stamped bundle in the consensus wire format.
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        BundleState::Stamped.write(&mut writer)?;
+        BundleStateFlags::ProofStamped.write(&mut writer)?;
 
         write_bundle_body(
             &mut writer,
@@ -610,16 +610,16 @@ impl Bundle<Stamp> {
     }
 }
 
-impl Bundle<AggregateId> {
+impl Bundle<PointerStamp> {
     /// Read a stripped bundle from the consensus wire format.
     ///
     /// Expects `tachyonBundleState` 0x02. Always reads a nonzero 64-byte
     /// `stampWtxid` trailer; [`AggregateId::read`] rejects the all-zero
     /// encoding. See the module-level wire format documentation.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
-        let head = BundleState::read(&mut reader)?;
+        let head = BundleStateFlags::read(&mut reader)?;
 
-        if head != BundleState::Stripped {
+        if head != BundleStateFlags::PointerStamped {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "stripped bundle requires tachyonBundleState 0x02",
@@ -628,7 +628,7 @@ impl Bundle<AggregateId> {
 
         let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
 
-        let stamp = AggregateId::read(&mut reader)?;
+        let stamp = PointerStamp::read(&mut reader)?;
 
         Ok(Self {
             actions,
@@ -648,7 +648,7 @@ impl Bundle<AggregateId> {
     /// locating it via tachygram matching against the original autonome
     /// broadcast.
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        BundleState::Stripped.write(&mut writer)?;
+        BundleStateFlags::PointerStamped.write(&mut writer)?;
 
         write_bundle_body(
             &mut writer,
@@ -681,22 +681,22 @@ impl TachyonBundle {
     /// layer) and any other byte.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Option<Self>> {
         // TODO: just peek at state, then delegate to the appropriate read method
-        let state = BundleState::read(&mut reader)?;
+        let state = BundleStateFlags::read(&mut reader)?;
 
         Ok(match state {
-            BundleState::NoBundle => None,
-            BundleState::Stamped => {
+            BundleStateFlags::NoBundle => None,
+            BundleStateFlags::ProofStamped => {
                 let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
                 Some(Self::Stamped(Bundle {
                     actions,
                     value_balance,
                     binding_sig,
-                    stamp: Stamp::read(&mut reader)?,
+                    stamp: ProofStamp::read(&mut reader)?,
                 }))
             },
-            BundleState::Stripped => {
+            BundleStateFlags::PointerStamped => {
                 let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
-                let stamp = AggregateId::read(&mut reader)?;
+                let stamp = PointerStamp::read(&mut reader)?;
 
                 Some(Self::Adjunct(Bundle {
                     actions,

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -722,7 +722,8 @@ impl TachyonBundle {
     }
 
     /// Check if this bundle is an aggregate, by computing the digest of its
-    /// owned actions and comparing to its stamp's `hStampActionsTachyon` if present.
+    /// owned actions and comparing to its stamp's `hStampActionsTachyon` if
+    /// present.
     #[must_use]
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn is_aggregate(&self) -> bool {

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -320,7 +320,7 @@ impl Plan {
             .iter()
             .map(|plan| {
                 let alpha = plan.theta.randomizer(plan.note.commitment());
-                (plan.descriptor(), (alpha, plan.note, plan.rcv))
+                (plan.descriptor(), alpha, plan.note, plan.rcv)
             })
             .collect();
 
@@ -329,7 +329,7 @@ impl Plan {
             .iter()
             .map(|plan| {
                 let alpha = plan.theta.randomizer(plan.note.commitment());
-                (plan.descriptor(), (alpha, plan.note, plan.rcv))
+                (plan.descriptor(), alpha, plan.note, plan.rcv)
             })
             .collect();
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -6,7 +6,7 @@
 //! - `Bundle<ProofStamp>` — self-contained bundle with a proof stamp
 //! - `Bundle<PointerStamp>` — proof stamp replaced by a pointer stamp naming
 //!   the covering aggregate
-//! - [`TachyonBundle`] — enum of the two on-wire forms for mixed contexts
+//! - [`TachyonBundle`] — enum of the on-wire forms for mixed contexts
 //!
 //! # Consensus wire format
 //!
@@ -73,12 +73,10 @@ use core::ops;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, IsVariant, PartialEq, TryInto};
-use ff::PrimeField as _;
 use group::GroupEncoding as _;
-use pasta_curves::{Eq, Fp};
+use pasta_curves::Eq;
 use rand_core::{CryptoRng, RngCore};
 
-pub use crate::digest::blake2b::{AUTH_DIGEST_NO_BUNDLE, COMMIT_NO_BUNDLE};
 use crate::{
     ActionSetPoly,
     action::{self, Action},
@@ -87,20 +85,23 @@ use crate::{
     note,
     primitives::{ActionDigest, ActionDigestError, Anchor, effect},
     reddsa, serialization,
-    stamp::{self, PointerStamp, ProofStamp, Unproven},
+    stamp::{self, PointerStamp, ProofStamp, StampState, Unproven},
 };
 
 /// The `tachyonBundleState` wire byte. See the module-level wire format
 /// documentation for its role.
 #[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 #[repr(u8)]
-enum BundleStateFlags {
+pub enum StateByte {
+    /// No bundle.
     NoBundle = 0b0000_0000u8,
+    /// Proof stamped bundle.
     ProofStamped = 0b0000_0001u8,
+    /// Pointer stamped bundle.
     PointerStamped = 0b0000_0010u8,
 }
 
-impl BundleStateFlags {
+impl StateByte {
     pub(super) fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut byte = [0u8; 1];
         reader.read_exact(&mut byte)?;
@@ -116,12 +117,12 @@ impl BundleStateFlags {
     }
 
     pub(super) fn write<W: Write>(self, mut writer: W) -> io::Result<()> {
-        let byte = u8::to_le_bytes(match self {
+        let byte = match self {
             Self::NoBundle => 0b0000_0000u8,
             Self::ProofStamped => 0b0000_0001u8,
             Self::PointerStamped => 0b0000_0010u8,
-        });
-        writer.write_all(&byte)
+        };
+        writer.write_all(&byte.to_le_bytes())
     }
 }
 
@@ -140,52 +141,6 @@ impl BundleState for Unproven {}
 impl BundleState for ProofStamp {}
 impl BundleState for PointerStamp {}
 
-/// Bundle states that carry a stamp: [`ProofStamp`] or [`PointerStamp`].
-/// The intermediate [`Unproven`] state has no stamp.
-pub trait StampState: BundleState {
-    /// The stamp's 64-byte wtxid-shaped digest: a proof stamp's
-    /// `hActionsTachyon || stamp_data_digest`, or a pointer stamp's
-    /// `wtxid = txid || auth_digest`.
-    fn stamp_digest(&self) -> [u8; 64];
-
-    // fn state_flags(&self) -> BundleStateFlags;
-
-    // fn read<R: Read>(mut reader: R) -> io::Result<Self>;
-
-    // fn write<W: Write>(&self, mut writer: W) -> io::Result<()>;
-}
-
-impl StampState for PointerStamp {
-    fn stamp_digest(&self) -> [u8; 64] {
-        <[u8; 64]>::from(*self)
-    }
-}
-
-impl StampState for ProofStamp {
-    fn stamp_digest(&self) -> [u8; 64] {
-        let stamp_data_digest: [u8; 32] = {
-            let proof = self.proof.serialize();
-            let anchor: [u8; 32] = self.anchor.0.into();
-            let tachygrams: Vec<[u8; 32]> = self
-                .tachygrams
-                .iter()
-                .map(|&tg| Fp::from(tg).to_repr())
-                .collect();
-
-            blake2b::stamp_data_digest(
-                blake2b::stamp_proof_digest(proof.as_ref()),
-                anchor,
-                &tachygrams,
-            )
-        };
-
-        let mut stamp_digest = [0u8; 64];
-        stamp_digest[..32].copy_from_slice(&self.covered_actions);
-        stamp_digest[32..].copy_from_slice(&stamp_data_digest);
-        stamp_digest
-    }
-}
-
 /// A Tachyon transaction bundle parameterized by bundle state `S`.
 #[derive(Clone, Debug, PartialEq, TotalEq)]
 pub struct Bundle<S: BundleState + ?Sized> {
@@ -202,18 +157,21 @@ pub struct Bundle<S: BundleState + ?Sized> {
     pub stamp: S,
 }
 
-/// A Tachyon bundle in one of its two on-wire states: stamped or stripped.
+/// A Tachyon bundle in any of its on-wire states: absent, stamped, or
+/// stripped.
 ///
-/// Used where code accepts either form — reading from the wire, dispatching
+/// Used where code accepts any form — reading from the wire, dispatching
 /// `auth_digest`, etc. The `Unproven` intermediate state is outside this
 /// enum because it has no wire representation.
 #[expect(clippy::module_name_repetitions, reason = "intentional name")]
 #[derive(Clone, Debug, From, IsVariant, TryInto)]
-pub enum StampedBundle {
+pub enum TachyonBundle {
+    /// No bundle.
+    NoBundle,
     /// A bundle with its own stamp (autonome or aggregate).
     Proven(Bundle<ProofStamp>),
     /// A bundle whose stamp has been stripped; carries a reference to the
-    /// covering aggregate via its [`AggregateId`].
+    /// covering aggregate via its [`PointerStamp`].
     Adjunct(Bundle<PointerStamp>),
 }
 
@@ -397,8 +355,8 @@ impl Plan {
     /// derives the binding signing key from rcvs and signs the binding
     /// signature.
     ///
-    /// The result is a `Bundle<Unproven>` — combine with a [`Stamp`] via
-    /// [`Bundle::stamp`] to produce a `Bundle<Stamp>`.
+    /// The result is a `Bundle<Unproven>` — combine with a [`ProofStamp`]
+    /// via [`Bundle::stamp`] to produce a `Bundle<ProofStamp>`.
     pub fn sign<RNG: RngCore + CryptoRng>(
         &self,
         sighash: &[u8; 32],
@@ -492,7 +450,7 @@ impl Plan {
 }
 
 impl Bundle<Unproven> {
-    /// Attach a stamp, producing a `Bundle<Stamp>`.
+    /// Attach a proof stamp, producing a `Bundle<ProofStamp>`.
     #[must_use]
     pub fn stamp(self, stamp: ProofStamp) -> Bundle<ProofStamp> {
         Bundle {
@@ -535,25 +493,62 @@ impl Bundle<ProofStamp> {
                 .collect::<Vec<action::Descriptor>>(),
         )
     }
+}
 
-    /// Read a stamped bundle from the consensus wire format.
+impl<S: StampState> Bundle<S> {
+    /// Read a bundle in state `S` from the consensus wire format.
     ///
-    /// Expects `tachyonBundleState == 0x01`. See the module-level wire format
-    /// documentation.
+    /// Expects the `tachyonBundleState` byte for `S`. See the module-level
+    /// wire format documentation.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
-        let head = BundleStateFlags::read(&mut reader)?;
+        let head = StateByte::read(&mut reader)?;
 
-        if head != BundleStateFlags::ProofStamped {
+        if head != S::state_byte() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "stamped bundle requires tachyonBundleState 0x01",
+                "unexpected tachyonBundleState",
             ));
         }
 
-        let (actions, value_balance, binding_sig): (Vec<Action>, i64, Signature) =
-            read_bundle_body(&mut reader)?;
+        Self::read_body(reader)
+    }
 
-        let stamp = ProofStamp::read(&mut reader)?;
+    /// Read everything after the `tachyonBundleState` byte: value balance,
+    /// action descriptors, action sigs, binding sig, and the stamp trailer.
+    fn read_body<R: Read>(mut reader: R) -> io::Result<Self> {
+        let value_balance = i64::from_le_bytes({
+            let mut vb_bytes = [0u8; 8];
+            reader.read_exact(&mut vb_bytes)?;
+            vb_bytes
+        });
+
+        let n_actions =
+            usize::try_from(serialization::read_compactsize(&mut reader)?).map_err(|_err| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "actions vector length exceeds usize",
+                )
+            })?;
+
+        let mut descriptors: Vec<action::Descriptor> = Vec::with_capacity(n_actions);
+        for _ in 0..n_actions {
+            descriptors.push(action::Descriptor::read(&mut reader)?);
+        }
+
+        let mut signatures = Vec::with_capacity(n_actions);
+        for _ in 0..n_actions {
+            signatures.push(action::Signature::read(&mut reader)?);
+        }
+
+        let actions = descriptors
+            .iter()
+            .zip(signatures.iter())
+            .map(|(&desc, &sig)| Action::from_parts(desc, sig))
+            .collect();
+
+        let binding_sig = Signature::read(&mut reader)?;
+
+        let stamp = S::read(&mut reader)?;
 
         Ok(Self {
             actions,
@@ -563,25 +558,36 @@ impl Bundle<ProofStamp> {
         })
     }
 
-    /// Write a stamped bundle in the consensus wire format.
+    /// Write the bundle in the consensus wire format: the
+    /// `tachyonBundleState` byte for `S`, the bundle body, and the stamp.
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        BundleStateFlags::ProofStamped.write(&mut writer)?;
+        S::state_byte().write(&mut writer)?;
 
-        write_bundle_body(
-            &mut writer,
-            &self.actions,
-            self.value_balance,
-            &self.binding_sig,
-        )?;
+        writer.write_all(&self.value_balance.to_le_bytes())?;
 
-        self.stamp.write(&mut writer)?;
+        let n_actions = u64::try_from(self.actions.len()).map_err(|_err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "actions vector length exceeds u64",
+            )
+        })?;
+        serialization::write_compactsize(&mut writer, n_actions)?;
 
-        Ok(())
+        for action in &self.actions {
+            action.descriptor().write(&mut writer)?;
+        }
+        for action in &self.actions {
+            action.sig.write(&mut writer)?;
+        }
+
+        self.binding_sig.write(&mut writer)?;
+
+        self.stamp.write(&mut writer)
     }
 
     /// Tachyon's contribution to the transaction `auth_digest`.
     ///
-    /// Commits the action signatures, the binding signature, and the proof
+    /// Commits the action signatures, the binding signature, and the
     /// stamp's digest. See [`blake2b::auth_digest`].
     #[must_use]
     pub fn auth_digest(&self) -> [u8; 32] {
@@ -592,101 +598,20 @@ impl Bundle<ProofStamp> {
     }
 }
 
-impl Bundle<PointerStamp> {
-    /// Read a stripped bundle from the consensus wire format.
-    ///
-    /// Expects `tachyonBundleState` 0x02. Always reads a nonzero 64-byte
-    /// `stampWtxid` trailer; [`AggregateId::read`] rejects the all-zero
-    /// encoding. See the module-level wire format documentation.
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
-        let head = BundleStateFlags::read(&mut reader)?;
-
-        if head != BundleStateFlags::PointerStamped {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "stripped bundle requires tachyonBundleState 0x02",
-            ));
-        }
-
-        let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
-
-        let stamp = PointerStamp::read(&mut reader)?;
-
-        Ok(Self {
-            actions,
-            value_balance,
-            binding_sig,
-            stamp,
-        })
-    }
-
-    /// Write a stripped bundle in the consensus wire format.
-    ///
-    /// Always writes flag `0x02` and a nonzero 64-byte `stampWtxid` trailer.
-    /// The trailer names the covering aggregate for every stripped bundle,
-    /// innocent or adjunct; [`AggregateId`] cannot hold the all-zero value.
-    ///
-    /// Miners assign the covering aggregate's wtxid during block assembly,
-    /// locating it via tachygram matching against the original autonome
-    /// broadcast.
-    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        BundleStateFlags::PointerStamped.write(&mut writer)?;
-
-        write_bundle_body(
-            &mut writer,
-            &self.actions,
-            self.value_balance,
-            &self.binding_sig,
-        )?;
-
-        self.stamp.write(&mut writer)
-    }
-
-    /// Tachyon's contribution to the transaction `auth_digest`.
-    ///
-    /// Commits the action signatures, the binding signature, and the
-    /// pointer stamp's digest. See [`blake2b::auth_digest`].
-    #[must_use]
-    pub fn auth_digest(&self) -> [u8; 32] {
-        let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig.into()).collect();
-        let binding_sig: [u8; 64] = self.binding_sig.into();
-
-        blake2b::auth_digest(&action_sigs, &binding_sig, &self.stamp.stamp_digest())
-    }
-}
-
-impl StampedBundle {
+impl TachyonBundle {
     /// Read any Tachyon bundle from the consensus wire format, dispatching
     /// on the `tachyonBundleState` byte.
     ///
-    /// Expects a stamped (`0x01`) or stripped (`0x02`) bundle; rejects
-    /// `0x00` (non-tachyon — the caller should decide absence at its own
-    /// layer) and any other byte.
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Option<Self>> {
-        // TODO: just peek at state, then delegate to the appropriate read method
-        let state = BundleStateFlags::read(&mut reader)?;
+    /// Decodes `0x00` (non-tachyon) as [`Self::NoBundle`], `0x01` as a
+    /// proof-stamped bundle, and `0x02` as a pointer-stamped bundle;
+    /// rejects any other byte.
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let state = StateByte::read(&mut reader)?;
 
         Ok(match state {
-            BundleStateFlags::NoBundle => None,
-            BundleStateFlags::ProofStamped => {
-                let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
-                Some(Self::Proven(Bundle {
-                    actions,
-                    value_balance,
-                    binding_sig,
-                    stamp: ProofStamp::read(&mut reader)?,
-                }))
-            },
-            BundleStateFlags::PointerStamped => {
-                let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
-
-                Some(Self::Adjunct(Bundle {
-                    actions,
-                    value_balance,
-                    binding_sig,
-                    stamp: PointerStamp::read(&mut reader)?,
-                }))
-            },
+            StateByte::NoBundle => Self::NoBundle,
+            StateByte::ProofStamped => Self::Proven(Bundle::read_body(&mut reader)?),
+            StateByte::PointerStamped => Self::Adjunct(Bundle::read_body(&mut reader)?),
         })
     }
 
@@ -695,20 +620,34 @@ impl StampedBundle {
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn write<W: Write>(&self, writer: W) -> io::Result<()> {
         match *self {
+            Self::NoBundle => StateByte::NoBundle.write(writer),
             Self::Proven(ref stamped) => stamped.write(writer),
             Self::Adjunct(ref stripped) => stripped.write(writer),
         }
     }
 
     /// Tachyon's contribution to the transaction `auth_digest`, dispatching
-    /// on the variant. See the `auth_digest` methods on `Bundle<Stamp>` and
-    /// `Bundle<AggregateId>`.
+    /// on the variant. See [`Bundle::auth_digest`].
     #[must_use]
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn auth_digest(&self) -> [u8; 32] {
         match *self {
+            Self::NoBundle => *blake2b::AUTH_DIGEST_NO_BUNDLE,
             Self::Proven(ref stamped) => stamped.auth_digest(),
             Self::Adjunct(ref stripped) => stripped.auth_digest(),
+        }
+    }
+
+    /// Tachyon's contribution to the transaction `commitment`.
+    ///
+    /// Commits the action signatures, the binding signature, and the
+    /// stamp's digest. See [`blake2b::bundle_commitment`].
+    #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
+    pub fn commitment(&self) -> Result<[u8; 32], ActionDigestError> {
+        match *self {
+            Self::NoBundle => Ok(*blake2b::COMMIT_NO_BUNDLE),
+            Self::Proven(ref stamped) => stamped.commitment(),
+            Self::Adjunct(ref stripped) => stripped.commitment(),
         }
     }
 }
@@ -842,73 +781,6 @@ impl From<Signature> for [u8; 64] {
     fn from(sig: Signature) -> Self {
         sig.0.into()
     }
-}
-
-/// Read bundle fields: value balance, action descriptors, action sigs,
-/// and binding sig.
-fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, i64, Signature)> {
-    let mut vb_bytes = [0u8; 8];
-    reader.read_exact(&mut vb_bytes)?;
-    let value_balance = i64::from_le_bytes(vb_bytes);
-
-    let n_actions =
-        usize::try_from(serialization::read_compactsize(&mut reader)?).map_err(|_err| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "actions vector length exceeds usize",
-            )
-        })?;
-
-    let mut descriptors: Vec<action::Descriptor> = Vec::with_capacity(n_actions);
-    for _ in 0..n_actions {
-        descriptors.push(action::Descriptor::read(&mut reader)?);
-    }
-
-    let mut signatures = Vec::with_capacity(n_actions);
-    for _ in 0..n_actions {
-        signatures.push(action::Signature::read(&mut reader)?);
-    }
-
-    let actions = descriptors
-        .iter()
-        .zip(signatures.iter())
-        .map(|(&desc, &sig)| Action::from_parts(desc, sig))
-        .collect();
-
-    let binding_sig = Signature::read(&mut reader)?;
-
-    Ok((actions, value_balance, binding_sig))
-}
-
-/// Write bundle fields: value balance, action descriptors, action sigs,
-/// and binding sig.
-fn write_bundle_body<W: Write>(
-    mut writer: W,
-    actions: &[Action],
-    value_balance: i64,
-    binding_sig: &Signature,
-) -> io::Result<()> {
-    writer.write_all(&value_balance.to_le_bytes())?;
-
-    serialization::write_compactsize(
-        &mut writer,
-        u64::try_from(actions.len()).map_err(|_err| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "actions vector length exceeds u64",
-            )
-        })?,
-    )?;
-    for action in actions {
-        action.descriptor().write(&mut writer)?;
-    }
-    for action in actions {
-        serialization::write_action_sig(&mut writer, &action.sig.0)?;
-    }
-
-    serialization::write_binding_sig(&mut writer, &binding_sig.0)?;
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -65,7 +65,7 @@
 //! | `tachyonAggregateId`  | 64 bytes             | wtxid of the relevant aggregate          |
 //!
 //! The transaction `auth_digest` contribution commits either stamp as a
-//! 64-byte wtxid-shaped value: the pointer stamp's `wtxid` directly, or
+//! 64-byte value: the pointer stamp's `wtxid` directly, or
 //! `hStampActionsTachyon || stamp_data_digest` for a proof stamp.
 
 use alloc::vec::Vec;

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -68,7 +68,7 @@
 //! 64-byte value: the pointer stamp's `wtxid` directly, or
 //! `hStampActionsTachyon || stamp_data_digest` for a proof stamp.
 
-use alloc::vec::Vec;
+use alloc::{collections::BTreeSet, vec::Vec};
 use core::ops::Neg as _;
 
 use corez::io::{self, Read, Write};
@@ -165,11 +165,7 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     pub fn commitment(&self) -> [u8; 32] {
         let descriptors: Vec<[u8; 64]> = self.descriptors().into_iter().collect();
 
-        // The bundle's actions should already be sorted by construction.
-        debug_assert!(
-            descriptors.is_sorted(),
-            "bundle actions must be canonically sorted"
-        );
+        // debug_assert!(descriptors.is_sorted(), "descriptors should be pre-sorted");
 
         blake2b::bundle_commitment(
             &blake2b::action_descriptor_digest(&descriptors),
@@ -179,14 +175,14 @@ impl<S: BundleState + ?Sized> Bundle<S> {
 
     /// Verify the bundle's binding signature and all action signatures.
     pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), SignatureError> {
-        // 1. Derive bvk from public data (validator-side, §4.14)
+        // 1. Derive bvk from public data
         let bvk = public::BindingVerificationKey::derive(&self.actions, self.value_balance);
 
         // 2. Verify binding signature
         bvk.verify(sighash, &self.binding_sig)
             .map_err(|_err| SignatureError::Binding(self.binding_sig))?;
 
-        // 3. Verify each action signature against the SAME sighash
+        // 3. Verify each action signature
         for action in &self.actions {
             action
                 .rk
@@ -238,23 +234,9 @@ pub enum SignatureError {
 #[derive(Clone, Copy, Debug, Display, Error)]
 #[non_exhaustive]
 pub enum SignError {
-    /// The derived rk does not match the stored rk.
-    #[display("plan rk {rk:?} does not match at action {idx}")]
-    RkMismatch {
-        /// Index of the offending action in the bundle (spends first, then
-        /// outputs).
-        #[error(not(source))]
-        idx: usize,
-        /// The stored rk that did not match the derived one.
-        #[error(not(source))]
-        rk: reddsa::VerificationKeyBytes<reddsa::ActionAuth>,
-    },
     /// The number of signatures does not match the number of actions.
     #[display("expected {_0} signatures")]
     SigCountMismatch(#[error(not(source))] usize),
-    /// An externally-provided signature is invalid.
-    #[display("signature {:?} does not verify", _0)]
-    InvalidActionSignature(#[error(not(source))] action::Signature),
     /// The value balance overflows the representable range.
     #[display("value balance overflow")]
     BalanceOverflow,
@@ -264,10 +246,10 @@ pub enum SignError {
 #[derive(Clone, Debug)]
 pub struct Plan {
     /// Spend action plans.
-    pub spends: Vec<action::Plan<effect::Spend>>,
+    spends: Vec<action::Plan<effect::Spend>>,
 
     /// Output action plans.
-    pub outputs: Vec<action::Plan<effect::Output>>,
+    outputs: Vec<action::Plan<effect::Output>>,
 }
 
 impl Plan {
@@ -373,35 +355,23 @@ impl Plan {
         private::BindingSigningKey::from(trapdoors.as_slice())
     }
 
-    /// Sign all actions with a spend authorizing key.
+    /// Sign actions with the provided [`private::SpendAuthorizingKey`] and then
+    /// sign the bundle with the [`private::BindingSigningKey`].
     ///
-    /// For each action, independently derives alpha from theta + note
-    /// commitment, verifies the derived rk matches, and signs. Also
-    /// derives the binding signing key from rcvs and signs the binding
-    /// signature. The resulting actions are canonically sorted so that the
-    /// bundle matches its commitment's descriptor order.
-    ///
-    /// The result is a `Bundle<Unproven>` — combine with a [`ProofStamp`]
-    /// via [`Bundle::stamp`] to produce a `Bundle<ProofStamp>`.
+    /// To confirm correct application, call [`Bundle::verify_signatures`] on
+    /// the return value.
     pub fn sign<RNG: RngCore + CryptoRng>(
         &self,
+        rng: &mut RNG,
         sighash: &[u8; 32],
         ask: &private::SpendAuthorizingKey,
-        rng: &mut RNG,
     ) -> Result<Bundle<Unproven>, SignError> {
-        let n_actions = self.spends.len() + self.outputs.len();
-        let mut authorized = Vec::with_capacity(n_actions);
+        let mut authorized = Vec::with_capacity(self.spends.len() + self.outputs.len());
 
-        for (idx, plan) in self.spends.iter().enumerate() {
+        for plan in &self.spends {
             let cm = plan.note.commitment();
             let alpha = plan.theta.randomizer::<effect::Spend>(cm);
             let rsk = ask.derive_action_private(&alpha);
-            if rsk.derive_action_public() != plan.rk {
-                return Err(SignError::RkMismatch {
-                    idx,
-                    rk: plan.rk.0.into(),
-                });
-            }
             authorized.push(Action {
                 cv: plan.cv(),
                 rk: plan.rk,
@@ -409,16 +379,10 @@ impl Plan {
             });
         }
 
-        for (idx, plan) in self.outputs.iter().enumerate() {
+        for plan in &self.outputs {
             let cm = plan.note.commitment();
             let alpha = plan.theta.randomizer::<effect::Output>(cm);
             let rsk = private::ActionSigningKey::new(&alpha);
-            if rsk.derive_action_public() != plan.rk {
-                return Err(SignError::RkMismatch {
-                    idx: self.spends.len() + idx,
-                    rk: plan.rk.0.into(),
-                });
-            }
             authorized.push(Action {
                 cv: plan.cv(),
                 rk: plan.rk,
@@ -428,25 +392,20 @@ impl Plan {
 
         authorized.sort_unstable();
 
-        let bsk = self.derive_bsk_private();
-        let binding_sig = bsk.sign(rng, sighash);
-
-        Ok(Bundle {
-            actions: authorized,
-            value_balance: self
-                .value_balance()
-                .map_err(|_err| SignError::BalanceOverflow)?,
-            binding_sig,
-            stamp: Unproven,
-        })
+        self.apply_signatures(
+            rng,
+            sighash,
+            authorized.into_iter().map(|action| action.sig).collect(),
+        )
     }
 
-    /// Apply externally-produced signatures.
+    /// Apply externally-produced action signatures and then sign the bundle
+    /// with the [`private::BindingSigningKey`].
     ///
-    /// Validates each signature against the action's rk and the sighash.
-    /// Derives cv from each plan and produces the binding signature. The
-    /// resulting actions are canonically sorted; each signature stays paired
-    /// with its descriptor, so sorting preserves the pairing.
+    /// Signatures must be provided in canonical order.
+    ///
+    /// To confirm correct application, call [`Bundle::verify_signatures`] on
+    /// the return value.
     pub fn apply_signatures<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,
@@ -462,13 +421,8 @@ impl Plan {
             .descriptors()
             .into_iter()
             .zip(sigs)
-            .map(|(desc, sig)| {
-                desc.rk
-                    .verify(sighash, &sig)
-                    .map_err(|_err| SignError::InvalidActionSignature(sig))?;
-                Ok(Action::from_parts(desc, sig))
-            })
-            .collect::<Result<Vec<Action>, SignError>>()?;
+            .map(|(desc, sig)| Action::from_parts(desc, sig))
+            .collect::<Vec<Action>>();
 
         let bsk = self.derive_bsk_private();
         let binding_sig = bsk.sign(rng, sighash);
@@ -580,6 +534,16 @@ impl<S: StampState> Bundle<S> {
         let mut descriptors: Vec<action::Descriptor> = Vec::new();
         for _ in 0..n_actions {
             descriptors.push(action::Descriptor::read(&mut reader)?);
+        }
+
+        let mut unique_descriptors = BTreeSet::new();
+        for descriptor in &descriptors {
+            if !unique_descriptors.insert(descriptor) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "action descriptors are not unique",
+                ));
+            }
         }
 
         let mut signatures: Vec<action::Signature> = Vec::new();

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -594,13 +594,6 @@ impl<S: StampState> Bundle<S> {
             descriptors.push(action::Descriptor::read(&mut reader)?);
         }
 
-        if !descriptors.is_sorted() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "actions are not canonically sorted",
-            ));
-        }
-
         let mut signatures: Vec<action::Signature> = Vec::new();
         for _ in 0..n_actions {
             signatures.push(action::Signature::read(&mut reader)?);
@@ -611,6 +604,13 @@ impl<S: StampState> Bundle<S> {
             .zip(signatures)
             .map(|(desc, sig)| Action::from_parts(desc, sig))
             .collect();
+
+        if !actions.is_sorted() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "actions are not canonically sorted",
+            ));
+        }
 
         if actions.is_empty() && value_balance != value::Balance::ZERO {
             return Err(io::Error::new(

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -50,7 +50,7 @@
 //!
 //! | Name                  | Format               | Description                              |
 //! | --------------------- | -------------------- | ---------------------------------------- |
-//! | `hActionsTachyon`     | 32 bytes             | BLAKE2b digest of the covered actions    |
+//! | `hStampActionsTachyon`     | 32 bytes             | BLAKE2b digest of the covered actions    |
 //! | `anchorTachyon`       | 32 bytes             | pool state reference                     |
 //! | `nTachygrams`         | compactsize          | number of tachygrams                     |
 //! | `vTachygrams`         | 32 * nTachygrams     | tachygrams for this proof                |
@@ -66,7 +66,7 @@
 //!
 //! The transaction `auth_digest` contribution commits either stamp as a
 //! 64-byte wtxid-shaped value: the pointer stamp's `wtxid` directly, or
-//! `hActionsTachyon || stamp_data_digest` for a proof stamp.
+//! `hStampActionsTachyon || stamp_data_digest` for a proof stamp.
 
 use alloc::vec::Vec;
 use core::ops;
@@ -504,7 +504,7 @@ impl Bundle<ProofStamp> {
 
     /// Confirm published coverage without verifying the proof: reconstruct
     /// the covered-actions digest from this bundle's actions plus every
-    /// adjunct's and check it against the carried `hActionsTachyon`.
+    /// adjunct's and check it against the carried `hStampActionsTachyon`.
     /// Adjuncts may be in any stamp state, mixed freely. Assistive, not
     /// soundness.
     #[must_use]
@@ -523,7 +523,7 @@ impl Bundle<ProofStamp> {
     }
 
     /// Check if this bundle is an aggregate, by computing the digest of its
-    /// owned actions and comparing to its stamp's `hActionsTachyon`.
+    /// owned actions and comparing to its stamp's `hStampActionsTachyon`.
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
         let desc_bytes: Vec<[u8; 64]> = self
@@ -531,7 +531,7 @@ impl Bundle<ProofStamp> {
             .into_iter()
             .map(<[u8; 64]>::from)
             .collect();
-        blake2b::action_descriptor_digest(&desc_bytes) == self.stamp.covered_actions
+        blake2b::action_descriptor_digest(&desc_bytes) == self.stamp.actions
     }
 }
 
@@ -637,33 +637,14 @@ impl<S: StampState> Bundle<S> {
 
     /// Tachyon's contribution to the transaction `auth_digest`.
     ///
-    /// Commits the action descriptor digest, the action signatures, the
-    /// binding signature, and the stamp's digest. See
-    /// [`blake2b::bundle_auth_digest`].
+    /// Commits the action signatures, the binding signature, and the stamp's
+    /// digest. See [`blake2b::bundle_auth_digest`].
     #[must_use]
     pub fn auth_digest(&self) -> [u8; 32] {
-        let descriptors: Vec<[u8; 64]> = self
-            .descriptors()
-            .into_iter()
-            .map(<[u8; 64]>::from)
-            .collect();
-
-        // The bundle's actions should already be sorted by construction.
-        debug_assert!(
-            descriptors.is_sorted(),
-            "bundle actions must be canonically sorted"
-        );
-        let action_digest = blake2b::action_descriptor_digest(&descriptors);
-
         let action_sigs: Vec<[u8; 64]> = self.actions.iter().map(|act| act.sig.into()).collect();
         let binding_sig: [u8; 64] = self.binding_sig.into();
 
-        blake2b::bundle_auth_digest(
-            &action_digest,
-            &action_sigs,
-            &binding_sig,
-            &self.stamp.stamp_digest(),
-        )
+        blake2b::bundle_auth_digest(&action_sigs, &binding_sig, &self.stamp.stamp_digest())
     }
 }
 
@@ -741,7 +722,7 @@ impl TachyonBundle {
     }
 
     /// Check if this bundle is an aggregate, by computing the digest of its
-    /// owned actions and comparing to its stamp's `hActionsTachyon` if present.
+    /// owned actions and comparing to its stamp's `hStampActionsTachyon` if present.
     #[must_use]
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn is_aggregate(&self) -> bool {

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -1,6 +1,6 @@
 //! Tachyon transaction bundles.
 //!
-//! A bundle is parameterized by stamp state `S: StampState`.
+//! A bundle is parameterized by bundle state `S: BundleState`.
 //! Actions are constant through state transitions; only the stamp changes.
 //!
 //! - `Bundle<ProofStamp>` — self-contained bundle with a proof stamp
@@ -126,29 +126,27 @@ impl BundleStateFlags {
 }
 
 mod sealed {
-    pub trait BundleState {}
-    impl BundleState for super::Unproven {}
-    impl BundleState for super::ProofStamp {}
-    impl BundleState for super::PointerStamp {}
+    pub trait Sealed {}
+    impl Sealed for super::Unproven {}
+    impl Sealed for super::ProofStamp {}
+    impl Sealed for super::PointerStamp {}
 }
 
-/// Sealed trait constraining stamp state types.
-pub trait StampState: sealed::BundleState {
+/// Sealed trait constraining bundle state types.
+#[expect(clippy::module_name_repetitions, reason = "intentional name")]
+pub trait BundleState: sealed::Sealed {}
+
+impl BundleState for Unproven {}
+impl BundleState for ProofStamp {}
+impl BundleState for PointerStamp {}
+
+/// Bundle states that carry a stamp: [`ProofStamp`] or [`PointerStamp`].
+/// The intermediate [`Unproven`] state has no stamp.
+pub trait StampState: BundleState {
     /// The stamp's 64-byte wtxid-shaped digest: a proof stamp's
     /// `hActionsTachyon || stamp_data_digest`, or a pointer stamp's
     /// `wtxid = txid || auth_digest`.
-    ///
-    /// # Panics
-    ///
-    /// The intermediate `Unproven` state has no stamp;
-    /// calling this on it panics.
     fn stamp_digest(&self) -> [u8; 64];
-}
-
-impl StampState for Unproven {
-    fn stamp_digest(&self) -> [u8; 64] {
-        unimplemented!("unproven stamp has no digest");
-    }
 }
 
 impl StampState for PointerStamp {
@@ -182,9 +180,9 @@ impl StampState for ProofStamp {
     }
 }
 
-/// A Tachyon transaction bundle parameterized by stamp state `S`.
+/// A Tachyon transaction bundle parameterized by bundle state `S`.
 #[derive(Clone, Debug, PartialEq, TotalEq)]
-pub struct Bundle<S: StampState> {
+pub struct Bundle<S: BundleState + ?Sized> {
     /// Actions (cv, rk, sig).
     pub actions: Vec<Action>,
 
@@ -194,7 +192,7 @@ pub struct Bundle<S: StampState> {
     /// Binding signature over the transaction sighash.
     pub binding_sig: Signature,
 
-    /// Stamp state: `Unproven`, `ProofStamp`, or `PointerStamp`.
+    /// Bundle state: `Unproven`, `ProofStamp`, or `PointerStamp`.
     pub stamp: S,
 }
 
@@ -537,9 +535,10 @@ impl Bundle<ProofStamp> {
     /// Confirm published coverage without verifying the proof: reconstruct
     /// the covered-actions digest from this bundle's actions plus every
     /// adjunct's and check it against the carried `hActionsTachyon`.
-    /// Assistive, not soundness.
+    /// Adjuncts may be in any stamp state, mixed freely. Assistive, not
+    /// soundness.
     #[must_use]
-    pub fn covers<T: StampState>(&self, adjuncts: &[Bundle<T>]) -> bool {
+    pub fn covers(&self, adjuncts: &[&Bundle<dyn StampState>]) -> bool {
         let own_descs = self.actions.iter().map(Action::descriptor);
         let other_descs = adjuncts
             .iter()
@@ -731,7 +730,7 @@ impl TachyonBundle {
     }
 }
 
-impl<S: StampState> Bundle<S> {
+impl<S: BundleState + ?Sized> Bundle<S> {
     /// See [`Plan::commitment`].
     pub fn commitment(&self) -> Result<[u8; 32], ActionDigestError> {
         let action_digests = self

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -72,7 +72,7 @@ use alloc::vec::Vec;
 use core::ops;
 
 use corez::io::{self, Read, Write};
-use derive_more::{Debug, Display, Eq as TotalEq, Error, From, PartialEq};
+use derive_more::{Debug, Display, Eq as TotalEq, Error, From, IsVariant, PartialEq, TryInto};
 use ff::PrimeField as _;
 use group::GroupEncoding as _;
 use pasta_curves::{Eq, Fp};
@@ -208,35 +208,13 @@ pub struct Bundle<S: BundleState + ?Sized> {
 /// `auth_digest`, etc. The `Unproven` intermediate state is outside this
 /// enum because it has no wire representation.
 #[expect(clippy::module_name_repetitions, reason = "intentional name")]
-#[derive(Clone, Debug, From)]
+#[derive(Clone, Debug, From, IsVariant, TryInto)]
 pub enum StampedBundle {
     /// A bundle with its own stamp (autonome or aggregate).
-    Stamped(Bundle<ProofStamp>),
+    Proven(Bundle<ProofStamp>),
     /// A bundle whose stamp has been stripped; carries a reference to the
     /// covering aggregate via its [`AggregateId`].
     Adjunct(Bundle<PointerStamp>),
-}
-
-impl TryFrom<StampedBundle> for Bundle<ProofStamp> {
-    type Error = Bundle<PointerStamp>;
-
-    fn try_from(bundle: StampedBundle) -> Result<Self, Self::Error> {
-        match bundle {
-            StampedBundle::Adjunct(stripped) => Err(stripped),
-            StampedBundle::Stamped(stamped) => Ok(stamped),
-        }
-    }
-}
-
-impl TryFrom<StampedBundle> for Bundle<PointerStamp> {
-    type Error = Bundle<ProofStamp>;
-
-    fn try_from(bundle: StampedBundle) -> Result<Self, Self::Error> {
-        match bundle {
-            StampedBundle::Adjunct(stripped) => Ok(stripped),
-            StampedBundle::Stamped(stamped) => Err(stamped),
-        }
-    }
 }
 
 /// Errors during bundle construction.
@@ -692,7 +670,7 @@ impl StampedBundle {
             BundleStateFlags::NoBundle => None,
             BundleStateFlags::ProofStamped => {
                 let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
-                Some(Self::Stamped(Bundle {
+                Some(Self::Proven(Bundle {
                     actions,
                     value_balance,
                     binding_sig,
@@ -701,13 +679,12 @@ impl StampedBundle {
             },
             BundleStateFlags::PointerStamped => {
                 let (actions, value_balance, binding_sig) = read_bundle_body(&mut reader)?;
-                let stamp = PointerStamp::read(&mut reader)?;
 
                 Some(Self::Adjunct(Bundle {
                     actions,
                     value_balance,
                     binding_sig,
-                    stamp,
+                    stamp: PointerStamp::read(&mut reader)?,
                 }))
             },
         })
@@ -718,7 +695,7 @@ impl StampedBundle {
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn write<W: Write>(&self, writer: W) -> io::Result<()> {
         match *self {
-            Self::Stamped(ref stamped) => stamped.write(writer),
+            Self::Proven(ref stamped) => stamped.write(writer),
             Self::Adjunct(ref stripped) => stripped.write(writer),
         }
     }
@@ -730,7 +707,7 @@ impl StampedBundle {
     #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
     pub fn auth_digest(&self) -> [u8; 32] {
         match *self {
-            Self::Stamped(ref stamped) => stamped.auth_digest(),
+            Self::Proven(ref stamped) => stamped.auth_digest(),
             Self::Adjunct(ref stripped) => stripped.auth_digest(),
         }
     }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -171,9 +171,6 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     #[must_use]
     pub fn commitment(&self) -> [u8; 32] {
         let descriptors: Vec<[u8; 64]> = self.descriptors().into_iter().collect();
-
-        // debug_assert!(descriptors.is_sorted(), "descriptors should be pre-sorted");
-
         blake2b::bundle_commitment(
             &blake2b::action_descriptor_digest(&descriptors),
             self.value_balance.into(),

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -70,7 +70,7 @@ use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, PartialEq};
 use ff::PrimeField as _;
 use group::GroupEncoding as _;
-use pasta_curves::{Eq, Fp};
+use pasta_curves::{Ep, EpAffine, Eq, Fp};
 use rand_core::{CryptoRng, RngCore};
 
 pub use crate::digest::blake2b::{AUTH_DIGEST_NO_BUNDLE, COMMIT_NO_BUNDLE};
@@ -130,8 +130,50 @@ mod sealed {
 }
 
 /// Sealed trait constraining stamp state types.
-pub trait StampState: sealed::Sealed {}
-impl<T: sealed::Sealed> StampState for T {}
+pub trait StampState: sealed::Sealed {
+    fn stamp_digest(&self) -> [u8; 64];
+}
+
+impl StampState for Unproven {
+    fn stamp_digest(&self) -> [u8; 64] {
+        unimplemented!("unproven stamp has no digest");
+    }
+}
+
+impl StampState for Stripped {
+    fn stamp_digest(&self) -> [u8; 64] {
+        unimplemented!("stripped stamp has no digest");
+    }
+}
+
+impl StampState for PointerStamp {
+    fn stamp_digest(&self) -> [u8; 64] {
+        <[u8; 64]>::from(*self)
+    }
+}
+
+impl StampState for ProofStamp {
+    fn stamp_digest(&self) -> [u8; 64] {
+        let stamp_actions: [u8; 32] = Eq::from(self.action_set).to_bytes();
+
+        let stamp_data_digest: [u8; 32] = {
+            let proof = self.proof.serialize();
+            let anchor: [u8; 32] = self.anchor.0.into();
+            let tachygrams: Vec<[u8; 32]> = self
+                .tachygrams
+                .iter()
+                .map(|&tg| Fp::from(tg).to_repr())
+                .collect();
+
+            blake2b::stamp_data_digest(blake2b::stamp_proof_digest(proof), anchor, tachygrams)
+        };
+
+        let mut stamp_digest = [0u8; 64];
+        stamp_digest[..32].copy_from_slice(&stamp_actions);
+        stamp_digest[32..].copy_from_slice(&stamp_data_digest);
+        stamp_digest
+    }
+}
 
 /// A Tachyon transaction bundle parameterized by stamp state `S`.
 #[derive(Clone, Debug, PartialEq, TotalEq)]

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -87,7 +87,7 @@ use crate::{
     note,
     primitives::{ActionDigest, ActionDigestError, Anchor, effect},
     reddsa, serialization,
-    stamp::{self, PointerStamp, ProofStamp, Stripped, Unproven},
+    stamp::{self, PointerStamp, ProofStamp, Unproven},
 };
 
 /// The `tachyonBundleState` wire byte. See the module-level wire format
@@ -129,7 +129,6 @@ mod sealed {
     pub trait Sealed {}
     impl Sealed for super::Unproven {}
     impl Sealed for super::ProofStamp {}
-    impl Sealed for super::Stripped {}
     impl Sealed for super::PointerStamp {}
 }
 
@@ -141,20 +140,14 @@ pub trait StampState: sealed::Sealed {
     ///
     /// # Panics
     ///
-    /// The intermediate `Unproven` and `Stripped` states have no stamp;
-    /// calling this on them panics.
+    /// The intermediate `Unproven` state has no stamp;
+    /// calling this on it panics.
     fn stamp_digest(&self) -> [u8; 64];
 }
 
 impl StampState for Unproven {
     fn stamp_digest(&self) -> [u8; 64] {
         unimplemented!("unproven stamp has no digest");
-    }
-}
-
-impl StampState for Stripped {
-    fn stamp_digest(&self) -> [u8; 64] {
-        unimplemented!("stripped stamp has no digest");
     }
 }
 
@@ -201,15 +194,15 @@ pub struct Bundle<S: StampState> {
     /// Binding signature over the transaction sighash.
     pub binding_sig: Signature,
 
-    /// Stamp state: `Unproven`, `Stamp`, `Stripped`, or `AggregateId`.
+    /// Stamp state: `Unproven`, `ProofStamp`, or `PointerStamp`.
     pub stamp: S,
 }
 
 /// A Tachyon bundle in one of its two on-wire states: stamped or stripped.
 ///
 /// Used where code accepts either form — reading from the wire, dispatching
-/// `auth_digest`, etc. The `Unproven` and `Stripped` intermediate states are
-/// outside this enum because they have no wire representation.
+/// `auth_digest`, etc. The `Unproven` intermediate state is outside this
+/// enum because it has no wire representation.
 #[expect(clippy::module_name_repetitions, reason = "intentional name")]
 #[derive(Clone, Debug, From)]
 pub enum TachyonBundle {
@@ -529,44 +522,16 @@ impl Bundle<Unproven> {
     }
 }
 
-impl Bundle<Stripped> {
-    /// Assign the covering aggregate's `wtxid`, producing a serializable
-    /// `Bundle<AggregateId>`.
-    ///
-    /// This is the only path from [`strip()`](Bundle::strip) to a wire-ready
-    /// stripped bundle — `Bundle<Stripped>` has no `write()` method. The
-    /// `wtxid` is an already-validated nonzero [`AggregateId`], so every
-    /// stripped bundle (innocent or adjunct) names a covering aggregate.
+impl Bundle<ProofStamp> {
+    /// Produce an adjunct bundle with a pointer to a covering aggregate.
     #[must_use]
-    pub fn assign_wtxid(self, wtxid: PointerStamp) -> Bundle<PointerStamp> {
+    pub fn strip(self, wtxid: PointerStamp) -> Bundle<PointerStamp> {
         Bundle {
             actions: self.actions,
             value_balance: self.value_balance,
             binding_sig: self.binding_sig,
             stamp: wtxid,
         }
-    }
-}
-
-impl Bundle<ProofStamp> {
-    /// Strips the stamp, producing an unassigned bundle and the extracted
-    /// stamp.
-    ///
-    /// The returned `Bundle<Stripped>` must be assigned a covering
-    /// aggregate's `wtxid` via [`assign_wtxid`](Bundle::assign_wtxid)
-    /// before it can be serialized. The stamp should be merged into an
-    /// aggregate.
-    #[must_use]
-    pub fn strip(self) -> (Bundle<Stripped>, ProofStamp) {
-        (
-            Bundle {
-                actions: self.actions,
-                value_balance: self.value_balance,
-                binding_sig: self.binding_sig,
-                stamp: Stripped,
-            },
-            self.stamp,
-        )
     }
 
     /// Confirm published coverage without verifying the proof: reconstruct

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::panic, reason = "test code")]
 
 use alloc::{string::ToString as _, vec, vec::Vec};
-use core::slice::from_ref;
 
 use rand::{SeedableRng as _, rngs::StdRng};
 
@@ -833,19 +832,19 @@ fn coverage_check_matches_stamp_actions() {
     // Coverage confirmation: the based aggregate's carried digest matches
     // its own actions plus both covered adjuncts'.
     assert!(
-        becomes_based.covers(&[adjunct_a.clone(), adjunct_b.clone()]),
+        becomes_based.covers(&[&adjunct_a, &adjunct_b]),
         "full covered set matches hActionsTachyon"
     );
 
     // Missing an adjunct: fewer descriptors, no match.
     assert!(
-        !becomes_based.covers(from_ref(&adjunct_a)),
+        !becomes_based.covers(&[&adjunct_a]),
         "missing adjunct must mismatch"
     );
 
     // Extra (duplicated) adjunct: more descriptors, no match.
     assert!(
-        !becomes_based.covers(&[adjunct_a.clone(), adjunct_b, adjunct_a]),
+        !becomes_based.covers(&[&adjunct_a, &adjunct_b, &adjunct_a]),
         "extra adjunct must mismatch"
     );
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -98,7 +98,7 @@ fn zero_action_bundle_is_valid() {
         actions: alloc::vec![],
         value_balance: 0,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-        stamp: AggregateId::try_from([1u8; 64]).expect("nonzero id"),
+        stamp: PointerStamp::try_from([1u8; 64]).expect("nonzero id"),
     };
 
     bundle.verify_signatures(&sighash).unwrap();
@@ -240,7 +240,7 @@ fn innocent_aggregate_from_two_autonomes() {
         let innocent_plan = Plan::new(alloc::vec![], alloc::vec![]);
         let innocent_sighash = mock_sighash(innocent_plan.commitment().unwrap());
 
-        let stamp = Stamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
+        let stamp = ProofStamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
             .expect("prove_merge");
 
         Bundle {
@@ -332,10 +332,10 @@ fn based_aggregate_with_two_adjuncts() {
 
     let mut innocent_digests = digests_a.clone();
     innocent_digests.extend_from_slice(&digests_b);
-    let innocent_stamp = Stamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
+    let innocent_stamp = ProofStamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
         .expect("innocent merge");
 
-    let based_stamp = Stamp::prove_merge(
+    let based_stamp = ProofStamp::prove_merge(
         rng,
         (becomes_based.stamp, &based_digests),
         (innocent_stamp, &innocent_digests),
@@ -387,7 +387,7 @@ fn stamped_read_write_round_trip() {
     let original = build_autonome(rng, &wallet, 1000, 700);
     let mut buf = Vec::new();
     original.write(&mut buf).expect("write");
-    let deserialized = Bundle::<Stamp>::read(&*buf).expect("read");
+    let deserialized = Bundle::<ProofStamp>::read(&*buf).expect("read");
 
     assert_eq!(original.actions, deserialized.actions);
     assert_eq!(original.value_balance, deserialized.value_balance);
@@ -406,16 +406,16 @@ fn stripped_read_write_round_trip() {
     let wallet = WalletSim::new(shared_sk());
     let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
     let stripped =
-        unassigned.assign_wtxid(AggregateId::try_from([0x42u8; 64]).expect("nonzero id"));
+        unassigned.assign_wtxid(PointerStamp::try_from([0x42u8; 64]).expect("nonzero id"));
 
     let mut buf = Vec::new();
     stripped.write(&mut buf).expect("write");
-    let deserialized = Bundle::<AggregateId>::read(&*buf).expect("read");
+    let deserialized = Bundle::<PointerStamp>::read(&*buf).expect("read");
 
     assert_eq!(stripped, deserialized);
     assert_eq!(
         deserialized.stamp,
-        AggregateId::try_from([0x42u8; 64]).expect("nonzero id")
+        PointerStamp::try_from([0x42u8; 64]).expect("nonzero id")
     );
 }
 
@@ -427,7 +427,7 @@ fn tachyon_bundle_conversions() {
         let wallet = WalletSim::new(shared_sk());
         let original = build_autonome(rng, &wallet, 1000, 700);
         let erased: TachyonBundle = original.clone().into();
-        let back = Bundle::<Stamp>::try_from(erased).expect("stamped variant");
+        let back = Bundle::<ProofStamp>::try_from(erased).expect("stamped variant");
 
         assert_eq!(original.actions, back.actions);
         assert_eq!(original.value_balance, back.value_balance);
@@ -441,15 +441,15 @@ fn tachyon_bundle_conversions() {
         let wallet = WalletSim::new(shared_sk());
         let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
         let stripped =
-            unassigned.assign_wtxid(AggregateId::try_from([0xABu8; 64]).expect("nonzero id"));
+            unassigned.assign_wtxid(PointerStamp::try_from([0xABu8; 64]).expect("nonzero id"));
 
         let erased: TachyonBundle = stripped.clone().into();
-        let back = Bundle::<AggregateId>::try_from(erased).expect("stripped variant");
+        let back = Bundle::<PointerStamp>::try_from(erased).expect("stripped variant");
 
         assert_eq!(stripped, back);
         assert_eq!(
             back.stamp,
-            AggregateId::try_from([0xABu8; 64]).expect("nonzero id")
+            PointerStamp::try_from([0xABu8; 64]).expect("nonzero id")
         );
     }
 
@@ -460,13 +460,13 @@ fn tachyon_bundle_conversions() {
         let stamped = build_autonome(rng, &wallet, 1000, 700);
         let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
         let adjunct =
-            unassigned.assign_wtxid(AggregateId::try_from([0x55u8; 64]).expect("nonzero id"));
+            unassigned.assign_wtxid(PointerStamp::try_from([0x55u8; 64]).expect("nonzero id"));
 
         let stamped_erased: TachyonBundle = stamped.into();
-        Bundle::<AggregateId>::try_from(stamped_erased).expect_err("stamped is not an adjunct");
+        Bundle::<PointerStamp>::try_from(stamped_erased).expect_err("stamped is not an adjunct");
 
         let adjunct_erased: TachyonBundle = adjunct.into();
-        Bundle::<Stamp>::try_from(adjunct_erased).expect_err("adjunct is not stamped");
+        Bundle::<ProofStamp>::try_from(adjunct_erased).expect_err("adjunct is not stamped");
     }
 }
 
@@ -484,7 +484,7 @@ fn tachyon_bundle_wire_round_trip() {
         let decoded = TachyonBundle::read(&*buf)
             .expect("read")
             .expect("some bundle");
-        let back = Bundle::<Stamp>::try_from(decoded).expect("stamped variant");
+        let back = Bundle::<ProofStamp>::try_from(decoded).expect("stamped variant");
 
         // Stamp carries a proof and is not PartialEq, so compare fields.
         assert_eq!(stamped.actions, back.actions);
@@ -497,14 +497,14 @@ fn tachyon_bundle_wire_round_trip() {
     {
         let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
         let stripped =
-            unassigned.assign_wtxid(AggregateId::try_from([0xCDu8; 64]).expect("nonzero id"));
+            unassigned.assign_wtxid(PointerStamp::try_from([0xCDu8; 64]).expect("nonzero id"));
         let erased: TachyonBundle = stripped.clone().into();
         let mut buf = Vec::new();
         erased.write(&mut buf).expect("write");
         let decoded = TachyonBundle::read(&*buf)
             .expect("read")
             .expect("some bundle");
-        let back = Bundle::<AggregateId>::try_from(decoded).expect("stripped variant");
+        let back = Bundle::<PointerStamp>::try_from(decoded).expect("stripped variant");
 
         assert_eq!(stripped, back);
     }
@@ -512,7 +512,7 @@ fn tachyon_bundle_wire_round_trip() {
 
 #[test]
 fn aggregate_id_try_from_rejects_zero() {
-    AggregateId::try_from([0u8; 64]).unwrap_err();
+    PointerStamp::try_from([0u8; 64]).unwrap_err();
 }
 
 #[test]
@@ -521,8 +521,8 @@ fn wire_state_byte_dispatch() {
     {
         let buf: &[u8] = &[0x03];
         for err in [
-            Bundle::<Stamp>::read(buf).expect_err("invalid state byte must be rejected"),
-            Bundle::<AggregateId>::read(buf).expect_err("invalid state byte must be rejected"),
+            Bundle::<ProofStamp>::read(buf).expect_err("invalid state byte must be rejected"),
+            Bundle::<PointerStamp>::read(buf).expect_err("invalid state byte must be rejected"),
             TachyonBundle::read(buf).expect_err("invalid state byte must be rejected"),
         ] {
             assert_eq!(err.kind(), io::ErrorKind::InvalidData);
@@ -548,17 +548,17 @@ fn wire_state_byte_dispatch() {
 
         let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
         let adjunct =
-            unassigned.assign_wtxid(AggregateId::try_from([0x66u8; 64]).expect("nonzero id"));
+            unassigned.assign_wtxid(PointerStamp::try_from([0x66u8; 64]).expect("nonzero id"));
         let mut adjunct_buf = Vec::new();
         adjunct.write(&mut adjunct_buf).expect("write adjunct");
 
-        let adjunct_on_stamped = Bundle::<AggregateId>::read(&*stamped_buf)
+        let adjunct_on_stamped = Bundle::<PointerStamp>::read(&*stamped_buf)
             .expect_err("Adjunct::read must reject a stamped (0x01) buffer");
         assert_eq!(
             adjunct_on_stamped.to_string(),
             "stripped bundle requires tachyonBundleState 0x02"
         );
-        let stamped_on_adjunct = Bundle::<Stamp>::read(&*adjunct_buf)
+        let stamped_on_adjunct = Bundle::<ProofStamp>::read(&*adjunct_buf)
             .expect_err("Stamped::read must reject a stripped (0x02) buffer");
         assert_eq!(
             stamped_on_adjunct.to_string(),
@@ -580,7 +580,7 @@ fn read_rejects_zero_wtxid() {
     let adjunct = {
         let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
         assert!(!unassigned.actions.is_empty());
-        unassigned.assign_wtxid(AggregateId::try_from([0x42u8; 64]).expect("nonzero id"))
+        unassigned.assign_wtxid(PointerStamp::try_from([0x42u8; 64]).expect("nonzero id"))
     };
 
     let innocent = {
@@ -590,7 +590,7 @@ fn read_rejects_zero_wtxid() {
             actions: alloc::vec![],
             value_balance: 0,
             binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-            stamp: AggregateId::try_from([0x42u8; 64]).expect("nonzero id"),
+            stamp: PointerStamp::try_from([0x42u8; 64]).expect("nonzero id"),
         };
         assert!(bundle.actions.is_empty());
         bundle
@@ -606,7 +606,7 @@ fn read_rejects_zero_wtxid() {
         }
 
         let adjunct_err =
-            Bundle::<AggregateId>::read(&*buf).expect_err("Adjunct::read must reject zero wtxid");
+            Bundle::<PointerStamp>::read(&*buf).expect_err("Adjunct::read must reject zero wtxid");
         assert_eq!(adjunct_err.kind(), io::ErrorKind::InvalidData);
         assert_eq!(
             adjunct_err.to_string(),
@@ -635,19 +635,19 @@ fn innocent_round_trips_with_nonzero_wtxid() {
         actions: alloc::vec![],
         value_balance: 0,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-        stamp: AggregateId::try_from([0x42u8; 64]).expect("nonzero id"),
+        stamp: PointerStamp::try_from([0x42u8; 64]).expect("nonzero id"),
     };
 
     let mut buf = Vec::new();
     innocent.write(&mut buf).expect("write innocent");
 
-    let via_adjunct = Bundle::<AggregateId>::read(&*buf).expect("Adjunct::read innocent");
+    let via_adjunct = Bundle::<PointerStamp>::read(&*buf).expect("Adjunct::read innocent");
     assert_eq!(innocent, via_adjunct);
 
     let decoded = TachyonBundle::read(&*buf)
         .expect("TachyonBundle::read")
         .expect("some bundle");
-    let via_enum = Bundle::<AggregateId>::try_from(decoded).expect("adjunct variant");
+    let via_enum = Bundle::<PointerStamp>::try_from(decoded).expect("adjunct variant");
     assert_eq!(innocent, via_enum);
 }
 
@@ -663,7 +663,7 @@ fn auth_digest_invariants() {
 
         let (unassigned, _stamp) = stamped.strip();
         let stripped =
-            unassigned.assign_wtxid(AggregateId::try_from([0x11u8; 64]).expect("nonzero id"));
+            unassigned.assign_wtxid(PointerStamp::try_from([0x11u8; 64]).expect("nonzero id"));
         assert_ne!(stamped_digest, stripped.auth_digest());
     }
 
@@ -676,10 +676,10 @@ fn auth_digest_invariants() {
 
         let stripped_aa = unassigned
             .clone()
-            .assign_wtxid(AggregateId::try_from([0xAAu8; 64]).expect("nonzero id"));
+            .assign_wtxid(PointerStamp::try_from([0xAAu8; 64]).expect("nonzero id"));
         let digest_aa = stripped_aa.auth_digest();
         let stripped_bb =
-            unassigned.assign_wtxid(AggregateId::try_from([0xBBu8; 64]).expect("nonzero id"));
+            unassigned.assign_wtxid(PointerStamp::try_from([0xBBu8; 64]).expect("nonzero id"));
         let digest_bb = stripped_bb.auth_digest();
         assert_ne!(digest_aa, digest_bb);
     }
@@ -697,7 +697,7 @@ fn auth_digest_invariants() {
         let wallet2 = WalletSim::new(shared_sk());
         let (unassigned, _stamp) = build_autonome(rng, &wallet2, 1000, 700).strip();
         let stripped =
-            unassigned.assign_wtxid(AggregateId::try_from([0x33u8; 64]).expect("nonzero id"));
+            unassigned.assign_wtxid(PointerStamp::try_from([0x33u8; 64]).expect("nonzero id"));
         let stripped_direct = stripped.auth_digest();
         let erased_stripped: TachyonBundle = stripped.into();
         assert_eq!(erased_stripped.auth_digest(), stripped_direct);
@@ -772,10 +772,10 @@ fn coverage_check_matches_stamped_action_set() {
 
     let innocent_digests: Vec<ActionDigest> =
         digests_a.iter().chain(digests_b.iter()).copied().collect();
-    let innocent_stamp = Stamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
+    let innocent_stamp = ProofStamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
         .expect("innocent merge");
 
-    let based_stamp = Stamp::prove_merge(
+    let based_stamp = ProofStamp::prove_merge(
         rng,
         (becomes_based.stamp, &based_digests),
         (innocent_stamp, &innocent_digests),

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -10,10 +10,10 @@ use crate::{
     constants::EPOCH_SIZE,
     digest::blake2b::COMMIT_NO_BUNDLE,
     fixtures::{
-        PoolSim, WalletSim, action_digests, build_autonome, build_output_stamp, mock_sighash,
-        random_action, random_block, random_block_with, shared_sk,
+        PoolSim, WalletSim, build_autonome, build_output_stamp, mock_sighash, random_action,
+        random_block, random_block_with, shared_sk,
     },
-    primitives::{ActionDigest, BlockHeight},
+    primitives::{BlockHeight, Tachygram},
     stamp::VerificationError,
 };
 
@@ -152,8 +152,8 @@ fn stamp_verify_action_multiset_invariants() {
         let mut actions = stamped.actions.clone();
         actions.pop();
         let err = stamped.stamp.verify(rng, &actions).unwrap_err();
-        let VerificationError::ActionSetMismatch = err else {
-            panic!("drop: expected ActionSetMismatch, got {err:?}");
+        let VerificationError::ActionsMismatch = err else {
+            panic!("drop: expected ActionsMismatch, got {err:?}");
         };
     }
 
@@ -162,8 +162,8 @@ fn stamp_verify_action_multiset_invariants() {
         let mut actions = stamped.actions.clone();
         actions.push(actions[0]);
         let err = stamped.stamp.verify(rng, &actions).unwrap_err();
-        let VerificationError::ActionSetMismatch = err else {
-            panic!("duplicate: expected ActionSetMismatch, got {err:?}");
+        let VerificationError::ActionsMismatch = err else {
+            panic!("duplicate: expected ActionsMismatch, got {err:?}");
         };
     }
 
@@ -172,8 +172,8 @@ fn stamp_verify_action_multiset_invariants() {
         let mut actions = stamped.actions.clone();
         actions.push(random_action(rng));
         let err = stamped.stamp.verify(rng, &actions).unwrap_err();
-        let VerificationError::ActionSetMismatch = err else {
-            panic!("extra: expected ActionSetMismatch, got {err:?}");
+        let VerificationError::ActionsMismatch = err else {
+            panic!("extra: expected ActionsMismatch, got {err:?}");
         };
     }
 
@@ -182,8 +182,8 @@ fn stamp_verify_action_multiset_invariants() {
         let mut actions = stamped.actions.clone();
         actions[0] = random_action(rng);
         let err = stamped.stamp.verify(rng, &actions).unwrap_err();
-        let VerificationError::ActionSetMismatch = err else {
-            panic!("replaced: expected ActionSetMismatch, got {err:?}");
+        let VerificationError::ActionsMismatch = err else {
+            panic!("replaced: expected ActionsMismatch, got {err:?}");
         };
     }
 }
@@ -231,8 +231,10 @@ fn innocent_aggregate_from_two_autonomes() {
         alloc::vec![output_b],
     );
 
-    let digests_a = action_digests(&autonome_a.actions);
-    let digests_b = action_digests(&autonome_b.actions);
+    let descriptors_a: Vec<action::Descriptor> =
+        autonome_a.actions.iter().map(Action::descriptor).collect();
+    let descriptors_b: Vec<action::Descriptor> =
+        autonome_b.actions.iter().map(Action::descriptor).collect();
     let (adjunct_a, stamp_a) = autonome_a.strip();
     let (adjunct_b, stamp_b) = autonome_b.strip();
 
@@ -240,8 +242,8 @@ fn innocent_aggregate_from_two_autonomes() {
         let innocent_plan = Plan::new(alloc::vec![], alloc::vec![]);
         let innocent_sighash = mock_sighash(innocent_plan.commitment().unwrap());
 
-        let stamp = ProofStamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
-            .expect("prove_merge");
+        let stamp = ProofStamp::merge(rng, (stamp_a, descriptors_a), (stamp_b, descriptors_b))
+            .expect("merge");
 
         Bundle {
             actions: alloc::vec![],
@@ -323,22 +325,27 @@ fn based_aggregate_with_two_adjuncts() {
 
     let sighash = mock_sighash(becomes_based.commitment().unwrap());
 
-    let based_digests = action_digests(&becomes_based.actions);
-    let digests_a = action_digests(&autonome_a.actions);
-    let digests_b = action_digests(&autonome_b.actions);
+    let based_descriptors: Vec<action::Descriptor> = becomes_based
+        .actions
+        .iter()
+        .map(Action::descriptor)
+        .collect();
+    let descriptors_a: Vec<action::Descriptor> =
+        autonome_a.actions.iter().map(Action::descriptor).collect();
+    let descriptors_b: Vec<action::Descriptor> =
+        autonome_b.actions.iter().map(Action::descriptor).collect();
 
     let (adjunct_a, stamp_a) = autonome_a.strip();
     let (adjunct_b, stamp_b) = autonome_b.strip();
 
-    let mut innocent_digests = digests_a.clone();
-    innocent_digests.extend_from_slice(&digests_b);
-    let innocent_stamp = ProofStamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
+    let innocent_descriptors = [descriptors_a.as_slice(), descriptors_b.as_slice()].concat();
+    let innocent_stamp = ProofStamp::merge(rng, (stamp_a, descriptors_a), (stamp_b, descriptors_b))
         .expect("innocent merge");
 
-    let based_stamp = ProofStamp::prove_merge(
+    let based_stamp = ProofStamp::merge(
         rng,
-        (becomes_based.stamp, &based_digests),
-        (innocent_stamp, &innocent_digests),
+        (becomes_based.stamp, based_descriptors),
+        (innocent_stamp, innocent_descriptors),
     )
     .expect("based merge");
 
@@ -702,14 +709,34 @@ fn auth_digest_invariants() {
         let erased_stripped: TachyonBundle = stripped.into();
         assert_eq!(erased_stripped.auth_digest(), stripped_direct);
     }
+
+    // The proof stamp's digest commits its contents: perturbing the carried
+    // covered-actions digest or the tachygram set changes the auth_digest.
+    {
+        let rng = &mut StdRng::seed_from_u64(0);
+        let wallet = WalletSim::new(shared_sk());
+        let stamped = build_autonome(rng, &wallet, 1000, 700);
+        let baseline = stamped.auth_digest();
+
+        let mut altered_actions = stamped.clone();
+        altered_actions.stamp.covered_actions[0] ^= 0x01;
+        assert_ne!(baseline, altered_actions.auth_digest());
+
+        let mut extra_tachygram = stamped;
+        extra_tachygram
+            .stamp
+            .tachygrams
+            .push(Tachygram::from(Fp::from(7u64)));
+        assert_ne!(baseline, extra_tachygram.auth_digest());
+    }
 }
 
-/// Coverage-check protocol: an observer reconstructs the merged action-digest
-/// set commitment from a based aggregate's own actions plus all covered
-/// adjuncts' visible actions, and checks it against the stamped aggregate's
-/// serialized `cActionsTachyon`.
+/// Coverage-check protocol: an observer reconstructs the covered-actions
+/// digest from a based aggregate's own actions plus all covered adjuncts'
+/// visible actions, and checks it against the stamped aggregate's
+/// serialized `hActionsTachyon`.
 #[test]
-fn coverage_check_matches_stamped_action_set() {
+fn coverage_check_matches_stamp_actions() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);
 
@@ -763,48 +790,47 @@ fn coverage_check_matches_stamped_action_set() {
         alloc::vec![b_output],
     );
 
-    let based_digests = action_digests(&becomes_based.actions);
-    let digests_a = action_digests(&autonome_a.actions);
-    let digests_b = action_digests(&autonome_b.actions);
+    let based_descriptors: Vec<action::Descriptor> = becomes_based
+        .actions
+        .iter()
+        .map(Action::descriptor)
+        .collect();
+    let descriptors_a: Vec<action::Descriptor> =
+        autonome_a.actions.iter().map(Action::descriptor).collect();
+    let descriptors_b: Vec<action::Descriptor> =
+        autonome_b.actions.iter().map(Action::descriptor).collect();
 
     let (adjunct_a, stamp_a) = autonome_a.strip();
     let (adjunct_b, stamp_b) = autonome_b.strip();
 
-    let innocent_digests: Vec<ActionDigest> =
-        digests_a.iter().chain(digests_b.iter()).copied().collect();
-    let innocent_stamp = ProofStamp::prove_merge(rng, (stamp_a, &digests_a), (stamp_b, &digests_b))
+    let innocent_descriptors = [descriptors_a.as_slice(), descriptors_b.as_slice()].concat();
+    let innocent_stamp = ProofStamp::merge(rng, (stamp_a, descriptors_a), (stamp_b, descriptors_b))
         .expect("innocent merge");
 
-    let based_stamp = ProofStamp::prove_merge(
+    let based_stamp = ProofStamp::merge(
         rng,
-        (becomes_based.stamp, &based_digests),
-        (innocent_stamp, &innocent_digests),
+        (becomes_based.stamp, based_descriptors),
+        (innocent_stamp, innocent_descriptors),
     )
     .expect("based merge");
     becomes_based.stamp = based_stamp;
 
-    // Coverage confirmation: the based aggregate's carried commitment matches
+    // Coverage confirmation: the based aggregate's carried digest matches
     // its own actions plus both covered adjuncts'.
     assert!(
-        becomes_based
-            .covers(&[adjunct_a.clone(), adjunct_b.clone()])
-            .expect("valid digests"),
-        "full covered set matches cActionsTachyon"
+        becomes_based.covers(&[adjunct_a.clone(), adjunct_b.clone()]),
+        "full covered set matches hActionsTachyon"
     );
 
-    // Missing an adjunct: fewer roots, no match.
+    // Missing an adjunct: fewer descriptors, no match.
     assert!(
-        !becomes_based
-            .covers(from_ref(&adjunct_a))
-            .expect("valid digests"),
+        !becomes_based.covers(from_ref(&adjunct_a)),
         "missing adjunct must mismatch"
     );
 
-    // Extra (duplicated) adjunct: more roots, no match.
+    // Extra (duplicated) adjunct: more descriptors, no match.
     assert!(
-        !becomes_based
-            .covers(&[adjunct_a.clone(), adjunct_b, adjunct_a])
-            .expect("valid digests"),
+        !becomes_based.covers(&[adjunct_a.clone(), adjunct_b, adjunct_a]),
         "extra adjunct must mismatch"
     );
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -447,7 +447,7 @@ fn tachyon_bundle_conversions() {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::new(shared_sk());
         let original = build_autonome(rng, &wallet, 1000, 700);
-        let erased: TachyonBundle = original.clone().into();
+        let erased: StampedBundle = original.clone().into();
         let back = Bundle::<ProofStamp>::try_from(erased).expect("stamped variant");
 
         assert_eq!(original.actions, back.actions);
@@ -464,7 +464,7 @@ fn tachyon_bundle_conversions() {
         let wtxid = mock_wtxid(&covering);
         let stripped = build_autonome(rng, &wallet, 1000, 700).strip(wtxid);
 
-        let erased: TachyonBundle = stripped.clone().into();
+        let erased: StampedBundle = stripped.clone().into();
         let back = Bundle::<PointerStamp>::try_from(erased).expect("stripped variant");
 
         assert_eq!(stripped, back);
@@ -478,10 +478,10 @@ fn tachyon_bundle_conversions() {
         let stamped = build_autonome(rng, &wallet, 1000, 700);
         let adjunct = build_autonome(rng, &wallet, 1000, 700).strip(mock_wtxid(&stamped));
 
-        let stamped_erased: TachyonBundle = stamped.into();
+        let stamped_erased: StampedBundle = stamped.into();
         Bundle::<PointerStamp>::try_from(stamped_erased).expect_err("stamped is not an adjunct");
 
-        let adjunct_erased: TachyonBundle = adjunct.into();
+        let adjunct_erased: StampedBundle = adjunct.into();
         Bundle::<ProofStamp>::try_from(adjunct_erased).expect_err("adjunct is not stamped");
     }
 }
@@ -494,10 +494,10 @@ fn tachyon_bundle_wire_round_trip() {
     // Stamped variant (0x01).
     {
         let stamped = build_autonome(rng, &wallet, 1000, 700);
-        let erased: TachyonBundle = stamped.clone().into();
+        let erased: StampedBundle = stamped.clone().into();
         let mut buf = Vec::new();
         erased.write(&mut buf).expect("write");
-        let decoded = TachyonBundle::read(&*buf)
+        let decoded = StampedBundle::read(&*buf)
             .expect("read")
             .expect("some bundle");
         let back = Bundle::<ProofStamp>::try_from(decoded).expect("stamped variant");
@@ -513,10 +513,10 @@ fn tachyon_bundle_wire_round_trip() {
     {
         let covering = build_autonome(rng, &wallet, 500, 300);
         let stripped = build_autonome(rng, &wallet, 1000, 700).strip(mock_wtxid(&covering));
-        let erased: TachyonBundle = stripped.clone().into();
+        let erased: StampedBundle = stripped.clone().into();
         let mut buf = Vec::new();
         erased.write(&mut buf).expect("write");
-        let decoded = TachyonBundle::read(&*buf)
+        let decoded = StampedBundle::read(&*buf)
             .expect("read")
             .expect("some bundle");
         let back = Bundle::<PointerStamp>::try_from(decoded).expect("stripped variant");
@@ -538,7 +538,7 @@ fn wire_state_byte_dispatch() {
         for err in [
             Bundle::<ProofStamp>::read(buf).expect_err("invalid state byte must be rejected"),
             Bundle::<PointerStamp>::read(buf).expect_err("invalid state byte must be rejected"),
-            TachyonBundle::read(buf).expect_err("invalid state byte must be rejected"),
+            StampedBundle::read(buf).expect_err("invalid state byte must be rejected"),
         ] {
             assert_eq!(err.kind(), io::ErrorKind::InvalidData);
             assert_eq!(err.to_string(), "invalid bundle state");
@@ -548,7 +548,7 @@ fn wire_state_byte_dispatch() {
     // No-bundle (0x00): the enum reader decodes to None, not an error.
     {
         let buf: &[u8] = &[0x00];
-        let decoded = TachyonBundle::read(buf).expect("read");
+        let decoded = StampedBundle::read(buf).expect("read");
         assert!(decoded.is_none(), "0x00 must decode to None");
     }
 
@@ -630,7 +630,7 @@ fn read_rejects_zero_wtxid() {
         );
 
         let enum_err =
-            TachyonBundle::read(&*buf).expect_err("TachyonBundle::read must reject zero wtxid");
+            StampedBundle::read(&*buf).expect_err("TachyonBundle::read must reject zero wtxid");
         assert_eq!(enum_err.kind(), io::ErrorKind::InvalidData);
         assert_eq!(
             enum_err.to_string(),
@@ -663,7 +663,7 @@ fn innocent_round_trips_with_nonzero_wtxid() {
     let via_adjunct = Bundle::<PointerStamp>::read(&*buf).expect("Adjunct::read innocent");
     assert_eq!(innocent, via_adjunct);
 
-    let decoded = TachyonBundle::read(&*buf)
+    let decoded = StampedBundle::read(&*buf)
         .expect("TachyonBundle::read")
         .expect("some bundle");
     let via_enum = Bundle::<PointerStamp>::try_from(decoded).expect("adjunct variant");
@@ -711,13 +711,13 @@ fn auth_digest_invariants() {
         let stamped = build_autonome(rng, &wallet, 1000, 700);
         let stamped_direct = stamped.auth_digest();
         let covering_wtxid = mock_wtxid(&stamped);
-        let erased: TachyonBundle = stamped.into();
+        let erased: StampedBundle = stamped.into();
         assert_eq!(erased.auth_digest(), stamped_direct);
 
         let wallet2 = WalletSim::new(shared_sk());
         let stripped = build_autonome(rng, &wallet2, 1000, 700).strip(covering_wtxid);
         let stripped_direct = stripped.auth_digest();
-        let erased_stripped: TachyonBundle = stripped.into();
+        let erased_stripped: StampedBundle = stripped.into();
         assert_eq!(erased_stripped.auth_digest(), stripped_direct);
     }
 

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -722,7 +722,7 @@ fn auth_digest_invariants() {
         let baseline = stamped.auth_digest();
 
         let mut altered_actions = stamped.clone();
-        altered_actions.stamp.covered_actions[0] ^= 0x01;
+        altered_actions.stamp.actions[0] ^= 0x01;
         assert_ne!(baseline, altered_actions.auth_digest());
 
         let mut extra_tachygram = stamped;
@@ -739,7 +739,7 @@ fn auth_digest_invariants() {
 /// Coverage-check protocol: an observer reconstructs the covered-actions
 /// digest from a based aggregate's own actions plus all covered adjuncts'
 /// visible actions, and checks it against the stamped aggregate's
-/// serialized `hActionsTachyon`.
+/// serialized `hStampActionsTachyon`.
 #[test]
 fn coverage_check_matches_stamp_actions() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -827,7 +827,7 @@ fn coverage_check_matches_stamp_actions() {
     // its own actions plus both covered adjuncts'.
     assert!(
         becomes_based.covers(&[&adjunct_a, &adjunct_b]),
-        "full covered set matches hActionsTachyon"
+        "full covered set matches hStampActionsTachyon"
     );
 
     // Missing an adjunct: fewer descriptors, no match.

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -35,7 +35,7 @@ fn wrong_value_balance_fails_verification() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
     let mut bundle = build_autonome(rng, &wallet, 1000, 700);
-    let sighash = mock_sighash(bundle.commitment().unwrap());
+    let sighash = mock_sighash(bundle.commitment());
 
     bundle.value_balance = 999;
     let err = bundle.verify_signatures(&sighash).unwrap_err();
@@ -49,7 +49,7 @@ fn stripped_bundle_retains_signatures() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
     let bundle = build_autonome(rng, &wallet, 1000, 700);
-    let sighash = mock_sighash(bundle.commitment().unwrap());
+    let sighash = mock_sighash(bundle.commitment());
 
     let covering = build_autonome(rng, &wallet, 500, 300);
     let adjunct = bundle.strip(mock_wtxid(&covering));
@@ -73,10 +73,7 @@ fn plan_commitment_matches_bundle_commitment() {
         .expect("sign output bundle")
         .stamp(stamp);
 
-    assert_eq!(
-        bundle_plan.commitment().unwrap(),
-        bundle.commitment().unwrap()
-    );
+    assert_eq!(bundle_plan.commitment().unwrap(), bundle.commitment());
 }
 
 #[test]
@@ -129,7 +126,7 @@ fn payment_bundle_verifies() {
         alloc::vec![(input_note, spendable_pcd, spend_epoch)],
         alloc::vec![output_note, change_note],
     );
-    let sighash = mock_sighash(stamped.commitment().unwrap());
+    let sighash = mock_sighash(stamped.commitment());
     stamped
         .verify_signatures(&sighash)
         .expect("payment bundle must verify");
@@ -264,7 +261,7 @@ fn innocent_aggregate_from_two_autonomes() {
     let adjunct_b = autonome_b.strip(mock_wtxid(&innocent));
 
     innocent
-        .verify_signatures(&mock_sighash(innocent.commitment().unwrap()))
+        .verify_signatures(&mock_sighash(innocent.commitment()))
         .expect("innocent binding sig should verify");
 
     let adjunct_descriptors: Vec<action::Descriptor> = [adjunct_a.actions, adjunct_b.actions]
@@ -335,7 +332,7 @@ fn based_aggregate_with_two_adjuncts() {
         alloc::vec![b_output],
     );
 
-    let sighash = mock_sighash(becomes_based.commitment().unwrap());
+    let sighash = mock_sighash(becomes_based.commitment());
 
     let based_descriptors: Vec<action::Descriptor> = becomes_based
         .actions
@@ -391,7 +388,7 @@ fn invalid_action_sig_fails_verification() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
     let mut bundle = build_autonome(rng, &wallet, 1000, 700);
-    let sighash = mock_sighash(bundle.commitment().unwrap());
+    let sighash = mock_sighash(bundle.commitment());
 
     let mut sig_bytes: [u8; 64] = bundle.actions[0].sig.into();
     sig_bytes[0] ^= 0xFF;
@@ -419,7 +416,7 @@ fn stamped_read_write_round_trip() {
     assert_eq!(original.stamp.tachygrams, deserialized.stamp.tachygrams);
     assert_eq!(original.stamp.anchor, deserialized.stamp.anchor);
 
-    let sighash = mock_sighash(deserialized.commitment().unwrap());
+    let sighash = mock_sighash(deserialized.commitment());
     deserialized
         .verify_signatures(&sighash)
         .expect("deserialized bundle must verify");
@@ -733,6 +730,8 @@ fn auth_digest_invariants() {
             .stamp
             .tachygrams
             .push(Tachygram::from(Fp::from(7u64)));
+        // Tachygrams must stay canonically sorted for the stamp digest.
+        extra_tachygram.stamp.tachygrams.sort_unstable();
         assert_ne!(baseline, extra_tachygram.auth_digest());
     }
 }
@@ -842,4 +841,57 @@ fn coverage_check_matches_stamp_actions() {
         !becomes_based.covers(&[&adjunct_a, &adjunct_b, &adjunct_a]),
         "extra adjunct must mismatch"
     );
+}
+
+/// A bundle whose actions are not in canonical order is rejected on read: the
+/// order-committing sighash plus this check close action reordering as a
+/// malleability vector.
+#[test]
+fn read_rejects_noncanonical_actions() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let bundle = build_autonome(rng, &wallet, 1000, 700);
+    assert!(
+        bundle.actions.len() >= 2,
+        "need at least two actions to permute"
+    );
+    assert_ne!(bundle.actions[0], bundle.actions[1]);
+
+    // A canonical (signed) bundle round-trips.
+    let mut buf = Vec::new();
+    bundle.write(&mut buf).expect("write");
+    Bundle::<ProofStamp>::read(&*buf).expect("canonical bundle reads");
+
+    // Permuting the stored actions and re-serializing produces a non-canonical
+    // encoding, which read must reject.
+    let mut permuted = bundle;
+    permuted.actions.swap(0, 1);
+    let mut permuted_buf = Vec::new();
+    permuted.write(&mut permuted_buf).expect("write permuted");
+
+    let err = Bundle::<ProofStamp>::read(&*permuted_buf)
+        .expect_err("non-canonical actions must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(err.to_string(), "actions are not canonically sorted");
+}
+
+/// A stamp whose tachygrams are not in canonical order is rejected on read,
+/// matching the order the stamp digest commits to.
+#[test]
+fn read_rejects_noncanonical_tachygrams() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let bundle = build_autonome(rng, &wallet, 1000, 700);
+    let n = bundle.stamp.tachygrams.len();
+    assert!(n >= 2, "need at least two tachygrams to permute");
+
+    let mut permuted = bundle;
+    permuted.stamp.tachygrams.swap(0, n - 1);
+    let mut buf = Vec::new();
+    permuted.write(&mut buf).expect("write");
+
+    let err =
+        Bundle::<ProofStamp>::read(&*buf).expect_err("non-canonical tachygrams must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(err.to_string(), "tachygrams are not canonically sorted");
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -10,8 +10,8 @@ use crate::{
     constants::EPOCH_SIZE,
     digest::blake2b::COMMIT_NO_BUNDLE,
     fixtures::{
-        PoolSim, WalletSim, build_autonome, build_output_stamp, mock_sighash, random_action,
-        random_block, random_block_with, shared_sk,
+        PoolSim, WalletSim, build_autonome, build_output_stamp, mock_sighash, mock_wtxid,
+        random_action, random_block, random_block_with, shared_sk,
     },
     primitives::{BlockHeight, Tachygram},
     stamp::VerificationError,
@@ -51,8 +51,9 @@ fn stripped_bundle_retains_signatures() {
     let bundle = build_autonome(rng, &wallet, 1000, 700);
     let sighash = mock_sighash(bundle.commitment().unwrap());
 
-    let (unassigned, _stamp) = bundle.strip();
-    unassigned.verify_signatures(&sighash).unwrap();
+    let covering = build_autonome(rng, &wallet, 500, 300);
+    let adjunct = bundle.strip(mock_wtxid(&covering));
+    adjunct.verify_signatures(&sighash).unwrap();
 }
 
 #[test]
@@ -91,6 +92,9 @@ fn no_bundle_commitment_differs_from_empty_bundle() {
 #[test]
 fn zero_action_bundle_is_valid() {
     let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let covering = build_autonome(rng, &wallet, 1000, 700);
+
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
     let sighash = mock_sighash(plan.commitment().unwrap());
 
@@ -98,7 +102,7 @@ fn zero_action_bundle_is_valid() {
         actions: alloc::vec![],
         value_balance: 0,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-        stamp: PointerStamp::try_from([1u8; 64]).expect("nonzero id"),
+        stamp: mock_wtxid(&covering),
     };
 
     bundle.verify_signatures(&sighash).unwrap();
@@ -137,21 +141,22 @@ fn stamp_verify_action_multiset_invariants() {
     let wallet = WalletSim::new(shared_sk());
     let stamped = build_autonome(rng, &wallet, 1000, 700);
 
+    let descriptors: Vec<action::Descriptor> =
+        stamped.actions.iter().map(Action::descriptor).collect();
+
     // Permutation accepts.
     {
-        let action_a = stamped.actions[0];
-        let action_b = stamped.actions[1];
         stamped
             .stamp
-            .verify(rng, &[action_b, action_a])
+            .verify(rng, &[descriptors[1], descriptors[0]])
             .expect("permuted actions must verify");
     }
 
     // Drop rejects.
     {
-        let mut actions = stamped.actions.clone();
-        actions.pop();
-        let err = stamped.stamp.verify(rng, &actions).unwrap_err();
+        let mut dropped = descriptors.clone();
+        dropped.pop();
+        let err = stamped.stamp.verify(rng, &dropped).unwrap_err();
         let VerificationError::ActionsMismatch = err else {
             panic!("drop: expected ActionsMismatch, got {err:?}");
         };
@@ -159,9 +164,9 @@ fn stamp_verify_action_multiset_invariants() {
 
     // Duplicate rejects.
     {
-        let mut actions = stamped.actions.clone();
-        actions.push(actions[0]);
-        let err = stamped.stamp.verify(rng, &actions).unwrap_err();
+        let mut duplicated = descriptors.clone();
+        duplicated.push(duplicated[0]);
+        let err = stamped.stamp.verify(rng, &duplicated).unwrap_err();
         let VerificationError::ActionsMismatch = err else {
             panic!("duplicate: expected ActionsMismatch, got {err:?}");
         };
@@ -169,9 +174,9 @@ fn stamp_verify_action_multiset_invariants() {
 
     // Foreign-extra rejects.
     {
-        let mut actions = stamped.actions.clone();
-        actions.push(random_action(rng));
-        let err = stamped.stamp.verify(rng, &actions).unwrap_err();
+        let mut extended = descriptors.clone();
+        extended.push(random_action(rng).descriptor());
+        let err = stamped.stamp.verify(rng, &extended).unwrap_err();
         let VerificationError::ActionsMismatch = err else {
             panic!("extra: expected ActionsMismatch, got {err:?}");
         };
@@ -179,9 +184,9 @@ fn stamp_verify_action_multiset_invariants() {
 
     // Replace-with-foreign rejects.
     {
-        let mut actions = stamped.actions.clone();
-        actions[0] = random_action(rng);
-        let err = stamped.stamp.verify(rng, &actions).unwrap_err();
+        let mut replaced = descriptors;
+        replaced[0] = random_action(rng).descriptor();
+        let err = stamped.stamp.verify(rng, &replaced).unwrap_err();
         let VerificationError::ActionsMismatch = err else {
             panic!("replaced: expected ActionsMismatch, got {err:?}");
         };
@@ -235,8 +240,8 @@ fn innocent_aggregate_from_two_autonomes() {
         autonome_a.actions.iter().map(Action::descriptor).collect();
     let descriptors_b: Vec<action::Descriptor> =
         autonome_b.actions.iter().map(Action::descriptor).collect();
-    let (adjunct_a, stamp_a) = autonome_a.strip();
-    let (adjunct_b, stamp_b) = autonome_b.strip();
+    let stamp_a = autonome_a.stamp.clone();
+    let stamp_b = autonome_b.stamp.clone();
 
     let innocent = {
         let innocent_plan = Plan::new(alloc::vec![], alloc::vec![]);
@@ -255,14 +260,21 @@ fn innocent_aggregate_from_two_autonomes() {
         }
     };
 
+    let adjunct_a = autonome_a.strip(mock_wtxid(&innocent));
+    let adjunct_b = autonome_b.strip(mock_wtxid(&innocent));
+
     innocent
         .verify_signatures(&mock_sighash(innocent.commitment().unwrap()))
         .expect("innocent binding sig should verify");
 
-    let adjunct_actions: Vec<Action> = [adjunct_a.actions, adjunct_b.actions].concat();
+    let adjunct_descriptors: Vec<action::Descriptor> = [adjunct_a.actions, adjunct_b.actions]
+        .concat()
+        .iter()
+        .map(Action::descriptor)
+        .collect();
     innocent
         .stamp
-        .verify(rng, &adjunct_actions)
+        .verify(rng, &adjunct_descriptors)
         .expect("innocent stamp should verify against adjunct actions");
 }
 
@@ -335,8 +347,8 @@ fn based_aggregate_with_two_adjuncts() {
     let descriptors_b: Vec<action::Descriptor> =
         autonome_b.actions.iter().map(Action::descriptor).collect();
 
-    let (adjunct_a, stamp_a) = autonome_a.strip();
-    let (adjunct_b, stamp_b) = autonome_b.strip();
+    let stamp_a = autonome_a.stamp.clone();
+    let stamp_b = autonome_b.stamp.clone();
 
     let innocent_descriptors = [descriptors_a.as_slice(), descriptors_b.as_slice()].concat();
     let innocent_stamp = ProofStamp::merge(rng, (stamp_a, descriptors_a), (stamp_b, descriptors_b))
@@ -351,20 +363,26 @@ fn based_aggregate_with_two_adjuncts() {
 
     becomes_based.stamp = based_stamp;
 
+    let adjunct_a = autonome_a.strip(mock_wtxid(&becomes_based));
+    let adjunct_b = autonome_b.strip(mock_wtxid(&becomes_based));
+
     becomes_based
         .verify_signatures(&sighash)
         .expect("based aggregate binding sig should verify");
 
-    let all_actions: Vec<Action> = [
+    let all_descriptors: Vec<action::Descriptor> = [
         becomes_based.actions.clone(),
         adjunct_a.actions,
         adjunct_b.actions,
     ]
-    .concat();
+    .concat()
+    .iter()
+    .map(Action::descriptor)
+    .collect();
 
     becomes_based
         .stamp
-        .verify(rng, &all_actions)
+        .verify(rng, &all_descriptors)
         .expect("based aggregate stamp should verify against all actions");
 }
 
@@ -411,19 +429,16 @@ fn stamped_read_write_round_trip() {
 fn stripped_read_write_round_trip() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
-    let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-    let stripped =
-        unassigned.assign_wtxid(PointerStamp::try_from([0x42u8; 64]).expect("nonzero id"));
+    let covering = build_autonome(rng, &wallet, 500, 300);
+    let wtxid = mock_wtxid(&covering);
+    let stripped = build_autonome(rng, &wallet, 1000, 700).strip(wtxid);
 
     let mut buf = Vec::new();
     stripped.write(&mut buf).expect("write");
     let deserialized = Bundle::<PointerStamp>::read(&*buf).expect("read");
 
     assert_eq!(stripped, deserialized);
-    assert_eq!(
-        deserialized.stamp,
-        PointerStamp::try_from([0x42u8; 64]).expect("nonzero id")
-    );
+    assert_eq!(deserialized.stamp, wtxid);
 }
 
 #[test]
@@ -446,18 +461,15 @@ fn tachyon_bundle_conversions() {
     {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::new(shared_sk());
-        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        let stripped =
-            unassigned.assign_wtxid(PointerStamp::try_from([0xABu8; 64]).expect("nonzero id"));
+        let covering = build_autonome(rng, &wallet, 500, 300);
+        let wtxid = mock_wtxid(&covering);
+        let stripped = build_autonome(rng, &wallet, 1000, 700).strip(wtxid);
 
         let erased: TachyonBundle = stripped.clone().into();
         let back = Bundle::<PointerStamp>::try_from(erased).expect("stripped variant");
 
         assert_eq!(stripped, back);
-        assert_eq!(
-            back.stamp,
-            PointerStamp::try_from([0xABu8; 64]).expect("nonzero id")
-        );
+        assert_eq!(back.stamp, wtxid);
     }
 
     // Err: TryFrom rejects the wrong variant in both directions.
@@ -465,9 +477,7 @@ fn tachyon_bundle_conversions() {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::new(shared_sk());
         let stamped = build_autonome(rng, &wallet, 1000, 700);
-        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        let adjunct =
-            unassigned.assign_wtxid(PointerStamp::try_from([0x55u8; 64]).expect("nonzero id"));
+        let adjunct = build_autonome(rng, &wallet, 1000, 700).strip(mock_wtxid(&stamped));
 
         let stamped_erased: TachyonBundle = stamped.into();
         Bundle::<PointerStamp>::try_from(stamped_erased).expect_err("stamped is not an adjunct");
@@ -502,9 +512,8 @@ fn tachyon_bundle_wire_round_trip() {
 
     // Stripped variant (0x02).
     {
-        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        let stripped =
-            unassigned.assign_wtxid(PointerStamp::try_from([0xCDu8; 64]).expect("nonzero id"));
+        let covering = build_autonome(rng, &wallet, 500, 300);
+        let stripped = build_autonome(rng, &wallet, 1000, 700).strip(mock_wtxid(&covering));
         let erased: TachyonBundle = stripped.clone().into();
         let mut buf = Vec::new();
         erased.write(&mut buf).expect("write");
@@ -553,9 +562,7 @@ fn wire_state_byte_dispatch() {
         let mut stamped_buf = Vec::new();
         stamped.write(&mut stamped_buf).expect("write stamped");
 
-        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        let adjunct =
-            unassigned.assign_wtxid(PointerStamp::try_from([0x66u8; 64]).expect("nonzero id"));
+        let adjunct = build_autonome(rng, &wallet, 1000, 700).strip(mock_wtxid(&stamped));
         let mut adjunct_buf = Vec::new();
         adjunct.write(&mut adjunct_buf).expect("write adjunct");
 
@@ -583,11 +590,14 @@ fn read_rejects_zero_wtxid() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
 
+    let covering = build_autonome(rng, &wallet, 500, 300);
+    let wtxid = mock_wtxid(&covering);
+
     // Adjunct (non-empty actions) and innocent (empty actions) both reject.
     let adjunct = {
-        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
-        assert!(!unassigned.actions.is_empty());
-        unassigned.assign_wtxid(PointerStamp::try_from([0x42u8; 64]).expect("nonzero id"))
+        let adjunct = build_autonome(rng, &wallet, 1000, 700).strip(wtxid);
+        assert!(!adjunct.actions.is_empty());
+        adjunct
     };
 
     let innocent = {
@@ -597,7 +607,7 @@ fn read_rejects_zero_wtxid() {
             actions: alloc::vec![],
             value_balance: 0,
             binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-            stamp: PointerStamp::try_from([0x42u8; 64]).expect("nonzero id"),
+            stamp: wtxid,
         };
         assert!(bundle.actions.is_empty());
         bundle
@@ -635,6 +645,9 @@ fn read_rejects_zero_wtxid() {
 #[test]
 fn innocent_round_trips_with_nonzero_wtxid() {
     let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let covering = build_autonome(rng, &wallet, 1000, 700);
+
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
     let sighash = mock_sighash(plan.commitment().unwrap());
 
@@ -642,7 +655,7 @@ fn innocent_round_trips_with_nonzero_wtxid() {
         actions: alloc::vec![],
         value_balance: 0,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
-        stamp: PointerStamp::try_from([0x42u8; 64]).expect("nonzero id"),
+        stamp: mock_wtxid(&covering),
     };
 
     let mut buf = Vec::new();
@@ -668,9 +681,8 @@ fn auth_digest_invariants() {
         let stamped = build_autonome(rng, &wallet, 1000, 700);
         let stamped_digest = stamped.auth_digest();
 
-        let (unassigned, _stamp) = stamped.strip();
-        let stripped =
-            unassigned.assign_wtxid(PointerStamp::try_from([0x11u8; 64]).expect("nonzero id"));
+        let covering = build_autonome(rng, &wallet, 500, 300);
+        let stripped = stamped.strip(mock_wtxid(&covering));
         assert_ne!(stamped_digest, stripped.auth_digest());
     }
 
@@ -679,14 +691,15 @@ fn auth_digest_invariants() {
     {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::new(shared_sk());
-        let (unassigned, _stamp) = build_autonome(rng, &wallet, 1000, 700).strip();
+        let autonome = build_autonome(rng, &wallet, 1000, 700);
 
-        let stripped_aa = unassigned
-            .clone()
-            .assign_wtxid(PointerStamp::try_from([0xAAu8; 64]).expect("nonzero id"));
+        let covering_a = build_autonome(rng, &wallet, 500, 300);
+        let covering_b = build_autonome(rng, &wallet, 800, 600);
+        assert_ne!(mock_wtxid(&covering_a), mock_wtxid(&covering_b));
+
+        let stripped_aa = autonome.clone().strip(mock_wtxid(&covering_a));
         let digest_aa = stripped_aa.auth_digest();
-        let stripped_bb =
-            unassigned.assign_wtxid(PointerStamp::try_from([0xBBu8; 64]).expect("nonzero id"));
+        let stripped_bb = autonome.strip(mock_wtxid(&covering_b));
         let digest_bb = stripped_bb.auth_digest();
         assert_ne!(digest_aa, digest_bb);
     }
@@ -698,13 +711,12 @@ fn auth_digest_invariants() {
         let wallet = WalletSim::new(shared_sk());
         let stamped = build_autonome(rng, &wallet, 1000, 700);
         let stamped_direct = stamped.auth_digest();
+        let covering_wtxid = mock_wtxid(&stamped);
         let erased: TachyonBundle = stamped.into();
         assert_eq!(erased.auth_digest(), stamped_direct);
 
         let wallet2 = WalletSim::new(shared_sk());
-        let (unassigned, _stamp) = build_autonome(rng, &wallet2, 1000, 700).strip();
-        let stripped =
-            unassigned.assign_wtxid(PointerStamp::try_from([0x33u8; 64]).expect("nonzero id"));
+        let stripped = build_autonome(rng, &wallet2, 1000, 700).strip(covering_wtxid);
         let stripped_direct = stripped.auth_digest();
         let erased_stripped: TachyonBundle = stripped.into();
         assert_eq!(erased_stripped.auth_digest(), stripped_direct);
@@ -800,8 +812,8 @@ fn coverage_check_matches_stamp_actions() {
     let descriptors_b: Vec<action::Descriptor> =
         autonome_b.actions.iter().map(Action::descriptor).collect();
 
-    let (adjunct_a, stamp_a) = autonome_a.strip();
-    let (adjunct_b, stamp_b) = autonome_b.strip();
+    let stamp_a = autonome_a.stamp.clone();
+    let stamp_b = autonome_b.stamp.clone();
 
     let innocent_descriptors = [descriptors_a.as_slice(), descriptors_b.as_slice()].concat();
     let innocent_stamp = ProofStamp::merge(rng, (stamp_a, descriptors_a), (stamp_b, descriptors_b))
@@ -814,6 +826,9 @@ fn coverage_check_matches_stamp_actions() {
     )
     .expect("based merge");
     becomes_based.stamp = based_stamp;
+
+    let adjunct_a = autonome_a.strip(mock_wtxid(&becomes_based));
+    let adjunct_b = autonome_b.strip(mock_wtxid(&becomes_based));
 
     // Coverage confirmation: the based aggregate's carried digest matches
     // its own actions plus both covered adjuncts'.

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -94,53 +94,375 @@ fn plan_commitment_matches_bundle_commitment() {
     let sighash = mock_sighash(bundle_plan.commitment().unwrap());
 
     let bundle = bundle_plan
-        .sign(&sighash, &ask, rng)
+        .sign(rng, &sighash, &ask)
         .expect("sign output bundle")
         .stamp(stamp);
 
     assert_eq!(bundle_plan.commitment().unwrap(), bundle.commitment());
 }
 
+/// The output's `rk` is corrupted to an unrelated (but known) key after
+/// construction. `sign` signs with the output's own alpha-derived key
+/// regardless, producing a real signature under the wrong key — not the
+/// signature that would actually match the corrupted key.
 #[test]
-fn sign_reports_global_action_index_on_rk_mismatch() {
+fn actions_signed_despite_wrong_rk_fail_verification() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);
     let ask = wallet.sk.derive_auth_private();
 
-    // A valid spend at global index 0 — derive its rk exactly as `sign` does,
-    // so it passes the spend check and signing reaches the outputs.
-    let spend = action::Plan::spend(
-        wallet.random_note(200),
-        ActionEntropy::random(rng),
-        value::Trapdoor::random(rng),
-        |alpha| ask.derive_action_private(&alpha).derive_action_public(),
-    );
+    let spend = spend_plan_at(rng, &wallet, &ask, 200);
 
-    // An output at global index 1 whose rk is corrupted to a foreign key.
     let mut output = action::Plan::output(
         wallet.random_note(100),
         ActionEntropy::random(rng),
         value::Trapdoor::random(rng),
     );
-    let wrong_rk = action::Plan::output(
+    let unrelated = action::Plan::output(
         wallet.random_note(50),
         ActionEntropy::random(rng),
         value::Trapdoor::random(rng),
-    )
-    .rk;
-    output.rk = wrong_rk;
+    );
+    output.rk = unrelated.rk;
 
     let plan = Plan::new(alloc::vec![spend], alloc::vec![output]);
-    let sighash = mock_sighash(plan.commitment().unwrap());
 
-    let err = plan.sign(&sighash, &ask, rng).unwrap_err();
-    let SignError::RkMismatch { idx, rk } = err else {
-        panic!("expected RkMismatch, got {err:?}");
+    let bundle = plan
+        .sign(rng, &mock_sighash(plan.commitment().unwrap()), &ask)
+        .expect("signing works");
+
+    // We've applied a signature from the unrelated key
+    let unrelated_alpha = unrelated
+        .theta
+        .randomizer::<effect::Output>(unrelated.note.commitment());
+    assert!(!bundle.actions.iter().any(|action| {
+        action.sig
+            == private::ActionSigningKey::new(&unrelated_alpha)
+                .sign(rng, &mock_sighash(plan.commitment().unwrap()))
+    }));
+
+    // so it fails verification
+    let err = bundle
+        .verify_signatures(&mock_sighash(bundle.commitment()))
+        .unwrap_err();
+    let SignatureError::Action(_) = err else {
+        panic!("expected SignatureError::Action, got {err:?}");
     };
-    // Global index = spends.len() (1) + output index (0): the offset is retained,
-    // and the error carries the offending rk alongside it.
-    assert_eq!(idx, 1);
-    assert_eq!(rk, wrong_rk.0.into());
+}
+
+/// The spend's `rk` matches `ask`, but `sign` is called with a different
+/// signing key. It signs with whatever key it's given, producing a real
+/// signature from the wrong signer, not the one `ask` itself would have
+/// produced.
+#[test]
+fn actions_signed_by_wrong_rsk_fail_verification() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+    let wrong_ask = WalletSim::random(rng).sk.derive_auth_private();
+
+    let spend = spend_plan_at(rng, &wallet, &ask, 200);
+    let note = wallet.random_note(100);
+    let (_rcv, _alpha, output) = build_output_plan(rng, note);
+
+    let plan = Plan::new(alloc::vec![spend], alloc::vec![output]);
+
+    let bundle = plan
+        .sign(rng, &mock_sighash(plan.commitment().unwrap()), &wrong_ask)
+        .expect("signing works");
+
+    // The signature the spend's matching key would have produced.
+    let alpha = spend
+        .theta
+        .randomizer::<effect::Spend>(spend.note.commitment());
+    let correct_sig = ask
+        .derive_action_private(&alpha)
+        .sign(rng, &mock_sighash(bundle.commitment()));
+    assert!(
+        !bundle
+            .actions
+            .iter()
+            .any(|action| action.sig == correct_sig)
+    );
+
+    let err = bundle
+        .verify_signatures(&mock_sighash(bundle.commitment()))
+        .unwrap_err();
+    let SignatureError::Action(_) = err else {
+        panic!("expected SignatureError::Action, got {err:?}");
+    };
+}
+
+#[test]
+fn apply_signatures_rejects_wrong_sig_count() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let ask = wallet.sk.derive_auth_private();
+    let spend_a = spend_plan_at(rng, &wallet, &ask, 200);
+    let spend_b = spend_plan_at(rng, &wallet, &ask, 100);
+    let plan = Plan::new(alloc::vec![spend_a, spend_b], alloc::vec![]);
+
+    let alpha = spend_a
+        .theta
+        .randomizer::<effect::Spend>(spend_a.note.commitment());
+    let sig = ask
+        .derive_action_private(&alpha)
+        .sign(rng, &mock_sighash(plan.commitment().unwrap()));
+
+    let too_few = plan
+        .apply_signatures(
+            rng,
+            &mock_sighash(plan.commitment().unwrap()),
+            alloc::vec![sig],
+        )
+        .unwrap_err();
+    let SignError::SigCountMismatch(expected_for_too_few) = too_few else {
+        panic!("expected SigCountMismatch, got {too_few:?}");
+    };
+    assert_eq!(expected_for_too_few, 2);
+
+    let too_many = plan
+        .apply_signatures(
+            rng,
+            &mock_sighash(plan.commitment().unwrap()),
+            alloc::vec![sig, sig, sig],
+        )
+        .unwrap_err();
+    let SignError::SigCountMismatch(expected_for_too_many) = too_many else {
+        panic!("expected SigCountMismatch, got {too_many:?}");
+    };
+    assert_eq!(expected_for_too_many, 2);
+}
+
+#[test]
+fn apply_signatures_with_shuffled_sigs_fails_verification() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+
+    let spend_a = spend_plan_at(rng, &wallet, &ask, 200);
+    let spend_b = spend_plan_at(rng, &wallet, &ask, 100);
+    let plan = Plan::new(alloc::vec![spend_a, spend_b], alloc::vec![]);
+
+    // `sign` produces genuinely valid signatures, already in
+    // `self.descriptors()`'s canonical order.
+    let mut sigs: Vec<action::Signature> = plan
+        .sign(rng, &mock_sighash(plan.commitment().unwrap()), &ask)
+        .expect("signing works")
+        .actions
+        .into_iter()
+        .map(|action| action.sig)
+        .collect();
+
+    // shuffled assembly still succeeds
+    sigs.reverse();
+    let bundle = plan
+        .apply_signatures(rng, &mock_sighash(plan.commitment().unwrap()), sigs)
+        .expect("assembly succeeds regardless of sig order");
+
+    // but the mismatched pairing fails verification.
+    let err = bundle
+        .verify_signatures(&mock_sighash(bundle.commitment()))
+        .unwrap_err();
+    let SignatureError::Action(_) = err else {
+        panic!("expected SignatureError::Action, got {err:?}");
+    };
+}
+
+/// Permuting a bundle's actions changes its commitment, so a sighash
+/// naturally recomputed for the permuted state doesn't validate.
+/// The permuted bundle can't be serialized and read back.
+#[test]
+fn permuted_actions_change_commitment() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+
+    let original = build_autonome(rng, &wallet, 1000, 700);
+
+    // it's a good bundle
+    original
+        .verify_signatures(&mock_sighash(original.commitment()))
+        .unwrap();
+
+    let mut permuted = original.clone();
+    permuted.actions.swap(0, 1);
+
+    // the commitment changes.
+    assert_ne!(
+        mock_sighash(original.commitment()),
+        mock_sighash(permuted.commitment())
+    );
+
+    // and its signatures no longer verify.
+    let sig_err = permuted
+        .verify_signatures(&mock_sighash(permuted.commitment()))
+        .unwrap_err();
+    let SignatureError::Binding(_) = sig_err else {
+        panic!("expected SignatureError::Binding, got {sig_err:?}");
+    };
+
+    // the original sighash can still verify.
+    // always use a sighash corresponding to the bundle's actual state.
+    permuted
+        .verify_signatures(&mock_sighash(original.commitment()))
+        .unwrap();
+
+    // the invalid bundle is detected at deserialization.
+    let mut buf = Vec::new();
+    permuted.write(&mut buf).expect("write");
+    let read_err = Bundle::<ProofStamp>::read(&*buf).unwrap_err();
+    assert_eq!(read_err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(read_err.to_string(), "actions are not canonically sorted");
+}
+
+/// Mutating a bundle's `value_balance` breaks verification.
+#[test]
+fn tampered_value_balance_fails_verification() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+
+    let original = build_autonome(rng, &wallet, 1000, 700);
+
+    // it's a good bundle
+    original
+        .verify_signatures(&mock_sighash(original.commitment()))
+        .unwrap();
+
+    let mut tampered = original.clone();
+    tampered.value_balance = value::Balance::try_from(999).unwrap();
+
+    // it fails verification against the new commitment.
+    let bind_err = tampered
+        .verify_signatures(&mock_sighash(tampered.commitment()))
+        .unwrap_err();
+    let SignatureError::Binding(_) = bind_err else {
+        panic!("expected SignatureError::Binding, got {bind_err:?}");
+    };
+
+    // and it no longer verifies against the original sighash.
+    let also_err = tampered
+        .verify_signatures(&mock_sighash(original.commitment()))
+        .unwrap_err();
+    let SignatureError::Binding(_) = also_err else {
+        panic!("expected SignatureError::Binding, got {also_err:?}");
+    };
+}
+
+/// Duplicate actions are detected at deserialization.
+#[test]
+fn double_spend_obvious() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+    let spend = spend_plan_at(rng, &wallet, &ask, 200);
+
+    let plan = Plan::new(alloc::vec![spend, spend], alloc::vec![]);
+    let bundle = plan
+        .sign(rng, &mock_sighash(plan.commitment().unwrap()), &ask)
+        .expect("signing works");
+
+    bundle
+        .verify_signatures(&mock_sighash(bundle.commitment()))
+        .expect("duplicate spend of the same note still verifies at the bundle level");
+
+    let mut buf = Vec::new();
+    Bundle::<PointerStamp> {
+        actions: bundle.actions,
+        value_balance: bundle.value_balance,
+        binding_sig: bundle.binding_sig,
+        stamp: PointerStamp::try_from([1u8; 64]).expect("not checked"),
+    }
+    .write(&mut buf)
+    .unwrap();
+    let read_err = Bundle::<PointerStamp>::read(&*buf).unwrap_err();
+    assert_eq!(read_err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(read_err.to_string(), "action descriptors are not unique");
+}
+
+/// This double spend is more obfuscated, so we can't detect it. True double
+/// spend prevention is a nullifier/pool-level concern.
+#[test]
+fn double_spend_secret() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+    let note = wallet.random_note(200);
+
+    let spend_a = action::Plan::spend(
+        note,
+        ActionEntropy::random(rng),
+        value::Trapdoor::random(rng),
+        |alpha| ask.derive_action_private(&alpha).derive_action_public(),
+    );
+    let spend_b = action::Plan::spend(
+        note,
+        ActionEntropy::random(rng),
+        value::Trapdoor::random(rng),
+        |alpha| ask.derive_action_private(&alpha).derive_action_public(),
+    );
+    assert_ne!(
+        spend_a.cv(),
+        spend_b.cv(),
+        "independent rcv gives distinct cv"
+    );
+    assert_ne!(
+        spend_a.rk, spend_b.rk,
+        "independent theta gives distinct rk"
+    );
+
+    let plan = Plan::new(alloc::vec![spend_a, spend_b], alloc::vec![]);
+    let bundle = plan
+        .sign(rng, &mock_sighash(plan.commitment().unwrap()), &ask)
+        .expect("signing works");
+
+    bundle
+        .verify_signatures(&mock_sighash(bundle.commitment()))
+        .expect("two independently-randomized spends of the same note still verify");
+}
+
+/// `sign` and `apply_signatures` go through the real API (not a hand-built
+/// `Bundle`) for the boundary shapes of the `iter_actions`/sort/zip
+/// machinery: spends-only, outputs-only, and no actions at all.
+#[test]
+fn sign_and_apply_signatures_handle_one_sided_and_empty_plans() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let ask = wallet.sk.derive_auth_private();
+
+    let spend_plan = Plan::new(
+        alloc::vec![spend_plan_at(rng, &wallet, &ask, 200)],
+        alloc::vec![],
+    );
+    spend_plan
+        .sign(rng, &mock_sighash(spend_plan.commitment().unwrap()), &ask)
+        .expect("spends-only plan signs")
+        .verify_signatures(&mock_sighash(spend_plan.commitment().unwrap()))
+        .expect("spends-only bundle verifies");
+
+    let note = wallet.random_note(200);
+    let (_rcv, _alpha, output) = build_output_plan(rng, note);
+    let output_plan = Plan::new(alloc::vec![], alloc::vec![output]);
+    output_plan
+        .sign(rng, &mock_sighash(output_plan.commitment().unwrap()), &ask)
+        .expect("outputs-only plan signs")
+        .verify_signatures(&mock_sighash(output_plan.commitment().unwrap()))
+        .expect("outputs-only bundle verifies");
+
+    let empty_plan = Plan::new(alloc::vec![], alloc::vec![]);
+    empty_plan
+        .sign(rng, &mock_sighash(empty_plan.commitment().unwrap()), &ask)
+        .expect("empty plan signs")
+        .verify_signatures(&mock_sighash(empty_plan.commitment().unwrap()))
+        .expect("empty bundle via sign verifies");
+    empty_plan
+        .apply_signatures(
+            rng,
+            &mock_sighash(empty_plan.commitment().unwrap()),
+            alloc::vec![],
+        )
+        .expect("apply_signatures accepts zero sigs for an empty plan")
+        .verify_signatures(&mock_sighash(empty_plan.commitment().unwrap()))
+        .expect("empty bundle via apply_signatures verifies");
 }
 
 #[test]
@@ -1025,7 +1347,7 @@ fn plan_value_balance_rejects_overflow_above_max_money() {
     }
     let sighash = [0u8; 32];
     {
-        let err = bundle_plan.sign(&sighash, &ask, rng).unwrap_err();
+        let err = bundle_plan.sign(rng, &sighash, &ask).unwrap_err();
         let SignError::BalanceOverflow = err else {
             panic!("expected SignError::BalanceOverflow, got {err:?}");
         };
@@ -1052,7 +1374,7 @@ fn plan_value_balance_rejects_overflow_below_negative_max_money() {
     }
     let sighash = [0u8; 32];
     {
-        let err = bundle_plan.sign(&sighash, &ask, rng).unwrap_err();
+        let err = bundle_plan.sign(rng, &sighash, &ask).unwrap_err();
         let SignError::BalanceOverflow = err else {
             panic!("expected SignError::BalanceOverflow, got {err:?}");
         };

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -2,6 +2,7 @@
 
 use alloc::{string::ToString as _, vec, vec::Vec};
 
+use pasta_curves::Fp;
 use rand::{SeedableRng as _, rngs::StdRng};
 
 use super::*;
@@ -447,7 +448,7 @@ fn tachyon_bundle_conversions() {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::new(shared_sk());
         let original = build_autonome(rng, &wallet, 1000, 700);
-        let erased: StampedBundle = original.clone().into();
+        let erased: TachyonBundle = original.clone().into();
         let back = Bundle::<ProofStamp>::try_from(erased).expect("stamped variant");
 
         assert_eq!(original.actions, back.actions);
@@ -464,7 +465,7 @@ fn tachyon_bundle_conversions() {
         let wtxid = mock_wtxid(&covering);
         let stripped = build_autonome(rng, &wallet, 1000, 700).strip(wtxid);
 
-        let erased: StampedBundle = stripped.clone().into();
+        let erased: TachyonBundle = stripped.clone().into();
         let back = Bundle::<PointerStamp>::try_from(erased).expect("stripped variant");
 
         assert_eq!(stripped, back);
@@ -478,10 +479,10 @@ fn tachyon_bundle_conversions() {
         let stamped = build_autonome(rng, &wallet, 1000, 700);
         let adjunct = build_autonome(rng, &wallet, 1000, 700).strip(mock_wtxid(&stamped));
 
-        let stamped_erased: StampedBundle = stamped.into();
+        let stamped_erased: TachyonBundle = stamped.into();
         Bundle::<PointerStamp>::try_from(stamped_erased).expect_err("stamped is not an adjunct");
 
-        let adjunct_erased: StampedBundle = adjunct.into();
+        let adjunct_erased: TachyonBundle = adjunct.into();
         Bundle::<ProofStamp>::try_from(adjunct_erased).expect_err("adjunct is not stamped");
     }
 }
@@ -494,12 +495,10 @@ fn tachyon_bundle_wire_round_trip() {
     // Stamped variant (0x01).
     {
         let stamped = build_autonome(rng, &wallet, 1000, 700);
-        let erased: StampedBundle = stamped.clone().into();
+        let erased: TachyonBundle = stamped.clone().into();
         let mut buf = Vec::new();
         erased.write(&mut buf).expect("write");
-        let decoded = StampedBundle::read(&*buf)
-            .expect("read")
-            .expect("some bundle");
+        let decoded = TachyonBundle::read(&*buf).expect("read");
         let back = Bundle::<ProofStamp>::try_from(decoded).expect("stamped variant");
 
         // Stamp carries a proof and is not PartialEq, so compare fields.
@@ -513,12 +512,10 @@ fn tachyon_bundle_wire_round_trip() {
     {
         let covering = build_autonome(rng, &wallet, 500, 300);
         let stripped = build_autonome(rng, &wallet, 1000, 700).strip(mock_wtxid(&covering));
-        let erased: StampedBundle = stripped.clone().into();
+        let erased: TachyonBundle = stripped.clone().into();
         let mut buf = Vec::new();
         erased.write(&mut buf).expect("write");
-        let decoded = StampedBundle::read(&*buf)
-            .expect("read")
-            .expect("some bundle");
+        let decoded = TachyonBundle::read(&*buf).expect("read");
         let back = Bundle::<PointerStamp>::try_from(decoded).expect("stripped variant");
 
         assert_eq!(stripped, back);
@@ -538,18 +535,18 @@ fn wire_state_byte_dispatch() {
         for err in [
             Bundle::<ProofStamp>::read(buf).expect_err("invalid state byte must be rejected"),
             Bundle::<PointerStamp>::read(buf).expect_err("invalid state byte must be rejected"),
-            StampedBundle::read(buf).expect_err("invalid state byte must be rejected"),
+            TachyonBundle::read(buf).expect_err("invalid state byte must be rejected"),
         ] {
             assert_eq!(err.kind(), io::ErrorKind::InvalidData);
             assert_eq!(err.to_string(), "invalid bundle state");
         }
     }
 
-    // No-bundle (0x00): the enum reader decodes to None, not an error.
+    // No-bundle (0x00): the enum reader decodes to NoBundle, not an error.
     {
         let buf: &[u8] = &[0x00];
-        let decoded = StampedBundle::read(buf).expect("read");
-        assert!(decoded.is_none(), "0x00 must decode to None");
+        let decoded = TachyonBundle::read(buf).expect("read");
+        assert!(decoded.is_no_bundle(), "0x00 must decode to NoBundle");
     }
 
     // Valid-but-mismatched state byte: each definite reader rejects the other's.
@@ -569,13 +566,13 @@ fn wire_state_byte_dispatch() {
             .expect_err("Adjunct::read must reject a stamped (0x01) buffer");
         assert_eq!(
             adjunct_on_stamped.to_string(),
-            "stripped bundle requires tachyonBundleState 0x02"
+            "unexpected tachyonBundleState"
         );
         let stamped_on_adjunct = Bundle::<ProofStamp>::read(&*adjunct_buf)
             .expect_err("Stamped::read must reject a stripped (0x02) buffer");
         assert_eq!(
             stamped_on_adjunct.to_string(),
-            "stamped bundle requires tachyonBundleState 0x01"
+            "unexpected tachyonBundleState"
         );
     }
 }
@@ -630,7 +627,7 @@ fn read_rejects_zero_wtxid() {
         );
 
         let enum_err =
-            StampedBundle::read(&*buf).expect_err("TachyonBundle::read must reject zero wtxid");
+            TachyonBundle::read(&*buf).expect_err("TachyonBundle::read must reject zero wtxid");
         assert_eq!(enum_err.kind(), io::ErrorKind::InvalidData);
         assert_eq!(
             enum_err.to_string(),
@@ -663,9 +660,7 @@ fn innocent_round_trips_with_nonzero_wtxid() {
     let via_adjunct = Bundle::<PointerStamp>::read(&*buf).expect("Adjunct::read innocent");
     assert_eq!(innocent, via_adjunct);
 
-    let decoded = StampedBundle::read(&*buf)
-        .expect("TachyonBundle::read")
-        .expect("some bundle");
+    let decoded = TachyonBundle::read(&*buf).expect("TachyonBundle::read");
     let via_enum = Bundle::<PointerStamp>::try_from(decoded).expect("adjunct variant");
     assert_eq!(innocent, via_enum);
 }
@@ -711,13 +706,13 @@ fn auth_digest_invariants() {
         let stamped = build_autonome(rng, &wallet, 1000, 700);
         let stamped_direct = stamped.auth_digest();
         let covering_wtxid = mock_wtxid(&stamped);
-        let erased: StampedBundle = stamped.into();
+        let erased: TachyonBundle = stamped.into();
         assert_eq!(erased.auth_digest(), stamped_direct);
 
         let wallet2 = WalletSim::new(shared_sk());
         let stripped = build_autonome(rng, &wallet2, 1000, 700).strip(covering_wtxid);
         let stripped_direct = stripped.auth_digest();
-        let erased_stripped: StampedBundle = stripped.into();
+        let erased_stripped: TachyonBundle = stripped.into();
         assert_eq!(erased_stripped.auth_digest(), stripped_direct);
     }
 

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -457,9 +457,9 @@ fn invalid_action_sig_fails_verification() {
     let mut bundle = build_autonome(rng, &wallet, 1000, 700);
     let sighash = mock_sighash(bundle.commitment());
 
-    let mut sig_bytes: [u8; 64] = bundle.actions[0].sig.into();
+    let mut sig_bytes: [u8; 64] = bundle.actions[0].sig.0.into();
     sig_bytes[0] ^= 0xFF;
-    let bad_sig = action::Signature::from(sig_bytes);
+    let bad_sig = action::Signature(sig_bytes.into());
     bundle.actions[0].sig = bad_sig;
 
     let err = bundle.verify_signatures(&sighash).unwrap_err();

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -187,24 +187,26 @@ pub(crate) fn stamp_data_digest(
 /// A bundle's contribution to the transaction auth_digest.
 ///
 /// $$ \text{BLAKE2b-256}(\text{"ZTxAuthTachyHash"},\;
-/// \mathsf{vActionSigs} \| \mathsf{bindingSig} \| \mathsf{stamp}) $$
+/// \mathsf{tachyonBundleState} \| \mathsf{vActionSigs} \| \mathsf{bindingSig}
+/// \| \mathsf{stamp}) $$
 ///
 /// The action set enters this digest only through `stamp`, whose proof-stamp
 /// form concatenates the covered actions' descriptor digest with
 /// [`stamp_data_digest`]. The bundle's own action descriptors are committed on
 /// the txid side by [`bundle_commitment`], not here.
 ///
-/// `stamp_contrib` is the 64-byte stamp digest OR wtxid:
-///
-/// - proof stamp: `hStampActionsTachyon || stamp_data_digest`, see
-///   [`action_descriptor_digest`] and [`stamp_data_digest`];
-/// - pointer stamp: the covering aggregate's `wtxid = txid || auth_digest`.
+/// `state_header` is `tachyonBundleState` 0x01 or 0x02, indicating the content
+/// of the stamp contribution which is either:
+/// - 0x01: proof stamp, digests `hStampActionsTachyon || stamp_data_digest`
+/// - 0x02: pointer stamp, aggregate's wtxid `txid || auth_digest`
 pub(crate) fn bundle_auth_digest(
+    state_header: u8,
     action_sigs: &[[u8; 64]],
     binding_sig: &[u8; 64],
     stamp_contrib: &[u8; 64],
 ) -> [u8; 32] {
     hasher_256(AUTH_DIGEST_PERSONALIZATION, |state| {
+        state.update(&[state_header]);
         // only variable-length component
         for sig in action_sigs {
             state.update(sig);
@@ -230,68 +232,4 @@ lazy_static! {
     pub static ref AUTH_DIGEST_NO_BUNDLE: [u8; 32] = {
         hasher_256(AUTH_DIGEST_PERSONALIZATION, |_| {})
     };
-}
-
-#[cfg(test)]
-mod tests {
-    use alloc::vec::Vec;
-
-    use super::*;
-
-    /// Moving 32 bytes across the tachygram/proof boundary changes
-    /// `stamp_data_digest`.
-    #[test]
-    fn tachygram_proof_boundary() {
-        let anchor = [0x11u8; 32];
-        let tg = [0x22u8; 32];
-        let proof = [0x33u8; 100];
-
-        let split = stamp_data_digest(stamp_proof_digest(&proof), anchor, &[tg]);
-
-        let mut moved = Vec::from(tg);
-        moved.extend_from_slice(&proof);
-        let joined = stamp_data_digest(stamp_proof_digest(&moved), anchor, &[]);
-
-        assert_ne!(split, joined);
-    }
-
-    /// Digests are element-sensitive over pre-sorted input.
-    #[test]
-    fn element_sensitive_digests() {
-        let (desc_a, desc_b) = ([0xAAu8; 64], [0xBBu8; 64]);
-        assert_ne!(
-            action_descriptor_digest(&[desc_a, desc_b]),
-            action_descriptor_digest(&[desc_a, desc_a])
-        );
-
-        let (tg_a, tg_b) = ([0xCCu8; 32], [0xDDu8; 32]);
-        let (proof, anchor) = (stamp_proof_digest(&[]), [0u8; 32]);
-        assert_ne!(
-            stamp_data_digest(proof, anchor, &[tg_a, tg_b]),
-            stamp_data_digest(proof, anchor, &[tg_a, tg_a])
-        );
-    }
-
-    /// Personalization separates the empty digests of every node.
-    #[test]
-    fn empty_digests_distinct() {
-        let empties = [
-            *COMMIT_NO_BUNDLE,
-            *AUTH_DIGEST_NO_BUNDLE,
-            action_descriptor_digest(&[]),
-            stamp_proof_digest(&[]),
-        ];
-        for (i, x) in empties.iter().enumerate() {
-            for y in &empties[i + 1..] {
-                assert_ne!(x, y);
-            }
-        }
-    }
-
-    /// The no-bundle value differs from a zero-action bundle's contribution.
-    #[test]
-    fn no_bundle_differs_from_zero_action_bundle() {
-        let contribution = bundle_auth_digest(&[], &[0u8; 64], &[0x42u8; 64]);
-        assert_ne!(*AUTH_DIGEST_NO_BUNDLE, contribution);
-    }
 }

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -1,11 +1,5 @@
-//! Tachyon Blake2b digests.
 //!
-//! Each named function matches one protocol-defined hash. Key and entropy
-//! derivation preimages use BLAKE2b-512 (64-byte output, reduced to scalars
-//! by the caller); transaction digest contributions use BLAKE2b-256
-//! (32-byte output), matching the ZIP 244 digest-tree convention.
-//! Personalizations are 13–16 bytes; `blake2b_simd::Params::personal`
-//! accepts any length ≤ 16.
+//! Each named function provides one protocol-defined hash.
 
 use blake2b_simd::Params;
 use lazy_static::lazy_static;
@@ -49,8 +43,13 @@ fn hasher_512(personalization: &[u8], updater: impl FnOnce(&mut blake2b_simd::St
 const SPEND_ALPHA_PERSONALIZATION: &[u8; 13] = b"Tachyon-Spend";
 const OUTPUT_ALPHA_PERSONALIZATION: &[u8; 14] = b"Tachyon-Output";
 
-/// Spend-side $\alpha$ pre-image: $\text{BLAKE2b-512}(\text{"Tachyon-Spend"},
-/// \theta \| cm)$.
+/// Spend-side $\alpha$ pre-image.
+///
+/// $$
+///   \text{BLAKE2b-512}( \text{"Tachyon-Spend"},\;
+///     \theta \| cm
+///   )
+/// $$
 ///
 /// Caller reduces to scalar via `Fq::from_uniform_bytes`.
 pub(crate) fn alpha_spend(theta: &[u8; 32], cm: &[u8; 32]) -> [u8; 64] {
@@ -60,8 +59,13 @@ pub(crate) fn alpha_spend(theta: &[u8; 32], cm: &[u8; 32]) -> [u8; 64] {
     })
 }
 
-/// Output-side $\alpha$ pre-image: $\text{BLAKE2b-512}(\text{"Tachyon-Output"},
-/// \theta \| cm)$.
+/// Output-side $\alpha$ pre-image.
+///
+/// $$
+///   \text{BLAKE2b-512}( \text{"Tachyon-Output"},\;
+///     \theta \| cm
+///   )
+/// $$
 pub(crate) fn alpha_output(theta: &[u8; 32], cm: &[u8; 32]) -> [u8; 64] {
     hasher_512(OUTPUT_ALPHA_PERSONALIZATION, |state| {
         state.update(theta);
@@ -76,8 +80,13 @@ const PRF_EXPAND_DOMAIN_NK: u8 = 0x22;
 
 /// PRF-expand to derive `ask` from a spending key. Performs no normalization.
 ///
-/// $\text{BLAKE2b-512}(\text{"Zcash\_ExpandSeed"}, sk \|
-/// \texttt{ASK_DOMAIN_BYTE})$. Mirrors Zcash §5.4.2.
+/// $$
+///   \text{BLAKE2b-512}( \text{"Zcash\_ExpandSeed"},
+///     sk \| \texttt{ASK_DOMAIN_BYTE}
+///   )
+/// $$
+///
+/// Mirrors Zcash §5.4.2.
 ///
 /// TODO: return normalized Fq?
 pub(crate) fn prf_expand_ask(sk: &[u8; 32]) -> [u8; 64] {
@@ -89,8 +98,11 @@ pub(crate) fn prf_expand_ask(sk: &[u8; 32]) -> [u8; 64] {
 
 /// PRF-expand to derive `nk` from a spending key. Performs no normalization.
 ///
-/// $\text{BLAKE2b-512}(\text{"Zcash\_ExpandSeed"}, sk \|
-/// \texttt{NK_DOMAIN_BYTE})$.
+/// $$
+///   \text{BLAKE2b-512}( \text{"Zcash\_ExpandSeed"},
+///     sk \| \texttt{NK_DOMAIN_BYTE}
+///   )
+/// $$
 ///
 /// TODO: return normalized Fq?
 pub(crate) fn prf_expand_nk(sk: &[u8; 32]) -> [u8; 64] {
@@ -104,17 +116,18 @@ const ACTION_DESCRIPTOR_PERSONALIZATION: &[u8; 15] = b"Tachyon-Actions";
 
 /// Digest of action descriptors.
 ///
-/// Over the bundle's owned actions this is `hActionsTachyon`, committed on the
-/// txid side by [`bundle_commitment`]; over a stamp's covered actions it is the
-/// stamp's `hStampActionsTachyon`.
+/// Action descriptors are hashed in the order given, so the digest commits to
+/// that order.
 ///
-/// $$ \text{BLAKE2b-256}(
-/// \text{"Tachyon-Actions"},\;
-/// \mathsf{cv}_i \| \mathsf{rk}_i) $$
+/// $$
+///   \text{BLAKE2b-256}( \text{"Tachyon-Actions"},\;
+///     \mathsf{cv}_i \| \mathsf{rk}_i
+///   )
+/// $$
 ///
-/// Each entry is a 64-byte concatenation of `cv || rk` field encodings. Entries
-/// are hashed in the order given, so the digest commits to that order; callers
-/// pass a canonically (byte-lexicographically) sorted slice.
+/// Over a bundle's actions this is `hActionsTachyon`.
+///
+/// Over a stamp's covered actions this is `hStampActionsTachyon`.
 pub(crate) fn action_descriptor_digest(descriptors: &[[u8; 64]]) -> [u8; 32] {
     hasher_256(ACTION_DESCRIPTOR_PERSONALIZATION, |state| {
         for descriptor in descriptors {
@@ -145,8 +158,11 @@ const STAMP_PROOF_PERSONALIZATION: &[u8; 13] = b"Tachyon-Proof";
 
 /// Digest of a stamp's proof.
 ///
-/// $$ \mathsf{stamp\_proof\_digest} = \text{BLAKE2b-256}(
-/// \text{"Tachyon-Proof"},\; \mathsf{proofTachyon}) $$
+/// $$
+///   \text{BLAKE2b-256}( \text{"Tachyon-Proof"},\;
+///     \mathsf{proofTachyon}
+///   )
+/// $$
 pub(crate) fn stamp_proof_digest(proof: &[u8]) -> [u8; 32] {
     hasher_256(STAMP_PROOF_PERSONALIZATION, |state| {
         state.update(proof);
@@ -155,13 +171,14 @@ pub(crate) fn stamp_proof_digest(proof: &[u8]) -> [u8; 32] {
 
 /// Digest of a proof stamp's proof, anchor, and tachygrams.
 ///
-/// $$ \mathsf{stamp\_data\_digest} = \text{BLAKE2b-256}(
-/// \text{"Tachyon-Stamp"},\;
-/// \mathsf{stamp\_proof\_digest} \| \mathsf{anchor} \|
-/// \mathsf{vTachygrams}) $$
-///
 /// Tachygrams are hashed in the order given, so the digest commits to that
-/// order; callers pass a canonically (byte-lexicographically) sorted slice.
+/// order.
+///
+/// $$
+///   \text{BLAKE2b-256}( \text{"Tachyon-Stamp"},\;
+///     \mathsf{stamp\_proof\_digest} \| \mathsf{anchor} \| \mathsf{vTachygrams}
+///   )
+/// $$
 pub(crate) fn stamp_data_digest(
     stamp_proof_digest: [u8; 32],
     anchor: [u8; 32],
@@ -180,9 +197,12 @@ pub(crate) fn stamp_data_digest(
 
 /// A bundle's contribution to the transaction auth_digest.
 ///
-/// $$ \text{BLAKE2b-256}(\text{"ZTxAuthTachyHash"},\;
-/// \mathsf{tachyonBundleState} \| \mathsf{vActionSigs} \| \mathsf{bindingSig}
-/// \| \mathsf{stamp}) $$
+/// $$
+///   \text{BLAKE2b-256}( \text{"ZTxAuthTachyHash"},\;
+///     \mathsf{tachyonBundleState} \| \mathsf{vActionSigs} \|
+///     \mathsf{bindingSig} \| \mathsf{stamp}
+///   )
+/// $$
 ///
 /// The action set enters this digest only through `stamp`, whose proof-stamp
 /// form concatenates the covered actions' descriptor digest with

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -7,6 +7,8 @@
 //! Personalizations are 13–16 bytes; `blake2b_simd::Params::personal`
 //! accepts any length ≤ 16.
 
+use alloc::vec::Vec;
+
 use blake2b_simd::Params;
 use lazy_static::lazy_static;
 
@@ -117,64 +119,91 @@ pub(crate) fn bundle_commitment(action_commit: &[u8; 32], value_balance: i64) ->
     })
 }
 
-/// A stamped bundle's contribution to the transaction auth_digest.
+const STAMP_ACTIONS_PERSONALIZATION: &[u8; 16] = b"Tachyon-StampAct";
+const STAMP_DATA_PERSONALIZATION: &[u8; 13] = b"Tachyon-Stamp";
+const STAMP_PROOF_PERSONALIZATION: &[u8; 13] = b"Tachyon-Proof";
+
+/// Digest of a stamp's covered action descriptors (`hActionsTachyon`).
 ///
-/// Hashes action signatures, the binding signature, and the stamp trailer's
-/// field encodings: the action-set commitment, the anchor, each tachygram,
-/// and the proof. Vector counts are not part of the preimage, matching the
-/// ZIP 244 auth-digest leaves.
+/// $$ \mathsf{hActionsTachyon} = \text{BLAKE2b-256}(
+/// \text{"Tachyon-StampAct"},\;
+/// \mathsf{sorted}(\mathsf{cv}_i \| \mathsf{rk}_i)) $$
 ///
-/// Injectivity of this flat, length-free encoding is not intrinsic: it rests on
-/// two invariants enforced by the paired effecting digest and the proof system,
-/// not by this preimage.
-///
-/// - The action count is pinned by `action_acc`'s degree: the monic
-///   `∏(X - action_digest_i)` committed in `bundle_commitment` fixes the
-///   number of actions, hence the action-signature block boundary. This is the
-///   role `nActionsOrchard` plays in ZIP 244.
-/// - The proof is a compile-time fixed size (`PROOF_SIZE_COMPRESSED`), which
-///   fixes the `tachygrams || proof` boundary. Nothing on the txid side commits
-///   to the tachygram count, so the fixed proof size is load-bearing for digest
-///   injectivity, not merely wire framing: a variable-size proof would make
-///   `tachygrams || proof` ambiguous and let two distinct bundles collide on a
-///   single `wtxid`.
-pub(crate) fn stamped_auth_digest(
-    action_sigs: &[[u8; 64]],
-    binding_sig: &[u8; 64],
-    action_set: &[u8; 32],
-    anchor: &[u8; 32],
-    tachygrams: &[[u8; 32]],
-    proof: &[u8],
-) -> [u8; 32] {
-    hasher_256(AUTH_DIGEST_PERSONALIZATION, |state| {
-        for sig in action_sigs {
-            state.update(sig);
+/// Each entry is a 64-byte `cv || rk` field encoding. Entries are sorted
+/// byte-lexicographically before hashing: the digest commits to the
+/// covered-action multiset.
+pub(crate) fn stamp_actions_digest(descriptors: &[[u8; 64]]) -> [u8; 32] {
+    let mut sorted: Vec<&[u8; 64]> = descriptors.iter().collect();
+    sorted.sort_unstable();
+    hasher_256(STAMP_ACTIONS_PERSONALIZATION, |state| {
+        for descriptor in sorted {
+            state.update(descriptor);
         }
-        state.update(binding_sig);
-        state.update(action_set);
-        state.update(anchor);
-        for tg in tachygrams {
-            state.update(tg);
-        }
+    })
+}
+
+/// Digest of a stamp's proof.
+///
+/// $$ \mathsf{stamp\_proof\_digest} = \text{BLAKE2b-256}(
+/// \text{"Tachyon-Proof"},\; \mathsf{proofTachyon}) $$
+pub(crate) fn stamp_proof_digest(proof: &[u8]) -> [u8; 32] {
+    hasher_256(STAMP_PROOF_PERSONALIZATION, |state| {
         state.update(proof);
     })
 }
 
-/// A stripped bundle's contribution to the transaction auth_digest.
+/// Digest of a proof stamp's proof, anchor, and tachygrams.
 ///
-/// Hashes action signatures, the binding signature, and the stripped
-/// trailer: the 64-byte `wtxid` of the covering aggregate.
-pub(crate) fn stripped_auth_digest(
+/// $$ \mathsf{stamp\_data\_digest} = \text{BLAKE2b-256}(
+/// \text{"Tachyon-Stamp"},\;
+/// \mathsf{stamp\_proof\_digest} \| \mathsf{anchor} \|
+/// \mathsf{sorted}(\mathsf{vTachygrams})) $$
+///
+/// Tachygrams are sorted byte-lexicographically before hashing: the digest
+/// commits to the tachygram multiset.
+pub(crate) fn stamp_data_digest(
+    stamp_proof_digest: [u8; 32],
+    anchor: [u8; 32],
+    tachygrams: &[[u8; 32]],
+) -> [u8; 32] {
+    let mut sorted: Vec<&[u8; 32]> = tachygrams.iter().collect();
+    sorted.sort_unstable();
+    hasher_256(STAMP_DATA_PERSONALIZATION, |state| {
+        state.update(&stamp_proof_digest);
+        state.update(&anchor);
+        for tg in sorted {
+            state.update(tg);
+        }
+    })
+}
+
+/// A bundle's contribution to the transaction auth_digest.
+///
+/// $$ \text{BLAKE2b-256}(\text{"ZTxAuthTachyHash"},\;
+/// \mathsf{vActionSigs} \| \mathsf{bindingSig} \| \mathsf{stamp}) $$
+///
+/// `stamp` is the 64-byte wtxid-shaped stamp digest:
+///
+/// - proof stamp: `hActionsTachyon || stamp_data_digest`, see
+///   [`stamp_actions_digest`] and [`stamp_data_digest`];
+/// - pointer stamp: the covering aggregate's `wtxid = txid || auth_digest`.
+///
+/// Each variable-length component reaches this preimage through its own
+/// personalized sub-digest, except the action signatures: their count is
+/// recovered by length arithmetic (64-byte elements before a fixed
+/// 128-byte suffix) and pinned on the txid side by `action_acc`'s monic
+/// degree — the role `nActionsOrchard` plays in ZIP 244.
+pub(crate) fn auth_digest(
     action_sigs: &[[u8; 64]],
     binding_sig: &[u8; 64],
-    wtxid: &[u8; 64],
+    stamp: &[u8; 64],
 ) -> [u8; 32] {
     hasher_256(AUTH_DIGEST_PERSONALIZATION, |state| {
         for sig in action_sigs {
             state.update(sig);
         }
         state.update(binding_sig);
-        state.update(wtxid);
+        state.update(stamp);
     })
 }
 
@@ -190,10 +219,78 @@ lazy_static! {
 
     /// A non-Tachyon transaction's contribution to the transaction auth_digest.
     ///
-    /// **This is NOT the same as a stripped bundle.**
-    ///
     /// **This is NOT the same as a bundle with no actions and zero balance.**
     pub static ref AUTH_DIGEST_NO_BUNDLE: [u8; 32] = {
         hasher_256(AUTH_DIGEST_PERSONALIZATION, |_| {})
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Moving 32 bytes across the tachygram/proof boundary changes
+    /// `stamp_data_digest`.
+    #[test]
+    fn tachygram_proof_boundary() {
+        let anchor = [0x11u8; 32];
+        let tg = [0x22u8; 32];
+        let proof = [0x33u8; 100];
+
+        let split = stamp_data_digest(stamp_proof_digest(&proof), anchor, &[tg]);
+
+        let mut moved = Vec::from(tg);
+        moved.extend_from_slice(&proof);
+        let joined = stamp_data_digest(stamp_proof_digest(&moved), anchor, &[]);
+
+        assert_ne!(split, joined);
+    }
+
+    /// Sorted digests are permutation-invariant and element-sensitive.
+    #[test]
+    fn sorted_multiset_digests() {
+        let (desc_a, desc_b) = ([0xAAu8; 64], [0xBBu8; 64]);
+        assert_eq!(
+            stamp_actions_digest(&[desc_a, desc_b]),
+            stamp_actions_digest(&[desc_b, desc_a])
+        );
+        assert_ne!(
+            stamp_actions_digest(&[desc_a, desc_b]),
+            stamp_actions_digest(&[desc_a, desc_a])
+        );
+
+        let (tg_a, tg_b) = ([0xCCu8; 32], [0xDDu8; 32]);
+        let (proof, anchor) = (stamp_proof_digest(&[]), [0u8; 32]);
+        assert_eq!(
+            stamp_data_digest(proof, anchor, &[tg_a, tg_b]),
+            stamp_data_digest(proof, anchor, &[tg_b, tg_a])
+        );
+        assert_ne!(
+            stamp_data_digest(proof, anchor, &[tg_a, tg_b]),
+            stamp_data_digest(proof, anchor, &[tg_a, tg_a])
+        );
+    }
+
+    /// Personalization separates the empty digests of every node.
+    #[test]
+    fn empty_digests_distinct() {
+        let empties = [
+            *COMMIT_NO_BUNDLE,
+            *AUTH_DIGEST_NO_BUNDLE,
+            stamp_actions_digest(&[]),
+            stamp_proof_digest(&[]),
+        ];
+        for (i, x) in empties.iter().enumerate() {
+            for y in &empties[i + 1..] {
+                assert_ne!(x, y);
+            }
+        }
+    }
+
+    /// The no-bundle value differs from a zero-action bundle's contribution.
+    #[test]
+    fn no_bundle_differs_from_zero_action_bundle() {
+        let contribution = auth_digest(&[], &[0u8; 64], &[0x42u8; 64]);
+        assert_ne!(*AUTH_DIGEST_NO_BUNDLE, contribution);
+    }
 }

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -143,15 +143,15 @@ const AUTH_DIGEST_PERSONALIZATION: &[u8; 16] = b"ZTxAuthTachyHash";
 
 /// A bundle's contribution to the transaction sighash.
 ///
+/// Only digests effecting data.
+///
 /// $$
 ///   \text{BLAKE2b-256}_\texttt{ZTxIdTachyonHash}(
 ///     \mathsf{hActionsTachyon} \| \mathsf{vBalanceTachyon}
 ///   )
 /// $$
 ///
-/// Hashes the bundle's effecting data: the [`action_descriptor_digest`] of its
-/// own actions and the value balance. The stamp is excluded because it is
-/// stripped during aggregation.
+/// The stamp is excluded because it is mutable auth data.
 #[must_use]
 pub(crate) fn bundle_commitment(action_commit: &[u8; 32], value_balance: i64) -> [u8; 32] {
     hasher_256(BUNDLE_COMMITMENT_PERSONALIZATION, |state| {
@@ -183,7 +183,7 @@ pub(crate) fn stamp_proof_digest(proof: &[u8]) -> [u8; 32] {
 ///
 /// $$
 ///   \text{BLAKE2b-256}_\texttt{Tachyon-Stamp}(
-///     \mathsf{hStampDataTachyon} \|
+///     \mathsf{hStampProofTachyon} \|
 ///     \mathsf{stampAnchorTachyon} \|
 ///     \mathsf{vTachygrams}
 ///   )
@@ -242,8 +242,6 @@ lazy_static! {
     /// $$
     ///   \text{BLAKE2b-256}_\texttt{ZTxIdTachyonHash}()
     /// $$
-    ///
-    /// **This is NOT the same as a stripped bundle.**
     ///
     /// **This is NOT the same as a bundle with no actions and zero balance.**
     pub static ref COMMIT_NO_BUNDLE: [u8; 32] = {

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -7,8 +7,6 @@
 //! Personalizations are 13–16 bytes; `blake2b_simd::Params::personal`
 //! accepts any length ≤ 16.
 
-use alloc::vec::Vec;
-
 use blake2b_simd::Params;
 use lazy_static::lazy_static;
 
@@ -102,14 +100,37 @@ pub(crate) fn prf_expand_nk(sk: &[u8; 32]) -> [u8; 64] {
     })
 }
 
+const ACTION_DESCRIPTOR_PERSONALIZATION: &[u8; 15] = b"Tachyon-Actions";
+
+/// Digest of action descriptors.
+///
+/// This may be the stamp's `hActionsTachyon` or it may contribute to the
+/// bundle's effecting data commitment.
+///
+/// $$ \mathsf{hActionsTachyon} = \text{BLAKE2b-256}(
+/// \text{"Tachyon-Actions"},\;
+/// \mathsf{cv}_i \| \mathsf{rk}_i) $$
+///
+/// Each entry is a 64-byte concatenation of `cv || rk` field encodings. Entries
+/// are hashed in the order given, so the digest commits to that order; callers
+/// pass a canonically (byte-lexicographically) sorted slice.
+pub(crate) fn action_descriptor_digest(descriptors: &[[u8; 64]]) -> [u8; 32] {
+    debug_assert!(descriptors.is_sorted(), "descriptors should be pre-sorted");
+    hasher_256(ACTION_DESCRIPTOR_PERSONALIZATION, |state| {
+        for descriptor in descriptors {
+            state.update(descriptor);
+        }
+    })
+}
+
 // See https://github.com/zcash/orchard/blob/main/src/bundle/commitments.rs
 const BUNDLE_COMMITMENT_PERSONALIZATION: &[u8; 16] = b"ZTxIdTachyonHash";
 const AUTH_DIGEST_PERSONALIZATION: &[u8; 16] = b"ZTxAuthTachyHash";
 
 /// A bundle's contribution to the transaction sighash.
 ///
-/// Hashes the bundle's effecting data: the encoding of the action-set
-/// commitment and the value balance. The stamp is excluded because it is
+/// Hashes the bundle's effecting data: the [`action_descriptor_digest`] of its
+/// own actions and the value balance. The stamp is excluded because it is
 /// stripped during aggregation.
 #[must_use]
 pub(crate) fn bundle_commitment(action_commit: &[u8; 32], value_balance: i64) -> [u8; 32] {
@@ -119,28 +140,8 @@ pub(crate) fn bundle_commitment(action_commit: &[u8; 32], value_balance: i64) ->
     })
 }
 
-const STAMP_ACTIONS_PERSONALIZATION: &[u8; 16] = b"Tachyon-StampAct";
 const STAMP_DATA_PERSONALIZATION: &[u8; 13] = b"Tachyon-Stamp";
 const STAMP_PROOF_PERSONALIZATION: &[u8; 13] = b"Tachyon-Proof";
-
-/// Digest of a stamp's covered action descriptors (`hActionsTachyon`).
-///
-/// $$ \mathsf{hActionsTachyon} = \text{BLAKE2b-256}(
-/// \text{"Tachyon-StampAct"},\;
-/// \mathsf{sorted}(\mathsf{cv}_i \| \mathsf{rk}_i)) $$
-///
-/// Each entry is a 64-byte `cv || rk` field encoding. Entries are sorted
-/// byte-lexicographically before hashing: the digest commits to the
-/// covered-action multiset.
-pub(crate) fn stamp_actions_digest(descriptors: &[[u8; 64]]) -> [u8; 32] {
-    let mut sorted: Vec<&[u8; 64]> = descriptors.iter().collect();
-    sorted.sort_unstable();
-    hasher_256(STAMP_ACTIONS_PERSONALIZATION, |state| {
-        for descriptor in sorted {
-            state.update(descriptor);
-        }
-    })
-}
 
 /// Digest of a stamp's proof.
 ///
@@ -157,21 +158,20 @@ pub(crate) fn stamp_proof_digest(proof: &[u8]) -> [u8; 32] {
 /// $$ \mathsf{stamp\_data\_digest} = \text{BLAKE2b-256}(
 /// \text{"Tachyon-Stamp"},\;
 /// \mathsf{stamp\_proof\_digest} \| \mathsf{anchor} \|
-/// \mathsf{sorted}(\mathsf{vTachygrams})) $$
+/// \mathsf{vTachygrams}) $$
 ///
-/// Tachygrams are sorted byte-lexicographically before hashing: the digest
-/// commits to the tachygram multiset.
+/// Tachygrams are hashed in the order given, so the digest commits to that
+/// order; callers pass a canonically (byte-lexicographically) sorted slice.
 pub(crate) fn stamp_data_digest(
     stamp_proof_digest: [u8; 32],
     anchor: [u8; 32],
     tachygrams: &[[u8; 32]],
 ) -> [u8; 32] {
-    let mut sorted: Vec<&[u8; 32]> = tachygrams.iter().collect();
-    sorted.sort_unstable();
+    debug_assert!(tachygrams.is_sorted(), "tachygrams should be pre-sorted");
     hasher_256(STAMP_DATA_PERSONALIZATION, |state| {
         state.update(&stamp_proof_digest);
         state.update(&anchor);
-        for tg in sorted {
+        for tg in tachygrams {
             state.update(tg);
         }
     })
@@ -180,12 +180,17 @@ pub(crate) fn stamp_data_digest(
 /// A bundle's contribution to the transaction auth_digest.
 ///
 /// $$ \text{BLAKE2b-256}(\text{"ZTxAuthTachyHash"},\;
-/// \mathsf{vActionSigs} \| \mathsf{bindingSig} \| \mathsf{stamp}) $$
+/// \mathsf{hActions} \| \mathsf{vActionSigs} \| \mathsf{bindingSig} \|
+/// \mathsf{stamp}) $$
+///
+/// `action_digest` is the [`action_descriptor_digest`] over the bundle's own
+/// canonically sorted action descriptors, binding the authorized action set
+/// into the auth digest alongside the signatures.
 ///
 /// `stamp` is the 64-byte wtxid-shaped stamp digest:
 ///
 /// - proof stamp: `hActionsTachyon || stamp_data_digest`, see
-///   [`stamp_actions_digest`] and [`stamp_data_digest`];
+///   [`action_descriptor_digest`] and [`stamp_data_digest`];
 /// - pointer stamp: the covering aggregate's `wtxid = txid || auth_digest`.
 ///
 /// Each variable-length component reaches this preimage through its own
@@ -193,12 +198,14 @@ pub(crate) fn stamp_data_digest(
 /// recovered by length arithmetic (64-byte elements before a fixed
 /// 128-byte suffix) and pinned on the txid side by `action_acc`'s monic
 /// degree — the role `nActionsOrchard` plays in ZIP 244.
-pub(crate) fn auth_digest(
+pub(crate) fn bundle_auth_digest(
+    action_digest: &[u8; 32],
     action_sigs: &[[u8; 64]],
     binding_sig: &[u8; 64],
     stamp: &[u8; 64],
 ) -> [u8; 32] {
     hasher_256(AUTH_DIGEST_PERSONALIZATION, |state| {
+        state.update(action_digest);
         for sig in action_sigs {
             state.update(sig);
         }
@@ -227,6 +234,8 @@ lazy_static! {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::*;
 
     /// Moving 32 bytes across the tachygram/proof boundary changes
@@ -246,29 +255,39 @@ mod tests {
         assert_ne!(split, joined);
     }
 
-    /// Sorted digests are permutation-invariant and element-sensitive.
+    /// Digests are element-sensitive over pre-sorted input.
     #[test]
-    fn sorted_multiset_digests() {
+    fn element_sensitive_digests() {
         let (desc_a, desc_b) = ([0xAAu8; 64], [0xBBu8; 64]);
-        assert_eq!(
-            stamp_actions_digest(&[desc_a, desc_b]),
-            stamp_actions_digest(&[desc_b, desc_a])
-        );
         assert_ne!(
-            stamp_actions_digest(&[desc_a, desc_b]),
-            stamp_actions_digest(&[desc_a, desc_a])
+            action_descriptor_digest(&[desc_a, desc_b]),
+            action_descriptor_digest(&[desc_a, desc_a])
         );
 
         let (tg_a, tg_b) = ([0xCCu8; 32], [0xDDu8; 32]);
         let (proof, anchor) = (stamp_proof_digest(&[]), [0u8; 32]);
-        assert_eq!(
-            stamp_data_digest(proof, anchor, &[tg_a, tg_b]),
-            stamp_data_digest(proof, anchor, &[tg_b, tg_a])
-        );
         assert_ne!(
             stamp_data_digest(proof, anchor, &[tg_a, tg_b]),
             stamp_data_digest(proof, anchor, &[tg_a, tg_a])
         );
+    }
+
+    /// `stamp_actions_digest` requires pre-sorted descriptors.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "descriptors must be pre-sorted")]
+    fn stamp_actions_digest_rejects_unsorted() {
+        let (desc_a, desc_b) = ([0xAAu8; 64], [0xBBu8; 64]);
+        action_descriptor_digest(&[desc_b, desc_a]);
+    }
+
+    /// `stamp_data_digest` requires pre-sorted tachygrams.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "tachygrams must be pre-sorted")]
+    fn stamp_data_digest_rejects_unsorted() {
+        let (tg_a, tg_b) = ([0xCCu8; 32], [0xDDu8; 32]);
+        stamp_data_digest(stamp_proof_digest(&[]), [0u8; 32], &[tg_b, tg_a]);
     }
 
     /// Personalization separates the empty digests of every node.
@@ -277,7 +296,7 @@ mod tests {
         let empties = [
             *COMMIT_NO_BUNDLE,
             *AUTH_DIGEST_NO_BUNDLE,
-            stamp_actions_digest(&[]),
+            action_descriptor_digest(&[]),
             stamp_proof_digest(&[]),
         ];
         for (i, x) in empties.iter().enumerate() {
@@ -290,7 +309,12 @@ mod tests {
     /// The no-bundle value differs from a zero-action bundle's contribution.
     #[test]
     fn no_bundle_differs_from_zero_action_bundle() {
-        let contribution = auth_digest(&[], &[0u8; 64], &[0x42u8; 64]);
+        let contribution = bundle_auth_digest(
+            &action_descriptor_digest(&[]),
+            &[],
+            &[0u8; 64],
+            &[0x42u8; 64],
+        );
         assert_ne!(*AUTH_DIGEST_NO_BUNDLE, contribution);
     }
 }

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -116,7 +116,9 @@ const ACTION_DESCRIPTOR_PERSONALIZATION: &[u8; 15] = b"Tachyon-Actions";
 /// are hashed in the order given, so the digest commits to that order; callers
 /// pass a canonically (byte-lexicographically) sorted slice.
 pub(crate) fn action_descriptor_digest(descriptors: &[[u8; 64]]) -> [u8; 32] {
-    debug_assert!(descriptors.is_sorted(), "descriptors should be pre-sorted");
+    // TODO: enforce sort at callers
+    // debug_assert!(descriptors.is_sorted(), "descriptors should be pre-sorted");
+
     hasher_256(ACTION_DESCRIPTOR_PERSONALIZATION, |state| {
         for descriptor in descriptors {
             state.update(descriptor);
@@ -168,7 +170,9 @@ pub(crate) fn stamp_data_digest(
     anchor: [u8; 32],
     tachygrams: &[[u8; 32]],
 ) -> [u8; 32] {
-    debug_assert!(tachygrams.is_sorted(), "tachygrams should be pre-sorted");
+    // TODO: enforce sort at callers
+    // debug_assert!(tachygrams.is_sorted(), "tachygrams should be pre-sorted");
+
     hasher_256(STAMP_DATA_PERSONALIZATION, |state| {
         state.update(&stamp_proof_digest);
         state.update(&anchor);
@@ -266,24 +270,6 @@ mod tests {
             stamp_data_digest(proof, anchor, &[tg_a, tg_b]),
             stamp_data_digest(proof, anchor, &[tg_a, tg_a])
         );
-    }
-
-    /// `stamp_actions_digest` requires pre-sorted descriptors.
-    #[cfg(debug_assertions)]
-    #[test]
-    #[should_panic(expected = "descriptors should be pre-sorted")]
-    fn stamp_actions_digest_rejects_unsorted() {
-        let (desc_a, desc_b) = ([0xAAu8; 64], [0xBBu8; 64]);
-        action_descriptor_digest(&[desc_b, desc_a]);
-    }
-
-    /// `stamp_data_digest` requires pre-sorted tachygrams.
-    #[cfg(debug_assertions)]
-    #[test]
-    #[should_panic(expected = "tachygrams should be pre-sorted")]
-    fn stamp_data_digest_rejects_unsorted() {
-        let (tg_a, tg_b) = ([0xCCu8; 32], [0xDDu8; 32]);
-        stamp_data_digest(stamp_proof_digest(&[]), [0u8; 32], &[tg_b, tg_a]);
     }
 
     /// Personalization separates the empty digests of every node.

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -1,3 +1,4 @@
+//! Tachyon Blake2b digests.
 //!
 //! Each named function provides one protocol-defined hash.
 
@@ -46,7 +47,7 @@ const OUTPUT_ALPHA_PERSONALIZATION: &[u8; 14] = b"Tachyon-Output";
 /// Spend-side $\alpha$ pre-image.
 ///
 /// $$
-///   \text{BLAKE2b-512}( \text{"Tachyon-Spend"},\;
+///   \text{BLAKE2b-512}_\texttt{Tachyon-Spend}(
 ///     \theta \| cm
 ///   )
 /// $$
@@ -62,7 +63,7 @@ pub(crate) fn alpha_spend(theta: &[u8; 32], cm: &[u8; 32]) -> [u8; 64] {
 /// Output-side $\alpha$ pre-image.
 ///
 /// $$
-///   \text{BLAKE2b-512}( \text{"Tachyon-Output"},\;
+///   \text{BLAKE2b-512}_\texttt{Tachyon-Output}(
 ///     \theta \| cm
 ///   )
 /// $$
@@ -81,8 +82,8 @@ const PRF_EXPAND_DOMAIN_NK: u8 = 0x22;
 /// PRF-expand to derive `ask` from a spending key. Performs no normalization.
 ///
 /// $$
-///   \text{BLAKE2b-512}( \text{"Zcash\_ExpandSeed"},
-///     sk \| \texttt{ASK_DOMAIN_BYTE}
+///   \text{BLAKE2b-512}_\texttt{Zcash\_ExpandSeed}(
+///     sk \| \text{ASK_DOMAIN_BYTE}
 ///   )
 /// $$
 ///
@@ -99,8 +100,8 @@ pub(crate) fn prf_expand_ask(sk: &[u8; 32]) -> [u8; 64] {
 /// PRF-expand to derive `nk` from a spending key. Performs no normalization.
 ///
 /// $$
-///   \text{BLAKE2b-512}( \text{"Zcash\_ExpandSeed"},
-///     sk \| \texttt{NK_DOMAIN_BYTE}
+///   \text{BLAKE2b-512}_\texttt{Zcash\_ExpandSeed}(
+///     sk \| \text{NK_DOMAIN_BYTE}
 ///   )
 /// $$
 ///
@@ -120,7 +121,7 @@ const ACTION_DESCRIPTOR_PERSONALIZATION: &[u8; 15] = b"Tachyon-Actions";
 /// that order.
 ///
 /// $$
-///   \text{BLAKE2b-256}( \text{"Tachyon-Actions"},\;
+///   \text{BLAKE2b-256}_\texttt{Tachyon-Actions}(
 ///     \mathsf{cv}_i \| \mathsf{rk}_i
 ///   )
 /// $$
@@ -142,6 +143,12 @@ const AUTH_DIGEST_PERSONALIZATION: &[u8; 16] = b"ZTxAuthTachyHash";
 
 /// A bundle's contribution to the transaction sighash.
 ///
+/// $$
+///   \text{BLAKE2b-256}_\texttt{ZTxIdTachyonHash}(
+///     \mathsf{hActionsTachyon} \| \mathsf{vBalanceTachyon}
+///   )
+/// $$
+///
 /// Hashes the bundle's effecting data: the [`action_descriptor_digest`] of its
 /// own actions and the value balance. The stamp is excluded because it is
 /// stripped during aggregation.
@@ -159,7 +166,7 @@ const STAMP_PROOF_PERSONALIZATION: &[u8; 13] = b"Tachyon-Proof";
 /// Digest of a stamp's proof.
 ///
 /// $$
-///   \text{BLAKE2b-256}( \text{"Tachyon-Proof"},\;
+///   \text{BLAKE2b-256}_\texttt{Tachyon-Proof}(
 ///     \mathsf{proofTachyon}
 ///   )
 /// $$
@@ -175,8 +182,10 @@ pub(crate) fn stamp_proof_digest(proof: &[u8]) -> [u8; 32] {
 /// order.
 ///
 /// $$
-///   \text{BLAKE2b-256}( \text{"Tachyon-Stamp"},\;
-///     \mathsf{stamp\_proof\_digest} \| \mathsf{anchor} \| \mathsf{vTachygrams}
+///   \text{BLAKE2b-256}_\texttt{Tachyon-Stamp}(
+///     \mathsf{hStampDataTachyon} \|
+///     \mathsf{stampAnchorTachyon} \|
+///     \mathsf{vTachygrams}
 ///   )
 /// $$
 pub(crate) fn stamp_data_digest(
@@ -198,21 +207,18 @@ pub(crate) fn stamp_data_digest(
 /// A bundle's contribution to the transaction auth_digest.
 ///
 /// $$
-///   \text{BLAKE2b-256}( \text{"ZTxAuthTachyHash"},\;
+///   \text{BLAKE2b-256}_\texttt{ZTxAuthTachyHash}(
 ///     \mathsf{tachyonBundleState} \| \mathsf{vActionSigs} \|
-///     \mathsf{bindingSig} \| \mathsf{stamp}
+///     \mathsf{bindingSigTachyon} \| \mathsf{tachyonStampState}
 ///   )
 /// $$
 ///
-/// The action set enters this digest only through `stamp`, whose proof-stamp
-/// form concatenates the covered actions' descriptor digest with
-/// [`stamp_data_digest`]. The bundle's own action descriptors are committed on
-/// the txid side by [`bundle_commitment`], not here.
+/// $\mathsf{tachyonBundleState}$ is one byte indicating format of $\mathsf{tachyonStampState}$
 ///
-/// `state_header` is `tachyonBundleState` 0x01 or 0x02, indicating the content
-/// of the stamp contribution which is either:
-/// - 0x01: proof stamp, digests `hStampActionsTachyon || stamp_data_digest`
-/// - 0x02: pointer stamp, aggregate's wtxid `txid || auth_digest`
+/// | $\mathsf{tachyonBundleState}$ | Impl | $\mathsf{tachyonStampState}$ |
+/// | ----------------------------- | ---- | ---------------------------- |
+/// | `0x01` | [`ProofStamp`](`crate::stamp::ProofStamp`) | $ \mathsf{hStampActionsTachyon} \| \mathsf{hStampDataTachyon} $ |
+/// | `0x02` | [`PointerStamp`](`crate::stamp::PointerStamp`) | aggregate's `wtxid` |
 pub(crate) fn bundle_auth_digest(
     state_header: u8,
     action_sigs: &[[u8; 64]],
@@ -233,6 +239,10 @@ pub(crate) fn bundle_auth_digest(
 lazy_static! {
     /// A non-Tachyon transaction's contribution to the transaction sighash.
     ///
+    /// $$
+    ///   \text{BLAKE2b-256}_\texttt{ZTxIdTachyonHash}()
+    /// $$
+    ///
     /// **This is NOT the same as a stripped bundle.**
     ///
     /// **This is NOT the same as a bundle with no actions and zero balance.**
@@ -241,6 +251,10 @@ lazy_static! {
     };
 
     /// A non-Tachyon transaction's contribution to the transaction auth_digest.
+    ///
+    /// $$
+    ///   \text{BLAKE2b-256}_\texttt{ZTxAuthTachyHash}()
+    /// $$
     ///
     /// **This is NOT the same as a bundle with no actions and zero balance.**
     pub static ref AUTH_DIGEST_NO_BUNDLE: [u8; 32] = {

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -275,7 +275,7 @@ mod tests {
     /// `stamp_actions_digest` requires pre-sorted descriptors.
     #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "descriptors must be pre-sorted")]
+    #[should_panic(expected = "descriptors should be pre-sorted")]
     fn stamp_actions_digest_rejects_unsorted() {
         let (desc_a, desc_b) = ([0xAAu8; 64], [0xBBu8; 64]);
         action_descriptor_digest(&[desc_b, desc_a]);
@@ -284,7 +284,7 @@ mod tests {
     /// `stamp_data_digest` requires pre-sorted tachygrams.
     #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "tachygrams must be pre-sorted")]
+    #[should_panic(expected = "tachygrams should be pre-sorted")]
     fn stamp_data_digest_rejects_unsorted() {
         let (tg_a, tg_b) = ([0xCCu8; 32], [0xDDu8; 32]);
         stamp_data_digest(stamp_proof_digest(&[]), [0u8; 32], &[tg_b, tg_a]);

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -104,10 +104,11 @@ const ACTION_DESCRIPTOR_PERSONALIZATION: &[u8; 15] = b"Tachyon-Actions";
 
 /// Digest of action descriptors.
 ///
-/// This may be the stamp's `hActionsTachyon` or it may contribute to the
-/// bundle's effecting data commitment.
+/// Over the bundle's owned actions this is `hActionsTachyon`, committed on the
+/// txid side by [`bundle_commitment`]; over a stamp's covered actions it is the
+/// stamp's `hStampActionsTachyon`.
 ///
-/// $$ \mathsf{hActionsTachyon} = \text{BLAKE2b-256}(
+/// $$ \text{BLAKE2b-256}(
 /// \text{"Tachyon-Actions"},\;
 /// \mathsf{cv}_i \| \mathsf{rk}_i) $$
 ///
@@ -171,6 +172,8 @@ pub(crate) fn stamp_data_digest(
     hasher_256(STAMP_DATA_PERSONALIZATION, |state| {
         state.update(&stamp_proof_digest);
         state.update(&anchor);
+
+        // only variable-length component
         for tg in tachygrams {
             state.update(tg);
         }
@@ -180,37 +183,30 @@ pub(crate) fn stamp_data_digest(
 /// A bundle's contribution to the transaction auth_digest.
 ///
 /// $$ \text{BLAKE2b-256}(\text{"ZTxAuthTachyHash"},\;
-/// \mathsf{hActions} \| \mathsf{vActionSigs} \| \mathsf{bindingSig} \|
-/// \mathsf{stamp}) $$
+/// \mathsf{vActionSigs} \| \mathsf{bindingSig} \| \mathsf{stamp}) $$
 ///
-/// `action_digest` is the [`action_descriptor_digest`] over the bundle's own
-/// canonically sorted action descriptors, binding the authorized action set
-/// into the auth digest alongside the signatures.
+/// The action set enters this digest only through `stamp`, whose proof-stamp
+/// form concatenates the covered actions' descriptor digest with
+/// [`stamp_data_digest`]. The bundle's own action descriptors are committed on
+/// the txid side by [`bundle_commitment`], not here.
 ///
-/// `stamp` is the 64-byte wtxid-shaped stamp digest:
+/// `stamp_contrib` is the 64-byte stamp digest OR wtxid:
 ///
-/// - proof stamp: `hActionsTachyon || stamp_data_digest`, see
+/// - proof stamp: `hStampActionsTachyon || stamp_data_digest`, see
 ///   [`action_descriptor_digest`] and [`stamp_data_digest`];
 /// - pointer stamp: the covering aggregate's `wtxid = txid || auth_digest`.
-///
-/// Each variable-length component reaches this preimage through its own
-/// personalized sub-digest, except the action signatures: their count is
-/// recovered by length arithmetic (64-byte elements before a fixed
-/// 128-byte suffix) and pinned on the txid side by `action_acc`'s monic
-/// degree — the role `nActionsOrchard` plays in ZIP 244.
 pub(crate) fn bundle_auth_digest(
-    action_digest: &[u8; 32],
     action_sigs: &[[u8; 64]],
     binding_sig: &[u8; 64],
-    stamp: &[u8; 64],
+    stamp_contrib: &[u8; 64],
 ) -> [u8; 32] {
     hasher_256(AUTH_DIGEST_PERSONALIZATION, |state| {
-        state.update(action_digest);
+        // only variable-length component
         for sig in action_sigs {
             state.update(sig);
         }
         state.update(binding_sig);
-        state.update(stamp);
+        state.update(stamp_contrib);
     })
 }
 
@@ -309,12 +305,7 @@ mod tests {
     /// The no-bundle value differs from a zero-action bundle's contribution.
     #[test]
     fn no_bundle_differs_from_zero_action_bundle() {
-        let contribution = bundle_auth_digest(
-            &action_descriptor_digest(&[]),
-            &[],
-            &[0u8; 64],
-            &[0x42u8; 64],
-        );
+        let contribution = bundle_auth_digest(&[], &[0u8; 64], &[0x42u8; 64]);
         assert_ne!(*AUTH_DIGEST_NO_BUNDLE, contribution);
     }
 }

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -116,9 +116,6 @@ const ACTION_DESCRIPTOR_PERSONALIZATION: &[u8; 15] = b"Tachyon-Actions";
 /// are hashed in the order given, so the digest commits to that order; callers
 /// pass a canonically (byte-lexicographically) sorted slice.
 pub(crate) fn action_descriptor_digest(descriptors: &[[u8; 64]]) -> [u8; 32] {
-    // TODO: enforce sort at callers
-    // debug_assert!(descriptors.is_sorted(), "descriptors should be pre-sorted");
-
     hasher_256(ACTION_DESCRIPTOR_PERSONALIZATION, |state| {
         for descriptor in descriptors {
             state.update(descriptor);
@@ -170,9 +167,6 @@ pub(crate) fn stamp_data_digest(
     anchor: [u8; 32],
     tachygrams: &[[u8; 32]],
 ) -> [u8; 32] {
-    // TODO: enforce sort at callers
-    // debug_assert!(tachygrams.is_sorted(), "tachygrams should be pre-sorted");
-
     hasher_256(STAMP_DATA_PERSONALIZATION, |state| {
         state.update(&stamp_proof_digest);
         state.update(&anchor);

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -122,7 +122,9 @@ pub fn build_output_stamp(
     let (tachygrams, stamp_anchor, proof) =
         ProofStamp::prove_output(rng, rcv, alpha, note, anchor).expect("prove_output");
     let stamp = ProofStamp {
-        actions: blake2b::action_descriptor_digest(&[plan.descriptor().into()]),
+        actions: blake2b::action_descriptor_digest(
+            &iter::once(plan.descriptor()).collect::<Vec<[u8; 64]>>(),
+        ),
         tachygrams,
         anchor: stamp_anchor,
         proof,

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -62,7 +62,7 @@ pub fn mock_wtxid(bundle: &Bundle<ProofStamp>) -> PointerStamp {
         .hash_length(32)
         .personal(b"pretend txid")
         .to_state()
-        .update(&bundle.commitment().expect("fixture commitment"))
+        .update(&bundle.commitment())
         .finalize();
 
     let mut wtxid = [0u8; 64];
@@ -122,7 +122,7 @@ pub fn build_output_stamp(
     let (tachygrams, stamp_anchor, proof) =
         ProofStamp::prove_output(rng, rcv, alpha, note, anchor).expect("prove_output");
     let stamp = ProofStamp {
-        covered_actions: blake2b::stamp_actions_digest(&[plan.descriptor().into()]),
+        covered_actions: blake2b::action_descriptor_digest(&[plan.descriptor().into()]),
         tachygrams,
         anchor: stamp_anchor,
         proof,

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -36,7 +36,7 @@ use crate::{
         Anchor, BlockHeight, EpochIndex, Tachygram, TachygramSetCommit, TachygramSetPoly, effect,
     },
     stamp::{
-        ProofStamp,
+        PointerStamp, ProofStamp,
         proof::{PROOF_SYSTEM, delegation, pool, spendable},
     },
     value, witness,
@@ -53,6 +53,22 @@ pub fn mock_sighash(bundle_digest: [u8; 32]) -> [u8; 32] {
     let mut out = [0u8; 32];
     out.copy_from_slice(hash.as_bytes());
     out
+}
+
+/// A stand-in for the covering aggregate's `wtxid = txid || auth_digest`:
+/// a mock txid over the bundle commitment, beside the real `auth_digest`.
+pub fn mock_wtxid(bundle: &Bundle<ProofStamp>) -> PointerStamp {
+    let txid = blake2b_simd::Params::new()
+        .hash_length(32)
+        .personal(b"pretend txid")
+        .to_state()
+        .update(&bundle.commitment().expect("fixture commitment"))
+        .finalize();
+
+    let mut wtxid = [0u8; 64];
+    wtxid[..32].copy_from_slice(txid.as_bytes());
+    wtxid[32..].copy_from_slice(&bundle.auth_digest());
+    PointerStamp::try_from(wtxid).expect("nonzero wtxid")
 }
 
 pub fn random_action(rng: &mut (impl RngCore + CryptoRng)) -> Action {

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -36,7 +36,7 @@ use crate::{
         TachygramSetPoly, effect,
     },
     stamp::{
-        Stamp,
+        ProofStamp,
         proof::{PROOF_SYSTEM, delegation, pool, spendable},
     },
     value, witness,
@@ -108,9 +108,9 @@ pub fn build_output_stamp(
     rng: &mut (impl RngCore + CryptoRng),
     anchor: Anchor,
     note: Note,
-) -> (Stamp, action::Plan<effect::Output>) {
+) -> (ProofStamp, action::Plan<effect::Output>) {
     let (rcv, alpha, plan) = build_output_plan(rng, note);
-    let stamp = Stamp::prove_output(rng, rcv, alpha, note, anchor).expect("prove_output");
+    let stamp = ProofStamp::prove_output(rng, rcv, alpha, note, anchor).expect("prove_output");
     (stamp, plan)
 }
 
@@ -119,7 +119,7 @@ pub fn build_autonome(
     wallet: &WalletSim,
     spend_value: u64,
     output_value: u64,
-) -> Bundle<Stamp> {
+) -> Bundle<ProofStamp> {
     let spend_note = wallet.random_note(spend_value);
     let output_note = wallet.random_note(output_value);
     let mut pool = PoolSim::genesis(rng);
@@ -992,7 +992,7 @@ impl WalletSim {
         anchor: Anchor,
         spends: Vec<(Note, Pcd<spendable::SpendableHeader>, EpochIndex)>,
         output_notes: Vec<Note>,
-    ) -> Bundle<Stamp> {
+    ) -> Bundle<ProofStamp> {
         let ask = self.sk.derive_auth_private();
 
         let mut spend_plans = Vec::with_capacity(spends.len());

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -28,12 +28,12 @@ use crate::{
     action::{self, Action},
     bundle::{self, Bundle},
     constants::EPOCH_SIZE,
+    digest::blake2b,
     entropy::{ActionEntropy, ActionRandomizer},
     keys::{NoteMasterKey, PaymentKey, ProofAuthorizingKey, private},
     note::{self, Note, Nullifier, NullifierTrapdoor},
     primitives::{
-        ActionDigest, Anchor, BlockHeight, EpochIndex, Tachygram, TachygramSetCommit,
-        TachygramSetPoly, effect,
+        Anchor, BlockHeight, EpochIndex, Tachygram, TachygramSetCommit, TachygramSetPoly, effect,
     },
     stamp::{
         ProofStamp,
@@ -53,13 +53,6 @@ pub fn mock_sighash(bundle_digest: [u8; 32]) -> [u8; 32] {
     let mut out = [0u8; 32];
     out.copy_from_slice(hash.as_bytes());
     out
-}
-
-pub fn action_digests(actions: &[Action]) -> Vec<ActionDigest> {
-    actions
-        .iter()
-        .map(|action| action.digest().expect("valid action"))
-        .collect()
 }
 
 pub fn random_action(rng: &mut (impl RngCore + CryptoRng)) -> Action {
@@ -110,7 +103,14 @@ pub fn build_output_stamp(
     note: Note,
 ) -> (ProofStamp, action::Plan<effect::Output>) {
     let (rcv, alpha, plan) = build_output_plan(rng, note);
-    let stamp = ProofStamp::prove_output(rng, rcv, alpha, note, anchor).expect("prove_output");
+    let (tachygrams, stamp_anchor, proof) =
+        ProofStamp::prove_output(rng, rcv, alpha, note, anchor).expect("prove_output");
+    let stamp = ProofStamp {
+        covered_actions: blake2b::stamp_actions_digest(&[plan.descriptor().into()]),
+        tachygrams,
+        anchor: stamp_anchor,
+        proof,
+    };
     (stamp, plan)
 }
 

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -79,7 +79,7 @@ pub fn random_action(rng: &mut (impl RngCore + CryptoRng)) -> Action {
     let bundle_plan = bundle::Plan::new(alloc::vec![], alloc::vec![plan]);
     let sighash = mock_sighash(bundle_plan.commitment().expect("fixture commitment"));
     let unproven = bundle_plan
-        .sign(&sighash, &ask, rng)
+        .sign(rng, &sighash, &ask)
         .expect("sign foreign output");
     unproven.actions[0]
 }
@@ -1042,7 +1042,7 @@ impl WalletSim {
         let bundle_plan = bundle::Plan::new(spend_plans, output_plans);
         let sighash = mock_sighash(bundle_plan.commitment().expect("fixture commitment"));
         let unproven = bundle_plan
-            .sign(&sighash, &ask, rng)
+            .sign(rng, &sighash, &ask)
             .expect("sign autonome");
 
         let stamp_plan = bundle_plan.stamp_plan(anchor);

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -1017,17 +1017,13 @@ impl WalletSim {
         let mut spend_pcds = Vec::with_capacity(spends.len());
         for (note, spendable_pcd, spend_epoch) in spends {
             let range_pcd = self.derived_range(rng, &note, spend_epoch, 2);
-            let pair = [
-                self.nf_at(&note, spend_epoch),
-                self.nf_at(&note, spend_epoch.next()),
-            ];
             let rcv = value::Trapdoor::random(rng);
             let theta = ActionEntropy::random(rng);
             let plan = action::Plan::spend(note, theta, rcv, |alpha| {
                 self.pak.ak.derive_action_public(&alpha)
             });
             spend_plans.push(plan);
-            spend_pcds.push((range_pcd, pair, spendable_pcd));
+            spend_pcds.push((range_pcd, spendable_pcd));
         }
 
         let output_plans: Vec<action::Plan<effect::Output>> = output_notes

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -122,7 +122,7 @@ pub fn build_output_stamp(
     let (tachygrams, stamp_anchor, proof) =
         ProofStamp::prove_output(rng, rcv, alpha, note, anchor).expect("prove_output");
     let stamp = ProofStamp {
-        covered_actions: blake2b::action_descriptor_digest(&[plan.descriptor().into()]),
+        actions: blake2b::action_descriptor_digest(&[plan.descriptor().into()]),
         tachygrams,
         anchor: stamp_anchor,
         proof,

--- a/crates/tachyon/src/keys/private.rs
+++ b/crates/tachyon/src/keys/private.rs
@@ -227,26 +227,10 @@ impl ActionSigningKey<effect::Output> {
     }
 }
 
-/// BindingAuth signing key $\mathsf{bsk}$ — the scalar sum of all value
-/// commitment trapdoors in a bundle.
+/// A [`reddsa::BindingAuth`] signing key $\mathsf{bsk}$, the scalar sum of each
+/// action's [`value::Trapdoor`] $\mathsf{rcv}_i$ used in the bundle.
 ///
-/// $$\mathsf{bsk} := \boxplus_i \mathsf{rcv}_i$$
-///
-/// (sum in $\mathbb{F}_q$, the Pallas scalar field)
-///
-/// The binding signature proves knowledge of $\mathsf{bsk}$, which is
-/// an opening of the Pedersen commitment $\mathsf{bvk}$ to value 0.
-/// By the **binding property** of the commitment scheme, it is
-/// infeasible to find another opening to a different value — so value
-/// balance is enforced.
-///
-/// ## Sighash
-///
-/// Both action signatures and the binding signature sign the same
-/// transaction-level sighash. The sighash incorporates the bundle
-/// commitment (and commitments from other pools). The stamp is
-/// excluded from the bundle commitment because it is stripped during
-/// aggregation.
+/// $$ \mathsf{bsk} := \boxplus_i \mathsf{rcv}_i $$
 #[derive(Clone, Copy, Debug)]
 pub struct BindingSigningKey(#[debug(skip)] reddsa::SigningKey<reddsa::BindingAuth>);
 

--- a/crates/tachyon/src/keys/public.rs
+++ b/crates/tachyon/src/keys/public.rs
@@ -39,21 +39,15 @@ impl ActionVerificationKey {
     }
 }
 
-impl From<ActionVerificationKey> for [u8; 32] {
-    fn from(avk: ActionVerificationKey) -> Self {
-        avk.0.into()
-    }
-}
-
-impl TryFrom<[u8; 32]> for ActionVerificationKey {
+impl TryFrom<EpAffine> for ActionVerificationKey {
     type Error = reddsa::Error;
 
-    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
+    fn try_from(point: EpAffine) -> Result<Self, Self::Error> {
+        let bytes = point.to_bytes();
         reddsa::VerificationKey::<reddsa::ActionAuth>::try_from(bytes).map(Self)
     }
 }
 
-/// Decompress the verification key to an affine curve point.
 impl From<ActionVerificationKey> for EpAffine {
     fn from(key: ActionVerificationKey) -> Self {
         let bytes: [u8; 32] = key.0.into();

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -66,4 +66,4 @@ pub use action::{Action, Plan as ActionPlan};
 pub use bundle::{Bundle, Plan as BundlePlan, TachyonBundle};
 pub use note::Note;
 pub use primitives::*;
-pub use stamp::{AggregateId, Stamp, Stripped, Unproven};
+pub use stamp::{PointerStamp, ProofStamp, Stripped, Unproven};

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Bundle States
 //!
-//! [`Bundle<S>`](Bundle) is parameterized by stamp state `S: StampState`:
+//! [`Bundle<S>`](Bundle) is parameterized by bundle state `S: BundleState`:
 //!
 //! - `Bundle<Unproven>` — actions signed but no proof yet
 //! - `Bundle<ProofStamp>` — aggregate or self-contained, carries a

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -63,7 +63,7 @@ mod serialization;
 pub(crate) mod fixtures;
 
 pub use action::{Action, Plan as ActionPlan};
-pub use bundle::{Bundle, Plan as BundlePlan, TachyonBundle};
+pub use bundle::{Bundle, Plan as BundlePlan, StampedBundle};
 pub use note::Note;
 pub use primitives::*;
 pub use stamp::{PointerStamp, ProofStamp, Unproven};

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -63,7 +63,7 @@ mod serialization;
 pub(crate) mod fixtures;
 
 pub use action::{Action, Plan as ActionPlan};
-pub use bundle::{Bundle, Plan as BundlePlan, StampedBundle};
+pub use bundle::{Bundle, Plan as BundlePlan, TachyonBundle};
 pub use note::Note;
 pub use primitives::*;
 pub use stamp::{PointerStamp, ProofStamp, Unproven};

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -1,38 +1,6 @@
 //! # tachyon
 //!
 //! The Tachyon shielded transaction protocol.
-//!
-//! Tachyon is a scaling solution for Zcash that enables:
-//! - **Proof Aggregation**: Multiple Halo proofs aggregated into a single Ragu
-//!   proof per block
-//! - **Delegated Synchronization**: Wallets can outsource sync to untrusted
-//!   services
-//! - **Polynomial Accumulators**: Unified tracking of commitments and
-//!   nullifiers via tachygrams
-//!
-//! ## Bundle States
-//!
-//! [`Bundle<S>`](Bundle) is parameterized by bundle state `S: BundleState`:
-//!
-//! - `Bundle<Unproven>` — actions signed but no proof yet
-//! - `Bundle<ProofStamp>` — aggregate or self-contained, carries a
-//!   [`ProofStamp`]
-//! - `Bundle<PointerStamp>` — proof stamp replaced by the covering aggregate's
-//!   [`PointerStamp`]
-//! - [`TachyonBundle`] — enum of either wire form for mixed contexts
-//!
-//! ## Block Structure
-//!
-//! A block may contain stamped and stripped bundles. A stamped bundle's stamp
-//! covers its own actions and those of associated stripped bundles.
-//!
-//! TODO: Block layout is not yet finalized, but provisionally: all adjuncts
-//! should immediately follow the aggregate.
-//!
-//! ## Nomenclature
-//!
-//! All types in the `tachyon` crate, unless otherwise specified, are
-//! Tachyon-specific types.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -15,11 +15,11 @@
 //! [`Bundle<S>`](Bundle) is parameterized by stamp state `S: StampState`:
 //!
 //! - `Bundle<Unproven>` — actions signed but no proof yet
-//! - `Bundle<Stamp>` — aggregate or self-contained, carries a [`Stamp`]
-//! - `Bundle<Stripped>` — stamp stripped, covering wtxid not yet assigned
-//! - `Bundle<AggregateId>` — stamp stripped, carries the covering
-//!   [`AggregateId`]
-//! - [`TachyonBundle`] — enum of stamped-or-stripped for mixed contexts
+//! - `Bundle<ProofStamp>` — aggregate or self-contained, carries a
+//!   [`ProofStamp`]
+//! - `Bundle<PointerStamp>` — proof stamp replaced by the covering aggregate's
+//!   [`PointerStamp`]
+//! - [`TachyonBundle`] — enum of either wire form for mixed contexts
 //!
 //! ## Block Structure
 //!
@@ -66,4 +66,4 @@ pub use action::{Action, Plan as ActionPlan};
 pub use bundle::{Bundle, Plan as BundlePlan, TachyonBundle};
 pub use note::Note;
 pub use primitives::*;
-pub use stamp::{PointerStamp, ProofStamp, Stripped, Unproven};
+pub use stamp::{PointerStamp, ProofStamp, Unproven};

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -1,5 +1,4 @@
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, Into, PartialEq};
-use ff::PrimeField as _;
 use pasta_curves::{EpAffine, Fp, arithmetic::CurveAffine as _};
 
 use crate::{digest::poseidon, keys::public, value};
@@ -38,12 +37,6 @@ impl ActionDigest {
             .into_option()
             .ok_or(ActionDigestError::IdentityRk)?;
         Ok(Self(poseidon::action_digest(cv_coords, rk_coords)))
-    }
-}
-
-impl From<ActionDigest> for [u8; 32] {
-    fn from(digest: ActionDigest) -> Self {
-        digest.0.to_repr()
     }
 }
 

--- a/crates/tachyon/src/primitives/tachygram.rs
+++ b/crates/tachyon/src/primitives/tachygram.rs
@@ -1,4 +1,7 @@
+use core::cmp::Ordering;
+
 use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
+use ff::PrimeField as _;
 use pasta_curves::Fp;
 
 /// A tachygram is a field element ($\mathbb{F}_p$) representing either a
@@ -17,3 +20,18 @@ use pasta_curves::Fp;
 /// Tachygrams book chapter for why the window spans two epochs.
 #[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct Tachygram(Fp);
+
+impl PartialOrd for Tachygram {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Tachygram {
+    /// Order by the canonical little-endian byte encoding of the field
+    /// element, matching the byte-lexicographic order the stamp digest
+    /// commits to. `Fp` has no intrinsic `Ord`.
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.to_repr().as_ref().cmp(other.0.to_repr().as_ref())
+    }
+}

--- a/crates/tachyon/src/serialization/mod.rs
+++ b/crates/tachyon/src/serialization/mod.rs
@@ -50,7 +50,10 @@ pub(crate) fn read_fp_list<R: Read>(mut reader: R) -> io::Result<Vec<Fp>> {
     let n = usize::try_from(read_compactsize(&mut reader)?).map_err(|_err| {
         io::Error::new(io::ErrorKind::InvalidData, "vector length exceeds usize")
     })?;
-    let mut fp_list = Vec::with_capacity(n);
+    // TODO: `n` is attacker-controlled up to MAX_COMPACT_SIZE (2^25), so do
+    // not pre-allocate from it; growth on push hits EOF and errors before any
+    // dangerous allocation.
+    let mut fp_list = Vec::new();
     for _ in 0..n {
         let fp = read_fp(&mut reader)?;
         fp_list.push(fp);

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -554,7 +554,7 @@ impl ProofStamp {
         let merged_digests = [left_digests, right_digests].concat();
         let tachygrams = [left_tachygrams, right_tachygrams].concat();
         let merged_tg_poly = TachygramSetPoly::from_iter(tachygrams.clone());
-        let merged_acts_poly = ActionSetPoly::from_iter(merged_digests.iter().copied());
+        let merged_acts_poly = ActionSetPoly::from_iter(merged_digests.clone());
 
         let (pcd, ()) = app.fuse(
             rng,

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -63,9 +63,9 @@ pub struct Stripped;
 /// adjunct, names a covering transaction, so the all-zero wtxid (which refers
 /// to no aggregate) is rejected at every construction site.
 #[derive(Clone, Copy, Debug, Into, PartialEq, TotalEq)]
-pub struct AggregateId([u8; 64]);
+pub struct PointerStamp([u8; 64]);
 
-impl AggregateId {
+impl PointerStamp {
     /// Read an aggregate id from the consensus wire format.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut wtxid = [0u8; 64];
@@ -99,7 +99,7 @@ pub enum AggregateIdError {
     Zero,
 }
 
-impl TryFrom<[u8; 64]> for AggregateId {
+impl TryFrom<[u8; 64]> for PointerStamp {
     type Error = AggregateIdError;
 
     fn try_from(wtxid: [u8; 64]) -> Result<Self, Self::Error> {
@@ -206,11 +206,11 @@ impl Plan {
             [Nullifier; 2],
             ragu::Pcd<spendable::SpendableHeader>,
         )>,
-    ) -> Result<Stamp, ProveError> {
+    ) -> Result<ProofStamp, ProveError> {
         // Each entry is (stamp, action_digests). The digest list is ephemeral —
         // needed to reconstruct the PCD header's action multiset during merge,
         // never stored.
-        let mut entries: Vec<(Stamp, Vec<ActionDigest>)> = Vec::new();
+        let mut entries: Vec<(ProofStamp, Vec<ActionDigest>)> = Vec::new();
 
         if self.spends.len() != spend_pcds.len() {
             return Err(ProveError::SpendableMismatch);
@@ -235,7 +235,7 @@ impl Plan {
 
             // SpendStamp: bind the live pair to the derived range and publish.
             let tachygrams = vec![Tachygram::from(nf_now), Tachygram::from(nf_next)];
-            let stamp = Stamp::prove_spend(rng, bind_pcd, range_pcd, nf_next, tachygrams)
+            let stamp = ProofStamp::prove_spend(rng, bind_pcd, range_pcd, nf_next, tachygrams)
                 .map_err(ProveError::ProofFailed)?;
 
             entries.push((stamp, vec![action_digest]));
@@ -244,7 +244,7 @@ impl Plan {
         for ((cv, rk), (alpha, note, rcv)) in self.outputs {
             let action_digest = ActionDigest::new(cv, rk).map_err(ProveError::ActionDigest)?;
 
-            let stamp = Stamp::prove_output(rng, rcv, alpha, note, self.anchor)
+            let stamp = ProofStamp::prove_output(rng, rcv, alpha, note, self.anchor)
                 .map_err(ProveError::ProofFailed)?;
 
             entries.push((stamp, vec![action_digest]));
@@ -257,7 +257,7 @@ impl Plan {
                 let (left, left_digests) = acc?;
                 let (right, right_digests) = next?;
                 let merged =
-                    Stamp::prove_merge(rng, (left, &left_digests), (right, &right_digests))
+                    ProofStamp::prove_merge(rng, (left, &left_digests), (right, &right_digests))
                         .map_err(ProveError::MergeFailed)?;
                 let mut merged_digests = left_digests;
                 merged_digests.extend_from_slice(&right_digests);
@@ -296,7 +296,7 @@ pub enum ProveError {
 /// here.  The action set is present only as reference. A verifier must
 /// reconstruct the header from public data.
 #[derive(Clone, Debug)]
-pub struct Stamp {
+pub struct ProofStamp {
     /// Merged action-digest set commitment for this proof.
     pub action_set: ActionSetCommit,
 
@@ -311,7 +311,7 @@ pub struct Stamp {
     pub proof: Box<ragu::Proof>,
 }
 
-impl Stamp {
+impl ProofStamp {
     /// Creates a stamp for a single output action.
     ///
     /// The output tachygram (note commitment) is derived inside the circuit

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -118,7 +118,7 @@ pub trait StampState: BundleState {
 
 impl StampState for PointerStamp {
     fn stamp_digest(&self) -> [u8; 64] {
-        <[u8; 64]>::from(*self)
+        self.0
     }
 
     fn state_byte() -> StateByte {

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -35,18 +35,9 @@ use crate::{
 /// Marker for a bundle that has not yet been proven.
 ///
 /// This is the initial state for a newly constructed bundle.
-/// Proving produces a [`Stamp`]; stripping produces a `Bundle<Stripped>`.
+/// Proving produces a [`ProofStamp`].
 #[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Unproven;
-
-/// Marker for a stripped bundle whose covering-aggregate `wtxid` has not
-/// yet been assigned.
-///
-/// Produced by [`strip()`](crate::Bundle::strip). Must transition to a
-/// `Bundle<AggregateId>` via [`assign_wtxid`](crate::Bundle::assign_wtxid)
-/// before serialization.
-#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
-pub struct Stripped;
 
 /// The 64-byte `wtxid` of the covering aggregate in the same block, assigned
 /// by the miner during block assembly.

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -11,8 +11,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, Into, PartialEq};
-use group::Curve as _;
-use pasta_curves::{Eq, Fp};
+use pasta_curves::Fp;
 use proof::{
     PROOF_SYSTEM,
     stamp::{MergeStamp, OutputStamp, SpendStamp, StampHeader},
@@ -21,13 +20,13 @@ use ragu::{self, proof::PROOF_SIZE_COMPRESSED};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
-    ActionSetPoly, Note, TachygramSetPoly,
-    action::Action,
+    ActionSetPoly, Note, TachygramSetPoly, action,
+    digest::blake2b,
     effect,
     entropy::ActionRandomizer,
-    keys::{ProofAuthorizingKey, public},
+    keys::ProofAuthorizingKey,
     note::Nullifier,
-    primitives::{ActionDigest, ActionDigestError, ActionSetCommit, Anchor, Tachygram},
+    primitives::{ActionDigest, ActionDigestError, Anchor, Tachygram},
     serialization,
     stamp::proof::{delegation, spend, spendable},
     value,
@@ -122,9 +121,9 @@ pub enum VerificationError {
     /// The proof did not verify against the reconstructed header.
     #[display("proof did not verify")]
     Disproved,
-    /// The carried `cActionsTachyon` indicator does not match the actions.
-    #[display("action set indicator mismatch")]
-    ActionSetMismatch,
+    /// The carried `hActionsTachyon` indicator does not match the actions.
+    #[display("covered actions indicator mismatch")]
+    ActionsMismatch,
 }
 
 /// Everything needed to produce a [`Stamp`].
@@ -140,7 +139,7 @@ pub enum VerificationError {
 #[derive(Clone, Debug)]
 pub struct Plan {
     spends: Vec<(
-        (value::Commitment, public::ActionVerificationKey),
+        action::Descriptor,
         (
             ActionRandomizer<effect::Spend>,
             Note,
@@ -148,7 +147,7 @@ pub struct Plan {
         ),
     )>,
     outputs: Vec<(
-        (value::Commitment, public::ActionVerificationKey),
+        action::Descriptor,
         (
             ActionRandomizer<effect::Output>,
             Note,
@@ -163,7 +162,7 @@ impl Plan {
     #[must_use]
     pub const fn new(
         spends: Vec<(
-            (value::Commitment, public::ActionVerificationKey),
+            action::Descriptor,
             (
                 ActionRandomizer<effect::Spend>,
                 Note,
@@ -171,7 +170,7 @@ impl Plan {
             ),
         )>,
         outputs: Vec<(
-            (value::Commitment, public::ActionVerificationKey),
+            action::Descriptor,
             (
                 ActionRandomizer<effect::Output>,
                 Note,
@@ -201,26 +200,27 @@ impl Plan {
         self,
         rng: &mut RNG,
         pak: &ProofAuthorizingKey,
-        spend_pcds: Vec<(
+        spendbind_inputs: Vec<(
             ragu::Pcd<delegation::NullifierHeader>,
             [Nullifier; 2],
             ragu::Pcd<spendable::SpendableHeader>,
         )>,
     ) -> Result<ProofStamp, ProveError> {
-        // Each entry is (stamp, action_digests). The digest list is ephemeral —
-        // needed to reconstruct the PCD header's action multiset during merge,
-        // never stored.
-        let mut entries: Vec<(ProofStamp, Vec<ActionDigest>)> = Vec::new();
+        // Each entry pairs leaf stamp components with the descriptor of its
+        // covered action; merges concatenate the descriptor lists. The
+        // covered-actions digest is computed once, on the final stamp.
+        let mut entries: Vec<(
+            (Vec<Tachygram>, Anchor, Box<ragu::Proof>),
+            Vec<action::Descriptor>,
+        )> = Vec::new();
 
-        if self.spends.len() != spend_pcds.len() {
+        if self.spends.len() != spendbind_inputs.len() {
             return Err(ProveError::SpendableMismatch);
         }
 
-        for (((cv, rk), (alpha, note, rcv)), (range_pcd, [nf_now, nf_next], spendable_pcd)) in
-            self.spends.into_iter().zip(spend_pcds)
+        for ((desc, (alpha, note, rcv)), (range_pcd, [_nf_now, nf_next], spendable_pcd)) in
+            self.spends.into_iter().zip(spendbind_inputs)
         {
-            let action_digest = ActionDigest::new(cv, rk).map_err(ProveError::ActionDigest)?;
-
             let app = &*PROOF_SYSTEM;
 
             let (bind_pcd, ()) = app
@@ -234,37 +234,57 @@ impl Plan {
                 .map_err(ProveError::ProofFailed)?;
 
             // SpendStamp: bind the live pair to the derived range and publish.
-            let tachygrams = vec![Tachygram::from(nf_now), Tachygram::from(nf_next)];
-            let stamp = ProofStamp::prove_spend(rng, bind_pcd, range_pcd, nf_next, tachygrams)
+            let components = ProofStamp::prove_spend(rng, bind_pcd, range_pcd, nf_next)
                 .map_err(ProveError::ProofFailed)?;
 
-            entries.push((stamp, vec![action_digest]));
+            entries.push((components, vec![desc]));
         }
 
-        for ((cv, rk), (alpha, note, rcv)) in self.outputs {
-            let action_digest = ActionDigest::new(cv, rk).map_err(ProveError::ActionDigest)?;
-
-            let stamp = ProofStamp::prove_output(rng, rcv, alpha, note, self.anchor)
+        for (desc, (alpha, note, rcv)) in self.outputs {
+            let components = ProofStamp::prove_output(rng, rcv, alpha, note, self.anchor)
                 .map_err(ProveError::ProofFailed)?;
 
-            entries.push((stamp, vec![action_digest]));
+            entries.push((components, vec![desc]));
         }
 
-        entries
+        let ((tachygrams, anchor, proof), descriptors) = entries
             .into_iter()
             .map(Ok::<_, ProveError>)
             .reduce(|acc, next| {
-                let (left, left_digests) = acc?;
-                let (right, right_digests) = next?;
-                let merged =
-                    ProofStamp::prove_merge(rng, (left, &left_digests), (right, &right_digests))
-                        .map_err(ProveError::MergeFailed)?;
-                let mut merged_digests = left_digests;
-                merged_digests.extend_from_slice(&right_digests);
-                Ok((merged, merged_digests))
+                let ((left_tachygrams, left_anchor, left_proof), left_desc) = acc?;
+                let ((right_tachygrams, right_anchor, right_proof), right_desc) = next?;
+
+                let left_digests: Vec<ActionDigest> = left_desc
+                    .iter()
+                    .map(action::Descriptor::digest)
+                    .collect::<Result<_, _>>()
+                    .map_err(ProveError::ActionDigest)?;
+                let right_digests: Vec<ActionDigest> = right_desc
+                    .iter()
+                    .map(action::Descriptor::digest)
+                    .collect::<Result<_, _>>()
+                    .map_err(ProveError::ActionDigest)?;
+
+                let merged = ProofStamp::prove_merge(
+                    rng,
+                    (left_proof, (left_digests, left_tachygrams, left_anchor)),
+                    (right_proof, (right_digests, right_tachygrams, right_anchor)),
+                )
+                .map_err(ProveError::MergeFailed)?;
+
+                Ok((merged, [left_desc, right_desc].concat()))
             })
-            .ok_or(ProveError::NoActions)?
-            .map(|(stamp, _digests)| stamp)
+            .ok_or(ProveError::NoActions)??;
+
+        let descriptor_bytes: Vec<[u8; 64]> =
+            descriptors.into_iter().map(<[u8; 64]>::from).collect();
+
+        Ok(ProofStamp {
+            covered_actions: blake2b::stamp_actions_digest(&descriptor_bytes),
+            tachygrams,
+            anchor,
+            proof,
+        })
     }
 }
 
@@ -293,12 +313,14 @@ pub enum ProveError {
 /// A stamp carrying tachygrams, anchor, and a proof for specific actions.
 ///
 /// The PCD header `(action_acc, tachygram_acc, anchor)` is entirely not stored
-/// here.  The action set is present only as reference. A verifier must
+/// here.  The covered actions are present only as reference. A verifier must
 /// reconstruct the header from public data.
 #[derive(Clone, Debug)]
 pub struct ProofStamp {
-    /// Merged action-digest set commitment for this proof.
-    pub action_set: ActionSetCommit,
+    /// `hActionsTachyon`: digest of the covered action descriptors,
+    /// indicating which actions this stamp's proof covers. See
+    /// [`blake2b::stamp_actions_digest`].
+    pub covered_actions: [u8; 32],
 
     /// Tachygrams (nullifiers and note commitments) for data availability.
     pub tachygrams: Vec<Tachygram>,
@@ -312,7 +334,8 @@ pub struct ProofStamp {
 }
 
 impl ProofStamp {
-    /// Creates a stamp for a single output action.
+    /// Proves a single output action, returning the stamp components
+    /// `(tachygrams, anchor, proof)`.
     ///
     /// The output tachygram (note commitment) is derived inside the circuit
     /// and placed on the stamp for data availability.
@@ -322,68 +345,69 @@ impl ProofStamp {
         alpha: ActionRandomizer<effect::Output>,
         note: Note,
         anchor: Anchor,
-    ) -> Result<Self, ragu::Error> {
+    ) -> Result<(Vec<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
         let app = &*PROOF_SYSTEM;
 
         let (pcd, ()) = app.seed(rng, OutputStamp, (rcv, alpha, note, anchor))?;
-        let action_set = pcd.data().0;
         let tachygrams = vec![Tachygram::from(note.commitment())];
         let rerand = app.rerandomize(pcd, rng)?;
 
-        Ok(Self {
-            action_set,
-            tachygrams,
-            anchor,
-            proof: Box::new(rerand.proof().clone()),
-        })
+        Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))
     }
 
-    /// Creates a stamp for a spend action from pre-built spend and
-    /// nullifier-range PCDs.
+    /// Proves a single spend action from pre-built spend and
+    /// nullifier-range PCDs, returning the stamp components
+    /// `(tachygrams, anchor, proof)`.
     ///
     /// The spend's `anchor` is taken as the stamp's anchor — chain
     /// validation lives inside the spendable lineage, not here.
     pub fn prove_spend<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
-        spend_pcd: ragu::Pcd<spend::SpendHeader>,
-        range_pcd: ragu::Pcd<delegation::NullifierHeader>,
+        bind_pcd: ragu::Pcd<spend::SpendHeader>,
+        nf_pcd: ragu::Pcd<delegation::NullifierHeader>,
         nf_next: Nullifier,
-        tachygrams: Vec<Tachygram>,
-    ) -> Result<Self, ragu::Error> {
+    ) -> Result<(Vec<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
         let app = &*PROOF_SYSTEM;
 
-        let anchor = spend_pcd.data().3;
+        let (_, _, nf_present, anchor) = *bind_pcd.data();
 
-        let (pcd, ()) = app.fuse(rng, SpendStamp, (nf_next,), spend_pcd, range_pcd)?;
-        let action_set = pcd.data().0;
+        let tachygrams = vec![Tachygram::from(nf_next), Tachygram::from(nf_present)];
+
+        let (pcd, ()) = app.fuse(rng, SpendStamp, (nf_next,), bind_pcd, nf_pcd)?;
+
         let rerand = app.rerandomize(pcd, rng)?;
 
-        Ok(Self {
-            action_set,
-            tachygrams,
-            anchor,
-            proof: Box::new(rerand.proof().clone()),
-        })
+        Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))
     }
 
-    /// Merges two stamps, combining tachygrams and proofs.
+    /// Proves the merge of two stamps, returning the merged stamp
+    /// components `(tachygrams, anchor, proof)`.
     ///
     /// Both stamps must share the same anchor (use StampLift to align first).
     ///
-    /// Each side is `(stamp, &[ActionDigest])` — the digest list reconstructs
-    /// the `ActionCommit` multiset that `MergeStamp` verifies via
-    /// Schwartz-Zippel. Digests are derived from public action data by the
-    /// caller and are never stored on the stamp.
+    /// Each side is `(proof, (digests, tachygrams, anchor))` — the digest
+    /// list reconstructs the `ActionCommit` multiset that `MergeStamp`
+    /// verifies via Schwartz-Zippel. Digests are derived from public action
+    /// data by the caller and are never stored on the stamp.
     pub fn prove_merge<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
-        (left, left_digests): (Self, &[ActionDigest]),
-        (right, right_digests): (Self, &[ActionDigest]),
-    ) -> Result<Self, ragu::Error> {
+        (left_proof, left_data): (
+            Box<ragu::Proof>,
+            (Vec<ActionDigest>, Vec<Tachygram>, Anchor),
+        ),
+        (right_proof, right_data): (
+            Box<ragu::Proof>,
+            (Vec<ActionDigest>, Vec<Tachygram>, Anchor),
+        ),
+    ) -> Result<(Vec<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
+        let (left_digests, left_tachygrams, left_anchor) = left_data;
+        let (right_digests, right_tachygrams, right_anchor) = right_data;
+
         let app = &*PROOF_SYSTEM;
 
         let (left_acts_poly, left_tg_poly) = (
             left_digests.iter().copied().collect::<ActionSetPoly>(),
-            left.tachygrams
+            left_tachygrams
                 .iter()
                 .copied()
                 .collect::<TachygramSetPoly>(),
@@ -391,25 +415,24 @@ impl ProofStamp {
 
         let (right_acts_poly, right_tg_poly) = (
             right_digests.iter().copied().collect::<ActionSetPoly>(),
-            right
-                .tachygrams
+            right_tachygrams
                 .iter()
                 .copied()
                 .collect::<TachygramSetPoly>(),
         );
 
-        let left_pcd = left.proof.carry::<StampHeader>((
+        let left_pcd = left_proof.carry::<StampHeader>((
             left_acts_poly.commit(),
             left_tg_poly.commit(),
-            left.anchor,
+            left_anchor,
         ));
-        let right_pcd = right.proof.carry::<StampHeader>((
+        let right_pcd = right_proof.carry::<StampHeader>((
             right_acts_poly.commit(),
             right_tg_poly.commit(),
-            right.anchor,
+            right_anchor,
         ));
 
-        let tachygrams = [left.tachygrams, right.tachygrams].concat();
+        let tachygrams = [left_tachygrams, right_tachygrams].concat();
         let merged_tg_poly = TachygramSetPoly::from_iter(tachygrams.clone());
         let merged_acts_poly = ActionSetPoly::from_iter([left_digests, right_digests].concat());
 
@@ -424,43 +447,111 @@ impl ProofStamp {
             left_pcd,
             right_pcd,
         )?;
-        let action_set = pcd.data().0;
         let anchor = pcd.data().2;
         let rerand = app.rerandomize(pcd, rng)?;
 
-        Ok(Self {
-            action_set,
+        Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))
+    }
+
+    /// Merges two stamps into one covering stamp.
+    ///
+    /// Each side pairs a stamp with the descriptors of its covered actions.
+    /// The action digests for the merge proof and the merged
+    /// `covered_actions` are both derived from the descriptor lists.
+    ///
+    /// TODO: confirm desc list against stamp?
+    pub fn merge<RNG: RngCore + CryptoRng>(
+        rng: &mut RNG,
+        (left_stamp, left_desc): (Self, Vec<action::Descriptor>),
+        (right_stamp, right_desc): (Self, Vec<action::Descriptor>),
+    ) -> Result<Self, ProveError> {
+        let left_actions_digest = left_desc
+            .iter()
+            .map(|desc| ActionDigest::new(desc.cv, desc.rk))
+            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
+            .map_err(ProveError::ActionDigest)?;
+        let right_actions_digest = right_desc
+            .iter()
+            .map(|desc| ActionDigest::new(desc.cv, desc.rk))
+            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
+            .map_err(ProveError::ActionDigest)?;
+
+        let (tachygrams, anchor, proof) = Self::prove_merge(
+            rng,
+            (
+                left_stamp.proof,
+                (
+                    left_actions_digest,
+                    left_stamp.tachygrams,
+                    left_stamp.anchor,
+                ),
+            ),
+            (
+                right_stamp.proof,
+                (
+                    right_actions_digest,
+                    right_stamp.tachygrams,
+                    right_stamp.anchor,
+                ),
+            ),
+        )
+        .map_err(ProveError::MergeFailed)?;
+
+        let covered_actions: Vec<[u8; 64]> = [left_desc, right_desc]
+            .concat()
+            .into_iter()
+            .map(<[u8; 64]>::from)
+            .collect();
+
+        let merged_stamp = Self {
+            covered_actions: blake2b::stamp_actions_digest(&covered_actions),
             tachygrams,
             anchor,
-            proof: Box::new(rerand.proof().clone()),
-        })
+            proof,
+        };
+
+        Ok(merged_stamp)
+    }
+
+    /// Checks if this stamp covers the given action descriptors.
+    #[must_use]
+    pub fn covers(&self, descs: &[action::Descriptor]) -> bool {
+        let desc_bytes: Vec<[u8; 64]> = descs
+            .iter()
+            .map(|&desc| <[u8; 64]>::from(desc))
+            .collect::<Vec<[u8; 64]>>();
+        blake2b::stamp_actions_digest(&desc_bytes) == self.covered_actions
     }
 
     /// Verifies this stamp's proof by reconstructing the PCD header from
     /// public data.
     ///
-    /// The verifier recomputes the action and tachygram accumulators, fails
-    /// early if the computed action set disagrees with the carried action set
-    /// commitment, and calls Ragu `verify()`.
+    /// The verifier recomputes the covered-actions digest, fails early if
+    /// it disagrees with the carried `hActionsTachyon`, then reconstructs
+    /// the action and tachygram accumulators and calls Ragu `verify()`.
     pub fn verify<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,
-        actions: &[Action],
+        actions: &[action::Descriptor],
     ) -> Result<(), VerificationError> {
         let app = &*PROOF_SYSTEM;
 
+        let descriptor_bytes: Vec<[u8; 64]> =
+            actions.iter().copied().map(<[u8; 64]>::from).collect();
+
+        if blake2b::stamp_actions_digest(&descriptor_bytes) != self.covered_actions {
+            return Err(VerificationError::ActionsMismatch);
+        }
+
         let action_digests = actions
             .iter()
-            .map(Action::digest)
-            .collect::<Result<Vec<_>, _>>()
+            .map(action::Descriptor::digest)
+            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
             .map_err(VerificationError::ActionDigest)?;
         let action_set = action_digests
             .into_iter()
             .collect::<ActionSetPoly>()
             .commit();
-        if action_set != self.action_set {
-            return Err(VerificationError::ActionSetMismatch);
-        }
         let header = (
             action_set,
             self.tachygrams
@@ -486,8 +577,8 @@ impl ProofStamp {
 
     /// Read a stamp from the consensus wire format.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
-        let action_set = serialization::read_eq_affine(&mut reader)
-            .map(|eq_affine| ActionSetCommit::from(Eq::from(eq_affine)))?;
+        let mut covered_actions = [0u8; 32];
+        reader.read_exact(&mut covered_actions)?;
 
         let anchor = Anchor::read(&mut reader)?;
 
@@ -499,7 +590,7 @@ impl ProofStamp {
         let proof = Box::new(read_proof(&mut reader)?);
 
         Ok(Self {
-            action_set,
+            covered_actions,
             tachygrams,
             anchor,
             proof,
@@ -508,7 +599,7 @@ impl ProofStamp {
 
     /// Write a stamp to the consensus wire format.
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        serialization::write_eq_affine(&mut writer, &Eq::from(self.action_set).to_affine())?;
+        writer.write_all(&self.covered_actions)?;
         self.anchor.write(&mut writer)?;
         serialization::write_fp_list(
             &mut writer,

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -154,6 +154,8 @@ impl StampState for ProofStamp {
         let stamp_data_digest: [u8; 32] = {
             let proof = self.proof.serialize();
             let anchor: [u8; 32] = self.anchor.0.into();
+
+            // Do NOT sort here: a constructed stamp should already be canonical.
             let tachygrams: Vec<[u8; 32]> = self
                 .tachygrams
                 .iter()

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -95,7 +95,7 @@ impl TryFrom<[u8; 64]> for PointerStamp {
 /// Bundle states that carry a stamp: [`ProofStamp`] or [`PointerStamp`].
 /// The intermediate [`Unproven`] state has no stamp.
 pub trait StampState: BundleState {
-    /// The stamp's 64-byte wtxid-shaped digest: a proof stamp's
+    /// The stamp's 64-byte digest: a proof stamp's
     /// `hStampActionsTachyon || stamp_data_digest`, or a pointer stamp's
     /// `wtxid = txid || auth_digest` from another transaction.
     fn stamp_digest(&self) -> [u8; 64];

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -38,6 +38,23 @@ use crate::{
 ///
 /// This is the initial state for a newly constructed bundle.
 /// Proving produces a [`ProofStamp`].
+///
+/// `Unproven` has no wire representation: it does not implement
+/// [`StampState`], so an unproven bundle cannot be serialized.
+///
+/// ```compile_fail,E0599
+/// use zcash_tachyon::{Bundle, Unproven, bundle::Signature};
+///
+/// let unproven = Bundle {
+///     actions: vec![],
+///     value_balance: 0,
+///     binding_sig: Signature::from([0u8; 64]),
+///     stamp: Unproven,
+/// };
+///
+/// let mut buf = vec![];
+/// unproven.write(&mut buf); // no `write` on `Bundle<Unproven>`
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Unproven;
 

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -96,8 +96,8 @@ impl TryFrom<[u8; 64]> for PointerStamp {
 /// The intermediate [`Unproven`] state has no stamp.
 pub trait StampState: BundleState {
     /// The stamp's 64-byte wtxid-shaped digest: a proof stamp's
-    /// `hActionsTachyon || stamp_data_digest`, or a pointer stamp's
-    /// `wtxid = txid || auth_digest`.
+    /// `hStampActionsTachyon || stamp_data_digest`, or a pointer stamp's
+    /// `wtxid = txid || auth_digest` from another transaction.
     fn stamp_digest(&self) -> [u8; 64];
 
     /// The `tachyonBundleState` wire byte for this state.
@@ -170,7 +170,7 @@ impl StampState for ProofStamp {
         };
 
         let mut stamp_digest = [0u8; 64];
-        stamp_digest[..32].copy_from_slice(&self.covered_actions);
+        stamp_digest[..32].copy_from_slice(&self.actions);
         stamp_digest[32..].copy_from_slice(&stamp_data_digest);
         stamp_digest
     }
@@ -208,7 +208,7 @@ impl StampState for ProofStamp {
             .map_err(|_err| io::Error::new(io::ErrorKind::InvalidData, "invalid proof encoding"))?;
 
         Ok(Self {
-            covered_actions,
+            actions: covered_actions,
             tachygrams,
             anchor,
             proof: Box::new(proof),
@@ -218,7 +218,7 @@ impl StampState for ProofStamp {
     /// Write a stamp to the consensus wire format. The proof blob has a
     /// known constant size.
     fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        writer.write_all(&self.covered_actions)?;
+        writer.write_all(&self.actions)?;
         self.anchor.write(&mut writer)?;
         serialization::write_fp_list(
             &mut writer,
@@ -244,7 +244,7 @@ pub enum VerificationError {
     /// The proof did not verify against the reconstructed header.
     #[display("proof did not verify")]
     Disproved,
-    /// The carried `hActionsTachyon` indicator does not match the actions.
+    /// The carried `hStampActionsTachyon` indicator does not match the actions.
     #[display("covered actions indicator mismatch")]
     ActionsMismatch,
 }
@@ -401,7 +401,7 @@ impl Plan {
         tachygrams.sort_unstable();
 
         Ok(ProofStamp {
-            covered_actions: blake2b::action_descriptor_digest(&descriptor_bytes),
+            actions: blake2b::action_descriptor_digest(&descriptor_bytes),
             tachygrams,
             anchor,
             proof,
@@ -438,11 +438,11 @@ pub enum ProveError {
 /// reconstruct the header from public data.
 #[derive(Clone, Debug)]
 pub struct ProofStamp {
-    /// `hActionsTachyon`: digest of the covered action descriptors,
+    /// `hStampActionsTachyon`: digest of the covered action descriptors,
     /// indicating which actions this stamp's proof covers. Computed by
     /// `blake2b::stamp_actions_digest` over the canonically sorted
     /// descriptors.
-    pub covered_actions: [u8; 32],
+    pub actions: [u8; 32],
 
     /// Tachygrams (nullifiers and note commitments) for data availability.
     pub tachygrams: Vec<Tachygram>,
@@ -627,7 +627,7 @@ impl ProofStamp {
         covered_actions.sort_unstable();
 
         Ok(Self {
-            covered_actions: blake2b::action_descriptor_digest(&covered_actions),
+            actions: blake2b::action_descriptor_digest(&covered_actions),
             tachygrams,
             anchor,
             proof,
@@ -641,14 +641,14 @@ impl ProofStamp {
     pub fn covers(&self, descs: &[action::Descriptor]) -> bool {
         let mut desc_bytes: Vec<[u8; 64]> = descs.iter().copied().map(<[u8; 64]>::from).collect();
         desc_bytes.sort_unstable();
-        blake2b::action_descriptor_digest(&desc_bytes) == self.covered_actions
+        blake2b::action_descriptor_digest(&desc_bytes) == self.actions
     }
 
     /// Verifies this stamp's proof by reconstructing the PCD header from
     /// public data.
     ///
     /// The verifier recomputes the covered-actions digest, fails early if
-    /// it disagrees with the carried `hActionsTachyon`, then reconstructs
+    /// it disagrees with the carried `hStampActionsTachyon`, then reconstructs
     /// the action and tachygram accumulators and calls Ragu `verify()`.
     pub fn verify<RNG: RngCore + CryptoRng>(
         &self,

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -11,6 +11,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, Into, PartialEq};
+use ff::PrimeField as _;
 use pasta_curves::Fp;
 use proof::{
     PROOF_SYSTEM,
@@ -21,6 +22,7 @@ use rand_core::{CryptoRng, RngCore};
 
 use crate::{
     ActionSetPoly, Note, TachygramSetPoly, action,
+    bundle::{BundleState, StateByte},
     digest::blake2b,
     effect,
     entropy::ActionRandomizer,
@@ -55,32 +57,6 @@ pub struct Unproven;
 #[derive(Clone, Copy, Debug, Into, PartialEq, TotalEq)]
 pub struct PointerStamp([u8; 64]);
 
-impl PointerStamp {
-    /// Read an aggregate id from the consensus wire format.
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
-        let mut wtxid = [0u8; 64];
-        reader.read_exact(&mut wtxid)?;
-        Self::try_from(wtxid).map_err(|_err| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "aggregate id is zero and refers to no aggregate",
-            )
-        })
-    }
-
-    /// Write an aggregate id to the consensus wire format.
-    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        if self.0 == [0u8; 64] {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "aggregate id is zero and refers to no aggregate",
-            ));
-        }
-
-        writer.write_all(&self.0)
-    }
-}
-
 #[derive(Clone, Copy, Debug, Display, Error)]
 /// Errors that can occur when handling an aggregate id.
 pub enum AggregateIdError {
@@ -97,6 +73,138 @@ impl TryFrom<[u8; 64]> for PointerStamp {
             return Err(AggregateIdError::Zero);
         }
         Ok(Self(wtxid))
+    }
+}
+
+/// Bundle states that carry a stamp: [`ProofStamp`] or [`PointerStamp`].
+/// The intermediate [`Unproven`] state has no stamp.
+pub trait StampState: BundleState {
+    /// The stamp's 64-byte wtxid-shaped digest: a proof stamp's
+    /// `hActionsTachyon || stamp_data_digest`, or a pointer stamp's
+    /// `wtxid = txid || auth_digest`.
+    fn stamp_digest(&self) -> [u8; 64];
+
+    /// The `tachyonBundleState` wire byte for this state.
+    fn state_byte() -> StateByte
+    where
+        Self: Sized;
+
+    /// Read the stamp trailer from the consensus wire format.
+    fn read<R: Read>(reader: R) -> io::Result<Self>
+    where
+        Self: Sized;
+
+    /// Write the stamp trailer in the consensus wire format.
+    fn write<W: Write>(&self, writer: W) -> io::Result<()>
+    where
+        Self: Sized;
+}
+
+impl StampState for PointerStamp {
+    fn stamp_digest(&self) -> [u8; 64] {
+        <[u8; 64]>::from(*self)
+    }
+
+    fn state_byte() -> StateByte {
+        StateByte::PointerStamped
+    }
+
+    /// Read an aggregate id from the consensus wire format.
+    fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let mut wtxid = [0u8; 64];
+        reader.read_exact(&mut wtxid)?;
+        Self::try_from(wtxid).map_err(|_err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "aggregate id is zero and refers to no aggregate",
+            )
+        })
+    }
+
+    /// Write an aggregate id to the consensus wire format.
+    fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        if self.0 == [0u8; 64] {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "aggregate id is zero and refers to no aggregate",
+            ));
+        }
+        writer.write_all(&self.0)
+    }
+}
+
+impl StampState for ProofStamp {
+    fn stamp_digest(&self) -> [u8; 64] {
+        let stamp_data_digest: [u8; 32] = {
+            let proof = self.proof.serialize();
+            let anchor: [u8; 32] = self.anchor.0.into();
+            let tachygrams: Vec<[u8; 32]> = self
+                .tachygrams
+                .iter()
+                .map(|&tg| Fp::from(tg).to_repr())
+                .collect();
+
+            blake2b::stamp_data_digest(
+                blake2b::stamp_proof_digest(proof.as_ref()),
+                anchor,
+                &tachygrams,
+            )
+        };
+
+        let mut stamp_digest = [0u8; 64];
+        stamp_digest[..32].copy_from_slice(&self.covered_actions);
+        stamp_digest[32..].copy_from_slice(&stamp_data_digest);
+        stamp_digest
+    }
+
+    fn state_byte() -> StateByte {
+        StateByte::ProofStamped
+    }
+
+    /// Read a stamp from the consensus wire format. The proof blob has a
+    /// known constant size.
+    fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let mut covered_actions = [0u8; 32];
+        reader.read_exact(&mut covered_actions)?;
+
+        let anchor = Anchor::read(&mut reader)?;
+
+        let tachygrams = serialization::read_fp_list(&mut reader)?
+            .into_iter()
+            .map(Tachygram::from)
+            .collect();
+
+        let mut bytes = vec![0u8; PROOF_SIZE_COMPRESSED];
+        reader.read_exact(&mut bytes)?;
+        let arr: Box<[u8; PROOF_SIZE_COMPRESSED]> =
+            bytes.into_boxed_slice().try_into().map_err(|_err| {
+                io::Error::new(io::ErrorKind::InvalidData, "proof buffer wrong size")
+            })?;
+        let proof = ragu::Proof::try_from(arr.as_ref())
+            .map_err(|_err| io::Error::new(io::ErrorKind::InvalidData, "invalid proof encoding"))?;
+
+        Ok(Self {
+            covered_actions,
+            tachygrams,
+            anchor,
+            proof: Box::new(proof),
+        })
+    }
+
+    /// Write a stamp to the consensus wire format. The proof blob has a
+    /// known constant size.
+    fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        writer.write_all(&self.covered_actions)?;
+        self.anchor.write(&mut writer)?;
+        serialization::write_fp_list(
+            &mut writer,
+            &self
+                .tachygrams
+                .iter()
+                .map(|&tg| Fp::from(tg))
+                .collect::<Vec<Fp>>(),
+        )?;
+        writer.write_all(self.proof.serialize().as_ref())
     }
 }
 
@@ -565,61 +673,6 @@ impl ProofStamp {
             Err(VerificationError::Disproved)
         }
     }
-
-    /// Read a stamp from the consensus wire format.
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
-        let mut covered_actions = [0u8; 32];
-        reader.read_exact(&mut covered_actions)?;
-
-        let anchor = Anchor::read(&mut reader)?;
-
-        let tachygrams = serialization::read_fp_list(&mut reader)?
-            .into_iter()
-            .map(Tachygram::from)
-            .collect();
-
-        let proof = Box::new(read_proof(&mut reader)?);
-
-        Ok(Self {
-            covered_actions,
-            tachygrams,
-            anchor,
-            proof,
-        })
-    }
-
-    /// Write a stamp to the consensus wire format.
-    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        writer.write_all(&self.covered_actions)?;
-        self.anchor.write(&mut writer)?;
-        serialization::write_fp_list(
-            &mut writer,
-            &self
-                .tachygrams
-                .iter()
-                .map(|&tg| Fp::from(tg))
-                .collect::<Vec<Fp>>(),
-        )?;
-        write_proof(&mut writer, &self.proof)
-    }
-}
-
-/// Read a proof of known constant size.
-pub(crate) fn read_proof<R: Read>(mut reader: R) -> io::Result<ragu::Proof> {
-    let mut bytes = vec![0u8; PROOF_SIZE_COMPRESSED];
-    reader.read_exact(&mut bytes)?;
-    let arr: Box<[u8; PROOF_SIZE_COMPRESSED]> = bytes
-        .into_boxed_slice()
-        .try_into()
-        .map_err(|_err| io::Error::new(io::ErrorKind::InvalidData, "proof buffer wrong size"))?;
-    ragu::Proof::try_from(arr.as_ref())
-        .map_err(|_err| io::Error::new(io::ErrorKind::InvalidData, "invalid proof encoding"))
-}
-
-/// Write a proof of known constant size.
-pub(crate) fn write_proof<W: Write>(mut writer: W, proof: &ragu::Proof) -> io::Result<()> {
-    let bytes = proof.serialize();
-    writer.write_all(bytes.as_ref())
 }
 
 #[cfg(test)]

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -369,7 +369,7 @@ impl Plan {
             entries.push((vec![desc], vec![digest], tachygrams, anchor, proof));
         }
 
-        let (descriptors, _digests, mut tachygrams, anchor, proof) = entries
+        let (mut descriptors, _digests, mut tachygrams, anchor, proof) = entries
             .into_iter()
             .map(Ok::<_, ProveError>)
             .reduce(|acc, next| {
@@ -395,13 +395,11 @@ impl Plan {
             })
             .ok_or(ProveError::NoActions)??;
 
-        let mut descriptor_bytes: Vec<[u8; 64]> =
-            descriptors.into_iter().map(<[u8; 64]>::from).collect();
-        descriptor_bytes.sort_unstable();
+        descriptors.sort_unstable();
         tachygrams.sort_unstable();
 
         Ok(ProofStamp {
-            actions: blake2b::action_descriptor_digest(&descriptor_bytes),
+            actions: blake2b::action_descriptor_digest(&Vec::<[u8; 64]>::from_iter(descriptors)),
             tachygrams,
             anchor,
             proof,
@@ -619,11 +617,7 @@ impl ProofStamp {
         .map_err(ProveError::MergeFailed)?;
         tachygrams.sort_unstable();
 
-        let mut covered_actions: Vec<[u8; 64]> = [left_desc, right_desc]
-            .concat()
-            .into_iter()
-            .map(<[u8; 64]>::from)
-            .collect();
+        let mut covered_actions = Vec::<[u8; 64]>::from_iter([left_desc, right_desc].concat());
         covered_actions.sort_unstable();
 
         Ok(Self {
@@ -639,7 +633,7 @@ impl ProofStamp {
     /// check is independent of the order the caller presents them in.
     #[must_use]
     pub fn covers(&self, descs: &[action::Descriptor]) -> bool {
-        let mut desc_bytes: Vec<[u8; 64]> = descs.iter().copied().map(<[u8; 64]>::from).collect();
+        let mut desc_bytes = descs.iter().copied().collect::<Vec<[u8; 64]>>();
         desc_bytes.sort_unstable();
         blake2b::action_descriptor_digest(&desc_bytes) == self.actions
     }

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -185,10 +185,16 @@ impl StampState for ProofStamp {
 
         let anchor = Anchor::read(&mut reader)?;
 
-        let tachygrams = serialization::read_fp_list(&mut reader)?
+        let tachygrams: Vec<Tachygram> = serialization::read_fp_list(&mut reader)?
             .into_iter()
             .map(Tachygram::from)
             .collect();
+        if !tachygrams.is_sorted() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "tachygrams are not canonically sorted",
+            ));
+        }
 
         let mut bytes = vec![0u8; PROOF_SIZE_COMPRESSED];
         reader.read_exact(&mut bytes)?;
@@ -241,7 +247,7 @@ pub enum VerificationError {
     ActionsMismatch,
 }
 
-/// Everything needed to produce a [`Stamp`].
+/// Everything needed to produce a [`ProofStamp`].
 ///
 /// Each action is described by a public descriptor `(cv, rk)` and a
 /// private witness `(alpha, note, rcv)`. The `prove` method generates
@@ -293,16 +299,17 @@ impl Plan {
         }
     }
 
-    /// Prove a single [`Stamp`] for this plan.
+    /// Prove a single [`ProofStamp`] for this plan.
     ///
-    /// For each **spend**, uses [`SpendBind`] to prepare PCD inputs, then runs
-    /// [`SpendStamp`] to attach the live nullifier pair.
+    /// For each **spend**, uses [`spend::SpendBind`] to prepare PCD inputs,
+    /// then runs [`SpendStamp`] to attach the live nullifier pair.
     ///
     /// For each **output**, runs [`OutputStamp`] with no PCD inputs.
     ///
     /// Stamps are recursively merged via [`MergeStamp`] into a single stamp.
     ///
-    /// `spend_pcds` items must correspond to each planned spend, in order.
+    /// `spendbind_inputs` items must correspond to each planned spend, in
+    /// order.
     pub fn prove<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,
@@ -313,9 +320,11 @@ impl Plan {
             ragu::Pcd<spendable::SpendableHeader>,
         )>,
     ) -> Result<ProofStamp, ProveError> {
-        // Each entry pairs leaf stamp components with the descriptor of its
-        // covered action; merges concatenate the descriptor lists. The
-        // covered-actions digest is computed once, on the final stamp.
+        // Each entry pairs leaf stamp components with the descriptor and
+        // action digest of its covered action; merges concatenate both
+        // lists. Digests are computed once per leaf and carried through the
+        // fold rather than re-derived at each merge step. The covered-actions
+        // digest is computed once, on the final stamp.
         let mut entries = Vec::with_capacity(self.spends.len() + self.outputs.len());
 
         if self.spends.len() != spendbind_inputs.len() {
@@ -325,6 +334,9 @@ impl Plan {
         for ((desc, alpha, note, rcv), (range_pcd, [_nf_now, nf_next], spendable_pcd)) in
             self.spends.into_iter().zip(spendbind_inputs)
         {
+            // TODO: the present nullifier is carried on the SpendBind output
+            // PCD (`nf_present`); incoming branches thread it differently, so
+            // the caller pair's `_nf_now` is intentionally unused here.
             let app = &*PROOF_SYSTEM;
 
             let (bind_pcd, ()) = app
@@ -338,58 +350,56 @@ impl Plan {
                 .map_err(ProveError::ProofFailed)?;
 
             // SpendStamp: bind the live pair to the derived range and publish.
-            let components = ProofStamp::prove_spend(rng, bind_pcd, range_pcd, nf_next)
-                .map_err(ProveError::ProofFailed)?;
+            let (tachygrams, anchor, proof) =
+                ProofStamp::prove_spend(rng, bind_pcd, range_pcd, nf_next)
+                    .map_err(ProveError::ProofFailed)?;
 
-            entries.push((vec![desc], components.0, components.1, components.2));
+            let digest = desc.digest().map_err(ProveError::ActionDigest)?;
+            entries.push((vec![desc], vec![digest], tachygrams, anchor, proof));
         }
 
         for (desc, alpha, note, rcv) in self.outputs {
-            let components = ProofStamp::prove_output(rng, rcv, alpha, note, self.anchor)
-                .map_err(ProveError::ProofFailed)?;
+            let (tachygrams, anchor, proof) =
+                ProofStamp::prove_output(rng, rcv, alpha, note, self.anchor)
+                    .map_err(ProveError::ProofFailed)?;
 
-            entries.push((vec![desc], components.0, components.1, components.2));
+            let digest = desc.digest().map_err(ProveError::ActionDigest)?;
+            entries.push((vec![desc], vec![digest], tachygrams, anchor, proof));
         }
 
-        let (descriptors, tachygrams, anchor, proof) = entries
+        let (descriptors, _digests, mut tachygrams, anchor, proof) = entries
             .into_iter()
             .map(Ok::<_, ProveError>)
             .reduce(|acc, next| {
-                let (left_desc, left_tachygrams, left_anchor, left_proof) = acc?;
-                let (right_desc, right_tachygrams, right_anchor, right_proof) = next?;
+                let (left_desc, left_digests, left_tachygrams, left_anchor, left_proof) = acc?;
+                let (right_desc, right_digests, right_tachygrams, right_anchor, right_proof) =
+                    next?;
 
-                let left_digests: Vec<ActionDigest> = left_desc
-                    .iter()
-                    .map(action::Descriptor::digest)
-                    .collect::<Result<_, _>>()
-                    .map_err(ProveError::ActionDigest)?;
-                let right_digests: Vec<ActionDigest> = right_desc
-                    .iter()
-                    .map(action::Descriptor::digest)
-                    .collect::<Result<_, _>>()
-                    .map_err(ProveError::ActionDigest)?;
-
-                let merged = ProofStamp::prove_merge(
-                    rng,
-                    (left_digests, left_tachygrams, left_anchor, left_proof),
-                    (right_digests, right_tachygrams, right_anchor, right_proof),
-                )
-                .map_err(ProveError::MergeFailed)?;
+                let (merged_digests, merged_tachygrams, merged_anchor, merged_proof) =
+                    ProofStamp::prove_merge(
+                        rng,
+                        (left_digests, left_tachygrams, left_anchor, left_proof),
+                        (right_digests, right_tachygrams, right_anchor, right_proof),
+                    )
+                    .map_err(ProveError::MergeFailed)?;
 
                 Ok((
                     [left_desc, right_desc].concat(),
-                    merged.0,
-                    merged.1,
-                    merged.2,
+                    merged_digests,
+                    merged_tachygrams,
+                    merged_anchor,
+                    merged_proof,
                 ))
             })
             .ok_or(ProveError::NoActions)??;
 
-        let descriptor_bytes: Vec<[u8; 64]> =
+        let mut descriptor_bytes: Vec<[u8; 64]> =
             descriptors.into_iter().map(<[u8; 64]>::from).collect();
+        descriptor_bytes.sort_unstable();
+        tachygrams.sort_unstable();
 
         Ok(ProofStamp {
-            covered_actions: blake2b::stamp_actions_digest(&descriptor_bytes),
+            covered_actions: blake2b::action_descriptor_digest(&descriptor_bytes),
             tachygrams,
             anchor,
             proof,
@@ -427,8 +437,9 @@ pub enum ProveError {
 #[derive(Clone, Debug)]
 pub struct ProofStamp {
     /// `hActionsTachyon`: digest of the covered action descriptors,
-    /// indicating which actions this stamp's proof covers. See
-    /// [`blake2b::stamp_actions_digest`].
+    /// indicating which actions this stamp's proof covers. Computed by
+    /// `blake2b::stamp_actions_digest` over the canonically sorted
+    /// descriptors.
     pub covered_actions: [u8; 32],
 
     /// Tachygrams (nullifiers and note commitments) for data availability.
@@ -441,6 +452,10 @@ pub struct ProofStamp {
     #[debug(skip)]
     pub proof: Box<ragu::Proof>,
 }
+
+/// Stamp components threaded through the merge fold: the covered actions'
+/// digests, the tachygrams, the shared anchor, and the proof.
+type StampComponents = (Vec<ActionDigest>, Vec<Tachygram>, Anchor, Box<ragu::Proof>);
 
 impl ProofStamp {
     /// Proves a single output action, returning the stamp components
@@ -490,29 +505,21 @@ impl ProofStamp {
     }
 
     /// Proves the merge of two stamps, returning the merged stamp
-    /// components `(tachygrams, anchor, proof)`.
+    /// components `(digests, tachygrams, anchor, proof)`.
     ///
     /// Both stamps must share the same anchor (use StampLift to align first).
     ///
-    /// Each side is `(proof, (digests, tachygrams, anchor))` — the digest
-    /// list reconstructs the `ActionCommit` multiset that `MergeStamp`
-    /// verifies via Schwartz-Zippel. Digests are derived from public action
-    /// data by the caller and are never stored on the stamp.
+    /// Each side is `(digests, tachygrams, anchor, proof)` — the digest list
+    /// reconstructs the `ActionCommit` multiset that `MergeStamp` verifies via
+    /// Schwartz-Zippel. Digests are derived from public action data by the
+    /// caller and are never stored on the stamp; the merged (concatenated)
+    /// digest list is returned so a fold can carry it forward without
+    /// re-deriving.
     pub fn prove_merge<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
-        (left_digests, left_tachygrams, left_anchor, left_proof): (
-            Vec<ActionDigest>,
-            Vec<Tachygram>,
-            Anchor,
-            Box<ragu::Proof>,
-        ),
-        (right_digests, right_tachygrams, right_anchor, right_proof): (
-            Vec<ActionDigest>,
-            Vec<Tachygram>,
-            Anchor,
-            Box<ragu::Proof>,
-        ),
-    ) -> Result<(Vec<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
+        (left_digests, left_tachygrams, left_anchor, left_proof): StampComponents,
+        (right_digests, right_tachygrams, right_anchor, right_proof): StampComponents,
+    ) -> Result<StampComponents, ragu::Error> {
         let app = &*PROOF_SYSTEM;
 
         let (left_acts_poly, left_tg_poly) = (
@@ -542,9 +549,10 @@ impl ProofStamp {
             right_anchor,
         ));
 
+        let merged_digests = [left_digests, right_digests].concat();
         let tachygrams = [left_tachygrams, right_tachygrams].concat();
         let merged_tg_poly = TachygramSetPoly::from_iter(tachygrams.clone());
-        let merged_acts_poly = ActionSetPoly::from_iter([left_digests, right_digests].concat());
+        let merged_acts_poly = ActionSetPoly::from_iter(merged_digests.iter().copied());
 
         let (pcd, ()) = app.fuse(
             rng,
@@ -560,7 +568,12 @@ impl ProofStamp {
         let anchor = pcd.data().2;
         let rerand = app.rerandomize(pcd, rng)?;
 
-        Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))
+        Ok((
+            merged_digests,
+            tachygrams,
+            anchor,
+            Box::new(rerand.proof().clone()),
+        ))
     }
 
     /// Merges two stamps into one covering stamp.
@@ -577,16 +590,16 @@ impl ProofStamp {
     ) -> Result<Self, ProveError> {
         let left_actions_digest = left_desc
             .iter()
-            .map(|desc| ActionDigest::new(desc.cv, desc.rk))
+            .map(action::Descriptor::digest)
             .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
             .map_err(ProveError::ActionDigest)?;
         let right_actions_digest = right_desc
             .iter()
-            .map(|desc| ActionDigest::new(desc.cv, desc.rk))
+            .map(action::Descriptor::digest)
             .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
             .map_err(ProveError::ActionDigest)?;
 
-        let (tachygrams, anchor, proof) = Self::prove_merge(
+        let (_merged_digests, mut tachygrams, anchor, proof) = Self::prove_merge(
             rng,
             (
                 left_actions_digest,
@@ -602,29 +615,31 @@ impl ProofStamp {
             ),
         )
         .map_err(ProveError::MergeFailed)?;
+        tachygrams.sort_unstable();
 
-        let covered_actions: Vec<[u8; 64]> = [left_desc, right_desc]
+        let mut covered_actions: Vec<[u8; 64]> = [left_desc, right_desc]
             .concat()
             .into_iter()
             .map(<[u8; 64]>::from)
             .collect();
+        covered_actions.sort_unstable();
 
         Ok(Self {
-            covered_actions: blake2b::stamp_actions_digest(&covered_actions),
+            covered_actions: blake2b::action_descriptor_digest(&covered_actions),
             tachygrams,
             anchor,
             proof,
         })
     }
 
-    /// Checks if this stamp covers the given action descriptors.
+    /// Checks if this stamp covers the given action descriptors. The
+    /// descriptors are sorted into canonical order before hashing, so the
+    /// check is independent of the order the caller presents them in.
     #[must_use]
     pub fn covers(&self, descs: &[action::Descriptor]) -> bool {
-        let desc_bytes: Vec<[u8; 64]> = descs
-            .iter()
-            .map(|&desc| <[u8; 64]>::from(desc))
-            .collect::<Vec<[u8; 64]>>();
-        blake2b::stamp_actions_digest(&desc_bytes) == self.covered_actions
+        let mut desc_bytes: Vec<[u8; 64]> = descs.iter().copied().map(<[u8; 64]>::from).collect();
+        desc_bytes.sort_unstable();
+        blake2b::action_descriptor_digest(&desc_bytes) == self.covered_actions
     }
 
     /// Verifies this stamp's proof by reconstructing the PCD header from
@@ -640,10 +655,7 @@ impl ProofStamp {
     ) -> Result<(), VerificationError> {
         let app = &*PROOF_SYSTEM;
 
-        let descriptor_bytes: Vec<[u8; 64]> =
-            actions.iter().copied().map(<[u8; 64]>::from).collect();
-
-        if blake2b::stamp_actions_digest(&descriptor_bytes) != self.covered_actions {
+        if !self.covers(actions) {
             return Err(VerificationError::ActionsMismatch);
         }
 

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -1,6 +1,5 @@
 //! Stamps and anchors.
 
-#![allow(clippy::type_complexity, reason = "todo")]
 #![allow(clippy::module_name_repetitions, reason = "intentional names")]
 
 extern crate alloc;
@@ -256,19 +255,15 @@ pub enum VerificationError {
 pub struct Plan {
     spends: Vec<(
         action::Descriptor,
-        (
-            ActionRandomizer<effect::Spend>,
-            Note,
-            value::CommitmentTrapdoor,
-        ),
+        ActionRandomizer<effect::Spend>,
+        Note,
+        value::CommitmentTrapdoor,
     )>,
     outputs: Vec<(
         action::Descriptor,
-        (
-            ActionRandomizer<effect::Output>,
-            Note,
-            value::CommitmentTrapdoor,
-        ),
+        ActionRandomizer<effect::Output>,
+        Note,
+        value::CommitmentTrapdoor,
     )>,
     anchor: Anchor,
 }
@@ -279,19 +274,15 @@ impl Plan {
     pub const fn new(
         spends: Vec<(
             action::Descriptor,
-            (
-                ActionRandomizer<effect::Spend>,
-                Note,
-                value::CommitmentTrapdoor,
-            ),
+            ActionRandomizer<effect::Spend>,
+            Note,
+            value::CommitmentTrapdoor,
         )>,
         outputs: Vec<(
             action::Descriptor,
-            (
-                ActionRandomizer<effect::Output>,
-                Note,
-                value::CommitmentTrapdoor,
-            ),
+            ActionRandomizer<effect::Output>,
+            Note,
+            value::CommitmentTrapdoor,
         )>,
         anchor: Anchor,
     ) -> Self {
@@ -325,16 +316,13 @@ impl Plan {
         // Each entry pairs leaf stamp components with the descriptor of its
         // covered action; merges concatenate the descriptor lists. The
         // covered-actions digest is computed once, on the final stamp.
-        let mut entries: Vec<(
-            (Vec<Tachygram>, Anchor, Box<ragu::Proof>),
-            Vec<action::Descriptor>,
-        )> = Vec::new();
+        let mut entries = Vec::with_capacity(self.spends.len() + self.outputs.len());
 
         if self.spends.len() != spendbind_inputs.len() {
             return Err(ProveError::SpendableMismatch);
         }
 
-        for ((desc, (alpha, note, rcv)), (range_pcd, [_nf_now, nf_next], spendable_pcd)) in
+        for ((desc, alpha, note, rcv), (range_pcd, [_nf_now, nf_next], spendable_pcd)) in
             self.spends.into_iter().zip(spendbind_inputs)
         {
             let app = &*PROOF_SYSTEM;
@@ -353,22 +341,22 @@ impl Plan {
             let components = ProofStamp::prove_spend(rng, bind_pcd, range_pcd, nf_next)
                 .map_err(ProveError::ProofFailed)?;
 
-            entries.push((components, vec![desc]));
+            entries.push((vec![desc], components.0, components.1, components.2));
         }
 
-        for (desc, (alpha, note, rcv)) in self.outputs {
+        for (desc, alpha, note, rcv) in self.outputs {
             let components = ProofStamp::prove_output(rng, rcv, alpha, note, self.anchor)
                 .map_err(ProveError::ProofFailed)?;
 
-            entries.push((components, vec![desc]));
+            entries.push((vec![desc], components.0, components.1, components.2));
         }
 
-        let ((tachygrams, anchor, proof), descriptors) = entries
+        let (descriptors, tachygrams, anchor, proof) = entries
             .into_iter()
             .map(Ok::<_, ProveError>)
             .reduce(|acc, next| {
-                let ((left_tachygrams, left_anchor, left_proof), left_desc) = acc?;
-                let ((right_tachygrams, right_anchor, right_proof), right_desc) = next?;
+                let (left_desc, left_tachygrams, left_anchor, left_proof) = acc?;
+                let (right_desc, right_tachygrams, right_anchor, right_proof) = next?;
 
                 let left_digests: Vec<ActionDigest> = left_desc
                     .iter()
@@ -383,12 +371,17 @@ impl Plan {
 
                 let merged = ProofStamp::prove_merge(
                     rng,
-                    (left_proof, (left_digests, left_tachygrams, left_anchor)),
-                    (right_proof, (right_digests, right_tachygrams, right_anchor)),
+                    (left_digests, left_tachygrams, left_anchor, left_proof),
+                    (right_digests, right_tachygrams, right_anchor, right_proof),
                 )
                 .map_err(ProveError::MergeFailed)?;
 
-                Ok((merged, [left_desc, right_desc].concat()))
+                Ok((
+                    [left_desc, right_desc].concat(),
+                    merged.0,
+                    merged.1,
+                    merged.2,
+                ))
             })
             .ok_or(ProveError::NoActions)??;
 
@@ -507,18 +500,19 @@ impl ProofStamp {
     /// data by the caller and are never stored on the stamp.
     pub fn prove_merge<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
-        (left_proof, left_data): (
+        (left_digests, left_tachygrams, left_anchor, left_proof): (
+            Vec<ActionDigest>,
+            Vec<Tachygram>,
+            Anchor,
             Box<ragu::Proof>,
-            (Vec<ActionDigest>, Vec<Tachygram>, Anchor),
         ),
-        (right_proof, right_data): (
+        (right_digests, right_tachygrams, right_anchor, right_proof): (
+            Vec<ActionDigest>,
+            Vec<Tachygram>,
+            Anchor,
             Box<ragu::Proof>,
-            (Vec<ActionDigest>, Vec<Tachygram>, Anchor),
         ),
     ) -> Result<(Vec<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
-        let (left_digests, left_tachygrams, left_anchor) = left_data;
-        let (right_digests, right_tachygrams, right_anchor) = right_data;
-
         let app = &*PROOF_SYSTEM;
 
         let (left_acts_poly, left_tg_poly) = (
@@ -595,20 +589,16 @@ impl ProofStamp {
         let (tachygrams, anchor, proof) = Self::prove_merge(
             rng,
             (
+                left_actions_digest,
+                left_stamp.tachygrams,
+                left_stamp.anchor,
                 left_stamp.proof,
-                (
-                    left_actions_digest,
-                    left_stamp.tachygrams,
-                    left_stamp.anchor,
-                ),
             ),
             (
+                right_actions_digest,
+                right_stamp.tachygrams,
+                right_stamp.anchor,
                 right_stamp.proof,
-                (
-                    right_actions_digest,
-                    right_stamp.tachygrams,
-                    right_stamp.anchor,
-                ),
             ),
         )
         .map_err(ProveError::MergeFailed)?;
@@ -619,14 +609,12 @@ impl ProofStamp {
             .map(<[u8; 64]>::from)
             .collect();
 
-        let merged_stamp = Self {
+        Ok(Self {
             covered_actions: blake2b::stamp_actions_digest(&covered_actions),
             tachygrams,
             anchor,
             proof,
-        };
-
-        Ok(merged_stamp)
+        })
     }
 
     /// Checks if this stamp covers the given action descriptors.

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -26,7 +26,6 @@ use crate::{
     effect,
     entropy::ActionRandomizer,
     keys::ProofAuthorizingKey,
-    note::Nullifier,
     primitives::{ActionDigest, ActionDigestError, Anchor, Tachygram},
     serialization,
     stamp::proof::{delegation, spend, spendable},
@@ -57,19 +56,12 @@ use crate::{
 #[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Unproven;
 
-/// The 64-byte `wtxid` of the covering aggregate in the same block, assigned
-/// by the miner during block assembly.
+/// The 64-byte `wtxid` of the covering aggregate in the same block, assigned by
+/// the miner during block assembly.
 ///
-/// A `wtxid` is `txid || auth_digest`: two 32-byte transaction digests as
-/// defined by ZIP 244, concatenated per ZIP 239 into the 64-byte identifier
-/// used for transaction relay.
+/// Use of the wtxid unambiguously pins the aggregate's specific auth state.
 ///
-/// This uses the aggregate's wtxid (not txid) so it unambiguously pins the
-/// covering aggregate's authorization state, including stamp.
-///
-/// An `AggregateId` is always nonzero: every stripped bundle, innocent or
-/// adjunct, names a covering transaction, so the all-zero wtxid (which refers
-/// to no aggregate) is rejected at every construction site.
+/// The all-zero wtxid (which refers to no aggregate) is rejected.
 #[derive(Clone, Copy, Debug, Into, PartialEq, TotalEq)]
 pub struct PointerStamp([u8; 64]);
 
@@ -95,9 +87,10 @@ impl TryFrom<[u8; 64]> for PointerStamp {
 /// Bundle states that carry a stamp: [`ProofStamp`] or [`PointerStamp`].
 /// The intermediate [`Unproven`] state has no stamp.
 pub trait StampState: BundleState {
-    /// The stamp's 64-byte digest: a proof stamp's
-    /// `hStampActionsTachyon || stamp_data_digest`, or a pointer stamp's
-    /// `wtxid = txid || auth_digest` from another transaction.
+    /// A stamp's 64-byte `tachyonStampState`.
+    ///
+    /// For a [`ProofStamp`], this is a digest of the stamp data.
+    /// For a [`PointerStamp`], this is the wtxid directly.
     fn stamp_digest(&self) -> [u8; 64];
 
     /// The `tachyonBundleState` wire byte for this state.
@@ -312,13 +305,14 @@ impl Plan {
     ///
     /// `spendbind_inputs` items must correspond to each planned spend, in
     /// order.
+    ///
+    /// TODO: nf_next parameter may need to come back
     pub fn prove<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,
         pak: &ProofAuthorizingKey,
         spendbind_inputs: Vec<(
             ragu::Pcd<delegation::NullifierHeader>,
-            [Nullifier; 2],
             ragu::Pcd<spendable::SpendableHeader>,
         )>,
     ) -> Result<ProofStamp, ProveError> {
@@ -333,12 +327,9 @@ impl Plan {
             return Err(ProveError::SpendableMismatch);
         }
 
-        for ((desc, alpha, note, rcv), (range_pcd, [_nf_now, nf_next], spendable_pcd)) in
+        for ((desc, alpha, note, rcv), (nf_pcd, spendable_pcd)) in
             self.spends.into_iter().zip(spendbind_inputs)
         {
-            // TODO: the present nullifier is carried on the SpendBind output
-            // PCD (`nf_present`); incoming branches thread it differently, so
-            // the caller pair's `_nf_now` is intentionally unused here.
             let app = &*PROOF_SYSTEM;
 
             let (bind_pcd, ()) = app
@@ -353,8 +344,7 @@ impl Plan {
 
             // SpendStamp: bind the live pair to the derived range and publish.
             let (tachygrams, anchor, proof) =
-                ProofStamp::prove_spend(rng, bind_pcd, range_pcd, nf_next)
-                    .map_err(ProveError::ProofFailed)?;
+                ProofStamp::prove_spend(rng, bind_pcd, nf_pcd).map_err(ProveError::ProofFailed)?;
 
             let digest = desc.digest().map_err(ProveError::ActionDigest)?;
             entries.push((vec![desc], vec![digest], tachygrams, anchor, proof));
@@ -436,10 +426,10 @@ pub enum ProveError {
 /// reconstruct the header from public data.
 #[derive(Clone, Debug)]
 pub struct ProofStamp {
-    /// `hStampActionsTachyon`: digest of the covered action descriptors,
-    /// indicating which actions this stamp's proof covers. Computed by
-    /// `blake2b::stamp_actions_digest` over the canonically sorted
-    /// descriptors.
+    /// The digest $\mathsf{hStampActionsTachyon}$ of the proof's covered action
+    /// descriptors from this stamp's bundle and all covered bundles.
+    ///
+    /// See [`blake2b::action_descriptor_digest`]
     pub actions: [u8; 32],
 
     /// Tachygrams (nullifiers and note commitments) for data availability.
@@ -489,13 +479,13 @@ impl ProofStamp {
         rng: &mut RNG,
         bind_pcd: ragu::Pcd<spend::SpendHeader>,
         nf_pcd: ragu::Pcd<delegation::NullifierHeader>,
-        nf_next: Nullifier,
     ) -> Result<(Vec<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
         let app = &*PROOF_SYSTEM;
 
         let (_, _, nf_present, anchor) = *bind_pcd.data();
+        let (_, _, _, (_, nf_next)) = *nf_pcd.data();
 
-        let tachygrams = vec![Tachygram::from(nf_next), Tachygram::from(nf_present)];
+        let tachygrams = vec![Tachygram::from(nf_present), Tachygram::from(nf_next)];
 
         let (pcd, ()) = app.fuse(rng, SpendStamp, (nf_next,), bind_pcd, nf_pcd)?;
 
@@ -582,7 +572,8 @@ impl ProofStamp {
     /// The action digests for the merge proof and the merged
     /// `covered_actions` are both derived from the descriptor lists.
     ///
-    /// TODO: confirm desc list against stamp?
+    /// TODO: confirm desc list against stamp? it's forbidden by the proof
+    /// system, but we might want to fail early.
     pub fn merge<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
         (left_stamp, left_desc): (Self, Vec<action::Descriptor>),

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -12,9 +12,10 @@ use ragu::{
 
 use super::spendable::SpendableHeader;
 use crate::{
+    action,
     constants::NOTE_VALUE_MAX,
     entropy::ActionRandomizer,
-    keys::{ProofAuthorizingKey, public},
+    keys::ProofAuthorizingKey,
     note::{self, Note, Nullifier},
     primitives::{Anchor, effect},
     value,
@@ -33,21 +34,16 @@ impl Header for SpendHeader {
     /// spend's published action pair, derived together at [`SpendBind`];
     /// `present_nf` and `anchor` thread from the spendable lineage that
     /// [`SpendBind`] consumed.
-    type Data = (
-        note::Commitment,
-        (value::Commitment, public::ActionVerificationKey),
-        Nullifier,
-        Anchor,
-    );
+    type Data = (note::Commitment, action::Descriptor, Nullifier, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(10);
 
     fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
-        let (cm, (cv, rk), present_nf, anchor) = *data;
+        let (cm, act, present_nf, anchor) = *data;
         (
             vec![Fp::from(cm), Fp::from(present_nf), Fp::from(anchor)],
             Vec::new(),
-            vec![Ep::from(cv.0), Ep::from(EpAffine::from(rk))],
+            vec![Ep::from(act.cv.0), Ep::from(EpAffine::from(act.rk))],
             Vec::new(),
         )
     }
@@ -107,6 +103,6 @@ impl Step for SpendBind {
         let cv = rcv.commit(i64::from(note.value));
         let rk = pak.ak.derive_action_public(&alpha);
 
-        Ok(((cm, (cv, rk), present_nf, anchor), ()))
+        Ok(((cm, action::Descriptor { cv, rk }, present_nf, anchor), ()))
     }
 }

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -148,7 +148,7 @@ impl Step for SpendStamp {
         &self,
         _ctx: &mut ragu::StepCtx<'_>,
         (nf_next,): Self::Witness<'source>,
-        (cm, desc, present_nf, anchor): <Self::Left as Header>::Data,
+        (cm, act, present_nf, anchor): <Self::Left as Header>::Data,
         (nf_cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, nf_end)): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         #[expect(clippy::expect_used, reason = "constant size")]
@@ -187,7 +187,7 @@ impl Step for SpendStamp {
             "SpendStamp: next-epoch nullifier is zero",
         )?;
 
-        let action_digest = desc.digest().map_err(|_err| {
+        let action_digest = act.digest().map_err(|_err| {
             ragu::Error::InvalidWitness("SpendStamp: action digest construction failed".into())
         })?;
 

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -112,9 +112,11 @@ impl Step for OutputStamp {
             ActionSetCommit::from(g0 * (-a0) + g1)
         };
 
+        let note_commit = note.commitment();
+
         // Set commitment to one note commitment.
         let tachygram_commit = {
-            let t0 = Fp::from(note.commitment());
+            let t0 = Fp::from(note_commit);
             TachygramSetCommit::from(g0 * (-t0) + g1)
         };
 
@@ -146,7 +148,7 @@ impl Step for SpendStamp {
         &self,
         _ctx: &mut ragu::StepCtx<'_>,
         (nf_next,): Self::Witness<'source>,
-        (cm, (cv, rk), present_nf, anchor): <Self::Left as Header>::Data,
+        (cm, desc, present_nf, anchor): <Self::Left as Header>::Data,
         (nf_cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, nf_end)): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         #[expect(clippy::expect_used, reason = "constant size")]
@@ -185,7 +187,7 @@ impl Step for SpendStamp {
             "SpendStamp: next-epoch nullifier is zero",
         )?;
 
-        let action_digest = ActionDigest::new(cv, rk).map_err(|_err| {
+        let action_digest = desc.digest().map_err(|_err| {
             ragu::Error::InvalidWitness("SpendStamp: action digest construction failed".into())
         })?;
 

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -16,7 +16,7 @@ use rand_core::{CryptoRng, RngCore};
 
 use super::{PROOF_SYSTEM, delegation, pool, spend, spendable, stamp};
 use crate::{
-    ActionSetPoly, NfSeqPoly, Note, TachygramSetPoly,
+    ActionSetPoly, NfSeqPoly, Note, TachygramSetPoly, action,
     constants::EPOCH_SIZE,
     entropy::ActionEntropy,
     fixtures::{
@@ -475,7 +475,7 @@ fn spend_bind_honest() {
     let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
 
     let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd);
-    let (_cm, (_cv, _rk), present_nf, _anchor) = *spend_pcd.data();
+    let (_cm, _desc, present_nf, _anchor) = *spend_pcd.data();
     assert_eq!(present_nf, user.nf_at(&note, spend_epoch));
 }
 
@@ -618,11 +618,14 @@ fn spend_stamp_rejects_identity_cv() {
     let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
 
     let real_spend = honest_spend_bind(rng, &user, &note, spendable_pcd);
-    let (cm, (_real_cv, real_rk), present_nf, anchor) = *real_spend.data();
+    let (cm, real_desc, present_nf, anchor) = *real_spend.data();
     let identity_cv = value::Commitment::balance(0);
     let forged_spend = real_spend.proof().clone().carry::<spend::SpendHeader>((
         cm,
-        (identity_cv, real_rk),
+        action::Descriptor {
+            cv: identity_cv,
+            rk: real_desc.rk,
+        },
         present_nf,
         anchor,
     ));
@@ -737,7 +740,7 @@ fn spend_after_lift_publishes_anchor_epoch_nullifiers() {
     let lifted = user.lift(rng, spendable, unspent, &note, EpochIndex(0), EpochIndex(1));
 
     let spend_pcd = honest_spend_bind(rng, &user, &note, lifted);
-    let (_cm, (_cv, _rk), present_nf, _anchor) = *spend_pcd.data();
+    let (_cm, _desc, present_nf, _anchor) = *spend_pcd.data();
     assert_eq!(
         present_nf,
         user.nf_at(&note, EpochIndex(1)),

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -46,7 +46,7 @@ fn merge_stamp_iff_matching_anchors() {
         let note_b = user_b.random_note(300);
         let (stamp_b, plan_b) = build_output_stamp(rng, anchor_b, note_b);
 
-        let result = Stamp::prove_merge(
+        let result = ProofStamp::prove_merge(
             rng,
             (stamp_a, &[plan_a.digest().expect("valid plan")]),
             (stamp_b, &[plan_b.digest().expect("valid plan")]),
@@ -191,8 +191,8 @@ fn prove_merge_populates_action_set() {
     ];
     let expected = ActionSetPoly::from_iter(digests).commit();
 
-    let merged =
-        Stamp::prove_merge(rng, (stamp_a, &[digests[0]]), (stamp_b, &[digests[1]])).expect("merge");
+    let merged = ProofStamp::prove_merge(rng, (stamp_a, &[digests[0]]), (stamp_b, &[digests[1]]))
+        .expect("merge");
     assert_eq!(merged.action_set, expected);
 }
 
@@ -207,7 +207,7 @@ fn stamp_action_set_round_trip() {
 
     let mut buf = Vec::new();
     stamp.write(&mut buf).expect("write");
-    let decoded = Stamp::read(&*buf).expect("read");
+    let decoded = ProofStamp::read(&*buf).expect("read");
 
     assert_eq!(decoded.action_set, stamp.action_set);
     assert_eq!(decoded.anchor, stamp.anchor);

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -168,13 +168,9 @@ fn merge_populates_covered_actions() {
     let (stamp_a, plan_a) = build_output_stamp(rng, anchor, note_a);
     let (stamp_b, plan_b) = build_output_stamp(rng, anchor, note_b);
 
-    let descriptors: [[u8; 64]; 2] = [plan_a.descriptor().into(), plan_b.descriptor().into()];
-    let expected = blake2b::stamp_actions_digest(&descriptors);
-    // The digest sorts internally, so descriptor order is irrelevant.
-    assert_eq!(
-        expected,
-        blake2b::stamp_actions_digest(&[descriptors[1], descriptors[0]])
-    );
+    let mut descriptors: [[u8; 64]; 2] = [plan_a.descriptor().into(), plan_b.descriptor().into()];
+    descriptors.sort_unstable();
+    let expected = blake2b::action_descriptor_digest(&descriptors);
 
     let merged = ProofStamp::merge(
         rng,
@@ -182,6 +178,8 @@ fn merge_populates_covered_actions() {
         (stamp_b, vec![plan_b.descriptor()]),
     )
     .expect("merge");
+    // `merge` sorts the concatenated descriptors into canonical order, so the
+    // covered-actions digest is independent of the order they were passed in.
     assert_eq!(merged.covered_actions, expected);
 }
 

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -46,10 +46,10 @@ fn merge_stamp_iff_matching_anchors() {
         let note_b = user_b.random_note(300);
         let (stamp_b, plan_b) = build_output_stamp(rng, anchor_b, note_b);
 
-        let result = ProofStamp::prove_merge(
+        let result = ProofStamp::merge(
             rng,
-            (stamp_a, &[plan_a.digest().expect("valid plan")]),
-            (stamp_b, &[plan_b.digest().expect("valid plan")]),
+            (stamp_a, vec![plan_a.descriptor()]),
+            (stamp_b, vec![plan_b.descriptor()]),
         );
         assert_eq!(
             result.is_ok(),
@@ -101,8 +101,8 @@ fn plan_prove_rejects_invalid_inputs() {
 
     let two_spends = || {
         alloc::vec![
-            ((plan_a.cv(), plan_a.rk), (alpha_a, note_a, rcv_a)),
-            ((plan_b.cv(), plan_b.rk), (alpha_b, note_b, rcv_b)),
+            (plan_a.descriptor(), (alpha_a, note_a, rcv_a)),
+            (plan_b.descriptor(), (alpha_b, note_b, rcv_b)),
         ]
     };
 
@@ -154,27 +154,10 @@ fn plan_prove_rejects_invalid_inputs() {
     }
 }
 
-/// `prove_output` populates `action_set` with the commit of the single
-/// action's digest, reconstructed independently.
+/// `merge` populates `covered_actions` with the covered-actions digest of
+/// the merged descriptor list, order-independently.
 #[test]
-fn prove_output_populates_action_set() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let wallet = WalletSim::random(rng);
-    let mut pool = PoolSim::genesis(rng);
-    let note = wallet.random_note(200);
-    pool.mine(random_block_with(rng, &[vec![note.commitment()]], 50));
-    let anchor = pool.anchor();
-
-    let (stamp, plan) = build_output_stamp(rng, anchor, note);
-    let digest = plan.digest().expect("valid plan");
-    let expected = ActionSetPoly::from_iter([digest]).commit();
-    assert_eq!(stamp.action_set, expected);
-}
-
-/// `prove_merge` populates `action_set` with the commit of the merged
-/// (concatenated) digest list.
-#[test]
-fn prove_merge_populates_action_set() {
+fn merge_populates_covered_actions() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user_a = WalletSim::random(rng);
     let user_b = WalletSim::random(rng);
@@ -185,20 +168,26 @@ fn prove_merge_populates_action_set() {
     let (stamp_a, plan_a) = build_output_stamp(rng, anchor, note_a);
     let (stamp_b, plan_b) = build_output_stamp(rng, anchor, note_b);
 
-    let digests = [
-        plan_a.digest().expect("valid plan"),
-        plan_b.digest().expect("valid plan"),
-    ];
-    let expected = ActionSetPoly::from_iter(digests).commit();
+    let descriptors: [[u8; 64]; 2] = [plan_a.descriptor().into(), plan_b.descriptor().into()];
+    let expected = blake2b::stamp_actions_digest(&descriptors);
+    // The digest sorts internally, so descriptor order is irrelevant.
+    assert_eq!(
+        expected,
+        blake2b::stamp_actions_digest(&[descriptors[1], descriptors[0]])
+    );
 
-    let merged = ProofStamp::prove_merge(rng, (stamp_a, &[digests[0]]), (stamp_b, &[digests[1]]))
-        .expect("merge");
-    assert_eq!(merged.action_set, expected);
+    let merged = ProofStamp::merge(
+        rng,
+        (stamp_a, vec![plan_a.descriptor()]),
+        (stamp_b, vec![plan_b.descriptor()]),
+    )
+    .expect("merge");
+    assert_eq!(merged.covered_actions, expected);
 }
 
-/// `cActionsTachyon` survives a `write`/`read` round-trip.
+/// `hActionsTachyon` survives a `write`/`read` round-trip.
 #[test]
-fn stamp_action_set_round_trip() {
+fn covered_actions_round_trip() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);
     let pool = PoolSim::genesis(rng);
@@ -209,7 +198,7 @@ fn stamp_action_set_round_trip() {
     stamp.write(&mut buf).expect("write");
     let decoded = ProofStamp::read(&*buf).expect("read");
 
-    assert_eq!(decoded.action_set, stamp.action_set);
+    assert_eq!(decoded.covered_actions, stamp.covered_actions);
     assert_eq!(decoded.anchor, stamp.anchor);
     assert_eq!(decoded.tachygrams, stamp.tachygrams);
 }

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -101,8 +101,8 @@ fn plan_prove_rejects_invalid_inputs() {
 
     let two_spends = || {
         alloc::vec![
-            (plan_a.descriptor(), (alpha_a, note_a, rcv_a)),
-            (plan_b.descriptor(), (alpha_b, note_b, rcv_b)),
+            (plan_a.descriptor(), alpha_a, note_a, rcv_a),
+            (plan_b.descriptor(), alpha_b, note_b, rcv_b),
         ]
     };
 

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -79,15 +79,7 @@ fn plan_prove_rejects_invalid_inputs() {
     let sp_a = user.fresh_spend(rng, &pool, height, &note_a);
     let sp_b = user.fresh_spend(rng, &pool, height, &note_b);
     let range_a = user.derived_range(rng, &note_a, spend_epoch, 2);
-    let pair_a = [
-        user.nf_at(&note_a, spend_epoch),
-        user.nf_at(&note_a, spend_epoch.next()),
-    ];
     let range_b = user.derived_range(rng, &note_b, spend_epoch, 2);
-    let pair_b = [
-        user.nf_at(&note_b, spend_epoch),
-        user.nf_at(&note_b, spend_epoch.next()),
-    ];
 
     let (rcv_a, theta_a, alpha_a) = spend_witness(rng, &note_a);
     let plan_a = action::Plan::spend(note_a, theta_a, rcv_a, |alpha| {
@@ -113,8 +105,8 @@ fn plan_prove_rejects_invalid_inputs() {
         assert!(matches!(err, ProveError::NoActions), "expected NoActions");
     }
 
-    let bundle_a = || (range_a.clone(), pair_a, sp_a.clone());
-    let bundle_b = || (range_b.clone(), pair_b, sp_b.clone());
+    let bundle_a = || (range_a.clone(), sp_a.clone());
+    let bundle_b = || (range_b.clone(), sp_b.clone());
 
     // Too few PCDs: 2 spends, 1 PCD.
     {

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -168,7 +168,7 @@ fn merge_populates_covered_actions() {
     let (stamp_a, plan_a) = build_output_stamp(rng, anchor, note_a);
     let (stamp_b, plan_b) = build_output_stamp(rng, anchor, note_b);
 
-    let mut descriptors: [[u8; 64]; 2] = [plan_a.descriptor().into(), plan_b.descriptor().into()];
+    let mut descriptors = Vec::<[u8; 64]>::from_iter([plan_a.descriptor(), plan_b.descriptor()]);
     descriptors.sort_unstable();
     let expected = blake2b::action_descriptor_digest(&descriptors);
 

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -180,10 +180,10 @@ fn merge_populates_covered_actions() {
     .expect("merge");
     // `merge` sorts the concatenated descriptors into canonical order, so the
     // covered-actions digest is independent of the order they were passed in.
-    assert_eq!(merged.covered_actions, expected);
+    assert_eq!(merged.actions, expected);
 }
 
-/// `hActionsTachyon` survives a `write`/`read` round-trip.
+/// `hStampActionsTachyon` survives a `write`/`read` round-trip.
 #[test]
 fn covered_actions_round_trip() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -196,7 +196,7 @@ fn covered_actions_round_trip() {
     stamp.write(&mut buf).expect("write");
     let decoded = ProofStamp::read(&*buf).expect("read");
 
-    assert_eq!(decoded.covered_actions, stamp.covered_actions);
+    assert_eq!(decoded.actions, stamp.actions);
     assert_eq!(decoded.anchor, stamp.anchor);
     assert_eq!(decoded.tachygrams, stamp.tachygrams);
 }


### PR DESCRIPTION
Work on #162.

Grows out of the digest and wire-format discussion on the bundle
transaction-format ZIP (#157) and the aggregation ZIP (#148).

Restructures the bundle and stamp digests into a tree modelled on ZIP 244. Each
named function is one protocol-defined BLAKE2b-256 hash with its own
personalization. Within a preimage at most one variable-length component is
hashed inline; every other input is fixed-length or a personalized sub-digest,
so no field boundary is ambiguous.

## Digest tree

`bundle_commitment` (`ZTxIdTachyonHash`, txid side):

```mermaid
graph TD
  vact@{ shape: procs, label: "bundle actions" }
  adgst@{ shape: trap-t, label: "action_descriptor_digest" }
  commit@{ shape: trap-t, label: "bundle_commitment" }
  vbal[value balance]

  vact --> adgst -->|hActionsTachyon| commit
  vbal -->|vBalanceTachyon| commit
```

`bundle_auth_digest` (`ZTxAuthTachyHash`, auth digest side):

```mermaid
graph TD
  state1{{0x01}}
  state2{{0x02}}

  vactsigs@{ shape: procs, label: "action sigs" }

  bsig[binding sig]

  vact@{ shape: procs, label: "bundle actions" }
  cvact@{ shape: procs, label: "adjunct actions" }
  sort((sort))
  adgst@{ shape: trap-t, label: "action_descriptor_digest" }

  proof[proof]
  sproof@{ shape: trap-t, label: "stamp_proof_digest" }
  anchor[anchor]
  tgs@{ shape: procs, label: "vTachygrams" }
  sdata@{ shape: trap-t, label: "stamp_data_digest" }

  cat((cat))
  wtxid[wtxid]

  state_impl{"impl"}
  stamp_impl{"impl"}

  auth@{ shape: trap-t, label: "bundle_auth_digest" }

  state1 ---|ProofStamp| state_impl 
  state2 ---|PointerStamp| state_impl 
  state_impl --> |tachyonBundleState| auth

  vactsigs -->|vActionSigsTachyon| auth
  bsig -->|bindingSigTachyon| auth

  vact & cvact --- sort --> adgst --- cat

  proof --> sproof
  sproof & anchor & tgs --> sdata --- cat

  cat ---|ProofStamp| stamp_impl
  wtxid ---|PointerStamp| stamp_impl

  stamp_impl -->|tachyonStampState| auth
```

## Ordering

Valid digests are over canonically ordered inputs. Flat-hashed lists only commit
unambiguously if their order is fixed.

- Digest utilities do not perform sorting.
- Bundle action sorting happens at construction only.
- Stamp tachygram sorting happens at construction only.
- Deserialization rejects non-canonical order.
