### PR TITLE
fix: enforce `valueBalanceTachyon` rules, introduce `Value` types

### DIFF
--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -22,7 +22,7 @@ pub struct Plan<E: Effect> {
     /// Per-action entropy for alpha derivation.
     pub theta: ActionEntropy,
     /// Value commitment trapdoor.
-    pub rcv: value::CommitmentTrapdoor,
+    pub rcv: value::Trapdoor,
     /// Effect marker (zero-sized).
     pub _effect: PhantomData<E>,
 }
@@ -35,7 +35,7 @@ impl Plan<effect::Spend> {
     pub fn spend(
         note: Note,
         theta: ActionEntropy,
-        rcv: value::CommitmentTrapdoor,
+        rcv: value::Trapdoor,
         derive_rk: impl FnOnce(ActionRandomizer<effect::Spend>) -> public::ActionVerificationKey,
     ) -> Self {
         let cm = note.commitment();
@@ -56,7 +56,7 @@ impl Plan<effect::Output> {
     ///
     /// $\mathsf{rk} = [\alpha]\,\mathcal{G}$.
     #[must_use]
-    pub fn output(note: Note, theta: ActionEntropy, rcv: value::CommitmentTrapdoor) -> Self {
+    pub fn output(note: Note, theta: ActionEntropy, rcv: value::Trapdoor) -> Self {
         let cm = note.commitment();
         let alpha = theta.randomizer::<effect::Output>(cm);
         let rsk = private::ActionSigningKey::new(&alpha);
@@ -93,11 +93,12 @@ impl<E: Effect> Plan<E> {
 /// - `sig`: Signature (by single-use `rsk`) over transaction sighash
 #[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
 pub struct Action {
-    /// Value commitment $\mathsf{cv} = [v]\,\mathcal{V}
-    /// + [\mathsf{rcv}]\,\mathcal{R}$ (EpAffine).
+    /// Value commitment.
+    ///
+    /// $$ \mathsf{cv} = \[v\]\mathcal{V} + \[\mathsf{rcv}\]\mathcal{R} $$
     pub cv: value::Commitment,
 
-    /// Randomized action verification key $\mathsf{rk}$ (EpAffine).
+    /// Randomized action verification key $\mathsf{rk}$.
     pub rk: public::ActionVerificationKey,
 
     /// RedPallas spend auth signature over the transaction sighash.

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -64,7 +64,6 @@
 //! | `tachyonAggregateId`  | 64 bytes             | wtxid of the relevant aggregate          |
 
 use alloc::vec::Vec;
-use core::ops;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, PartialEq};
@@ -77,9 +76,9 @@ pub use crate::digest::blake2b::{AUTH_DIGEST_NO_BUNDLE, COMMIT_NO_BUNDLE};
 use crate::{
     ActionSetPoly,
     action::{self, Action},
+    constants::MAX_MONEY,
     digest::blake2b,
     keys::{private, public},
-    note,
     primitives::{ActionDigest, ActionDigestError, Anchor, effect},
     reddsa, serialization,
     stamp::{self, AggregateId, Stamp, Stripped, Unproven},
@@ -140,7 +139,7 @@ pub struct Bundle<S: StampState> {
     pub actions: Vec<Action>,
 
     /// Net value of spends minus outputs (plaintext integer).
-    pub value_balance: i64,
+    pub value_balance: ValueBalance,
 
     /// Binding signature over the transaction sighash.
     pub binding_sig: Signature,
@@ -207,7 +206,7 @@ pub enum CommitError {
     ActionDigest(#[error(not(source))] ActionDigestError),
     /// The value balance overflows the representable range.
     #[display("value balance overflow")]
-    BalanceOverflow(#[error(not(source))] BalanceError),
+    BalanceOverflow(#[error(not(source))] ValueBalanceOverflow),
 }
 
 /// Errors from bundle signature verification.
@@ -286,17 +285,22 @@ impl Plan {
     /// $\mathsf{v\_balance} = \sum_i v_{\text{spend},i} - \sum_j
     /// v_{\text{output},j}$
     ///
-    /// Returns `Err` if the intermediate sum overflows or the result
-    /// does not fit in `i64`.
-    pub fn value_balance(&self) -> Result<i64, BalanceError> {
-        let mut sum = ValueBalance::ZERO;
+    ///
+    /// # Errors
+    ///
+    /// Fails if the final balance falls outside `-MAX_MONEY..=MAX_MONEY`.
+    /// Intermediate accumulating states are not constrained.
+    pub fn value_balance(&self) -> Result<ValueBalance, ValueBalanceOverflow> {
+        let mut sum = 0i128;
         for plan in &self.spends {
-            sum = (sum + plan.note.value)?;
+            sum += i128::from(i64::from(plan.note.value));
         }
         for plan in &self.outputs {
-            sum = (sum - plan.note.value)?;
+            sum -= i128::from(i64::from(plan.note.value));
         }
         i64::try_from(sum)
+            .map_err(|_err| ValueBalanceOverflow)
+            .and_then(ValueBalance::try_from)
     }
 
     /// Compute a digest of all the bundle's effecting data.
@@ -323,7 +327,7 @@ impl Plan {
 
         Ok(blake2b::bundle_commitment(
             &Eq::from(action_commit).to_bytes(),
-            self.value_balance()?,
+            self.value_balance()?.into(),
         ))
     }
 
@@ -562,7 +566,7 @@ impl Bundle<Stamp> {
             ));
         }
 
-        let (actions, value_balance, binding_sig): (Vec<Action>, i64, Signature) =
+        let (actions, value_balance, binding_sig): (Vec<Action>, ValueBalance, Signature) =
             read_bundle_body(&mut reader)?;
 
         let stamp = Stamp::read(&mut reader)?;
@@ -756,12 +760,21 @@ impl<S: StampState> Bundle<S> {
         let action_acc = ActionSetPoly::from_iter(action_digests).commit();
         Ok(blake2b::bundle_commitment(
             &Eq::from(action_acc).to_bytes(),
-            self.value_balance,
+            self.value_balance.into(),
         ))
     }
 
     /// Verify the bundle's binding signature and all action signatures.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the bundle has no actions but a nonzero value balance.
     pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), SignatureError> {
+        if self.actions.is_empty() && self.value_balance != ValueBalance::ZERO {
+            // Every construction path already guarantees this.
+            unreachable!("bundle with no actions cannot have nonzero value balance");
+        }
+
         // 1. Derive bvk from public data (validator-side, §4.14)
         let bvk = public::BindingVerificationKey::derive(&self.actions, self.value_balance);
 
@@ -781,56 +794,49 @@ impl<S: StampState> Bundle<S> {
     }
 }
 
-/// Signed sum of note values across actions.
+/// Signed sum of note values across actions, bounded to
+/// `-MAX_MONEY..=MAX_MONEY`.
 ///
 /// Spends contribute positive values, outputs contribute negative.
-/// Uses `i128` internally to provide additional headroom while accumulating
-/// values. Checked arithmetic still reports overflow, and conversion to the
-/// wire-format `i64` fails if the final balance is out of range.
-///
-/// Use `i64::try_from(sum)` to narrow to the wire-format `i64`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, TotalEq)]
-pub struct ValueBalance(i128);
+#[derive(Clone, Copy, Debug, Default, Ord, PartialEq, PartialOrd, TotalEq)]
+pub struct ValueBalance(i64);
 
 /// Error returned when a [`ValueBalance`] operation overflows the
 /// representable range.
-#[derive(Clone, Copy, Debug, Display, Error)]
+#[derive(Clone, Copy, Debug, Display, Error, PartialEq, TotalEq)]
 #[display("value balance overflow")]
-pub struct BalanceError;
+pub struct ValueBalanceOverflow;
 
 impl ValueBalance {
-    /// The zero sum (identity for addition).
+    /// The zero sum.
     pub const ZERO: Self = Self(0);
+
+    /// The maximum representable value.
+    #[expect(
+        clippy::as_conversions,
+        clippy::cast_possible_wrap,
+        reason = "constant"
+    )]
+    pub const MAX: Self = Self(MAX_MONEY as i64);
 }
 
-impl TryFrom<ValueBalance> for i64 {
-    type Error = BalanceError;
-
-    // This doesn't need to check against NOTE_VALUE_MAX
-    fn try_from(sum: ValueBalance) -> Result<Self, Self::Error> {
-        Self::try_from(sum.0).map_err(|_err| BalanceError)
+impl From<ValueBalance> for i64 {
+    fn from(balance: ValueBalance) -> Self {
+        assert!(
+            balance.0.unsigned_abs() <= MAX_MONEY,
+            "impossible value balance"
+        );
+        balance.0
     }
 }
 
-impl ops::Add<note::Value> for ValueBalance {
-    type Output = Result<Self, BalanceError>;
-
-    fn add(self, rhs: note::Value) -> Self::Output {
-        self.0
-            .checked_add(u64::from(rhs).into())
-            .map(Self)
-            .ok_or(BalanceError)
-    }
-}
-
-impl ops::Sub<note::Value> for ValueBalance {
-    type Output = Result<Self, BalanceError>;
-
-    fn sub(self, rhs: note::Value) -> Self::Output {
-        self.0
-            .checked_sub(u64::from(rhs).into())
-            .map(Self)
-            .ok_or(BalanceError)
+impl TryFrom<i64> for ValueBalance {
+    type Error = ValueBalanceOverflow;
+    fn try_from(balance: i64) -> Result<Self, Self::Error> {
+        if balance.unsigned_abs() > MAX_MONEY {
+            return Err(ValueBalanceOverflow);
+        }
+        Ok(Self(balance))
     }
 }
 
@@ -864,10 +870,11 @@ impl From<Signature> for [u8; 64] {
 
 /// Read bundle fields: value balance, action descriptors, action sigs,
 /// and binding sig.
-fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, i64, Signature)> {
+fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, ValueBalance, Signature)> {
     let mut vb_bytes = [0u8; 8];
     reader.read_exact(&mut vb_bytes)?;
-    let value_balance = i64::from_le_bytes(vb_bytes);
+    let value_balance = ValueBalance::try_from(i64::from_le_bytes(vb_bytes))
+        .map_err(|_err| io::Error::new(io::ErrorKind::InvalidData, "value balance out of range"))?;
 
     let n_actions =
         usize::try_from(serialization::read_compactsize(&mut reader)?).map_err(|_err| {
@@ -890,11 +897,18 @@ fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, i64, Sig
         signatures.push(sig);
     }
 
-    let actions = descriptors
+    let actions: Vec<Action> = descriptors
         .iter()
         .zip(signatures.iter())
         .map(|(&(cv, rk), &sig)| Action { cv, rk, sig })
         .collect();
+
+    if actions.is_empty() && i64::from(value_balance) != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "bundle with no actions must have zero value balance",
+        ));
+    }
 
     let binding_sig = Signature(serialization::read_binding_sig(&mut reader)?);
 
@@ -906,10 +920,10 @@ fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, i64, Sig
 fn write_bundle_body<W: Write>(
     mut writer: W,
     actions: &[Action],
-    value_balance: i64,
+    value_balance: ValueBalance,
     binding_sig: &Signature,
 ) -> io::Result<()> {
-    writer.write_all(&value_balance.to_le_bytes())?;
+    writer.write_all(&i64::from(value_balance).to_le_bytes())?;
 
     serialization::write_compactsize(
         &mut writer,

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -64,6 +64,7 @@
 //! | `tachyonAggregateId`  | 64 bytes             | wtxid of the relevant aggregate          |
 
 use alloc::vec::Vec;
+use core::ops::Neg as _;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, PartialEq};
@@ -76,7 +77,6 @@ pub use crate::digest::blake2b::{AUTH_DIGEST_NO_BUNDLE, COMMIT_NO_BUNDLE};
 use crate::{
     ActionSetPoly,
     action::{self, Action},
-    constants::MAX_MONEY,
     digest::blake2b,
     keys::{private, public},
     primitives::{ActionDigest, ActionDigestError, Anchor, effect},
@@ -139,7 +139,7 @@ pub struct Bundle<S: StampState> {
     pub actions: Vec<Action>,
 
     /// Net value of spends minus outputs (plaintext integer).
-    pub value_balance: ValueBalance,
+    pub value_balance: value::Balance,
 
     /// Binding signature over the transaction sighash.
     pub binding_sig: Signature,
@@ -206,7 +206,7 @@ pub enum CommitError {
     ActionDigest(#[error(not(source))] ActionDigestError),
     /// The value balance overflows the representable range.
     #[display("value balance overflow")]
-    BalanceOverflow(#[error(not(source))] ValueBalanceOverflow),
+    BalanceOverflow(#[error(not(source))] value::OutOfRange),
 }
 
 /// Errors from bundle signature verification.
@@ -289,17 +289,14 @@ impl Plan {
     ///
     /// Fails if the final balance falls outside `-MAX_MONEY..=MAX_MONEY`.
     /// Intermediate accumulating states are not constrained.
-    pub fn value_balance(&self) -> Result<ValueBalance, ValueBalanceOverflow> {
-        let mut sum = 0i128;
-        for plan in &self.spends {
-            sum += i128::from(u64::from(plan.note.value));
-        }
-        for plan in &self.outputs {
-            sum -= i128::from(u64::from(plan.note.value));
-        }
-        i64::try_from(sum)
-            .map_err(|_err| ValueBalanceOverflow)
-            .and_then(ValueBalance::try_from)
+    pub fn value_balance(&self) -> Result<value::Balance, value::OutOfRange> {
+        value::Balance::try_from(
+            self.iter_actions(
+                |plan| i128::from(plan.note.value),
+                |plan| i128::from(plan.note.value).neg(),
+            )
+            .sum::<i128>(),
+        )
     }
 
     /// Compute a digest of all the bundle's effecting data.
@@ -565,7 +562,7 @@ impl Bundle<Stamp> {
             ));
         }
 
-        let (actions, value_balance, binding_sig): (Vec<Action>, ValueBalance, Signature) =
+        let (actions, value_balance, binding_sig): (Vec<Action>, value::Balance, Signature) =
             read_bundle_body(&mut reader)?;
 
         let stamp = Stamp::read(&mut reader)?;
@@ -784,48 +781,6 @@ impl<S: StampState> Bundle<S> {
     }
 }
 
-/// Signed sum of note values across actions, bounded to
-/// `-MAX_MONEY..=MAX_MONEY`.
-///
-/// Spends contribute positive values, outputs contribute negative.
-#[derive(Clone, Copy, Debug, Default, Ord, PartialEq, PartialOrd, TotalEq)]
-pub struct ValueBalance(i64);
-
-/// Error returned when a [`ValueBalance`] operation overflows the
-/// representable range.
-#[derive(Clone, Copy, Debug, Display, Error, PartialEq, TotalEq)]
-#[display("value balance overflow")]
-pub struct ValueBalanceOverflow;
-
-impl ValueBalance {
-    /// The maximum representable value.
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_wrap,
-        reason = "constant"
-    )]
-    pub const MAX: Self = Self(MAX_MONEY as i64);
-    /// The zero sum.
-    pub const ZERO: Self = Self(0);
-}
-
-impl From<ValueBalance> for i64 {
-    fn from(balance: ValueBalance) -> Self {
-        balance.0
-    }
-}
-
-impl TryFrom<i64> for ValueBalance {
-    type Error = ValueBalanceOverflow;
-
-    fn try_from(balance: i64) -> Result<Self, Self::Error> {
-        if balance.unsigned_abs() > MAX_MONEY {
-            return Err(ValueBalanceOverflow);
-        }
-        Ok(Self(balance))
-    }
-}
-
 /// A binding signature (RedPallas over the Binding group).
 ///
 /// Proves the signer knew the opening $\mathsf{bsk}$ of the Pedersen
@@ -856,10 +811,12 @@ impl From<Signature> for [u8; 64] {
 
 /// Read bundle fields: value balance, action descriptors, action sigs,
 /// and binding sig.
-fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, ValueBalance, Signature)> {
+fn read_bundle_body<R: Read>(
+    mut reader: R,
+) -> io::Result<(Vec<Action>, value::Balance, Signature)> {
     let mut vb_bytes = [0u8; 8];
     reader.read_exact(&mut vb_bytes)?;
-    let value_balance = ValueBalance::try_from(i64::from_le_bytes(vb_bytes))
+    let value_balance = value::Balance::try_from(i64::from_le_bytes(vb_bytes))
         .map_err(|_err| io::Error::new(io::ErrorKind::InvalidData, "value balance out of range"))?;
 
     let n_actions =
@@ -872,7 +829,7 @@ fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, ValueBal
 
     let mut descriptors = Vec::with_capacity(n_actions);
     for _ in 0..n_actions {
-        let cv = value::Commitment(serialization::read_ep_affine(&mut reader)?);
+        let cv = value::Commitment::from(serialization::read_ep_affine(&mut reader)?);
         let rk = public::ActionVerificationKey(serialization::read_action_vk(&mut reader)?);
         descriptors.push((cv, rk));
     }
@@ -889,7 +846,7 @@ fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, ValueBal
         .map(|(&(cv, rk), &sig)| Action { cv, rk, sig })
         .collect();
 
-    if actions.is_empty() && value_balance != ValueBalance::ZERO {
+    if actions.is_empty() && value_balance != value::Balance::ZERO {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "bundle with no actions must have zero value balance",
@@ -906,7 +863,7 @@ fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, ValueBal
 fn write_bundle_body<W: Write>(
     mut writer: W,
     actions: &[Action],
-    value_balance: ValueBalance,
+    value_balance: value::Balance,
     binding_sig: &Signature,
 ) -> io::Result<()> {
     writer.write_all(&i64::from(value_balance).to_le_bytes())?;
@@ -921,7 +878,7 @@ fn write_bundle_body<W: Write>(
         })?,
     )?;
     for action in actions {
-        serialization::write_ep_affine(&mut writer, &action.cv.0)?;
+        serialization::write_ep_affine(&mut writer, &action.cv.into())?;
         serialization::write_action_vk(&mut writer, &action.rk.0)?;
     }
     for action in actions {

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -764,16 +764,7 @@ impl<S: StampState> Bundle<S> {
     }
 
     /// Verify the bundle's binding signature and all action signatures.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the bundle has no actions but a nonzero value balance.
     pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), SignatureError> {
-        if self.actions.is_empty() && self.value_balance != ValueBalance::ZERO {
-            // Every construction path already guarantees this.
-            unreachable!("bundle with no actions cannot have nonzero value balance");
-        }
-
         // 1. Derive bvk from public data (validator-side, §4.14)
         let bvk = public::BindingVerificationKey::derive(&self.actions, self.value_balance);
 
@@ -820,10 +811,6 @@ impl ValueBalance {
 
 impl From<ValueBalance> for i64 {
     fn from(balance: ValueBalance) -> Self {
-        assert!(
-            balance.0.unsigned_abs() <= MAX_MONEY,
-            "impossible value balance"
-        );
         balance.0
     }
 }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -285,7 +285,6 @@ impl Plan {
     /// $\mathsf{v\_balance} = \sum_i v_{\text{spend},i} - \sum_j
     /// v_{\text{output},j}$
     ///
-    ///
     /// # Errors
     ///
     /// Fails if the final balance falls outside `-MAX_MONEY..=MAX_MONEY`.
@@ -293,10 +292,10 @@ impl Plan {
     pub fn value_balance(&self) -> Result<ValueBalance, ValueBalanceOverflow> {
         let mut sum = 0i128;
         for plan in &self.spends {
-            sum += i128::from(i64::from(plan.note.value));
+            sum += i128::from(u64::from(plan.note.value));
         }
         for plan in &self.outputs {
-            sum -= i128::from(i64::from(plan.note.value));
+            sum -= i128::from(u64::from(plan.note.value));
         }
         i64::try_from(sum)
             .map_err(|_err| ValueBalanceOverflow)
@@ -808,9 +807,6 @@ pub struct ValueBalance(i64);
 pub struct ValueBalanceOverflow;
 
 impl ValueBalance {
-    /// The zero sum.
-    pub const ZERO: Self = Self(0);
-
     /// The maximum representable value.
     #[expect(
         clippy::as_conversions,
@@ -818,6 +814,8 @@ impl ValueBalance {
         reason = "constant"
     )]
     pub const MAX: Self = Self(MAX_MONEY as i64);
+    /// The zero sum.
+    pub const ZERO: Self = Self(0);
 }
 
 impl From<ValueBalance> for i64 {
@@ -832,6 +830,7 @@ impl From<ValueBalance> for i64 {
 
 impl TryFrom<i64> for ValueBalance {
     type Error = ValueBalanceOverflow;
+
     fn try_from(balance: i64) -> Result<Self, Self::Error> {
         if balance.unsigned_abs() > MAX_MONEY {
             return Err(ValueBalanceOverflow);
@@ -903,7 +902,7 @@ fn read_bundle_body<R: Read>(mut reader: R) -> io::Result<(Vec<Action>, ValueBal
         .map(|(&(cv, rk), &sig)| Action { cv, rk, sig })
         .collect();
 
-    if actions.is_empty() && i64::from(value_balance) != 0 {
+    if actions.is_empty() && value_balance != ValueBalance::ZERO {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "bundle with no actions must have zero value balance",

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     primitives::{ActionDigest, BlockHeight},
     stamp::VerificationError,
+    value,
 };
 
 #[test]
@@ -30,7 +31,7 @@ fn plan_value_balance_sums_spends_and_outputs() {
 
     assert_eq!(
         bundle_plan.value_balance(),
-        Ok(ValueBalance::try_from(100).unwrap())
+        Ok(value::Balance::try_from(100).unwrap())
     );
 }
 
@@ -41,7 +42,7 @@ fn wrong_value_balance_fails_verification() {
     let mut bundle = build_autonome(rng, &wallet, 1000, 700);
     let sighash = mock_sighash(bundle.commitment().unwrap());
 
-    bundle.value_balance = ValueBalance::try_from(999).unwrap();
+    bundle.value_balance = value::Balance::try_from(999).unwrap();
     let err = bundle.verify_signatures(&sighash).unwrap_err();
     let SignatureError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
@@ -49,7 +50,7 @@ fn wrong_value_balance_fails_verification() {
 }
 
 /// No separate range assertion is needed in `verify_signatures`: even a
-/// `ValueBalance` built directly with a magnitude far outside
+/// `value::Balance` built directly with a magnitude far outside
 /// `-MAX_MONEY..=MAX_MONEY` (bypassing `TryFrom`'s range check entirely, the
 /// same way `read_rejects_value_balance_out_of_range` forges an otherwise
 /// unconstructible wire encoding) is caught by the binding signature check
@@ -61,7 +62,7 @@ fn verify_signatures_rejects_out_of_range_value_balance_mutation() {
     let mut bundle = build_autonome(rng, &wallet, 1000, 700);
     let sighash = mock_sighash(bundle.commitment().unwrap());
 
-    bundle.value_balance = ValueBalance(i64::MAX);
+    bundle.value_balance = value::Balance::new_unchecked(i64::MAX);
     let err = bundle.verify_signatures(&sighash).unwrap_err();
     let SignatureError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
@@ -113,7 +114,7 @@ fn sign_reports_global_action_index_on_rk_mismatch() {
     let spend = action::Plan::spend(
         wallet.random_note(200),
         ActionEntropy::random(rng),
-        value::CommitmentTrapdoor::random(rng),
+        value::Trapdoor::random(rng),
         |alpha| ask.derive_action_private(&alpha).derive_action_public(),
     );
 
@@ -121,12 +122,12 @@ fn sign_reports_global_action_index_on_rk_mismatch() {
     let mut output = action::Plan::output(
         wallet.random_note(100),
         ActionEntropy::random(rng),
-        value::CommitmentTrapdoor::random(rng),
+        value::Trapdoor::random(rng),
     );
     let wrong_rk = action::Plan::output(
         wallet.random_note(50),
         ActionEntropy::random(rng),
-        value::CommitmentTrapdoor::random(rng),
+        value::Trapdoor::random(rng),
     )
     .rk;
     output.rk = wrong_rk;
@@ -162,7 +163,7 @@ fn zero_action_bundle_is_valid() {
 
     let bundle = Bundle {
         actions: alloc::vec![],
-        value_balance: ValueBalance::ZERO,
+        value_balance: value::Balance::ZERO,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
         stamp: AggregateId::try_from([1u8; 64]).expect("nonzero id"),
     };
@@ -311,7 +312,7 @@ fn innocent_aggregate_from_two_autonomes() {
 
         Bundle {
             actions: alloc::vec![],
-            value_balance: ValueBalance::ZERO,
+            value_balance: value::Balance::ZERO,
             binding_sig: innocent_plan
                 .derive_bsk_private()
                 .sign(rng, &innocent_sighash),
@@ -654,7 +655,7 @@ fn read_rejects_zero_wtxid() {
         let sighash = mock_sighash(plan.commitment().unwrap());
         let bundle = Bundle {
             actions: alloc::vec![],
-            value_balance: ValueBalance::ZERO,
+            value_balance: value::Balance::ZERO,
             binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
             stamp: AggregateId::try_from([0x42u8; 64]).expect("nonzero id"),
         };
@@ -699,7 +700,7 @@ fn innocent_round_trips_with_nonzero_wtxid() {
 
     let innocent = Bundle {
         actions: alloc::vec![],
-        value_balance: ValueBalance::ZERO,
+        value_balance: value::Balance::ZERO,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
         stamp: AggregateId::try_from([0x42u8; 64]).expect("nonzero id"),
     };
@@ -901,7 +902,7 @@ fn plan_value_balance_accepts_boundary_max_money() {
 
     assert_eq!(
         bundle_plan.value_balance(),
-        Ok(ValueBalance::try_from(i64::try_from(MAX_MONEY).unwrap()).unwrap())
+        Ok(value::Balance::try_from(i64::try_from(MAX_MONEY).unwrap()).unwrap())
     );
 }
 
@@ -915,7 +916,7 @@ fn plan_value_balance_accepts_boundary_negative_max_money() {
 
     assert_eq!(
         bundle_plan.value_balance(),
-        Ok(ValueBalance::try_from(-i64::try_from(MAX_MONEY).unwrap()).unwrap())
+        Ok(value::Balance::try_from(-i64::try_from(MAX_MONEY).unwrap()).unwrap())
     );
 }
 
@@ -928,7 +929,7 @@ fn plan_value_balance_rejects_overflow_above_max_money() {
     let spend_b = spend_plan_at(rng, &wallet, &ask, MAX_MONEY);
     let bundle_plan = Plan::new(alloc::vec![spend_a, spend_b], alloc::vec![]);
 
-    assert_eq!(bundle_plan.value_balance(), Err(ValueBalanceOverflow));
+    assert_eq!(bundle_plan.value_balance(), Err(value::OutOfRange));
     {
         let err = bundle_plan.commitment().unwrap_err();
         let CommitError::BalanceOverflow(_) = err else {
@@ -955,7 +956,7 @@ fn plan_value_balance_rejects_overflow_below_negative_max_money() {
     let (_, _, output_b) = build_output_plan(rng, note_b);
     let bundle_plan = Plan::new(alloc::vec![], alloc::vec![output_a, output_b]);
 
-    assert_eq!(bundle_plan.value_balance(), Err(ValueBalanceOverflow));
+    assert_eq!(bundle_plan.value_balance(), Err(value::OutOfRange));
     {
         let err = bundle_plan.commitment().unwrap_err();
         let CommitError::BalanceOverflow(_) = err else {
@@ -978,7 +979,7 @@ fn read_accepts_value_balance_at_max_money_boundaries() {
     let max_money = i64::try_from(MAX_MONEY).unwrap();
 
     for value_balance in [max_money, -max_money] {
-        let vb = ValueBalance::try_from(value_balance).unwrap();
+        let vb = value::Balance::try_from(value_balance).unwrap();
         let mut bundle = build_autonome(rng, &wallet, 1000, 700);
         bundle.value_balance = vb;
 
@@ -989,9 +990,9 @@ fn read_accepts_value_balance_at_max_money_boundaries() {
     }
 }
 
-/// `ValueBalance::try_from` cannot construct an out-of-range value at all, so
-/// this forges the invalid shape directly on the wire: `valueBalanceTachyon`
-/// is the 8 bytes right after the 1-byte state tag (see the module-level wire
+/// `value::Balance::try_from` cannot construct an out-of-range value at all, so
+/// this forges the invalid shape directly on the wire: `valueBalanceTachyon` is
+/// the 8 bytes right after the 1-byte state tag (see the module-level wire
 /// format documentation), mirroring `read_rejects_zero_wtxid`'s approach of
 /// overwriting valid-encoding bytes to build an otherwise-unconstructible
 /// input.
@@ -1028,7 +1029,7 @@ fn read_rejects_zero_actions_with_nonzero_balance() {
 
     let bundle = Bundle {
         actions: alloc::vec![],
-        value_balance: ValueBalance::try_from(1).unwrap(),
+        value_balance: value::Balance::try_from(1).unwrap(),
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
         stamp: AggregateId::try_from([0x42u8; 64]).expect("nonzero id"),
     };
@@ -1067,7 +1068,7 @@ fn zero_action_bundle_rejects_nonzero_balance() {
 
     let bundle = Bundle {
         actions: alloc::vec![],
-        value_balance: ValueBalance::try_from(1).unwrap(),
+        value_balance: value::Balance::try_from(1).unwrap(),
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
         stamp: AggregateId::try_from([1u8; 64]).expect("nonzero id"),
     };

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -48,6 +48,26 @@ fn wrong_value_balance_fails_verification() {
     };
 }
 
+/// No separate range assertion is needed in `verify_signatures`: even a
+/// `ValueBalance` built directly with a magnitude far outside
+/// `-MAX_MONEY..=MAX_MONEY` (bypassing `TryFrom`'s range check entirely, the
+/// same way `read_rejects_value_balance_out_of_range` forges an otherwise
+/// unconstructible wire encoding) is caught by the binding signature check
+/// alone, same as any other mismatched value.
+#[test]
+fn verify_signatures_rejects_out_of_range_value_balance_mutation() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let mut bundle = build_autonome(rng, &wallet, 1000, 700);
+    let sighash = mock_sighash(bundle.commitment().unwrap());
+
+    bundle.value_balance = ValueBalance(i64::MAX);
+    let err = bundle.verify_signatures(&sighash).unwrap_err();
+    let SignatureError::Binding(_) = err else {
+        panic!("expected SignatureError::Binding, got {err:?}");
+    };
+}
+
 #[test]
 fn stripped_bundle_retains_signatures() {
     let rng = &mut StdRng::seed_from_u64(0);

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -7,28 +7,31 @@ use rand::{SeedableRng as _, rngs::StdRng};
 
 use super::*;
 use crate::{
-    constants::EPOCH_SIZE,
+    constants::{EPOCH_SIZE, MAX_MONEY},
     digest::blake2b::COMMIT_NO_BUNDLE,
     entropy::ActionEntropy,
     fixtures::{
-        PoolSim, WalletSim, action_digests, build_autonome, build_output_stamp, mock_sighash,
-        random_action, random_block, random_block_with, shared_sk,
+        PoolSim, WalletSim, action_digests, build_autonome, build_output_plan, build_output_stamp,
+        mock_sighash, random_action, random_block, random_block_with, shared_sk, spend_witness,
     },
     primitives::{ActionDigest, BlockHeight},
     stamp::VerificationError,
 };
 
 #[test]
-fn value_sum_checked_arithmetic() {
-    let va = note::Value::try_from(100u64).unwrap();
-    let vb = note::Value::try_from(200u64).unwrap();
+fn plan_value_balance_sums_spends_and_outputs() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+    let spend = spend_plan_at(rng, &wallet, &ask, 300);
+    let note = wallet.random_note(200);
+    let (_rcv, _alpha, output) = build_output_plan(rng, note);
+    let bundle_plan = Plan::new(alloc::vec![spend], alloc::vec![output]);
 
-    let sum = (ValueBalance::ZERO + va).unwrap();
-    let total = (sum + vb).unwrap();
-    assert_eq!(i64::try_from(total).unwrap(), 300);
-
-    let diff = (ValueBalance::ZERO - va).unwrap();
-    assert_eq!(i64::try_from(diff).unwrap(), -100);
+    assert_eq!(
+        bundle_plan.value_balance(),
+        Ok(ValueBalance::try_from(100).unwrap())
+    );
 }
 
 #[test]
@@ -38,7 +41,7 @@ fn wrong_value_balance_fails_verification() {
     let mut bundle = build_autonome(rng, &wallet, 1000, 700);
     let sighash = mock_sighash(bundle.commitment().unwrap());
 
-    bundle.value_balance = 999;
+    bundle.value_balance = ValueBalance::try_from(999).unwrap();
     let err = bundle.verify_signatures(&sighash).unwrap_err();
     let SignatureError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
@@ -88,7 +91,7 @@ fn sign_reports_global_action_index_on_rk_mismatch() {
     // A valid spend at global index 0 — derive its rk exactly as `sign` does,
     // so it passes the spend check and signing reaches the outputs.
     let spend = action::Plan::spend(
-        wallet.random_note(rng, 200),
+        wallet.random_note(200),
         ActionEntropy::random(rng),
         value::CommitmentTrapdoor::random(rng),
         |alpha| ask.derive_action_private(&alpha).derive_action_public(),
@@ -96,12 +99,12 @@ fn sign_reports_global_action_index_on_rk_mismatch() {
 
     // An output at global index 1 whose rk is corrupted to a foreign key.
     let mut output = action::Plan::output(
-        wallet.random_note(rng, 100),
+        wallet.random_note(100),
         ActionEntropy::random(rng),
         value::CommitmentTrapdoor::random(rng),
     );
     let wrong_rk = action::Plan::output(
-        wallet.random_note(rng, 50),
+        wallet.random_note(50),
         ActionEntropy::random(rng),
         value::CommitmentTrapdoor::random(rng),
     )
@@ -139,7 +142,7 @@ fn zero_action_bundle_is_valid() {
 
     let bundle = Bundle {
         actions: alloc::vec![],
-        value_balance: 0,
+        value_balance: ValueBalance::ZERO,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
         stamp: AggregateId::try_from([1u8; 64]).expect("nonzero id"),
     };
@@ -288,7 +291,7 @@ fn innocent_aggregate_from_two_autonomes() {
 
         Bundle {
             actions: alloc::vec![],
-            value_balance: 0,
+            value_balance: ValueBalance::ZERO,
             binding_sig: innocent_plan
                 .derive_bsk_private()
                 .sign(rng, &innocent_sighash),
@@ -631,7 +634,7 @@ fn read_rejects_zero_wtxid() {
         let sighash = mock_sighash(plan.commitment().unwrap());
         let bundle = Bundle {
             actions: alloc::vec![],
-            value_balance: 0,
+            value_balance: ValueBalance::ZERO,
             binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
             stamp: AggregateId::try_from([0x42u8; 64]).expect("nonzero id"),
         };
@@ -676,7 +679,7 @@ fn innocent_round_trips_with_nonzero_wtxid() {
 
     let innocent = Bundle {
         actions: alloc::vec![],
-        value_balance: 0,
+        value_balance: ValueBalance::ZERO,
         binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
         stamp: AggregateId::try_from([0x42u8; 64]).expect("nonzero id"),
     };
@@ -850,4 +853,198 @@ fn coverage_check_matches_stamped_action_set() {
             .expect("valid digests"),
         "extra adjunct must mismatch"
     );
+}
+
+/// Build a spend action plan without a pool/anchor: `Plan::spend`'s
+/// `derive_rk` closure recomputes alpha internally, so only `ask` is needed
+/// to derive a matching `rk`.
+fn spend_plan_at(
+    rng: &mut StdRng,
+    wallet: &WalletSim,
+    ask: &private::SpendAuthorizingKey,
+    value: u64,
+) -> action::Plan<effect::Spend> {
+    let note = wallet.random_note(value);
+    let (rcv, theta, _alpha) = spend_witness(rng, &note);
+    action::Plan::spend(note, theta, rcv, |alpha| {
+        ask.derive_action_private(&alpha).derive_action_public()
+    })
+}
+
+#[test]
+fn plan_value_balance_accepts_boundary_max_money() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+    let spend = spend_plan_at(rng, &wallet, &ask, MAX_MONEY);
+    let bundle_plan = Plan::new(alloc::vec![spend], alloc::vec![]);
+
+    assert_eq!(
+        bundle_plan.value_balance(),
+        Ok(ValueBalance::try_from(i64::try_from(MAX_MONEY).unwrap()).unwrap())
+    );
+}
+
+#[test]
+fn plan_value_balance_accepts_boundary_negative_max_money() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let note = wallet.random_note(MAX_MONEY);
+    let (_rcv, _alpha, output) = build_output_plan(rng, note);
+    let bundle_plan = Plan::new(alloc::vec![], alloc::vec![output]);
+
+    assert_eq!(
+        bundle_plan.value_balance(),
+        Ok(ValueBalance::try_from(-i64::try_from(MAX_MONEY).unwrap()).unwrap())
+    );
+}
+
+#[test]
+fn plan_value_balance_rejects_overflow_above_max_money() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+    let spend_a = spend_plan_at(rng, &wallet, &ask, MAX_MONEY);
+    let spend_b = spend_plan_at(rng, &wallet, &ask, MAX_MONEY);
+    let bundle_plan = Plan::new(alloc::vec![spend_a, spend_b], alloc::vec![]);
+
+    assert_eq!(bundle_plan.value_balance(), Err(ValueBalanceOverflow));
+    assert!(matches!(
+        bundle_plan.commitment(),
+        Err(CommitError::BalanceOverflow(_))
+    ));
+    let sighash = [0u8; 32];
+    assert!(matches!(
+        bundle_plan.sign(&sighash, &ask, rng),
+        Err(SignError::BalanceOverflow)
+    ));
+}
+
+#[test]
+fn plan_value_balance_rejects_overflow_below_negative_max_money() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+    let note_a = wallet.random_note(MAX_MONEY);
+    let note_b = wallet.random_note(MAX_MONEY);
+    let (_, _, output_a) = build_output_plan(rng, note_a);
+    let (_, _, output_b) = build_output_plan(rng, note_b);
+    let bundle_plan = Plan::new(alloc::vec![], alloc::vec![output_a, output_b]);
+
+    assert_eq!(bundle_plan.value_balance(), Err(ValueBalanceOverflow));
+    assert!(matches!(
+        bundle_plan.commitment(),
+        Err(CommitError::BalanceOverflow(_))
+    ));
+    let sighash = [0u8; 32];
+    assert!(matches!(
+        bundle_plan.sign(&sighash, &ask, rng),
+        Err(SignError::BalanceOverflow)
+    ));
+}
+
+#[test]
+fn read_accepts_value_balance_at_max_money_boundaries() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let max_money = i64::try_from(MAX_MONEY).unwrap();
+
+    for value_balance in [max_money, -max_money] {
+        let vb = ValueBalance::try_from(value_balance).unwrap();
+        let mut bundle = build_autonome(rng, &wallet, 1000, 700);
+        bundle.value_balance = vb;
+
+        let mut buf = Vec::new();
+        bundle.write(&mut buf).expect("write");
+        let decoded = Bundle::<Stamp>::read(&*buf).expect("read must accept boundary balance");
+        assert_eq!(decoded.value_balance, vb);
+    }
+}
+
+/// `ValueBalance::try_from` cannot construct an out-of-range value at all, so
+/// this forges the invalid shape directly on the wire: `valueBalanceTachyon`
+/// is the 8 bytes right after the 1-byte state tag (see the module-level wire
+/// format documentation), mirroring `read_rejects_zero_wtxid`'s approach of
+/// overwriting valid-encoding bytes to build an otherwise-unconstructible
+/// input.
+#[test]
+fn read_rejects_value_balance_out_of_range() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let max_money = i64::try_from(MAX_MONEY).unwrap();
+
+    for value_balance in [max_money + 1, -max_money - 1] {
+        let bundle = build_autonome(rng, &wallet, 1000, 700);
+
+        let mut buf = Vec::new();
+        bundle.write(&mut buf).expect("write");
+        buf[1..9].copy_from_slice(&value_balance.to_le_bytes());
+
+        let stamp_err = Bundle::<Stamp>::read(&*buf)
+            .expect_err("Bundle::<Stamp>::read must reject out-of-range value balance");
+        assert_eq!(stamp_err.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(stamp_err.to_string(), "value balance out of range");
+
+        let enum_err = TachyonBundle::read(&*buf)
+            .expect_err("TachyonBundle::read must reject out-of-range value balance");
+        assert_eq!(enum_err.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(enum_err.to_string(), "value balance out of range");
+    }
+}
+
+#[test]
+fn read_rejects_zero_actions_with_nonzero_balance() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let plan = Plan::new(alloc::vec![], alloc::vec![]);
+    let sighash = mock_sighash(plan.commitment().unwrap());
+
+    let bundle = Bundle {
+        actions: alloc::vec![],
+        value_balance: ValueBalance::try_from(1).unwrap(),
+        binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
+        stamp: AggregateId::try_from([0x42u8; 64]).expect("nonzero id"),
+    };
+
+    let mut buf = Vec::new();
+    bundle.write(&mut buf).expect("write");
+
+    let adjunct_err = Bundle::<AggregateId>::read(&*buf)
+        .expect_err("Adjunct::read must reject zero actions with nonzero balance");
+    assert_eq!(adjunct_err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(
+        adjunct_err.to_string(),
+        "bundle with no actions must have zero value balance"
+    );
+
+    let enum_err = TachyonBundle::read(&*buf)
+        .expect_err("TachyonBundle::read must reject zero actions with nonzero balance");
+    assert_eq!(enum_err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(
+        enum_err.to_string(),
+        "bundle with no actions must have zero value balance"
+    );
+}
+
+/// Every construction path guarantees "no actions implies zero value
+/// balance", so a violation here can only come from a hand-constructed
+/// `Bundle` that bypasses `Plan`/`read`. `verify_signatures` treats that as
+/// an internal invariant violation (`unreachable!`), not a reachable
+/// `Result::Err`.
+#[test]
+#[should_panic(expected = "bundle with no actions cannot have nonzero value balance")]
+fn zero_action_bundle_rejects_nonzero_balance() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let plan = Plan::new(alloc::vec![], alloc::vec![]);
+    let sighash = mock_sighash(plan.commitment().unwrap());
+
+    let bundle = Bundle {
+        actions: alloc::vec![],
+        value_balance: ValueBalance::try_from(1).unwrap(),
+        binding_sig: plan.derive_bsk_private().sign(rng, &sighash),
+        stamp: AggregateId::try_from([1u8; 64]).expect("nonzero id"),
+    };
+
+    bundle
+        .verify_signatures(&sighash)
+        .expect("signature checks are unreachable: the assert panics first");
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -909,15 +909,19 @@ fn plan_value_balance_rejects_overflow_above_max_money() {
     let bundle_plan = Plan::new(alloc::vec![spend_a, spend_b], alloc::vec![]);
 
     assert_eq!(bundle_plan.value_balance(), Err(ValueBalanceOverflow));
-    assert!(matches!(
-        bundle_plan.commitment(),
-        Err(CommitError::BalanceOverflow(_))
-    ));
+    {
+        let err = bundle_plan.commitment().unwrap_err();
+        let CommitError::BalanceOverflow(_) = err else {
+            panic!("expected CommitError::BalanceOverflow, got {err:?}");
+        };
+    }
     let sighash = [0u8; 32];
-    assert!(matches!(
-        bundle_plan.sign(&sighash, &ask, rng),
-        Err(SignError::BalanceOverflow)
-    ));
+    {
+        let err = bundle_plan.sign(&sighash, &ask, rng).unwrap_err();
+        let SignError::BalanceOverflow = err else {
+            panic!("expected SignError::BalanceOverflow, got {err:?}");
+        };
+    }
 }
 
 #[test]
@@ -932,15 +936,19 @@ fn plan_value_balance_rejects_overflow_below_negative_max_money() {
     let bundle_plan = Plan::new(alloc::vec![], alloc::vec![output_a, output_b]);
 
     assert_eq!(bundle_plan.value_balance(), Err(ValueBalanceOverflow));
-    assert!(matches!(
-        bundle_plan.commitment(),
-        Err(CommitError::BalanceOverflow(_))
-    ));
+    {
+        let err = bundle_plan.commitment().unwrap_err();
+        let CommitError::BalanceOverflow(_) = err else {
+            panic!("expected CommitError::BalanceOverflow, got {err:?}");
+        };
+    }
     let sighash = [0u8; 32];
-    assert!(matches!(
-        bundle_plan.sign(&sighash, &ask, rng),
-        Err(SignError::BalanceOverflow)
-    ));
+    {
+        let err = bundle_plan.sign(&sighash, &ask, rng).unwrap_err();
+        let SignError::BalanceOverflow = err else {
+            panic!("expected SignError::BalanceOverflow, got {err:?}");
+        };
+    }
 }
 
 #[test]
@@ -1027,11 +1035,11 @@ fn read_rejects_zero_actions_with_nonzero_balance() {
 
 /// Every construction path guarantees "no actions implies zero value
 /// balance", so a violation here can only come from a hand-constructed
-/// `Bundle` that bypasses `Plan`/`read`. `verify_signatures` treats that as
-/// an internal invariant violation (`unreachable!`), not a reachable
-/// `Result::Err`.
+/// `Bundle` that bypasses `Plan`/`read`. `verify_signatures` has no special
+/// case for it: the binding signature was produced for the real (zero)
+/// balance, so it simply fails to validate against the `bvk` recomputed from
+/// the forged nonzero balance.
 #[test]
-#[should_panic(expected = "bundle with no actions cannot have nonzero value balance")]
 fn zero_action_bundle_rejects_nonzero_balance() {
     let rng = &mut StdRng::seed_from_u64(0);
     let plan = Plan::new(alloc::vec![], alloc::vec![]);
@@ -1044,7 +1052,8 @@ fn zero_action_bundle_rejects_nonzero_balance() {
         stamp: AggregateId::try_from([1u8; 64]).expect("nonzero id"),
     };
 
-    bundle
-        .verify_signatures(&sighash)
-        .expect("signature checks are unreachable: the assert panics first");
+    let err = bundle.verify_signatures(&sighash).unwrap_err();
+    let SignatureError::Binding(_) = err else {
+        panic!("expected SignatureError::Binding, got {err:?}");
+    };
 }

--- a/crates/tachyon/src/constants.rs
+++ b/crates/tachyon/src/constants.rs
@@ -1,7 +1,7 @@
 //! Protocol-wide non-hash constants.
 
-/// Maximum note value in zatoshis (§5.3 of the protocol spec)
-pub const NOTE_VALUE_MAX: u64 = 2_100_000_000_000_000;
+/// Maximum representable value in zatoshis (§5.3 of the protocol spec).
+pub const MAX_MONEY: u64 = 2_100_000_000_000_000;
 
 const EPOCH_SHIFT: u32 = if cfg!(test) { 4 } else { 12 };
 

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -128,10 +128,10 @@ pub(crate) fn bundle_commitment(action_commit: &[u8; 32], value_balance: i64) ->
 /// two invariants enforced by the paired effecting digest and the proof system,
 /// not by this preimage.
 ///
-/// - The action count is pinned by `action_acc`'s degree: the monic
-///   `∏(X - action_digest_i)` committed in `bundle_commitment` fixes the
-///   number of actions, hence the action-signature block boundary. This is the
-///   role `nActionsOrchard` plays in ZIP 244.
+/// - The action count is pinned by `action_acc`'s degree: the monic `∏(X -
+///   action_digest_i)` committed in `bundle_commitment` fixes the number of
+///   actions, hence the action-signature block boundary. This is the role
+///   `nActionsOrchard` plays in ZIP 244.
 /// - The proof is a compile-time fixed size (`PROOF_SIZE_COMPRESSED`), which
 ///   fixes the `tachygrams || proof` boundary. Nothing on the txid side commits
 ///   to the tachygram count, so the fixed proof size is load-bearing for digest

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -79,11 +79,11 @@ pub fn spend_witness(
     rng: &mut (impl RngCore + CryptoRng),
     note: &Note,
 ) -> (
-    value::CommitmentTrapdoor,
+    value::Trapdoor,
     ActionEntropy,
     ActionRandomizer<effect::Spend>,
 ) {
-    let rcv = value::CommitmentTrapdoor::random(rng);
+    let rcv = value::Trapdoor::random(rng);
     let theta = ActionEntropy::random(rng);
     let alpha = theta.randomizer::<effect::Spend>(note.commitment());
     (rcv, theta, alpha)
@@ -93,11 +93,11 @@ pub fn build_output_plan(
     rng: &mut (impl RngCore + CryptoRng),
     note: Note,
 ) -> (
-    value::CommitmentTrapdoor,
+    value::Trapdoor,
     ActionRandomizer<effect::Output>,
     action::Plan<effect::Output>,
 ) {
-    let rcv = value::CommitmentTrapdoor::random(rng);
+    let rcv = value::Trapdoor::random(rng);
     let theta = ActionEntropy::random(rng);
     let plan = action::Plan::output(note, theta, rcv);
     let alpha = theta.randomizer::<effect::Output>(note.commitment());
@@ -825,7 +825,7 @@ impl WalletSim {
             .or_insert_with(|| StdRng::from_seed(note_stream_seed(pk, value_amount)));
         Note {
             pk,
-            value: note::Value::try_from(value_amount).expect("fixture value in range"),
+            value: value::Positive::try_from(value_amount).expect("fixture value in range"),
             psi: NullifierTrapdoor::random(notes),
             rcm: note::CommitmentTrapdoor::random(notes),
         }
@@ -1003,7 +1003,7 @@ impl WalletSim {
                 self.nf_at(&note, spend_epoch),
                 self.nf_at(&note, spend_epoch.next()),
             ];
-            let rcv = value::CommitmentTrapdoor::random(rng);
+            let rcv = value::Trapdoor::random(rng);
             let theta = ActionEntropy::random(rng);
             let plan = action::Plan::spend(note, theta, rcv, |alpha| {
                 self.pak.ak.derive_action_public(&alpha)
@@ -1015,7 +1015,7 @@ impl WalletSim {
         let output_plans: Vec<action::Plan<effect::Output>> = output_notes
             .into_iter()
             .map(|note| {
-                let rcv = value::CommitmentTrapdoor::random(rng);
+                let rcv = value::Trapdoor::random(rng);
                 let theta = ActionEntropy::random(rng);
                 action::Plan::output(note, theta, rcv)
             })

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -95,6 +95,7 @@ mod tests {
         keys::{NullifierKey, PaymentKey, private},
         note::{self, Note},
         primitives::effect,
+        value,
     };
 
     /// ask, nk, pk derived from the same sk must all be different.
@@ -141,7 +142,7 @@ mod tests {
         let ak = ask.derive_auth_public();
         let note = Note {
             pk: sk.derive_payment_key(),
-            value: note::Value::try_from(1000u64).unwrap(),
+            value: value::Positive::try_from(1000u64).unwrap(),
             psi: note::NullifierTrapdoor::random(rng),
             rcm: note::CommitmentTrapdoor::random(rng),
         };

--- a/crates/tachyon/src/keys/private.rs
+++ b/crates/tachyon/src/keys/private.rs
@@ -276,13 +276,13 @@ impl BindingSigningKey {
     }
 }
 
-impl From<&[value::CommitmentTrapdoor]> for BindingSigningKey {
+impl From<&[value::Trapdoor]> for BindingSigningKey {
     /// BindingAuth signing key is the scalar sum of all value commitment
     /// trapdoors.
     ///
     /// Every Pallas scalar field element, including zero, is a valid binding
     /// signing key. See Zcash protocol §4.14.
-    fn from(trapdoors: &[value::CommitmentTrapdoor]) -> Self {
+    fn from(trapdoors: &[value::Trapdoor]) -> Self {
         let sum: Fq = trapdoors
             .iter()
             .fold(Fq::ZERO, |acc, rcv| acc + Into::<Fq>::into(*rcv));

--- a/crates/tachyon/src/keys/public.rs
+++ b/crates/tachyon/src/keys/public.rs
@@ -7,8 +7,7 @@ use pasta_curves::{EpAffine, group::GroupEncoding as _};
 
 use crate::{
     action::{self, Action},
-    bundle::{self, ValueBalance},
-    reddsa, value,
+    bundle, reddsa, value,
 };
 
 /// The randomized action verification key `rk` — per-action, public.
@@ -62,24 +61,6 @@ impl From<ActionVerificationKey> for EpAffine {
     }
 }
 
-/// Derive the binding verification key from public bundle data.
-///
-/// $$\mathsf{bvk} = \left(\bigoplus_i \mathsf{cv}_i\right) \ominus
-///   \text{ValueCommit}_0\!\left(\mathsf{v\_{balance}}\right)$$
-///
-/// The result should equal $[\mathsf{bsk}]\,\mathcal{R}$ if the signer
-/// constructed the bundle correctly, similar to Orchard's binding key
-/// derivation (Protocol §4.14)
-#[must_use]
-pub fn derive_bvk(
-    action_cvs: impl Iterator<Item = value::Commitment>,
-    value_balance: i64,
-) -> EpAffine {
-    let cv_sum: value::Commitment = action_cvs.sum();
-    let cb0 = value::Commitment::balance(value_balance);
-    EpAffine::from(cv_sum - cb0)
-}
-
 /// Binding verification key $\mathsf{bvk}$ — derived from value
 /// commitments.
 ///
@@ -122,9 +103,10 @@ impl BindingVerificationKey {
     /// result should equal $[\mathsf{bsk}]\,\mathcal{R}$ when the signer
     /// constructed the bundle correctly.
     #[must_use]
-    pub fn derive(actions: &[Action], value_balance: ValueBalance) -> Self {
-        let cvs = actions.iter().map(|action| action.cv);
-        Self::from(derive_bvk(cvs, value_balance.into()))
+    pub fn derive(actions: &[Action], value_balance: value::Balance) -> Self {
+        let cv_sum: value::Commitment = actions.iter().map(|action| action.cv).sum();
+        let cvb = value::Trapdoor::ZERO.commit(value_balance);
+        Self::from(EpAffine::from(cv_sum - cvb))
     }
 
     /// Verify a binding signature against a transaction sighash.

--- a/crates/tachyon/src/keys/public.rs
+++ b/crates/tachyon/src/keys/public.rs
@@ -5,7 +5,11 @@ use core::cmp::Eq as CoreTotalEq;
 use derive_more::{Debug, Display, PartialEq};
 use pasta_curves::{EpAffine, group::GroupEncoding as _};
 
-use crate::{action, action::Action, bundle, reddsa, value};
+use crate::{
+    action::{self, Action},
+    bundle::{self, ValueBalance},
+    reddsa, value,
+};
 
 /// The randomized action verification key `rk` — per-action, public.
 ///
@@ -118,9 +122,9 @@ impl BindingVerificationKey {
     /// result should equal $[\mathsf{bsk}]\,\mathcal{R}$ when the signer
     /// constructed the bundle correctly.
     #[must_use]
-    pub fn derive(actions: &[Action], value_balance: i64) -> Self {
+    pub fn derive(actions: &[Action], value_balance: ValueBalance) -> Self {
         let cvs = actions.iter().map(|action| action.cv);
-        Self::from(derive_bvk(cvs, value_balance))
+        Self::from(derive_bvk(cvs, value_balance.into()))
     }
 
     /// Verify a binding signature against a transaction sighash.

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -10,7 +10,7 @@
 //! | Field | Type | Description |
 //! | ----- | ---- | ----------- |
 //! | `pk`  | [`PaymentKey`] | Recipient's payment key |
-//! | `value`   | [`Value`] | Note value |
+//! | `value`   | [`value::Value`] | Note value |
 //! | `psi` | [`NullifierTrapdoor`] | Nullifier trapdoor ($\psi$) |
 //! | `rcm` | [`CommitmentTrapdoor`] | Note commitment randomness |
 //!
@@ -34,16 +34,16 @@
 //! (e.g. Sinsemilla, Poseidon) depends on what is efficient inside
 //! Ragu circuits and is TBD.
 
-use derive_more::{Debug, Display, Eq as TotalEq, Error, From, Into, PartialEq};
+use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use ff::Field as _;
 use pasta_curves::Fp;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
-    constants::MAX_MONEY,
     digest::poseidon,
     keys::{NullifierKey, PaymentKey},
     primitives::{EpochIndex, Tachygram},
+    value,
 };
 
 /// Nullifier trapdoor ($\psi$) — per-note randomness for nullifier derivation.
@@ -86,73 +86,13 @@ pub struct Note {
     pub pk: PaymentKey,
 
     /// The note value in zatoshis, less than 2.1e15
-    pub value: Value,
+    pub value: value::Positive,
 
     /// The nullifier trapdoor ($\psi$).
     pub psi: NullifierTrapdoor,
 
     /// Note commitment trapdoor ($rcm$).
     pub rcm: CommitmentTrapdoor,
-}
-
-/// A note value in zatoshis. Non-zero and no greater than 2.1e15.
-///
-/// Zero-valued notes are forbidden by construction: a zero-value action
-/// carries no economic meaning. Each PCD step that witnesses a `Note`
-/// *independently* rechecks `value != 0` — the compiler cannot prove the
-/// invariant from inside the circuit, and a compiled proof system sees
-/// only raw field elements without the Rust-level newtype protection.
-///
-/// Use [`Value::try_from`] or [`Value::new`] for fallible construction.
-#[derive(Clone, Copy, Debug, Ord, PartialEq, PartialOrd, TotalEq)]
-pub struct Value(u64);
-
-impl Value {
-    /// The maximum note value (2.1e15 zatoshis).
-    pub const MAX: Self = Self(MAX_MONEY);
-    /// The forbidden zero value.
-    #[cfg(test)]
-    pub const ZERO: Self = Self(0);
-}
-
-impl From<Value> for i64 {
-    fn from(value: Value) -> Self {
-        #[expect(clippy::expect_used, reason = "MAX_MONEY < i64::MAX")]
-        Self::try_from(value.0).expect("note value cannot exceed i64::MAX")
-    }
-}
-
-impl From<Value> for u64 {
-    fn from(value: Value) -> Self {
-        value.0
-    }
-}
-
-/// Error returned when a note value is out of the valid range
-/// `1..=MAX_MONEY`.
-#[derive(Clone, Copy, Debug, Display, Error, PartialEq, TotalEq)]
-#[non_exhaustive]
-pub enum ValueError {
-    /// The value was zero.
-    #[display("note value must be non-zero")]
-    Zero,
-    /// The value exceeds the maximum note value (2.1e15 zatoshis).
-    #[display("note value must not exceed maximum")]
-    Overflow,
-}
-
-impl TryFrom<u64> for Value {
-    type Error = ValueError;
-
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        if value == 0 {
-            return Err(ValueError::Zero);
-        }
-        if value > MAX_MONEY {
-            return Err(ValueError::Overflow);
-        }
-        Ok(Self(value))
-    }
 }
 
 impl Note {
@@ -174,7 +114,7 @@ impl Note {
         Commitment::from(poseidon::note_commitment(
             self.rcm.0,
             self.pk.0,
-            self.value.0,
+            u64::from(self.value),
             self.psi.0,
         ))
     }
@@ -232,24 +172,27 @@ mod tests {
     use rand::{SeedableRng as _, rngs::StdRng};
 
     use super::*;
-    use crate::{constants::MAX_MONEY, keys::private::SpendingKey, primitives::EpochIndex};
+    use crate::{constants::MAX_MONEY, keys::private::SpendingKey, primitives::EpochIndex, value};
 
     /// MAX_MONEY must be accepted (boundary is inclusive).
     #[test]
     fn value_accepts_max() {
-        Value::try_from(MAX_MONEY).unwrap();
+        value::Positive::try_from(MAX_MONEY).unwrap();
     }
 
     /// Anything above MAX_MONEY must be rejected.
     #[test]
     fn value_rejects_overflow() {
-        assert_eq!(Value::try_from(MAX_MONEY + 1), Err(ValueError::Overflow));
+        assert_eq!(
+            value::Positive::try_from(MAX_MONEY + 1),
+            Err(value::OutOfRange)
+        );
     }
 
-    /// Zero must be rejected — notes carry economic value.
+    /// Notes must have nonzero value.
     #[test]
     fn value_rejects_zero() {
-        assert_eq!(Value::try_from(0u64), Err(ValueError::Zero));
+        assert_eq!(value::Positive::try_from(0u64), Err(value::OutOfRange));
     }
 
     /// Different trapdoors produce different commitments.
@@ -261,13 +204,13 @@ mod tests {
 
         let note1 = Note {
             pk,
-            value: Value::try_from(100u64).unwrap(),
+            value: value::Positive::try_from(100u64).unwrap(),
             psi,
             rcm: CommitmentTrapdoor::random(rng),
         };
         let note2 = Note {
             pk,
-            value: Value::try_from(100u64).unwrap(),
+            value: value::Positive::try_from(100u64).unwrap(),
             psi,
             rcm: CommitmentTrapdoor::random(rng),
         };
@@ -284,7 +227,7 @@ mod tests {
         let nk = sk.derive_nullifier_private();
         let note = Note {
             pk: sk.derive_payment_key(),
-            value: Value::try_from(100u64).unwrap(),
+            value: value::Positive::try_from(100u64).unwrap(),
             psi: NullifierTrapdoor::random(rng),
             rcm: CommitmentTrapdoor::random(rng),
         };

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -108,25 +108,22 @@ pub struct Note {
 pub struct Value(u64);
 
 impl Value {
-    pub(crate) const MAX: Self = Self(MAX_MONEY);
+    /// The maximum note value (2.1e15 zatoshis).
+    pub const MAX: Self = Self(MAX_MONEY);
     /// The forbidden zero value.
     #[cfg(test)]
-    pub(crate) const ZERO: Self = Self(0);
+    pub const ZERO: Self = Self(0);
 }
 
 impl From<Value> for i64 {
     fn from(value: Value) -> Self {
-        assert!(value <= Value::MAX, "impossible note value");
-
         #[expect(clippy::expect_used, reason = "MAX_MONEY < i64::MAX")]
-        value.0.try_into().expect("must fit")
+        Self::try_from(value.0).expect("note value cannot exceed i64::MAX")
     }
 }
 
 impl From<Value> for u64 {
     fn from(value: Value) -> Self {
-        assert!(value <= Value::MAX, "impossible note value");
-
         value.0
     }
 }

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -109,11 +109,7 @@ pub struct Value(u64);
 
 impl Value {
     pub(crate) const MAX: Self = Self(MAX_MONEY);
-
-    /// A zero-value note, unconstructible via [`Value::try_from`].
-    ///
-    /// Lets proof-system tests witness an illegal zero-value note to confirm
-    /// the circuit's own `enforce_nonzero` check independently rejects it.
+    /// The forbidden zero value.
     #[cfg(test)]
     pub(crate) const ZERO: Self = Self(0);
 }

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -40,7 +40,7 @@ use pasta_curves::Fp;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
-    constants::NOTE_VALUE_MAX,
+    constants::MAX_MONEY,
     digest::poseidon,
     keys::{NullifierKey, PaymentKey},
     primitives::{EpochIndex, Tachygram},
@@ -104,17 +104,39 @@ pub struct Note {
 /// only raw field elements without the Rust-level newtype protection.
 ///
 /// Use [`Value::try_from`] or [`Value::new`] for fallible construction.
-#[derive(Clone, Copy, Debug, Into, PartialEq, TotalEq)]
+#[derive(Clone, Copy, Debug, Ord, PartialEq, PartialOrd, TotalEq)]
 pub struct Value(u64);
 
 impl Value {
-    /// The forbidden zero value.
+    pub(crate) const MAX: Self = Self(MAX_MONEY);
+
+    /// A zero-value note, unconstructible via [`Value::try_from`].
+    ///
+    /// Lets proof-system tests witness an illegal zero-value note to confirm
+    /// the circuit's own `enforce_nonzero` check independently rejects it.
     #[cfg(test)]
     pub(crate) const ZERO: Self = Self(0);
 }
 
+impl From<Value> for i64 {
+    fn from(value: Value) -> Self {
+        assert!(value <= Value::MAX, "impossible note value");
+
+        #[expect(clippy::expect_used, reason = "MAX_MONEY < i64::MAX")]
+        value.0.try_into().expect("must fit")
+    }
+}
+
+impl From<Value> for u64 {
+    fn from(value: Value) -> Self {
+        assert!(value <= Value::MAX, "impossible note value");
+
+        value.0
+    }
+}
+
 /// Error returned when a note value is out of the valid range
-/// `1..=NOTE_VALUE_MAX`.
+/// `1..=MAX_MONEY`.
 #[derive(Clone, Copy, Debug, Display, Error, PartialEq, TotalEq)]
 #[non_exhaustive]
 pub enum ValueError {
@@ -133,20 +155,10 @@ impl TryFrom<u64> for Value {
         if value == 0 {
             return Err(ValueError::Zero);
         }
-        if value > NOTE_VALUE_MAX {
+        if value > MAX_MONEY {
             return Err(ValueError::Overflow);
         }
         Ok(Self(value))
-    }
-}
-
-#[expect(
-    clippy::expect_used,
-    reason = "Value construction enforces NOTE_VALUE_MAX < i64::MAX"
-)]
-impl From<Value> for i64 {
-    fn from(value: Value) -> Self {
-        Self::try_from(value.0).expect("Value invariant guarantees it fits in i64")
     }
 }
 
@@ -227,21 +239,18 @@ mod tests {
     use rand::{SeedableRng as _, rngs::StdRng};
 
     use super::*;
-    use crate::{constants::NOTE_VALUE_MAX, keys::private::SpendingKey, primitives::EpochIndex};
+    use crate::{constants::MAX_MONEY, keys::private::SpendingKey, primitives::EpochIndex};
 
-    /// NOTE_VALUE_MAX must be accepted (boundary is inclusive).
+    /// MAX_MONEY must be accepted (boundary is inclusive).
     #[test]
     fn value_accepts_max() {
-        Value::try_from(NOTE_VALUE_MAX).unwrap();
+        Value::try_from(MAX_MONEY).unwrap();
     }
 
-    /// Anything above NOTE_VALUE_MAX must be rejected.
+    /// Anything above MAX_MONEY must be rejected.
     #[test]
     fn value_rejects_overflow() {
-        assert_eq!(
-            Value::try_from(NOTE_VALUE_MAX + 1),
-            Err(ValueError::Overflow)
-        );
+        assert_eq!(Value::try_from(MAX_MONEY + 1), Err(ValueError::Overflow));
     }
 
     /// Zero must be rejected — notes carry economic value.

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -67,12 +67,12 @@ mod tests {
         let sk = private::SpendingKey::random(rng);
         let note = Note {
             pk: sk.derive_payment_key(),
-            value: note::Value::try_from(val).unwrap(),
+            value: value::Positive::try_from(val).unwrap(),
             psi: note::NullifierTrapdoor::random(rng),
             rcm: note::CommitmentTrapdoor::random(rng),
         };
-        let rcv = value::CommitmentTrapdoor::random(rng);
-        let cv = rcv.commit(i64::from(note.value));
+        let rcv = value::Trapdoor::random(rng);
+        let cv = rcv.commit(note.value);
         let theta = ActionEntropy::random(rng);
         let alpha = theta.randomizer::<effect::Output>(note.commitment());
         let rk = private::ActionSigningKey::new(&alpha).derive_action_public();
@@ -95,11 +95,9 @@ mod tests {
     /// Identity cv is rejected.
     #[test]
     fn digest_rejects_identity_cv() {
-        use pasta_curves::group::prime::PrimeCurveAffine as _;
-
         let rng = &mut StdRng::seed_from_u64(0);
         let (_, rk) = make_action_parts(rng, 500);
-        let cv = value::Commitment::from(EpAffine::identity());
+        let cv = value::Commitment::default();
         assert!(matches!(
             ActionDigest::new(cv, rk),
             Err(ActionDigestError::IdentityCv)

--- a/crates/tachyon/src/primitives/effect.rs
+++ b/crates/tachyon/src/primitives/effect.rs
@@ -44,7 +44,8 @@ impl Effect for Spend {
     }
 
     fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment {
-        rcv.commit(i64::from(value))
+        let raw: i64 = value.into();
+        rcv.commit(raw)
     }
 }
 
@@ -54,6 +55,7 @@ impl Effect for Output {
     }
 
     fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment {
-        rcv.commit(-i64::from(value))
+        let raw: i64 = value.into();
+        rcv.commit(-raw)
     }
 }

--- a/crates/tachyon/src/primitives/effect.rs
+++ b/crates/tachyon/src/primitives/effect.rs
@@ -44,8 +44,7 @@ impl Effect for Spend {
     }
 
     fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment {
-        let raw: i64 = value.into();
-        rcv.commit(raw)
+        rcv.commit(i64::from(value))
     }
 }
 
@@ -55,7 +54,6 @@ impl Effect for Output {
     }
 
     fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment {
-        let raw: i64 = value.into();
-        rcv.commit(-raw)
+        rcv.commit(-i64::from(value))
     }
 }

--- a/crates/tachyon/src/primitives/effect.rs
+++ b/crates/tachyon/src/primitives/effect.rs
@@ -27,7 +27,7 @@ pub trait Effect: sealed::Sealed + 'static {
 
     /// Commit to this effect's signed value contribution using the given
     /// trapdoor.
-    fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment;
+    fn commit_value(rcv: value::Trapdoor, value: value::Positive) -> value::Commitment;
 }
 
 /// Spend effect marker.
@@ -43,9 +43,8 @@ impl Effect for Spend {
         Fq::from_uniform_bytes(&blake2b::alpha_spend(&theta.0, &Fp::from(cm).to_repr()))
     }
 
-    fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment {
-        let raw: i64 = value.into();
-        rcv.commit(raw)
+    fn commit_value(rcv: value::Trapdoor, value: value::Positive) -> value::Commitment {
+        rcv.commit(value)
     }
 }
 
@@ -54,8 +53,7 @@ impl Effect for Output {
         Fq::from_uniform_bytes(&blake2b::alpha_output(&theta.0, &Fp::from(cm).to_repr()))
     }
 
-    fn commit_value(rcv: value::CommitmentTrapdoor, value: note::Value) -> value::Commitment {
-        let raw: i64 = value.into();
-        rcv.commit(-raw)
+    fn commit_value(rcv: value::Trapdoor, value: value::Positive) -> value::Commitment {
+        rcv.commit(-value)
     }
 }

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -141,19 +141,11 @@ pub enum VerificationError {
 pub struct Plan {
     spends: Vec<(
         (value::Commitment, public::ActionVerificationKey),
-        (
-            ActionRandomizer<effect::Spend>,
-            Note,
-            value::CommitmentTrapdoor,
-        ),
+        (ActionRandomizer<effect::Spend>, Note, value::Trapdoor),
     )>,
     outputs: Vec<(
         (value::Commitment, public::ActionVerificationKey),
-        (
-            ActionRandomizer<effect::Output>,
-            Note,
-            value::CommitmentTrapdoor,
-        ),
+        (ActionRandomizer<effect::Output>, Note, value::Trapdoor),
     )>,
     anchor: Anchor,
 }
@@ -164,19 +156,11 @@ impl Plan {
     pub const fn new(
         spends: Vec<(
             (value::Commitment, public::ActionVerificationKey),
-            (
-                ActionRandomizer<effect::Spend>,
-                Note,
-                value::CommitmentTrapdoor,
-            ),
+            (ActionRandomizer<effect::Spend>, Note, value::Trapdoor),
         )>,
         outputs: Vec<(
             (value::Commitment, public::ActionVerificationKey),
-            (
-                ActionRandomizer<effect::Output>,
-                Note,
-                value::CommitmentTrapdoor,
-            ),
+            (ActionRandomizer<effect::Output>, Note, value::Trapdoor),
         )>,
         anchor: Anchor,
     ) -> Self {
@@ -318,7 +302,7 @@ impl Stamp {
     /// and placed on the stamp for data availability.
     pub fn prove_output<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
-        rcv: value::CommitmentTrapdoor,
+        rcv: value::Trapdoor,
         alpha: ActionRandomizer<effect::Output>,
         note: Note,
         anchor: Anchor,

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -47,7 +47,7 @@ impl Header for SpendHeader {
         (
             vec![Fp::from(cm), Fp::from(present_nf), Fp::from(anchor)],
             Vec::new(),
-            vec![Ep::from(cv.0), Ep::from(EpAffine::from(rk))],
+            vec![Ep::from(cv), EpAffine::from(rk).into()],
             Vec::new(),
         )
     }
@@ -70,7 +70,7 @@ impl Step for SpendBind {
     /// `(note, rcv, alpha, pak)`.
     type Witness<'source> = (
         Note,
-        value::CommitmentTrapdoor,
+        value::Trapdoor,
         ActionRandomizer<effect::Spend>,
         ProofAuthorizingKey,
     );
@@ -104,7 +104,7 @@ impl Step for SpendBind {
             "SpendBind: note does not match the spendable lineage",
         )?;
 
-        let cv = rcv.commit(i64::from(note.value));
+        let cv = rcv.commit(note.value);
         let rk = pak.ak.derive_action_public(&alpha);
 
         Ok(((cm, (cv, rk), present_nf, anchor), ()))

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -12,7 +12,7 @@ use ragu::{
 
 use super::spendable::SpendableHeader;
 use crate::{
-    constants::NOTE_VALUE_MAX,
+    constants::MAX_MONEY,
     entropy::ActionRandomizer,
     keys::{ProofAuthorizingKey, public},
     note::{self, Note, Nullifier},
@@ -88,7 +88,7 @@ impl Step for SpendBind {
             Fp::from(u64::from(note.value)),
             "SpendBind: zero-value note",
         )?;
-        if u64::from(note.value) > NOTE_VALUE_MAX {
+        if u64::from(note.value) > MAX_MONEY {
             return Err(ragu::Error::InvalidWitness(
                 "SpendBind: note value exceeds maximum".into(),
             ));

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -69,7 +69,7 @@ impl Step for OutputStamp {
     type Right = ();
     /// `(rcv, alpha, note, anchor)`.
     type Witness<'source> = (
-        value::CommitmentTrapdoor,
+        value::Trapdoor,
         ActionRandomizer<effect::Output>,
         Note,
         Anchor,
@@ -100,7 +100,7 @@ impl Step for OutputStamp {
                 "OutputStamp: note value exceeds maximum".into(),
             ));
         }
-        let cv = rcv.commit(-i64::from(note.value));
+        let cv = rcv.commit(-note.value);
         let rk = private::ActionSigningKey::new(&alpha).derive_action_public();
         let action_digest = ActionDigest::new(cv, rk).map_err(|_err| {
             ragu::Error::InvalidWitness("OutputStamp: action digest construction failed".into())

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -13,7 +13,7 @@ use ragu::{
 use super::{delegation::NullifierHeader, pool::AnchorChain, spend::SpendHeader};
 use crate::{
     ActionSetPoly, TachygramSetPoly,
-    constants::NOTE_VALUE_MAX,
+    constants::MAX_MONEY,
     entropy::ActionRandomizer,
     keys::private,
     note::{Note, Nullifier},
@@ -95,7 +95,7 @@ impl Step for OutputStamp {
             Fp::from(u64::from(note.value)),
             "OutputStamp: zero-value note",
         )?;
-        if u64::from(note.value) > NOTE_VALUE_MAX {
+        if u64::from(note.value) > MAX_MONEY {
             return Err(ragu::Error::InvalidWitness(
                 "OutputStamp: note value exceeds maximum".into(),
             ));

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -491,7 +491,7 @@ fn spend_bind_rejects_invalid_inputs() {
     let spend_epoch = height.epoch();
 
     let phantom = Note {
-        value: note::Value::try_from(999_999u64).expect("test value in range"),
+        value: value::Positive::try_from(999_999u64).expect("test value in range"),
         rcm: note::CommitmentTrapdoor::random(rng),
         ..note
     };
@@ -503,7 +503,7 @@ fn spend_bind_rejects_invalid_inputs() {
         "shared psi yields shared nullifiers"
     );
 
-    let wrong_value = note::Value::try_from(999_999u64).expect("test value in range");
+    let wrong_value = value::Positive::try_from(999_999u64).expect("test value in range");
     assert_ne!(u64::from(wrong_value), u64::from(note.value));
 
     let cases = [
@@ -619,7 +619,7 @@ fn spend_stamp_rejects_identity_cv() {
 
     let real_spend = honest_spend_bind(rng, &user, &note, spendable_pcd);
     let (cm, (_real_cv, real_rk), present_nf, anchor) = *real_spend.data();
-    let identity_cv = value::Commitment::balance(0);
+    let identity_cv = value::Commitment::default();
     let forged_spend = real_spend.proof().clone().carry::<spend::SpendHeader>((
         cm,
         (identity_cv, real_rk),
@@ -650,13 +650,13 @@ fn step_rejects_zero_value_note() {
 
     let zero_note = Note {
         pk: user.pak.derive_payment_key(),
-        value: note::Value::ZERO,
+        value: value::Positive::new_unchecked(0),
         psi: note::NullifierTrapdoor::random(rng),
         rcm: note::CommitmentTrapdoor::random(rng),
     };
 
     {
-        let out_rcv = value::CommitmentTrapdoor::random(rng);
+        let out_rcv = value::Trapdoor::random(rng);
         let out_theta = ActionEntropy::random(rng);
         let out_alpha = out_theta.randomizer::<effect::Output>(zero_note.commitment());
         let out_anchor = PoolSim::genesis(rng).anchor();
@@ -689,7 +689,7 @@ fn step_rejects_zero_value_note() {
                 spend::SpendBind,
                 (
                     Note {
-                        value: note::Value::ZERO,
+                        value: value::Positive::new_unchecked(0),
                         ..note
                     },
                     rcv,
@@ -786,7 +786,7 @@ fn notes_with_shared_psi_share_nullifiers() {
     let user = WalletSim::new(shared_sk());
     let note_a = user.random_note(500);
     let note_b = Note {
-        value: note::Value::try_from(700u64).expect("test value in range"),
+        value: value::Positive::try_from(700u64).expect("test value in range"),
         rcm: note::CommitmentTrapdoor::random(rng),
         ..note_a
     };
@@ -1661,7 +1661,7 @@ fn spendable_lift_rejects_wrong_cm() {
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(500);
     let phantom = Note {
-        value: note::Value::try_from(700u64).expect("test value in range"),
+        value: value::Positive::try_from(700u64).expect("test value in range"),
         rcm: note::CommitmentTrapdoor::random(rng),
         ..note
     };

--- a/crates/tachyon/src/value.rs
+++ b/crates/tachyon/src/value.rs
@@ -1,157 +1,253 @@
-//! Value commitments and related types.
-//!
-//! A value commitment hides the value transferred in an action:
-//! `cv = [v]V + [rcv]R` where `rcv` is the [`CommitmentTrapdoor`].
+//! Value commitments and bounded value types.
 
-use core::{iter, ops, ops::Neg as _};
-
-use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
-use ff::Field as _;
-use lazy_static::lazy_static;
-use pasta_curves::{
-    Ep, EpAffine, Fq,
-    arithmetic::CurveExt as _,
-    group::{GroupEncoding as _, prime::PrimeCurveAffine as _},
-    pallas,
+use core::{
+    cmp,
+    ops::{self, Neg as _},
 };
+
+use derive_more::{Add, Debug, Display, Eq as TotalEq, Error, From, Into, PartialEq, Sub, Sum};
+use ff::Field as _;
+use group::Curve as _;
+use lazy_static::lazy_static;
+use pasta_curves::{Ep, EpAffine, Fq, arithmetic::CurveExt as _};
 use rand_core::{CryptoRng, RngCore};
 
-/// Hash-to-curve domain for value commitment generators $\mathcal{V}$ and
-/// $\mathcal{R}$. Shared with Orchard to reuse `reddsa::orchard::Binding` —
-/// same generators, same basepoint, same binding signature verification.
+use crate::constants::MAX_MONEY;
+
+/// Alias for [`ValueTrapdoor`].
+pub type Trapdoor = ValueTrapdoor;
+
+/// Alias for [`ValueCommitment`].
+pub type Commitment = ValueCommitment;
+
+/// An integer bounded to `-MAX_MONEY..=MAX_MONEY`.
+pub type Balance = Value<{ -MAX_MONEY.cast_signed() }, { MAX_MONEY.cast_signed() }>;
+
+/// A nonzero positive integer not greater than `MAX_MONEY`.
+pub type Positive = Value<1, { MAX_MONEY.cast_signed() }>;
+
+/// A nonzero negative integer not less than `-MAX_MONEY`.
+pub type Negative = Value<{ -MAX_MONEY.cast_signed() }, -1>;
+
+/// Shared with Orchard (§5.4.8.3).
 const VALUE_COMMITMENT_DOMAIN: &str = "z.cash:Orchard-cv";
 
 lazy_static! {
     /// Generator $\mathcal{V}$ for value commitments.
-    static ref VALUE_COMMIT_V: pallas::Point =
-        pallas::Point::hash_to_curve(VALUE_COMMITMENT_DOMAIN)(b"v");
+    static ref VALUE_COMMIT_V: Ep = Ep::hash_to_curve(VALUE_COMMITMENT_DOMAIN)(b"v");
 
     /// Generator $\mathcal{R}$ for value commitments and binding signatures.
-    static ref VALUE_COMMIT_R: pallas::Point =
-        pallas::Point::hash_to_curve(VALUE_COMMITMENT_DOMAIN)(b"r");
+    static ref VALUE_COMMIT_R: Ep = Ep::hash_to_curve(VALUE_COMMITMENT_DOMAIN)(b"r");
 }
 
-/// Value commitment trapdoor $\mathsf{rcv}$ — the randomness in a
-/// Pedersen commitment.
+/// Entropy for a value commitment.
 ///
-/// Each action gets a fresh trapdoor:
-/// $\mathsf{cv} = [v]\,\mathcal{V} + [\mathsf{rcv}]\,\mathcal{R}$.
+/// Each action gets a fresh trapdoor, to commit its value secretly.
+/// $\mathsf{cv} = \[v\]\,\mathcal{V} + \[\mathsf{rcv}\]\,\mathcal{R}$.
 ///
-/// The binding signing key is the scalar sum of trapdoors:
+/// The bundle's binding signing key is the scalar sum of trapdoors:
 /// $\mathsf{bsk} = \boxplus_i \mathsf{rcv}_i$
 /// ($\mathbb{F}_q$, Pallas scalar field).
-///
-/// ## Type representation
-///
-/// An $\mathbb{F}_q$ element (Pallas scalar field, 32 bytes). Lives
-/// in the scalar field because $\mathsf{rcv}$ is used as a scalar in
-/// point multiplication $[\mathsf{rcv}]\,\mathcal{R}$.
-#[derive(Clone, Copy, Debug, Into)]
-pub struct CommitmentTrapdoor(#[debug(skip)] Fq);
+#[derive(Clone, Copy, Debug, Default, Into)]
+#[expect(clippy::module_name_repetitions, reason = "deliberate name")]
+pub struct ValueTrapdoor(#[debug(skip)] Fq);
 
-impl CommitmentTrapdoor {
-    /// Generate a fresh random trapdoor.
+impl Trapdoor {
+    /// The zero trapdoor.
+    pub const ZERO: Self = Self(Fq::ZERO);
+
+    /// Generate a random trapdoor.
     pub fn random<RNG: RngCore + CryptoRng>(rng: &mut RNG) -> Self {
         Self(Fq::random(rng))
     }
 
-    /// Commit to a value with this trapdoor.
+    /// Commit to a given value with this trapdoor.
     ///
-    /// $$\mathsf{cv} = [v]\,\mathcal{V} + [\mathsf{rcv}]\,\mathcal{R}$$
+    /// $$\mathsf{cv} = \[v\]\,\mathcal{V} + \[\mathsf{rcv}\]\,\mathcal{R}$$
     ///
-    /// Positive $v$ for spends (balance contributed), negative for
-    /// outputs (balance exhausted).
+    /// where $\mathcal{V}$, $\mathcal{R}$ are generator points shared with
+    /// Orchard (§5.4.8.3).
     #[must_use]
-    pub fn commit(self, raw_value: i64) -> Commitment {
-        assert_ne!(self.0, Fq::ZERO, "commitment trapdoor should not be zero");
-
-        let value_abs: Fq = Fq::from(raw_value.unsigned_abs());
-        let value_fq = if raw_value >= 0 {
-            value_abs
-        } else {
-            value_abs.neg()
-        };
-
-        let committed: EpAffine = {
-            let commit_value: Ep = *VALUE_COMMIT_V * value_fq;
-            let commit_trapdoor: Ep = *VALUE_COMMIT_R * self.0;
-            (commit_value + commit_trapdoor).into()
-        };
-
-        Commitment(committed)
+    pub fn commit<const MIN: i64, const MAX: i64>(self, value: Value<MIN, MAX>) -> Commitment {
+        let commit_value = *VALUE_COMMIT_V * Fq::from(value);
+        let commit_trapdoor = *VALUE_COMMIT_R * self.0;
+        ValueCommitment(commit_value + commit_trapdoor)
     }
 }
 
-/// A value commitment for a Tachyon action.
+/// A value commitment for Tachyon.
 ///
-/// Commits to the value being transferred in an action without
-/// revealing it. This is a Pedersen commitment (curve point) used in
-/// value balance verification.
+/// $$\mathsf{cv} = \[v\]\,\mathcal{V} + \[\mathsf{rcv}\]\,\mathcal{R}$$
 ///
-/// $$\mathsf{cv} = [v]\,\mathcal{V} + [\mathsf{rcv}]\,\mathcal{R}$$
-///
-/// where $v$ is the value, $\mathsf{rcv}$ is the randomness
-/// ([`CommitmentTrapdoor`]), and $\mathcal{V}$, $\mathcal{R}$ are
-/// generator points hashed-to-curve under the Orchard `cv` domain
-/// (§5.4.8.3).
-///
-/// ## Type representation
-///
-/// An EpAffine (Pallas affine curve point, 32 compressed bytes).
-#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
-pub struct Commitment(#[debug(skip)] pub(super) EpAffine);
+/// where $\mathcal{V}$, $\mathcal{R}$ are generator points
+/// shared with Orchard (§5.4.8.3).
+#[derive(Add, Clone, Copy, Debug, Default, From, Into, PartialEq, Sub, Sum, TotalEq)]
+#[expect(clippy::module_name_repetitions, reason = "deliberate name")]
+pub struct ValueCommitment(#[debug(skip)] Ep);
 
-impl Commitment {
-    /// Create the value balance commitment
-    /// $\text{ValueCommit}_0(\mathsf{v\_{balance}})$.
+impl From<EpAffine> for Commitment {
+    fn from(value: EpAffine) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Commitment> for EpAffine {
+    fn from(value: Commitment) -> Self {
+        value.0.to_affine()
+    }
+}
+
+/// A value bounded to `MIN..=MAX` (inclusive), backed by `i64`.
+///
+/// This could be replaced with `ranged_integers` if it was stable.
+#[derive(Clone, Copy, Debug, Into, Ord, PartialEq, PartialOrd, TotalEq)]
+pub struct Value<const MIN: i64, const MAX: i64>(i64);
+
+impl From<Negative> for Balance {
+    fn from(value: Negative) -> Self {
+        Self(value.0)
+    }
+}
+
+impl From<Positive> for Balance {
+    fn from(value: Positive) -> Self {
+        Self(value.0)
+    }
+}
+
+/// Error returned when a value falls outside its type's bound.
+#[derive(Clone, Copy, Debug, Display, Error, PartialEq, TotalEq)]
+#[display("value not in range")]
+pub struct OutOfRange;
+
+impl<const MIN: i64, const MAX: i64> Default for Value<MIN, MAX> {
+    // Do not derive. This manual impl will hit the const assert.
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<const MIN: i64, const MAX: i64> Value<MIN, MAX> {
+    /// The largest representable value within range.
+    pub const MAX: Self = Self(MAX);
+    /// The smallest representable value within range.
+    pub const MIN: Self = Self(MIN);
+    /// The zero value, if it is valid. Checked at compile time.
     ///
-    /// $$\text{ValueCommit}_0(v) = [v]\,\mathcal{V} + [0]\,\mathcal{R}
-    ///   = [v]\,\mathcal{V}$$
+    /// ```compile_fail
+    /// # use zcash_tachyon::value::Value;
+    /// let _ = Value::<1, 2>::ZERO; // does not compile
+    /// ```
+    pub const ZERO: Self = {
+        assert!(
+            MIN <= 0 && 0 <= MAX,
+            "Value::<MIN, MAX>::ZERO requires MIN <= 0 <= MAX"
+        );
+        Self(0)
+    };
+
+    /// Negate the value into the negative range.
     ///
-    /// This is a **deterministic** commitment with zero randomness.
-    /// Used by validators to derive the binding verification key:
-    ///
-    /// $$\mathsf{bvk} = \left(\bigoplus_i \mathsf{cv}_i\right)
-    ///   \ominus \text{ValueCommit}_0(\mathsf{v\_{balance}})$$
+    /// This isn't a `Neg` impl because const generic expressions are unstable.
     #[must_use]
-    pub fn balance(value: i64) -> Self {
-        let value_abs: Fq = Fq::from(value.unsigned_abs());
-        let value_fq = if value >= 0 {
-            value_abs
+    pub const fn negate<const NEG_MAX: i64, const NEG_MIN: i64>(self) -> Value<NEG_MAX, NEG_MIN> {
+        const {
+            assert!(
+                NEG_MAX == -MAX && NEG_MIN == -MIN,
+                "NEG_MAX must be -MAX and NEG_MIN must be -MIN"
+            );
+        }
+        Value(-self.0)
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn new_unchecked(value: i64) -> Self {
+        Self(value)
+    }
+}
+
+impl<const MIN: i64, const MAX: i64> TryFrom<i64> for Value<MIN, MAX> {
+    type Error = OutOfRange;
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        if MIN <= value && value <= MAX {
+            Ok(Self(value))
         } else {
-            value_abs.neg()
-        };
-        Self((*VALUE_COMMIT_V * value_fq).into())
+            Err(OutOfRange)
+        }
     }
 }
 
-impl From<Commitment> for [u8; 32] {
-    fn from(cv: Commitment) -> Self {
-        cv.0.to_bytes()
+impl<const MIN: i64, const MAX: i64> TryFrom<u64> for Value<MIN, MAX> {
+    type Error = OutOfRange;
+
+    fn try_from(u_value: u64) -> Result<Self, Self::Error> {
+        Self::try_from(i64::try_from(u_value).map_err(|_err| OutOfRange)?)
     }
 }
 
-impl ops::Add for Commitment {
+// Some literals are i32 unless explicitly named as i64, so this helps.
+impl<const MIN: i64, const MAX: i64> TryFrom<i32> for Value<MIN, MAX> {
+    type Error = OutOfRange;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Self::try_from(i64::from(value))
+    }
+}
+
+impl<const MIN: i64, const MAX: i64> TryFrom<i128> for Value<MIN, MAX> {
+    type Error = OutOfRange;
+
+    fn try_from(value: i128) -> Result<Self, Self::Error> {
+        Self::try_from(i64::try_from(value).map_err(|_err| OutOfRange)?)
+    }
+}
+
+impl<const MIN: i64, const MAX: i64> From<Value<MIN, MAX>> for i128 {
+    fn from(value: Value<MIN, MAX>) -> Self {
+        Self::from(value.0)
+    }
+}
+
+impl<const MAX: i64> From<Value<1, MAX>> for u64 {
+    fn from(value: Value<1, MAX>) -> Self {
+        value.0.unsigned_abs()
+    }
+}
+
+impl<const MIN: i64, const MAX: i64> From<Value<MIN, MAX>> for Fq {
+    /// Signed value as a Pallas scalar, for use as the `V`-component
+    /// exponent in a value commitment.
+    fn from(value: Value<MIN, MAX>) -> Self {
+        match value.0.cmp(&0) {
+            cmp::Ordering::Equal => Self::ZERO,
+            cmp::Ordering::Greater => Self::from(value.0.unsigned_abs()),
+            cmp::Ordering::Less => Self::from(value.0.unsigned_abs()).neg(),
+        }
+    }
+}
+
+impl ops::Neg for Balance {
     type Output = Self;
 
-    fn add(self, rhs: Self) -> Self::Output {
-        Self((self.0 + rhs.0).into())
+    fn neg(self) -> Self {
+        self.negate()
     }
 }
 
-impl ops::Sub for Commitment {
-    type Output = Self;
+impl ops::Neg for Negative {
+    type Output = Positive;
 
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self((self.0 - rhs.0).into())
+    fn neg(self) -> Self::Output {
+        self.negate()
     }
 }
 
-impl iter::Sum for Commitment {
-    /// $\bigoplus_i \mathsf{cv}_i$ — point addition over all value
-    /// commitments. Identity element is the point at infinity.
-    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(Self(EpAffine::identity()), |acc, cv| acc + cv)
+impl ops::Neg for Positive {
+    type Output = Negative;
+
+    fn neg(self) -> Self::Output {
+        self.negate()
     }
 }
 
@@ -161,11 +257,9 @@ mod tests {
 
     use super::*;
 
-    /// balance(0) must be the identity point — the V-component cancels
-    /// and the R-component has zero scalar.
     #[test]
     fn balance_zero_is_identity() {
-        assert_eq!(Commitment::balance(0), Commitment(EpAffine::identity()));
+        assert_eq!(Trapdoor::ZERO.commit(Balance::ZERO), Commitment::default());
     }
 
     /// The binding property: `cv_a + cv_b - balance(a+b) = [rcv_a + rcv_b]R`.
@@ -173,32 +267,27 @@ mod tests {
     #[test]
     fn commit_homomorphic_binding_property() {
         let rng = &mut StdRng::seed_from_u64(0);
-        let rcv_a = CommitmentTrapdoor::random(rng);
-        let cv_a = rcv_a.commit(100);
-        let rcv_b = CommitmentTrapdoor::random(rng);
-        let cv_b = rcv_b.commit(200);
+        let rcv_a = Trapdoor::random(rng);
+        let cv_a = rcv_a.commit(Balance::try_from(100).unwrap());
+        let rcv_b = Trapdoor::random(rng);
+        let cv_b = rcv_b.commit(Balance::try_from(200).unwrap());
 
-        let remainder = cv_a + cv_b - Commitment::balance(300);
+        let remainder = cv_a + cv_b - Trapdoor::ZERO.commit(Balance::try_from(300).unwrap());
 
         let rcv_sum: Fq = Into::<Fq>::into(rcv_a) + Into::<Fq>::into(rcv_b);
-        let expected: EpAffine = (*VALUE_COMMIT_R * rcv_sum).into();
 
-        assert_eq!(remainder, Commitment(expected));
+        assert_eq!(remainder, ValueCommitment(*VALUE_COMMIT_R * rcv_sum));
     }
 
     #[test]
     fn debug_value_trapdoor_redacts_scalar() {
-        let rcv = CommitmentTrapdoor(Fq::from(0xFACEu64));
-        let dbg = alloc::format!("{rcv:?}");
-        assert!(dbg.contains("CommitmentTrapdoor"), "must name the type");
-        assert!(!dbg.contains("FACE"), "must not leak scalar");
-        assert!(!dbg.contains("64206"), "must not leak decimal value");
+        let rcv = ValueTrapdoor(Fq::from(0xFACEu64));
+        assert_eq!(alloc::format!("{rcv:?}"), "ValueTrapdoor(..)");
     }
 
     #[test]
     fn debug_value_commitment_redacts_point() {
-        let cv = Commitment::balance(100);
-        let dbg = alloc::format!("{cv:?}");
-        assert!(dbg.contains("Commitment"), "must name the type");
+        let cv = Trapdoor::ZERO.commit(Balance::try_from(100).unwrap());
+        assert_eq!(alloc::format!("{cv:?}"), "ValueCommitment(..)");
     }
 }


### PR DESCRIPTION
Enforces the two `valueBalanceTachyon` consensus rules from the draft bundle ZIP that were previously unchecked:

- Range (rule 7): `valueBalanceTachyon` must fall within `-MAX_MONEY..=MAX_MONEY`.
- Zero-action (rule 8): a bundle with no actions must have a zero value balance.

Both rules are enforced by construction rather than rechecked at each call site. `Bundle::read` rejects an out-of-range or zero-action/nonzero-balance encoding at deserialization.

`bundle::ValueBalance` and `note::Value` are consolidated with the value-commitment trapdoor's value handling into one const-generic type, `value::Value<MIN, MAX>`, aliased `Balance`, `Positive`, and `Negative` for their respective ranges.

The value-commitment trapdoor and commitment types are renamed `value::Trapdoor` and `value::Commitment`; `Commitment` is now backed by `Ep` (projective) rather than `EpAffine` so it may derive `Add`, `Sub`, and `Sum`.

`NOTE_VALUE_MAX` is renamed `MAX_MONEY` to align with the spec name.

## Testing

- `just test`: full suite green, including boundary/overflow tests at the `Plan`, wire, and construction layers.
- `just lint`: clean.

Closes #165.
