### PR TITLE
refactor: relax bundle ordering

### DIFF
--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -200,8 +200,11 @@ impl Action {
 
     /// Obtain a descriptor for this action.
     #[must_use]
-    pub fn descriptor(&self) -> Descriptor {
-        Descriptor::from(*self)
+    pub const fn descriptor(&self) -> Descriptor {
+        Descriptor {
+            cv: self.cv,
+            rk: self.rk,
+        }
     }
 }
 

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -26,27 +26,6 @@ pub struct Descriptor {
     pub rk: public::ActionVerificationKey,
 }
 
-impl PartialOrd for Descriptor {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Descriptor {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        {
-            EpAffine::from(self.cv)
-                .to_bytes()
-                .cmp(&EpAffine::from(other.cv).to_bytes())
-        }
-        .then({
-            EpAffine::from(self.rk)
-                .to_bytes()
-                .cmp(&EpAffine::from(other.rk).to_bytes())
-        })
-    }
-}
-
 impl Descriptor {
     /// Derive the action digest.
     pub fn digest(&self) -> Result<ActionDigest, ActionDigestError> {
@@ -65,6 +44,27 @@ impl Descriptor {
         serialization::write_ep_affine(&mut writer, &self.cv.into())?;
         serialization::write_action_vk(&mut writer, &self.rk.0)?;
         Ok(())
+    }
+}
+
+impl PartialOrd for Descriptor {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Descriptor {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        {
+            EpAffine::from(self.cv)
+                .to_bytes()
+                .cmp(&EpAffine::from(other.cv).to_bytes())
+        }
+        .then({
+            EpAffine::from(self.rk)
+                .to_bytes()
+                .cmp(&EpAffine::from(other.rk).to_bytes())
+        })
     }
 }
 
@@ -182,20 +182,6 @@ pub struct Action {
     pub sig: Signature,
 }
 
-impl PartialOrd for Action {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Action {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.descriptor()
-            .cmp(&other.descriptor())
-            .then(self.sig.cmp(&other.sig))
-    }
-}
-
 impl From<(Descriptor, Signature)> for Action {
     fn from((desc, sig): (Descriptor, Signature)) -> Self {
         Self {
@@ -216,6 +202,20 @@ impl Action {
     #[must_use]
     pub fn descriptor(&self) -> Descriptor {
         Descriptor::from(*self)
+    }
+}
+
+impl PartialOrd for Action {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Action {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.descriptor()
+            .cmp(&other.descriptor())
+            .then(self.sig.cmp(&other.sig))
     }
 }
 

--- a/crates/tachyon/src/action.rs
+++ b/crates/tachyon/src/action.rs
@@ -1,7 +1,7 @@
 //! Tachyon Action descriptions.
 
 use alloc::vec::Vec;
-use core::{cmp, marker::PhantomData};
+use core::{cmp, cmp::Ord, marker::PhantomData};
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, PartialEq};
@@ -26,6 +26,27 @@ pub struct Descriptor {
     pub rk: public::ActionVerificationKey,
 }
 
+impl PartialOrd for Descriptor {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Descriptor {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        {
+            EpAffine::from(self.cv)
+                .to_bytes()
+                .cmp(&EpAffine::from(other.cv).to_bytes())
+        }
+        .then({
+            EpAffine::from(self.rk)
+                .to_bytes()
+                .cmp(&EpAffine::from(other.rk).to_bytes())
+        })
+    }
+}
+
 impl Descriptor {
     /// Derive the action digest.
     pub fn digest(&self) -> Result<ActionDigest, ActionDigestError> {
@@ -47,25 +68,6 @@ impl Descriptor {
     }
 }
 
-impl PartialOrd for Descriptor {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Descriptor {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        EpAffine::from(self.cv)
-            .to_bytes()
-            .cmp(&EpAffine::from(other.cv).to_bytes())
-            .then(
-                EpAffine::from(self.rk)
-                    .to_bytes()
-                    .cmp(&EpAffine::from(other.rk).to_bytes()),
-            )
-    }
-}
-
 /// A planned Tachyon action, not yet authorized.
 #[derive(Clone, Copy, Debug)]
 pub struct Plan<E: Effect> {
@@ -79,6 +81,18 @@ pub struct Plan<E: Effect> {
     pub rcv: value::Trapdoor,
     /// Effect marker (zero-sized).
     pub _effect: PhantomData<E>,
+}
+
+impl<E: Effect> PartialEq for Plan<E> {
+    fn eq(&self, other: &Self) -> bool {
+        self.descriptor() == other.descriptor()
+    }
+}
+
+impl<E: Effect> PartialOrd for Plan<E> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        self.descriptor().partial_cmp(&other.descriptor())
+    }
 }
 
 impl Plan<effect::Spend> {
@@ -168,29 +182,6 @@ pub struct Action {
     pub sig: Signature,
 }
 
-impl Action {
-    /// Construct an action from a descriptor and signature.
-    #[must_use]
-    pub const fn from_parts(desc: Descriptor, sig: Signature) -> Self {
-        Self {
-            cv: desc.cv,
-            rk: desc.rk,
-            sig,
-        }
-    }
-
-    /// Derive the action digest.
-    pub fn digest(&self) -> Result<ActionDigest, ActionDigestError> {
-        ActionDigest::new(self.cv, self.rk)
-    }
-
-    /// Obtain a descriptor for this action.
-    #[must_use]
-    pub fn descriptor(&self) -> Descriptor {
-        Descriptor::from(*self)
-    }
-}
-
 impl PartialOrd for Action {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
@@ -201,7 +192,30 @@ impl Ord for Action {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.descriptor()
             .cmp(&other.descriptor())
-            .then_with(|| <[u8; 64]>::from(self.sig.0).cmp(&<[u8; 64]>::from(other.sig.0)))
+            .then(self.sig.cmp(&other.sig))
+    }
+}
+
+impl From<(Descriptor, Signature)> for Action {
+    fn from((desc, sig): (Descriptor, Signature)) -> Self {
+        Self {
+            cv: desc.cv,
+            rk: desc.rk,
+            sig,
+        }
+    }
+}
+
+impl Action {
+    /// Derive the action digest.
+    pub fn digest(&self) -> Result<ActionDigest, ActionDigestError> {
+        ActionDigest::new(self.cv, self.rk)
+    }
+
+    /// Obtain a descriptor for this action.
+    #[must_use]
+    pub fn descriptor(&self) -> Descriptor {
+        Descriptor::from(*self)
     }
 }
 
@@ -218,6 +232,20 @@ impl From<Action> for Descriptor {
 #[derive(Clone, Copy, Debug, Display, PartialEq, TotalEq)]
 #[display("Signature({:?})", self.0)]
 pub struct Signature(pub(crate) reddsa::Signature<reddsa::ActionAuth>);
+
+impl PartialOrd for Signature {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Signature {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        let bytes: [u8; 64] = self.0.into();
+        let other_bytes: [u8; 64] = other.0.into();
+        bytes.cmp(&other_bytes)
+    }
+}
 
 impl Signature {
     /// Read an action signature from the consensus wire format.

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -458,13 +458,13 @@ impl Bundle<ProofStamp> {
     /// Confirm `hStampActionsTachyon` represents this bundle's actions.
     #[must_use]
     pub fn is_autonome(&self) -> bool {
-        self.covers(&[])
+        self.stamp.covers(&self.descriptors())
     }
 
     /// Confirm `hStampActionsTachyon` does not represent this bundle's actions.
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
-        !self.covers(&[])
+        !self.stamp.covers(&self.descriptors())
     }
 }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -143,15 +143,15 @@ impl<T: sealed::Sealed> BundleState for T {}
 /// A Tachyon transaction bundle parameterized by bundle state `S`.
 #[derive(Clone, Debug, PartialEq, TotalEq)]
 pub struct Bundle<S: BundleState + ?Sized> {
+    /// Net value of spends minus outputs (plaintext integer).
+    pub value_balance: value::Balance,
+
     /// Actions (cv, rk, sig).
     ///
     /// The bundle commitment is sensitive to the order of actions. The [`Plan`]
     /// utility in this crate sorts actions by descriptor, but other
     /// implementations may create any arbitrary ordering.
     pub actions: Vec<Action>,
-
-    /// Net value of spends minus outputs (plaintext integer).
-    pub value_balance: value::Balance,
 
     /// Binding signature over the transaction sighash.
     pub binding_sig: Signature,
@@ -481,7 +481,7 @@ impl Bundle<ProofStamp> {
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
         let desc_bytes = self.descriptors().into_iter().collect::<Vec<[u8; 64]>>();
-        blake2b::action_descriptor_digest(&desc_bytes) == self.stamp.actions
+        blake2b::action_descriptor_digest(&desc_bytes) == self.stamp.coverage
     }
 }
 
@@ -553,8 +553,8 @@ impl<S: StampState> Bundle<S> {
         let stamp = S::read(&mut reader)?;
 
         Ok(Self {
-            actions,
             value_balance,
+            actions,
             binding_sig,
             stamp,
         })

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -68,7 +68,8 @@
 //! 64-byte value: the pointer stamp's `wtxid` directly, or
 //! `hStampActionsTachyon || stamp_data_digest` for a proof stamp.
 
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::vec::Vec;
 use core::ops::Neg as _;
 
 use corez::io::{self, Read, Write};
@@ -143,6 +144,10 @@ impl<T: sealed::Sealed> BundleState for T {}
 #[derive(Clone, Debug, PartialEq, TotalEq)]
 pub struct Bundle<S: BundleState + ?Sized> {
     /// Actions (cv, rk, sig).
+    ///
+    /// The bundle commitment is sensitive to the order of actions. The [`Plan`]
+    /// utility in this crate sorts actions by descriptor, but other
+    /// implementations may create any arbitrary ordering.
     pub actions: Vec<Action>,
 
     /// Net value of spends minus outputs (plaintext integer).
@@ -155,11 +160,17 @@ pub struct Bundle<S: BundleState + ?Sized> {
     pub stamp: S,
 }
 
+impl PartialEq for Bundle<dyn BundleState> {
+    fn eq(&self, other: &Self) -> bool {
+        self.commitment() == other.commitment()
+    }
+}
+
 impl<S: BundleState + ?Sized> Bundle<S> {
     /// Collect the descriptors of all actions in the bundle.
     #[must_use]
     pub fn descriptors(&self) -> Vec<action::Descriptor> {
-        // Do NOT sort here: a constructed bundle should already be canonical.
+        // Do NOT sort here: maintain order as constructed.
         self.actions.iter().map(Action::descriptor).collect()
     }
 
@@ -170,6 +181,7 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     /// aggregation.
     #[must_use]
     pub fn commitment(&self) -> [u8; 32] {
+        // Do NOT sort here: maintain order as constructed.
         let descriptors: Vec<[u8; 64]> = self.descriptors().into_iter().collect();
         blake2b::bundle_commitment(
             &blake2b::action_descriptor_digest(&descriptors),
@@ -237,10 +249,10 @@ pub enum SignatureError {
 /// Errors that can occur while signing a bundle plan.
 #[derive(Clone, Copy, Debug, Display, Error)]
 #[non_exhaustive]
-pub enum SignError {
-    /// The number of signatures does not match the number of actions.
-    #[display("expected {_0} signatures")]
-    SigCountMismatch(#[error(not(source))] usize),
+pub enum FinalizePlanError {
+    /// The signatures do not match the planned actions.
+    #[display("planned actions do not match signed actions")]
+    ActionsMismatch,
     /// The value balance overflows the representable range.
     #[display("value balance overflow")]
     BalanceOverflow,
@@ -281,12 +293,9 @@ impl Plan {
 
     /// Collect and sort the descriptors of all actions in the plan.
     #[must_use]
-    pub fn descriptors(&self) -> Vec<action::Descriptor> {
-        let mut desc = self
-            .iter_actions(action::Plan::descriptor, action::Plan::descriptor)
-            .collect::<Vec<action::Descriptor>>();
-        desc.sort_unstable();
-        desc
+    pub fn descriptors(&self) -> BTreeSet<action::Descriptor> {
+        self.iter_actions(action::Plan::descriptor, action::Plan::descriptor)
+            .collect()
     }
 
     /// Derive value_balance from note values.
@@ -309,7 +318,9 @@ impl Plan {
     }
 
     /// Compute a digest of all the bundle's effecting data.
-    /// See [`Bundle::commitment`].
+    ///
+    /// Bundle digest is sensitive to the order of actions. Actions in this
+    /// planner are sorted by descriptor.
     pub fn commitment(&self) -> Result<[u8; 32], CommitError> {
         let desc_bytes: Vec<[u8; 64]> = self.descriptors().into_iter().collect();
 
@@ -353,10 +364,7 @@ impl Plan {
     /// $\mathsf{bsk} = \boxplus_i \mathsf{rcv}_i$.
     #[must_use]
     pub fn derive_bsk_private(&self) -> private::BindingSigningKey {
-        let trapdoors: Vec<_> = self
-            .iter_actions(|plan| plan.rcv, |plan| plan.rcv)
-            .collect();
-        private::BindingSigningKey::from(trapdoors.as_slice())
+        private::BindingSigningKey::from(self.iter_actions(|plan| plan.rcv, |plan| plan.rcv))
     }
 
     /// Sign actions with the provided [`private::SpendAuthorizingKey`] and then
@@ -369,44 +377,31 @@ impl Plan {
         rng: &mut RNG,
         sighash: &[u8; 32],
         ask: &private::SpendAuthorizingKey,
-    ) -> Result<Bundle<Unproven>, SignError> {
-        let mut authorized = Vec::with_capacity(self.spends.len() + self.outputs.len());
+    ) -> Result<Bundle<Unproven>, FinalizePlanError> {
+        let mut authorized: BTreeMap<action::Descriptor, action::Signature> = BTreeMap::new();
 
         for plan in &self.spends {
             let cm = plan.note.commitment();
             let alpha = plan.theta.randomizer::<effect::Spend>(cm);
             let rsk = ask.derive_action_private(&alpha);
-            authorized.push(Action {
-                cv: plan.cv(),
-                rk: plan.rk,
-                sig: rsk.sign(rng, sighash),
-            });
+            authorized.insert(plan.descriptor(), rsk.sign(rng, sighash));
         }
 
         for plan in &self.outputs {
             let cm = plan.note.commitment();
             let alpha = plan.theta.randomizer::<effect::Output>(cm);
             let rsk = private::ActionSigningKey::new(&alpha);
-            authorized.push(Action {
-                cv: plan.cv(),
-                rk: plan.rk,
-                sig: rsk.sign(rng, sighash),
-            });
+            authorized.insert(plan.descriptor(), rsk.sign(rng, sighash));
         }
 
-        authorized.sort_unstable();
-
-        self.apply_signatures(
-            rng,
-            sighash,
-            authorized.into_iter().map(|action| action.sig).collect(),
-        )
+        self.apply_signatures(rng, sighash, authorized)
     }
 
     /// Apply externally-produced action signatures and then sign the bundle
     /// with the [`private::BindingSigningKey`].
     ///
-    /// Signatures must be provided in canonical order.
+    /// Bundle digest is sensitive to the order of actions. Actions in this
+    /// planner are sorted by descriptor.
     ///
     /// To confirm correct application, call [`Bundle::verify_signatures`] on
     /// the return value.
@@ -414,28 +409,22 @@ impl Plan {
         &self,
         rng: &mut RNG,
         sighash: &[u8; 32],
-        sigs: Vec<action::Signature>,
-    ) -> Result<Bundle<Unproven>, SignError> {
-        let n_actions = self.spends.len() + self.outputs.len();
-        if sigs.len() != n_actions {
-            return Err(SignError::SigCountMismatch(n_actions));
+        authorized: BTreeMap<action::Descriptor, action::Signature>,
+    ) -> Result<Bundle<Unproven>, FinalizePlanError> {
+        let value_balance = self
+            .value_balance()
+            .map_err(|_err| FinalizePlanError::BalanceOverflow)?;
+
+        if self.descriptors() != authorized.keys().copied().collect() {
+            return Err(FinalizePlanError::ActionsMismatch);
         }
+        let actions = authorized.into_iter().map(Action::from).collect();
 
-        let authorized = self
-            .descriptors()
-            .into_iter()
-            .zip(sigs)
-            .map(|(desc, sig)| Action::from_parts(desc, sig))
-            .collect::<Vec<Action>>();
-
-        let bsk = self.derive_bsk_private();
-        let binding_sig = bsk.sign(rng, sighash);
+        let binding_sig = self.derive_bsk_private().sign(rng, sighash);
 
         Ok(Bundle {
-            actions: authorized,
-            value_balance: self
-                .value_balance()
-                .map_err(|_err| SignError::BalanceOverflow)?,
+            actions,
+            value_balance,
             binding_sig,
             stamp: Unproven,
         })
@@ -516,12 +505,13 @@ impl<S: StampState> Bundle<S> {
     /// Read everything after the `tachyonBundleState` byte: value balance,
     /// action descriptors, action sigs, binding sig, and the stamp trailer.
     fn read_body<R: Read>(mut reader: R) -> io::Result<Self> {
-        let mut vb_bytes = [0u8; 8];
-        reader.read_exact(&mut vb_bytes)?;
-        let value_balance =
-            value::Balance::try_from(i64::from_le_bytes(vb_bytes)).map_err(|_err| {
+        let value_balance = {
+            let mut bytes = [0u8; size_of::<i64>()];
+            reader.read_exact(&mut bytes)?;
+            value::Balance::try_from(i64::from_le_bytes(bytes)).map_err(|_err| {
                 io::Error::new(io::ErrorKind::InvalidData, "value balance out of range")
-            })?;
+            })
+        }?;
 
         // `n_actions` is attacker-controlled up to MAX_COMPACT_SIZE (2^25), so
         // do not pre-allocate vector capacity. vector reads are ASSUMED to hit
@@ -535,19 +525,16 @@ impl<S: StampState> Bundle<S> {
                 )
             })?;
 
+        if n_actions == 0 && value_balance != value::Balance::ZERO {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "bundle with no actions must have zero value balance",
+            ));
+        }
+
         let mut descriptors: Vec<action::Descriptor> = Vec::new();
         for _ in 0..n_actions {
             descriptors.push(action::Descriptor::read(&mut reader)?);
-        }
-
-        let mut unique_descriptors = BTreeSet::new();
-        for descriptor in &descriptors {
-            if !unique_descriptors.insert(descriptor) {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "action descriptors are not unique",
-                ));
-            }
         }
 
         let mut signatures: Vec<action::Signature> = Vec::new();
@@ -558,22 +545,8 @@ impl<S: StampState> Bundle<S> {
         let actions: Vec<Action> = descriptors
             .into_iter()
             .zip(signatures)
-            .map(|(desc, sig)| Action::from_parts(desc, sig))
+            .map(Action::from)
             .collect();
-
-        if !actions.is_sorted() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "actions are not canonically sorted",
-            ));
-        }
-
-        if actions.is_empty() && value_balance != value::Balance::ZERO {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "bundle with no actions must have zero value balance",
-            ));
-        }
 
         let binding_sig = Signature::read(&mut reader)?;
 
@@ -600,11 +573,12 @@ impl<S: StampState> Bundle<S> {
                 "actions vector length exceeds u64",
             )
         })?;
-        serialization::write_compactsize(&mut writer, n_actions)?;
 
+        serialization::write_compactsize(&mut writer, n_actions)?;
         for action in &self.actions {
             action.descriptor().write(&mut writer)?;
         }
+
         for action in &self.actions {
             action.sig.write(&mut writer)?;
         }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -72,7 +72,7 @@ use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
-use core::ops::Neg as _;
+use core::{cmp::Ordering, ops::Neg as _};
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, IsVariant, PartialEq, TryInto};
@@ -160,6 +160,12 @@ pub struct Bundle<S: BundleState + ?Sized> {
 
     /// Bundle state: `Unproven`, `ProofStamp`, or `PointerStamp`.
     pub stamp: S,
+}
+
+impl<S: StampState> PartialEq for Bundle<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.commitment() == other.commitment() && self.auth_digest() == other.auth_digest()
+    }
 }
 
 impl<S: BundleState + ?Sized> Bundle<S> {
@@ -432,18 +438,15 @@ impl Bundle<ProofStamp> {
         }
     }
 
-    /// Confirm published coverage without verifying the proof: reconstruct
-    /// the covered-actions digest from this bundle's actions plus every
-    /// adjunct's and check it against the carried `hStampActionsTachyon`.
-    /// Adjuncts may be in any stamp state, mixed freely. Assistive, not
-    /// soundness.
+    /// Confirm `hStampActionsTachyon` represents the combined actions of this
+    /// bundle and the given bundles.
+    ///
+    /// Action descriptors will be sorted but not deduplicated, so that a caller
+    /// checking a collection which contains duplicates can detect the mismatch.
     #[must_use]
     pub fn covers(&self, adjuncts: &[&Bundle<dyn StampState>]) -> bool {
-        let own_descs = self.actions.iter().map(Action::descriptor);
-        let other_descs = adjuncts
-            .iter()
-            .flat_map(|adjunct| adjunct.actions.iter())
-            .map(Action::descriptor);
+        let own_descs = self.descriptors().into_iter();
+        let other_descs = adjuncts.iter().flat_map(|&adjunct| adjunct.descriptors());
 
         self.stamp.covers(
             &own_descs
@@ -452,8 +455,7 @@ impl Bundle<ProofStamp> {
         )
     }
 
-    /// Check if this bundle is an aggregate, by computing the digest of its
-    /// owned actions and comparing to its stamp's `hStampActionsTachyon`.
+    /// Confirm `hStampActionsTachyon` represents this bundle's actions.
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
         self.stamp.covers(&self.descriptors())
@@ -607,7 +609,47 @@ pub enum TachyonBundle {
     Adjunct(Bundle<PointerStamp>),
 }
 
+impl PartialEq for TachyonBundle {
+    fn eq(&self, other: &Self) -> bool {
+        #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
+        match *self {
+            Self::NoBundle => other.is_no_bundle(),
+            Self::Proven(ref bundle) => {
+                other.is_proven()
+                    && bundle.commitment() == other.commitment()
+                    && bundle.auth_digest() == other.auth_digest()
+            },
+            Self::Adjunct(ref bundle) => {
+                other.is_adjunct()
+                    && bundle.commitment() == other.commitment()
+                    && bundle.auth_digest() == other.auth_digest()
+            },
+        }
+    }
+}
+
+impl PartialOrd for TachyonBundle {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(
+            self.commitment()
+                .cmp(&other.commitment())
+                .then(self.auth_digest().cmp(&other.auth_digest())),
+        )
+    }
+}
+
 impl TachyonBundle {
+    /// Borrow the inner bundle as a trait object, if it exists.
+    #[must_use]
+    pub fn as_dyn(&self) -> Option<&Bundle<dyn StampState>> {
+        #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
+        match *self {
+            Self::NoBundle => None,
+            Self::Proven(ref bundle) => Some(bundle),
+            Self::Adjunct(ref bundle) => Some(bundle),
+        }
+    }
+
     /// Read any Tachyon bundle from the consensus wire format, dispatching
     /// on the `tachyonBundleState` byte.
     ///
@@ -659,13 +701,32 @@ impl TachyonBundle {
         }
     }
 
-    /// Check if this bundle is an aggregate.
+    /// Confirm `hStampActionsTachyon` represents this bundle's actions.
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
         #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
         match *self {
             Self::NoBundle => false,
             Self::Proven(ref stamped) => stamped.is_aggregate(),
+            Self::Adjunct(ref _stamped) => false,
+        }
+    }
+
+    /// Confirm `hStampActionsTachyon` represents the combined actions of this
+    /// bundle and the given bundles.
+    ///
+    /// Action descriptors will be sorted but not deduplicated, so that a caller
+    /// checking a collection which contains duplicates can detect the mismatch.
+    #[must_use]
+    pub fn covers(&self, adjuncts: &[Self]) -> bool {
+        #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
+        match *self {
+            Self::NoBundle => false,
+            Self::Proven(ref stamped) => adjuncts
+                .iter()
+                .map(|adj| adj.as_dyn())
+                .collect::<Option<Vec<&Bundle<dyn StampState>>>>()
+                .is_some_and(|dyn_adjuncts| stamped.covers(&dyn_adjuncts)),
             Self::Adjunct(ref _stamped) => false,
         }
     }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -179,13 +179,11 @@ impl<S: StampState + 'static> PartialEq for Bundle<S> {
 }
 
 impl<S: BundleState + ?Sized> Bundle<S> {
-    /// Collect the descriptors of all actions in the bundle, in order.
+    /// Collect the descriptors of all actions in the bundle, preserving wire
+    /// order and duplicates.
     ///
-    /// Original construction or wire order is preserved and duplicates are
-    /// kept. Multiplicity is evident in both the bundle commitment and the set
-    /// commitment used for proof verification, so callers must not deduplicate
-    /// before before passing these to [`ProofStamp::verify`] or
-    /// [`ProofStamp::covers`].
+    /// Multiplicity is significant to both the bundle commitment and proof
+    /// verification, so callers must not deduplicate these.
     #[must_use]
     pub fn descriptors(&self) -> Vec<action::Descriptor> {
         // Do NOT sort here: maintain order as constructed.
@@ -495,8 +493,8 @@ impl Bundle<ProofStamp> {
     /// Confirm `hStampActionsTachyon` represents the combined actions of this
     /// bundle and the given bundles.
     ///
-    /// Action descriptors will be sorted but not deduplicated, so that a caller
-    /// checking a collection which contains duplicates can detect the mismatch.
+    /// Descriptors are sorted but not deduplicated, so a collection containing
+    /// duplicates mismatches.
     #[must_use]
     pub fn covers(&self, others: &[&Bundle<dyn StampState>]) -> bool {
         let own_descs = self.descriptors().into_iter();
@@ -559,15 +557,12 @@ impl Bundle<ProofStamp> {
         Ok(())
     }
 
-    /// Fully verify the bundle: stamp coverage, signatures, then the proof.
+    /// Fully verify the bundle: adjunct pointers, stamp coverage, signatures,
+    /// then the proof.
     ///
-    /// The coverage and proof checks span the combined action set of this
-    /// bundle and its `adjuncts` (empty for an autonome bundle). The value
-    /// balance is confirmed by the binding signature, which signs under a
-    /// verification key derived from the action value commitments and the
-    /// plaintext balance, so a balance error surfaces as a
-    /// binding-signature failure. Action uniqueness is enforced by
-    /// [`Bundle::verify_proof`].
+    /// Coverage and proof span this bundle's actions plus its `adjuncts` (empty
+    /// for an autonome). A wrong value balance surfaces as a binding-signature
+    /// failure; action uniqueness is enforced by [`Bundle::verify_proof`].
     pub fn verify<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,
@@ -864,8 +859,8 @@ impl TachyonBundle {
     /// Confirm `hStampActionsTachyon` represents the combined actions of this
     /// bundle and the given bundles.
     ///
-    /// Action descriptors will be sorted but not deduplicated, so that a caller
-    /// checking a collection which contains duplicates can detect the mismatch.
+    /// Descriptors are sorted but not deduplicated, so a collection containing
+    /// duplicates mismatches.
     #[must_use]
     pub fn covers(&self, adjuncts: &[Self]) -> bool {
         #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -457,8 +457,14 @@ impl Bundle<ProofStamp> {
 
     /// Confirm `hStampActionsTachyon` represents this bundle's actions.
     #[must_use]
+    pub fn is_autonome(&self) -> bool {
+        self.covers(&[])
+    }
+
+    /// Confirm `hStampActionsTachyon` does not represent this bundle's actions.
+    #[must_use]
     pub fn is_aggregate(&self) -> bool {
-        self.stamp.covers(&self.descriptors())
+        !self.covers(&[])
     }
 }
 
@@ -690,13 +696,26 @@ impl TachyonBundle {
         }
     }
 
-    /// Confirm `hStampActionsTachyon` represents this bundle's actions.
+    /// Confirm this bundle has a proof stamp, but its `hStampActionsTachyon`
+    /// does not represent this bundle's actions.
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
         #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
         match *self {
             Self::NoBundle => false,
             Self::Proven(ref stamped) => stamped.is_aggregate(),
+            Self::Adjunct(ref _stamped) => false,
+        }
+    }
+
+    /// Confirm this bundle has a proof stamp, and its `hStampActionsTachyon`
+    /// represents this bundle's actions.
+    #[must_use]
+    pub fn is_autonome(&self) -> bool {
+        #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
+        match *self {
+            Self::NoBundle => false,
+            Self::Proven(ref stamped) => stamped.is_autonome(),
             Self::Adjunct(ref _stamped) => false,
         }
     }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -444,9 +444,9 @@ impl Bundle<ProofStamp> {
     /// Action descriptors will be sorted but not deduplicated, so that a caller
     /// checking a collection which contains duplicates can detect the mismatch.
     #[must_use]
-    pub fn covers(&self, adjuncts: &[&Bundle<dyn StampState>]) -> bool {
+    pub fn covers(&self, others: &[&Bundle<dyn StampState>]) -> bool {
         let own_descs = self.descriptors().into_iter();
-        let other_descs = adjuncts.iter().flat_map(|&adjunct| adjunct.descriptors());
+        let other_descs = others.iter().flat_map(|&adjunct| adjunct.descriptors());
 
         self.stamp.covers(
             &own_descs
@@ -459,6 +459,22 @@ impl Bundle<ProofStamp> {
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
         self.stamp.covers(&self.descriptors())
+    }
+
+    /// Verify this bundle's proof by reconstructing the PCD header with actions
+    /// from other bundles.
+    pub fn verify_stamp<RNG: RngCore + CryptoRng>(
+        &self,
+        rng: &mut RNG,
+        others: &[&Bundle<dyn StampState>],
+    ) -> Result<(), stamp::VerificationError> {
+        let all_descs = self
+            .descriptors()
+            .into_iter()
+            .chain(others.iter().flat_map(|&other| other.descriptors()))
+            .collect::<Vec<action::Descriptor>>();
+
+        self.stamp.verify(rng, &all_descs)
     }
 }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -88,12 +88,13 @@ use derive_more::{Debug, Display, Eq as TotalEq, Error, From, IsVariant, Partial
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
+    ActionDigest, ActionDigestError,
     action::{self, Action},
     digest::blake2b,
     keys::{private, public},
     primitives::{Anchor, effect},
     reddsa, serialization,
-    stamp::{self, PointerStamp, ProofStamp, StampState, Unproven},
+    stamp::{self, AggregateIdError, PointerStamp, ProofStamp, StampState, Unproven},
     value,
 };
 
@@ -171,7 +172,7 @@ pub struct Bundle<S: BundleState + ?Sized> {
     pub stamp: S,
 }
 
-impl<S: StampState> PartialEq for Bundle<S> {
+impl<S: StampState + 'static> PartialEq for Bundle<S> {
     fn eq(&self, other: &Self) -> bool {
         self.commitment() == other.commitment() && self.auth_digest() == other.auth_digest()
     }
@@ -207,20 +208,20 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     }
 
     /// Verify the bundle's binding signature and all action signatures.
-    pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), SignatureError> {
+    pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), VerifySignaturesError> {
         // 1. Derive bvk from public data
         let bvk = public::BindingVerificationKey::derive(&self.actions, self.value_balance);
 
         // 2. Verify binding signature
         bvk.verify(sighash, &self.binding_sig)
-            .map_err(|_err| SignatureError::Binding(self.binding_sig))?;
+            .map_err(|_err| VerifySignaturesError::Binding(self.binding_sig))?;
 
         // 3. Verify each action signature
         for action in &self.actions {
             action
                 .rk
                 .verify(sighash, &action.sig)
-                .map_err(|_err| SignatureError::Action(action.sig))?;
+                .map_err(|_err| VerifySignaturesError::Action(action.sig))?;
         }
 
         Ok(())
@@ -230,13 +231,50 @@ impl<S: BundleState + ?Sized> Bundle<S> {
 /// Errors from bundle signature verification.
 #[derive(Clone, Copy, Debug, Display, Error)]
 #[non_exhaustive]
-pub enum SignatureError {
+pub enum VerifySignaturesError {
     /// The binding signature is invalid.
     #[display("invalid binding signature {_0:?}")]
     Binding(#[error(not(source))] Signature),
     /// An action signature is invalid.
     #[display("invalid action signature {_0:?}")]
     Action(#[error(not(source))] action::Signature),
+}
+
+/// Error during proof verification.
+#[derive(Debug, Display, Error)]
+pub enum VerifyProofError {
+    /// The actions are not unique.
+    #[display("actions are not unique")]
+    DuplicateActions,
+    /// An action's cv or rk is the identity point.
+    #[display("action digest error: {_0}")]
+    ActionDigest(ActionDigestError),
+    /// The proof system returned an error.
+    #[display("proof system error: {_0}")]
+    ProofSystem(ragu::Error),
+    /// The proof did not verify.
+    #[display("proof did not verify")]
+    Disproved,
+}
+
+/// Errors during bundle verification.
+#[derive(Debug, Display, Error)]
+pub enum VerificationError {
+    /// The provided wtxid for this bundle seems invalid.
+    #[display("provided aggregate id is invalid: {_0}")]
+    AggregateId(AggregateIdError),
+    /// The pointer of an adjunct is not the expected aggregate id.
+    #[display("stamp on an adjunct does not match the expected aggregate id")]
+    PointerStampMismatch,
+    /// The stamp on this bundle does not claim to cover these actions.
+    #[display("stamp on this bundle does not claim to cover these actions")]
+    StampActionsMismatch,
+    /// The signatures did not verify.
+    #[display("signatures did not verify: {_0}")]
+    Signatures(VerifySignaturesError),
+    /// The proof did not verify.
+    #[display("proof did not verify: {_0}")]
+    Proof(VerifyProofError),
 }
 
 /// Errors that can occur while signing a bundle plan.
@@ -485,9 +523,101 @@ impl Bundle<ProofStamp> {
     pub fn is_aggregate(&self) -> bool {
         !self.stamp.covers(&self.descriptors())
     }
+
+    /// Verify the proof against the combined actions of this bundle and the
+    /// provided bundles.
+    pub fn verify_proof<RNG: RngCore + CryptoRng>(
+        &self,
+        rng: &mut RNG,
+        adjuncts: &[&Bundle<dyn StampState>],
+    ) -> Result<(), VerifyProofError> {
+        let action_descriptors = self
+            .descriptors()
+            .into_iter()
+            .chain(adjuncts.iter().flat_map(|&adj| adj.descriptors()))
+            .collect::<Vec<action::Descriptor>>();
+
+        let action_digests = action_descriptors
+            .iter()
+            .map(action::Descriptor::digest)
+            .collect::<Result<BTreeSet<ActionDigest>, ActionDigestError>>()
+            .map_err(VerifyProofError::ActionDigest)?;
+
+        if action_digests.len() != action_descriptors.len() {
+            return Err(VerifyProofError::DuplicateActions);
+        }
+
+        let proof_verified = self
+            .stamp
+            .verify_proof(
+                rng,
+                &action_digests.into_iter().collect::<Vec<ActionDigest>>(),
+            )
+            .map_err(VerifyProofError::ProofSystem)?;
+
+        if !proof_verified {
+            return Err(VerifyProofError::Disproved);
+        }
+
+        Ok(())
+    }
+
+    /// Fully verify the bundle: stamp coverage, signatures, then the proof.
+    ///
+    /// The coverage and proof checks span the combined action set of this bundle
+    /// and its `adjuncts` (empty for an autonome bundle). The value balance is
+    /// confirmed by the binding signature, which signs under a verification key
+    /// derived from the action value commitments and the plaintext balance, so a
+    /// balance error surfaces as a binding-signature failure. Action uniqueness
+    /// is enforced by [`Bundle::verify_proof`].
+    pub fn verify<RNG: RngCore + CryptoRng>(
+        &self,
+        rng: &mut RNG,
+        sighash: &[u8; 32],
+        auth_digest: &[u8; 32],
+        adjuncts: &[&Bundle<PointerStamp>],
+    ) -> Result<(), VerificationError> {
+        let expect_pointers: PointerStamp = PointerStamp::try_from((sighash, auth_digest))
+            .map_err(VerificationError::AggregateId)?;
+
+        if adjuncts
+            .iter()
+            .any(|&adjunct| adjunct.stamp != expect_pointers)
+        {
+            return Err(VerificationError::PointerStampMismatch);
+        }
+
+        let descriptors: Vec<action::Descriptor> = self
+            .descriptors()
+            .into_iter()
+            .chain(adjuncts.iter().flat_map(|&input| input.descriptors()))
+            .collect();
+
+        if !self.stamp.covers(&descriptors) {
+            return Err(VerificationError::StampActionsMismatch);
+        }
+
+        self.verify_signatures(sighash)
+            .map_err(VerificationError::Signatures)?;
+
+        self.verify_proof(
+            rng,
+            &adjuncts
+                .iter()
+                .map(|&adj| adj.as_dyn())
+                .collect::<Vec<&Bundle<dyn StampState>>>(),
+        )
+        .map_err(VerificationError::Proof)
+    }
 }
 
-impl<S: StampState> Bundle<S> {
+impl<S: StampState + 'static> Bundle<S> {
+    /// Borrow this bundle as a trait object.
+    #[must_use]
+    pub fn as_dyn(&self) -> &Bundle<dyn StampState> {
+        self
+    }
+
     /// Read a stamped bundle in state `S` from the consensus wire format.
     ///
     /// See the module-level wire format documentation.

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -94,7 +94,7 @@ use crate::{
     keys::{private, public},
     primitives::{Anchor, effect},
     reddsa, serialization,
-    stamp::{self, PointerStamp, ProofStamp, StampState, Unproven},
+    stamp::{self, AggregateIdError, PointerStamp, ProofStamp, StampState, Unproven},
     value,
 };
 
@@ -206,20 +206,20 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     }
 
     /// Verify the bundle's binding signature and all action signatures.
-    pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), VerifySignaturesError> {
+    pub fn verify_signatures(&self, sighash: &[u8; 32]) -> Result<(), SignatureError> {
         // 1. Derive bvk from public data
         let bvk = public::BindingVerificationKey::derive(&self.actions, self.value_balance);
 
         // 2. Verify binding signature
         bvk.verify(sighash, &self.binding_sig)
-            .map_err(|_err| VerifySignaturesError::Binding(self.binding_sig))?;
+            .map_err(|_err| SignatureError::Binding(self.binding_sig))?;
 
         // 3. Verify each action signature
         for action in &self.actions {
             action
                 .rk
                 .verify(sighash, &action.sig)
-                .map_err(|_err| VerifySignaturesError::Action(action.sig))?;
+                .map_err(|_err| SignatureError::Action(action.sig))?;
         }
 
         Ok(())
@@ -229,7 +229,7 @@ impl<S: BundleState + ?Sized> Bundle<S> {
 /// Errors from bundle signature verification.
 #[derive(Clone, Copy, Debug, Display, Error)]
 #[non_exhaustive]
-pub enum VerifySignaturesError {
+pub enum SignatureError {
     /// The binding signature is invalid.
     #[display("invalid binding signature {_0:?}")]
     Binding(#[error(not(source))] Signature),
@@ -241,18 +241,35 @@ pub enum VerifySignaturesError {
 /// Error during proof verification.
 #[derive(Debug, Display, Error)]
 pub enum VerifyProofError {
-    /// The actions are not unique.
-    #[display("actions are not unique")]
-    DuplicateActions,
     /// An action's cv or rk is the identity point.
     #[display("action digest error: {_0}")]
     ActionDigest(ActionDigestError),
     /// The proof system returned an error.
     #[display("proof system error: {_0}")]
     ProofSystem(ragu::Error),
-    /// The proof did not verify.
-    #[display("proof did not verify")]
-    Disproved,
+}
+
+/// Errors during coverage verification.
+#[derive(Debug, Display, Error)]
+pub enum VerifyCoverageError {
+    /// The actions are not unique.
+    #[display("actions are not unique")]
+    DuplicateActions,
+    /// The stamp on this bundle does not claim to cover these actions.
+    #[display("stamp on this bundle does not claim to cover these actions")]
+    StampActionsMismatch,
+}
+
+/// Errors during adjunct pointer verification.
+#[derive(Debug, Display, Error)]
+pub enum VerifyPointersError {
+    /// The pointer of an adjunct is not the expected aggregate id.
+    #[display("stamp on an adjunct does not match the expected aggregate id")]
+    AdjunctPointerMismatch,
+
+    /// The adjunct is not in the expected state.
+    #[display("stamp on an adjunct does not contain a valid pointer")]
+    AdjunctPointerInvalid(AggregateIdError),
 }
 
 /// Errors during bundle verification.
@@ -260,16 +277,16 @@ pub enum VerifyProofError {
 pub enum VerificationError {
     /// The pointer of an adjunct is not the expected aggregate id.
     #[display("stamp on an adjunct does not match the expected aggregate id")]
-    PointerStampMismatch,
-    /// The stamp on this bundle does not claim to cover these actions.
-    #[display("stamp on this bundle does not claim to cover these actions")]
-    StampActionsMismatch,
-    /// The signatures did not verify.
-    #[display("signatures did not verify: {_0}")]
-    Signatures(VerifySignaturesError),
-    /// The proof did not verify.
-    #[display("proof did not verify: {_0}")]
+    Pointers(VerifyPointersError),
+    /// An error occurred while verifying the coverage.
+    #[display("coverage verification error: {_0}")]
+    Coverage(VerifyCoverageError),
+    /// An error occurred while verifying the proof.
+    #[display("proof verification error: {_0}")]
     Proof(VerifyProofError),
+    /// The proof did not verify.
+    #[display("proof did not verify")]
+    Disproved,
 }
 
 /// Errors that can occur while signing a bundle plan.
@@ -492,15 +509,13 @@ impl Bundle<ProofStamp> {
 
     /// Confirm `hStampActionsTachyon` represents the combined actions of this
     /// bundle and the given bundles.
-    ///
-    /// Descriptors are sorted but not deduplicated, so a collection containing
-    /// duplicates mismatches.
     #[must_use]
     pub fn is_covering(&self, others: &[&Bundle<dyn StampState>]) -> bool {
-        let own_descs = self.descriptors().into_iter();
+        let own_descs = self.descriptors();
         let other_descs = others.iter().flat_map(|&adjunct| adjunct.descriptors());
 
-        self.stamp.covers(own_descs.chain(other_descs))
+        self.stamp
+            .is_covering(own_descs.into_iter().chain(other_descs))
     }
 
     /// Confirm `hStampActionsTachyon` represents this bundle's actions.
@@ -515,91 +530,109 @@ impl Bundle<ProofStamp> {
         !self.is_covering(&[])
     }
 
-    /// Verify the proof against the combined actions of this bundle and the
-    /// provided bundles.
+    /// Verify the stamp's coverage against the combined unique actions of this
+    /// bundle and the provided bundles.
+    pub fn verify_coverage(
+        &self,
+        adjuncts: &[&Bundle<dyn StampState>],
+    ) -> Result<BTreeSet<action::Descriptor>, VerifyCoverageError> {
+        let own_descs = self.descriptors();
+        let other_descs: Vec<action::Descriptor> =
+            adjuncts.iter().flat_map(|&adj| adj.descriptors()).collect();
+
+        let n_descs = own_descs.len() + other_descs.len();
+
+        let unique_descs: BTreeSet<action::Descriptor> =
+            own_descs.into_iter().chain(other_descs).collect();
+
+        if unique_descs.len() != n_descs {
+            return Err(VerifyCoverageError::DuplicateActions);
+        }
+
+        if !self.stamp.is_covering(unique_descs.clone()) {
+            return Err(VerifyCoverageError::StampActionsMismatch);
+        }
+
+        Ok(unique_descs)
+    }
+
+    /// Verify the pointers of the adjuncts against the expected wtxid.
+    pub fn verify_pointers(
+        &self,
+        wtxid: &[u8; 64],
+        adjuncts: &[&Bundle<dyn StampState>],
+    ) -> Result<(), VerifyPointersError> {
+        PointerStamp::try_from(*wtxid).map_err(VerifyPointersError::AdjunctPointerInvalid)?;
+
+        if adjuncts
+            .iter()
+            .all(|&adj| &adj.stamp.stamp_digest() == wtxid)
+        {
+            Ok(())
+        } else {
+            Err(VerifyPointersError::AdjunctPointerMismatch)
+        }
+    }
+
+    /// Verify the stamp's proof against the combined actions of this bundle and
+    /// the provided bundles.
     pub fn verify_proof<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,
         adjuncts: &[&Bundle<dyn StampState>],
-    ) -> Result<(), VerifyProofError> {
-        let own_descs = self.descriptors();
-        let other_descs = adjuncts
+    ) -> Result<bool, VerifyProofError> {
+        let own_digests = self.actions.iter().map(|&action| action.digest());
+
+        let other_digests = adjuncts
             .iter()
-            .flat_map(|&adj| adj.descriptors())
-            .collect::<Vec<action::Descriptor>>();
+            .flat_map(|&adj| adj.actions.iter().map(|&action| action.digest()));
 
-        let n_descs = own_descs.len() + other_descs.len();
-
-        let action_descriptors: BTreeSet<action::Descriptor> =
-            own_descs.into_iter().chain(other_descs).collect();
-
-        if n_descs != action_descriptors.len() {
-            return Err(VerifyProofError::DuplicateActions);
-        }
-
-        let action_digests = action_descriptors
-            .iter()
-            .map(action::Descriptor::digest)
-            .collect::<Result<BTreeSet<ActionDigest>, ActionDigestError>>()
+        let action_digests = own_digests
+            .chain(other_digests)
+            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
             .map_err(VerifyProofError::ActionDigest)?;
 
-        let proof_verified = self
-            .stamp
+        self.stamp
             .verify_proof(rng, action_digests)
-            .map_err(VerifyProofError::ProofSystem)?;
-
-        if !proof_verified {
-            return Err(VerifyProofError::Disproved);
-        }
-
-        Ok(())
+            .map_err(VerifyProofError::ProofSystem)
     }
 
-    /// Fully verify the bundle: adjunct pointers, stamp coverage, signatures,
-    /// then the proof.
+    /// Verify the proof stamp with given adjuncts.
     ///
-    /// Coverage and proof span this bundle's actions plus its `adjuncts` (empty
-    /// for an autonome). A wrong value balance surfaces as a binding-signature
-    /// failure; action uniqueness is enforced by [`Bundle::verify_proof`].
+    /// Verification of signatures remains the responsibility of the caller.
     pub fn verify<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,
-        sighash: &[u8; 32],
-        wtxid: PointerStamp,
+        wtxid: &[u8; 64],
         adjuncts: &[&Bundle<PointerStamp>],
     ) -> Result<(), VerificationError> {
-        if adjuncts.iter().any(|&adjunct| adjunct.stamp != wtxid) {
-            return Err(VerificationError::PointerStampMismatch);
+        let adjuncts_dyn: Vec<&Bundle<dyn StampState>> =
+            adjuncts.iter().map(|&adj| adj.as_dyn()).collect();
+
+        self.verify_pointers(wtxid, &adjuncts_dyn)
+            .map_err(VerificationError::Pointers)?;
+
+        self.verify_coverage(&adjuncts_dyn)
+            .map_err(VerificationError::Coverage)?;
+
+        if self
+            .verify_proof(rng, &adjuncts_dyn)
+            .map_err(VerificationError::Proof)?
+        {
+            Ok(())
+        } else {
+            Err(VerificationError::Disproved)
         }
-
-        let descriptors: Vec<action::Descriptor> = self
-            .descriptors()
-            .into_iter()
-            .chain(adjuncts.iter().flat_map(|&input| input.descriptors()))
-            .collect();
-
-        if !self.stamp.covers(descriptors) {
-            return Err(VerificationError::StampActionsMismatch);
-        }
-
-        self.verify_signatures(sighash)
-            .map_err(VerificationError::Signatures)?;
-
-        self.verify_proof(
-            rng,
-            &adjuncts
-                .iter()
-                .map(|&adj| adj.as_dyn())
-                .collect::<Vec<&Bundle<dyn StampState>>>(),
-        )
-        .map_err(VerificationError::Proof)
     }
 }
 
-impl<S: StampState + 'static> Bundle<S> {
+impl<S: StampState> Bundle<S> {
     /// Borrow this bundle as a trait object.
     #[must_use]
-    pub fn as_dyn(&self) -> &Bundle<dyn StampState> {
+    pub fn as_dyn(&self) -> &Bundle<dyn StampState>
+    where
+        S: 'static,
+    {
         self
     }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -480,8 +480,7 @@ impl Bundle<ProofStamp> {
     /// owned actions and comparing to its stamp's `hStampActionsTachyon`.
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
-        let desc_bytes = self.descriptors().into_iter().collect::<Vec<[u8; 64]>>();
-        blake2b::action_descriptor_digest(&desc_bytes) == self.stamp.coverage
+        self.stamp.covers(&self.descriptors())
     }
 }
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -44,26 +44,17 @@
 //! | `vActionSigsTachyon`  | 64 * nActionsTachyon | authorization per action over tx sighash |
 //! | `bindingSigTachyon`   | 64 bytes             | binding over tx sighash                  |
 //!
-//! `vActionsTachyon` is a multiset: descriptors may repeat and multiplicity is
-//! significant, so it is neither sorted nor deduplicated on read. The proof
-//! validates the action set, reconstructing it as a product of roots, so a
-//! repeated descriptor is rejected there rather than at read.
-//!
 //! ### Proof stamp
 //!
 //! When `tachyonBundleState == 1`, the bundle carries a proof stamp.
 //!
-//! | Name                  | Format               | Description                              |
-//! | --------------------- | -------------------- | ---------------------------------------- |
-//! | `hStampActionsTachyon`     | 32 bytes             | BLAKE2b digest of the covered actions    |
-//! | `anchorTachyon`       | 32 bytes             | pool state reference                     |
-//! | `nTachygrams`         | compactsize          | number of tachygrams                     |
-//! | `vTachygrams`         | 32 * nTachygrams     | tachygrams for this proof                |
-//! | `proofTachyon`        | PROOF_SIZE blob      | serialized proof of fixed size           |
-//!
-//! Unlike `vActionsTachyon`, `vTachygrams` is a set: entries must be distinct
-//! and canonically ordered, and read rejects a duplicate or out-of-order
-//! tachygram.
+//! | Name                   | Format               | Description                              |
+//! | ---------------------- | -------------------- | ---------------------------------------- |
+//! | `hStampActionsTachyon` | 32 bytes             | BLAKE2b digest of the covered actions    |
+//! | `anchorTachyon`        | 32 bytes             | pool state reference                     |
+//! | `nTachygrams`          | compactsize          | number of tachygrams                     |
+//! | `vTachygrams`          | 32 * nTachygrams     | tachygrams for this proof                |
+//! | `proofTachyon`         | PROOF_SIZE blob      | serialized proof of fixed size           |
 //!
 //! ## Pointer stamp
 //!

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -511,18 +511,7 @@ impl<S: StampState> Bundle<S> {
 
         let mut descriptors: Vec<action::Descriptor> = Vec::new();
         for _ in 0..n_actions {
-            let descriptor = action::Descriptor::read(&mut reader)?;
-
-            // TODO: do we care about deduplication here?
-            // we could improve or delete this check.
-            if descriptors.contains(&descriptor) {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "action descriptors are not unique",
-                ));
-            }
-
-            descriptors.push(descriptor);
+            descriptors.push(action::Descriptor::read(&mut reader)?);
         }
 
         let mut signatures: Vec<action::Signature> = Vec::new();

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -68,8 +68,10 @@
 //! 64-byte value: the pointer stamp's `wtxid` directly, or
 //! `hStampActionsTachyon || stamp_data_digest` for a proof stamp.
 
-use alloc::collections::{BTreeMap, BTreeSet};
-use alloc::vec::Vec;
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use core::ops::Neg as _;
 
 use corez::io::{self, Read, Write};

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -82,7 +82,7 @@ use crate::{
     action::{self, Action},
     digest::blake2b,
     keys::{private, public},
-    primitives::{ActionDigestError, Anchor, effect},
+    primitives::{Anchor, effect},
     reddsa, serialization,
     stamp::{self, PointerStamp, ProofStamp, StampState, Unproven},
     value,
@@ -206,30 +206,6 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     }
 }
 
-/// Errors during bundle construction.
-#[derive(Clone, Copy, Debug, Display, Error)]
-pub enum BuildError {
-    /// Ragu proof verification failed.
-    #[display("proof verification failed")]
-    ProofInvalid,
-
-    /// BSK/BVK mismatch (see Protocol §4.14).
-    #[display("binding signing key does not match verification key")]
-    BalanceKeyMismatch,
-}
-
-/// Errors that can occur when computing a bundle plan commitment.
-#[derive(Debug, Display, Error, From)]
-#[non_exhaustive]
-pub enum CommitError {
-    /// An action digest could not be constructed.
-    #[display("action digest: {_0}")]
-    ActionDigest(#[error(not(source))] ActionDigestError),
-    /// The value balance overflows the representable range.
-    #[display("value balance overflow")]
-    BalanceOverflow(#[error(not(source))] value::OutOfRange),
-}
-
 /// Errors from bundle signature verification.
 #[derive(Clone, Copy, Debug, Display, Error)]
 #[non_exhaustive]
@@ -243,12 +219,12 @@ pub enum SignatureError {
 }
 
 /// Errors that can occur while signing a bundle plan.
-#[derive(Clone, Copy, Debug, Display, Error)]
+#[derive(Clone, Copy, Debug, Display, Error, PartialEq, TotalEq)]
 #[non_exhaustive]
-pub enum FinalizePlanError {
+pub enum PlanError {
     /// The signatures do not match the planned actions.
     #[display("planned actions do not match signed actions")]
-    ActionsMismatch,
+    ActionSigMismatch,
     /// The value balance overflows the representable range.
     #[display("value balance overflow")]
     BalanceOverflow,
@@ -317,7 +293,11 @@ impl Plan {
     ///
     /// Bundle digest is sensitive to the order of actions. Actions in this
     /// planner are sorted by descriptor.
-    pub fn commitment(&self) -> Result<[u8; 32], CommitError> {
+    ///
+    /// # Errors
+    ///
+    /// Fails if the value balance overflows the representable range.
+    pub fn commitment(&self) -> Result<[u8; 32], value::OutOfRange> {
         let desc_bytes: Vec<[u8; 64]> = self.descriptors().into_iter().collect();
 
         Ok(blake2b::bundle_commitment(
@@ -373,7 +353,7 @@ impl Plan {
         rng: &mut RNG,
         sighash: &[u8; 32],
         ask: &private::SpendAuthorizingKey,
-    ) -> Result<Bundle<Unproven>, FinalizePlanError> {
+    ) -> Result<Bundle<Unproven>, PlanError> {
         let mut authorized: BTreeMap<action::Descriptor, action::Signature> = BTreeMap::new();
 
         for plan in &self.spends {
@@ -406,13 +386,13 @@ impl Plan {
         rng: &mut RNG,
         sighash: &[u8; 32],
         authorized: BTreeMap<action::Descriptor, action::Signature>,
-    ) -> Result<Bundle<Unproven>, FinalizePlanError> {
+    ) -> Result<Bundle<Unproven>, PlanError> {
         let value_balance = self
             .value_balance()
-            .map_err(|_err| FinalizePlanError::BalanceOverflow)?;
+            .map_err(|_err| PlanError::BalanceOverflow)?;
 
         if self.descriptors() != authorized.keys().copied().collect() {
-            return Err(FinalizePlanError::ActionsMismatch);
+            return Err(PlanError::ActionSigMismatch);
         }
         let actions = authorized.into_iter().map(Action::from).collect();
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -564,12 +564,13 @@ impl Bundle<ProofStamp> {
 
     /// Fully verify the bundle: stamp coverage, signatures, then the proof.
     ///
-    /// The coverage and proof checks span the combined action set of this bundle
-    /// and its `adjuncts` (empty for an autonome bundle). The value balance is
-    /// confirmed by the binding signature, which signs under a verification key
-    /// derived from the action value commitments and the plaintext balance, so a
-    /// balance error surfaces as a binding-signature failure. Action uniqueness
-    /// is enforced by [`Bundle::verify_proof`].
+    /// The coverage and proof checks span the combined action set of this
+    /// bundle and its `adjuncts` (empty for an autonome bundle). The value
+    /// balance is confirmed by the binding signature, which signs under a
+    /// verification key derived from the action value commitments and the
+    /// plaintext balance, so a balance error surfaces as a
+    /// binding-signature failure. Action uniqueness is enforced by
+    /// [`Bundle::verify_proof`].
     pub fn verify<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -150,8 +150,6 @@ pub struct Bundle<S: BundleState + ?Sized> {
     pub value_balance: value::Balance,
 
     /// Actions (cv, rk, sig).
-    ///
-    /// Order is significant to [`Bundle::commitment`].
     pub actions: Vec<Action>,
 
     /// Binding signature over the transaction sighash.
@@ -184,6 +182,9 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     /// This contributes to the transaction sighash. The stamp is excluded
     /// because it is considered authorizing data, and is malleable during
     /// aggregation.
+    ///
+    /// The digest binds actions in wire order and is therefore sensitive to
+    /// their ordering.
     #[must_use]
     pub fn commitment(&self) -> [u8; 32] {
         let descriptors: Vec<[u8; 64]> = self.descriptors().into_iter().collect();

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -141,7 +141,7 @@ pub trait BundleState: sealed::Sealed {}
 impl<T: sealed::Sealed> BundleState for T {}
 
 /// A Tachyon transaction bundle parameterized by bundle state `S`.
-#[derive(Clone, Debug, PartialEq, TotalEq)]
+#[derive(Clone, Debug)]
 pub struct Bundle<S: BundleState + ?Sized> {
     /// Net value of spends minus outputs (plaintext integer).
     pub value_balance: value::Balance,
@@ -158,12 +158,6 @@ pub struct Bundle<S: BundleState + ?Sized> {
 
     /// Bundle state: `Unproven`, `ProofStamp`, or `PointerStamp`.
     pub stamp: S,
-}
-
-impl PartialEq for Bundle<dyn BundleState> {
-    fn eq(&self, other: &Self) -> bool {
-        self.commitment() == other.commitment()
-    }
 }
 
 impl<S: BundleState + ?Sized> Bundle<S> {

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -44,6 +44,11 @@
 //! | `vActionSigsTachyon`  | 64 * nActionsTachyon | authorization per action over tx sighash |
 //! | `bindingSigTachyon`   | 64 bytes             | binding over tx sighash                  |
 //!
+//! `vActionsTachyon` is a multiset: descriptors may repeat and multiplicity is
+//! significant, so it is neither sorted nor deduplicated on read. The proof
+//! validates the action set, reconstructing it as a product of roots, so a
+//! repeated descriptor is rejected there rather than at read.
+//!
 //! ### Proof stamp
 //!
 //! When `tachyonBundleState == 1`, the bundle carries a proof stamp.
@@ -55,6 +60,10 @@
 //! | `nTachygrams`         | compactsize          | number of tachygrams                     |
 //! | `vTachygrams`         | 32 * nTachygrams     | tachygrams for this proof                |
 //! | `proofTachyon`        | PROOF_SIZE blob      | serialized proof of fixed size           |
+//!
+//! Unlike `vActionsTachyon`, `vTachygrams` is a set: entries must be distinct
+//! and canonically ordered, and read rejects a duplicate or out-of-order
+//! tachygram.
 //!
 //! ## Pointer stamp
 //!
@@ -169,7 +178,13 @@ impl<S: StampState> PartialEq for Bundle<S> {
 }
 
 impl<S: BundleState + ?Sized> Bundle<S> {
-    /// Collect the descriptors of all actions in the bundle.
+    /// Collect the descriptors of all actions in the bundle, in order.
+    ///
+    /// Original construction or wire order is preserved and duplicates are
+    /// kept. Multiplicity is evident in both the bundle commitment and the set
+    /// commitment used for proof verification, so callers must not deduplicate
+    /// before before passing these to [`ProofStamp::verify`] or
+    /// [`ProofStamp::covers`].
     #[must_use]
     pub fn descriptors(&self) -> Vec<action::Descriptor> {
         // Do NOT sort here: maintain order as constructed.
@@ -269,7 +284,11 @@ impl Plan {
         spend_transform.chain(output_transform)
     }
 
-    /// Collect and sort the descriptors of all actions in the plan.
+    /// Collect the descriptors of all actions in the plan, sorted and
+    /// deduplicated.
+    ///
+    /// This is the prover-side set. Contrast [`Bundle::descriptors`], the wire
+    /// multiset that preserves order and duplicates.
     #[must_use]
     pub fn descriptors(&self) -> BTreeSet<action::Descriptor> {
         self.iter_actions(action::Plan::descriptor, action::Plan::descriptor)

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -151,9 +151,7 @@ pub struct Bundle<S: BundleState + ?Sized> {
 
     /// Actions (cv, rk, sig).
     ///
-    /// The bundle commitment is sensitive to the order of actions. The [`Plan`]
-    /// utility in this crate sorts actions by descriptor, but other
-    /// implementations may create any arbitrary ordering.
+    /// Order is significant to [`Bundle::commitment`].
     pub actions: Vec<Action>,
 
     /// Binding signature over the transaction sighash.
@@ -188,7 +186,6 @@ impl<S: BundleState + ?Sized> Bundle<S> {
     /// aggregation.
     #[must_use]
     pub fn commitment(&self) -> [u8; 32] {
-        // Do NOT sort here: maintain order as constructed.
         let descriptors: Vec<[u8; 64]> = self.descriptors().into_iter().collect();
         blake2b::bundle_commitment(
             &blake2b::action_descriptor_digest(&descriptors),
@@ -257,7 +254,6 @@ pub enum VerifyPointersError {
     /// The pointer of an adjunct is not the expected aggregate id.
     #[display("stamp on an adjunct does not match the expected aggregate id")]
     AdjunctPointerMismatch,
-
     /// The adjunct is not in the expected state.
     #[display("stamp on an adjunct does not contain a valid pointer")]
     AdjunctPointerInvalid(AggregateIdError),
@@ -357,9 +353,6 @@ impl Plan {
 
     /// Compute a digest of all the bundle's effecting data.
     ///
-    /// Bundle digest is sensitive to the order of actions. Actions in this
-    /// planner are sorted by descriptor.
-    ///
     /// # Errors
     ///
     /// Fails if the value balance overflows the representable range.
@@ -441,9 +434,6 @@ impl Plan {
 
     /// Apply externally-produced action signatures and then sign the bundle
     /// with the [`private::BindingSigningKey`].
-    ///
-    /// Bundle digest is sensitive to the order of actions. Actions in this
-    /// planner are sorted by descriptor.
     ///
     /// To confirm correct application, call [`Bundle::verify_signatures`] on
     /// the return value.

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -460,22 +460,6 @@ impl Bundle<ProofStamp> {
     pub fn is_aggregate(&self) -> bool {
         self.stamp.covers(&self.descriptors())
     }
-
-    /// Verify this bundle's proof by reconstructing the PCD header with actions
-    /// from other bundles.
-    pub fn verify_stamp<RNG: RngCore + CryptoRng>(
-        &self,
-        rng: &mut RNG,
-        others: &[&Bundle<dyn StampState>],
-    ) -> Result<(), stamp::VerificationError> {
-        let all_descs = self
-            .descriptors()
-            .into_iter()
-            .chain(others.iter().flat_map(|&other| other.descriptors()))
-            .collect::<Vec<action::Descriptor>>();
-
-        self.stamp.verify(rng, &all_descs)
-    }
 }
 
 impl<S: StampState> Bundle<S> {

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -509,7 +509,18 @@ impl<S: StampState> Bundle<S> {
 
         let mut descriptors: Vec<action::Descriptor> = Vec::new();
         for _ in 0..n_actions {
-            descriptors.push(action::Descriptor::read(&mut reader)?);
+            let descriptor = action::Descriptor::read(&mut reader)?;
+
+            // TODO: do we care about deduplication here?
+            // we could improve or delete this check.
+            if descriptors.contains(&descriptor) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "action descriptors are not unique",
+                ));
+            }
+
+            descriptors.push(descriptor);
         }
 
         let mut signatures: Vec<action::Signature> = Vec::new();

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -496,27 +496,23 @@ impl Bundle<ProofStamp> {
     /// Descriptors are sorted but not deduplicated, so a collection containing
     /// duplicates mismatches.
     #[must_use]
-    pub fn covers(&self, others: &[&Bundle<dyn StampState>]) -> bool {
+    pub fn is_covering(&self, others: &[&Bundle<dyn StampState>]) -> bool {
         let own_descs = self.descriptors().into_iter();
         let other_descs = others.iter().flat_map(|&adjunct| adjunct.descriptors());
 
-        self.stamp.covers(
-            &own_descs
-                .chain(other_descs)
-                .collect::<Vec<action::Descriptor>>(),
-        )
+        self.stamp.covers(own_descs.chain(other_descs))
     }
 
     /// Confirm `hStampActionsTachyon` represents this bundle's actions.
     #[must_use]
     pub fn is_autonome(&self) -> bool {
-        self.stamp.covers(&self.descriptors())
+        self.is_covering(&[])
     }
 
     /// Confirm `hStampActionsTachyon` does not represent this bundle's actions.
     #[must_use]
     pub fn is_aggregate(&self) -> bool {
-        !self.stamp.covers(&self.descriptors())
+        !self.is_covering(&[])
     }
 
     /// Verify the proof against the combined actions of this bundle and the
@@ -526,11 +522,20 @@ impl Bundle<ProofStamp> {
         rng: &mut RNG,
         adjuncts: &[&Bundle<dyn StampState>],
     ) -> Result<(), VerifyProofError> {
-        let action_descriptors = self
-            .descriptors()
-            .into_iter()
-            .chain(adjuncts.iter().flat_map(|&adj| adj.descriptors()))
+        let own_descs = self.descriptors();
+        let other_descs = adjuncts
+            .iter()
+            .flat_map(|&adj| adj.descriptors())
             .collect::<Vec<action::Descriptor>>();
+
+        let n_descs = own_descs.len() + other_descs.len();
+
+        let action_descriptors: BTreeSet<action::Descriptor> =
+            own_descs.into_iter().chain(other_descs).collect();
+
+        if n_descs != action_descriptors.len() {
+            return Err(VerifyProofError::DuplicateActions);
+        }
 
         let action_digests = action_descriptors
             .iter()
@@ -538,16 +543,9 @@ impl Bundle<ProofStamp> {
             .collect::<Result<BTreeSet<ActionDigest>, ActionDigestError>>()
             .map_err(VerifyProofError::ActionDigest)?;
 
-        if action_digests.len() != action_descriptors.len() {
-            return Err(VerifyProofError::DuplicateActions);
-        }
-
         let proof_verified = self
             .stamp
-            .verify_proof(
-                rng,
-                &action_digests.into_iter().collect::<Vec<ActionDigest>>(),
-            )
+            .verify_proof(rng, action_digests)
             .map_err(VerifyProofError::ProofSystem)?;
 
         if !proof_verified {
@@ -580,7 +578,7 @@ impl Bundle<ProofStamp> {
             .chain(adjuncts.iter().flat_map(|&input| input.descriptors()))
             .collect();
 
-        if !self.stamp.covers(&descriptors) {
+        if !self.stamp.covers(descriptors) {
             return Err(VerificationError::StampActionsMismatch);
         }
 
@@ -862,7 +860,7 @@ impl TachyonBundle {
     /// Descriptors are sorted but not deduplicated, so a collection containing
     /// duplicates mismatches.
     #[must_use]
-    pub fn covers(&self, adjuncts: &[Self]) -> bool {
+    pub fn is_covering(&self, adjuncts: &[Self]) -> bool {
         #[expect(clippy::ref_patterns, reason = "match needs explicit ref")]
         match *self {
             Self::NoBundle => false,
@@ -870,7 +868,7 @@ impl TachyonBundle {
                 .iter()
                 .map(|adj| adj.as_dyn())
                 .collect::<Option<Vec<&Bundle<dyn StampState>>>>()
-                .is_some_and(|dyn_adjuncts| stamped.covers(&dyn_adjuncts)),
+                .is_some_and(|dyn_adjuncts| stamped.is_covering(&dyn_adjuncts)),
             Self::Adjunct(ref _stamped) => false,
         }
     }

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -94,7 +94,7 @@ use crate::{
     keys::{private, public},
     primitives::{Anchor, effect},
     reddsa, serialization,
-    stamp::{self, AggregateIdError, PointerStamp, ProofStamp, StampState, Unproven},
+    stamp::{self, PointerStamp, ProofStamp, StampState, Unproven},
     value,
 };
 
@@ -260,9 +260,6 @@ pub enum VerifyProofError {
 /// Errors during bundle verification.
 #[derive(Debug, Display, Error)]
 pub enum VerificationError {
-    /// The provided wtxid for this bundle seems invalid.
-    #[display("provided aggregate id is invalid: {_0}")]
-    AggregateId(AggregateIdError),
     /// The pointer of an adjunct is not the expected aggregate id.
     #[display("stamp on an adjunct does not match the expected aggregate id")]
     PointerStampMismatch,
@@ -575,16 +572,10 @@ impl Bundle<ProofStamp> {
         &self,
         rng: &mut RNG,
         sighash: &[u8; 32],
-        auth_digest: &[u8; 32],
+        wtxid: PointerStamp,
         adjuncts: &[&Bundle<PointerStamp>],
     ) -> Result<(), VerificationError> {
-        let expect_pointers: PointerStamp = PointerStamp::try_from((sighash, auth_digest))
-            .map_err(VerificationError::AggregateId)?;
-
-        if adjuncts
-            .iter()
-            .any(|&adjunct| adjunct.stamp != expect_pointers)
-        {
+        if adjuncts.iter().any(|&adjunct| adjunct.stamp != wtxid) {
             return Err(VerificationError::PointerStampMismatch);
         }
 

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::panic, reason = "test code")]
 
-use alloc::{string::ToString as _, vec, vec::Vec};
+use alloc::{boxed::Box, string::ToString as _, vec, vec::Vec};
 
 use pasta_curves::Fp;
 use ragu::proof::PROOF_SIZE_COMPRESSED;
@@ -9,11 +9,12 @@ use rand::{SeedableRng as _, rngs::StdRng};
 use super::*;
 use crate::{
     constants::{EPOCH_SIZE, MAX_MONEY},
-    digest::blake2b::COMMIT_NO_BUNDLE,
+    digest::blake2b::{COMMIT_NO_BUNDLE, action_descriptor_digest, bundle_commitment},
     entropy::ActionEntropy,
     fixtures::{
-        PoolSim, WalletSim, build_autonome, build_output_plan, build_output_stamp, mock_sighash,
-        mock_wtxid, random_action, random_block, random_block_with, shared_sk, spend_witness,
+        PoolSim, WalletSim, build_autonome, build_output_plan, build_output_stamp,
+        forge_overlapping_merge, mock_sighash, mock_wtxid, random_action, random_block,
+        random_block_with, shared_sk, spend_witness,
     },
     primitives::{BlockHeight, Tachygram},
     stamp::VerificationError,
@@ -513,58 +514,96 @@ fn stamp_verify_action_multiset_invariants() {
     }
 }
 
-/// `is_aggregate` digests the bundle's own action descriptors and compares
-/// against the stamp's covered-actions digest, which is built from canonically
-/// sorted descriptors. It must therefore sort its own descriptors too: a
-/// validly-signed bundle whose actions are in non-canonical order is still its
-/// own aggregate.
-#[test]
-fn is_aggregate_independent_of_action_order() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let wallet = WalletSim::new(shared_sk());
-    let stamped = build_autonome(rng, &wallet, 1000, 700);
-    assert!(
-        stamped.actions.len() >= 2,
-        "need at least two actions to permute"
-    );
-    assert_ne!(stamped.actions[0], stamped.actions[1]);
-
-    assert!(
-        stamped.is_aggregate(),
-        "a self-covering bundle is its own aggregate"
-    );
-
-    let mut permuted = stamped;
-    permuted.actions.swap(0, 1);
-    assert!(
-        permuted.is_aggregate(),
-        "is_aggregate must hold regardless of action order"
-    );
-}
-
-/// Even an obvious double spend, two actions carrying identical descriptors, is
-/// not rejected by the parser, but no verifier will accept a proof for such a
-/// bundle. The `Plan` API cannot express this shape (it keys actions by
-/// descriptor), so the duplicate is forced by hand.
+/// An obvious double spend, two actions with identical descriptors, clears
+/// every cheap validator check yet fails proof verification.
 #[test]
 fn double_spend_obvious() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
-    let mut bundle = build_autonome(rng, &wallet, 1000, 700);
-    assert!(
-        bundle.actions.len() >= 2,
-        "need at least two actions to duplicate"
-    );
+    let anchor = PoolSim::genesis(rng).anchor();
+    let note = wallet.random_note(200);
 
-    bundle.actions[1] = bundle.actions[0];
+    // The Plan API keys actions by descriptor and cannot express a duplicate, so
+    // this bundle is assembled by hand from a single output action.
+    let (rcv, alpha, plan) = build_output_plan(rng, note);
+    let descriptor = plan.descriptor();
+
+    // Two identical output actions net to twice the single-output balance, and
+    // the binding key is the doubled trapdoor; the per-action signature is
+    // shared because the actions are byte-identical.
+    let doubled = -2 * i64::try_from(u64::from(note.value)).expect("note value fits i64");
+    let value_balance = value::Balance::try_from(doubled).expect("doubled balance stays in range");
+    let action_bytes: Vec<[u8; 64]> = vec![descriptor, descriptor].into_iter().collect();
+    let sighash = mock_sighash(bundle_commitment(
+        &action_descriptor_digest(&action_bytes),
+        doubled,
+    ));
+    let sig = private::ActionSigningKey::new(&alpha).sign(rng, &sighash);
+    let action = Action::from((descriptor, sig));
+    let binding_sig = private::BindingSigningKey::from([rcv, rcv]).sign(rng, &sighash);
+
+    // Forge the stamp by merging one output stamp with itself: the merge proof
+    // commits to the doubled action and tachygram multisets.
+    let (tachygrams, stamp_anchor, proof) =
+        ProofStamp::prove_output(rng, rcv, alpha, note, anchor).expect("prove_output");
+    let output_stamp = ProofStamp {
+        coverage: action_descriptor_digest(
+            &vec![descriptor].into_iter().collect::<Vec<[u8; 64]>>(),
+        ),
+        tachygrams,
+        anchor: stamp_anchor,
+        proof,
+    };
+    let evil_pcd = forge_overlapping_merge(
+        rng,
+        (&output_stamp, &vec![descriptor]),
+        (&output_stamp, &vec![descriptor]),
+    );
+    let coverage = {
+        let mut desc_bytes: Vec<[u8; 64]> = vec![descriptor, descriptor].into_iter().collect();
+        desc_bytes.sort_unstable();
+        action_descriptor_digest(&desc_bytes)
+    };
+
+    // A tachygram set with duplicated elements wouldn't be accepted by
+    // consensus actors. (see `read_rejects_duplicate_tachygrams`)
+    let stamp = ProofStamp {
+        coverage,
+        anchor: evil_pcd.data().2,
+        tachygrams: output_stamp.tachygrams.iter().copied().collect(),
+        proof: Box::new(evil_pcd.proof().clone()),
+    };
+
+    let bundle = Bundle {
+        actions: vec![action, action],
+        value_balance,
+        binding_sig,
+        stamp,
+    };
 
     let mut buf = Vec::new();
     bundle.write(&mut buf).expect("write");
 
-    // The parser accepts the duplicate: the double spend is wire-valid.
+    // The parser accepts the duplicate: the double action is wire-valid.
     let decoded = Bundle::<ProofStamp>::read(&*buf).expect("duplicate descriptors are wire-valid");
 
-    // But the proof does not verify against the duplicated action set.
+    // Every check ahead of the proof passes: the signatures verify and the
+    // stamp's coverage matches the duplicated action set.
+    decoded
+        .verify_signatures(&mock_sighash(decoded.commitment()))
+        .expect("binding and action signatures verify");
+    assert!(
+        decoded.is_autonome(),
+        "the forged coverage matches the duplicated action set"
+    );
+    assert!(
+        bundle.actions[0] == bundle.actions[1],
+        "the actions are identical"
+    );
+
+    // Proof verification rejects it: the doubled action set reconstructs to
+    // match the proof, but the collapsed tachygram set cannot reconstruct the
+    // doubled commitment the merge proof holds.
     let err = decoded
         .stamp
         .verify(rng, &decoded.descriptors())

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -1048,7 +1048,7 @@ fn auth_digest_invariants() {
         let baseline = stamped.auth_digest();
 
         let mut altered_actions = stamped.clone();
-        altered_actions.stamp.actions[0] ^= 0x01;
+        altered_actions.stamp.coverage[0] ^= 0x01;
         assert_ne!(baseline, altered_actions.auth_digest());
 
         let mut extra_tachygram = stamped;

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -1,6 +1,7 @@
-#![allow(clippy::panic, reason = "test code")]
+#![allow(clippy::panic, clippy::too_many_lines, reason = "test code")]
 
 use alloc::{boxed::Box, string::ToString as _, vec, vec::Vec};
+use core::cmp::Reverse;
 
 use pasta_curves::Fp;
 use ragu::proof::PROOF_SIZE_COMPRESSED;
@@ -13,8 +14,8 @@ use crate::{
     entropy::ActionEntropy,
     fixtures::{
         PoolSim, WalletSim, build_autonome, build_output_plan, build_output_stamp,
-        forge_overlapping_merge, mock_sighash, mock_wtxid, random_action, random_block,
-        random_block_with, shared_sk, spend_witness,
+        forge_overlapping_merge, mock_sighash, mock_wtxid, random_block, random_block_with,
+        shared_sk, spend_witness,
     },
     primitives::{BlockHeight, Tachygram},
     value,
@@ -455,92 +456,6 @@ fn payment_bundle_verifies() {
         .expect("payment bundle must verify");
 }
 
-/// `verify_proof` reconstructs the action polynomial from the action digests it
-/// is given, as a multiset: the exact covered actions verify (in any order),
-/// and any deviation — a dropped, duplicated, extra, or substituted action —
-/// reconstructs a different polynomial and does not verify.
-#[test]
-fn stamp_verify_action_multiset_invariants() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let wallet = WalletSim::new(shared_sk());
-    let stamped = build_autonome(rng, &wallet, 1000, 700);
-
-    let digests: Vec<ActionDigest> = stamped
-        .actions
-        .iter()
-        .map(|action| action.descriptor().digest().expect("action digest"))
-        .collect();
-
-    // Permutation accepts.
-    assert!(
-        stamped
-            .stamp
-            .verify_proof(rng, &[digests[1], digests[0]])
-            .expect("proof system verification"),
-        "permuted actions must verify"
-    );
-
-    // Drop rejects.
-    {
-        let mut dropped = digests.clone();
-        dropped.pop();
-        assert!(
-            !stamped
-                .stamp
-                .verify_proof(rng, &dropped)
-                .expect("proof system verification"),
-            "dropped action must not verify"
-        );
-    }
-
-    // Duplicate rejects.
-    {
-        let mut duplicated = digests.clone();
-        duplicated.push(digests[0]);
-        assert!(
-            !stamped
-                .stamp
-                .verify_proof(rng, &duplicated)
-                .expect("proof system verification"),
-            "duplicated action must not verify"
-        );
-    }
-
-    // Foreign-extra rejects.
-    {
-        let mut extended = digests.clone();
-        extended.push(
-            random_action(rng)
-                .descriptor()
-                .digest()
-                .expect("action digest"),
-        );
-        assert!(
-            !stamped
-                .stamp
-                .verify_proof(rng, &extended)
-                .expect("proof system verification"),
-            "extra action must not verify"
-        );
-    }
-
-    // Replace-with-foreign rejects.
-    {
-        let mut replaced = digests;
-        replaced[0] = random_action(rng)
-            .descriptor()
-            .digest()
-            .expect("action digest");
-        assert!(
-            !stamped
-                .stamp
-                .verify_proof(rng, &replaced)
-                .expect("proof system verification"),
-            "replaced action must not verify"
-        );
-    }
-}
-
 /// An obvious double spend, two actions with identical descriptors, clears
 /// every cheap validator check yet fails proof verification.
 #[test]
@@ -787,12 +702,73 @@ fn duplicated_spend_cannot_inflate() {
             .expect("proof system verification"),
         "the doubled action must not verify against the single-spend proof"
     );
+
+    // The same failure surfaces through the composed `verify` (autonome, no
+    // adjuncts): the pointer is unchecked, coverage matches the forged digest,
+    // signatures verify (over the same `sighash`), and the duplicate is caught at
+    // the proof step.
+    let err = decoded
+        .verify(rng, &sighash, mock_wtxid(&decoded), &[])
+        .expect_err("the duplicated spend must fail full verification");
+    let VerificationError::Proof(VerifyProofError::DuplicateActions) = err else {
+        panic!("expected Proof(DuplicateActions), got {err:?}");
+    };
 }
 
-/// A more obfuscated double spend, the same note spent under two independent
-/// randomizations, produces distinct descriptors and is not caught at the
-/// bundle level. True double-spend prevention is a nullifier/pool-level
-/// concern.
+/// `verify_proof` deduplicates across the self+adjunct boundary, not just
+/// within one bundle: an aggregate and one of its adjuncts claiming the same
+/// action is the cross-bundle double-cover, and the count check rejects it
+/// before the proof. Every other duplicate test passes `&[]`, exercising only
+/// the self-only path; this drives the chained adjunct descriptors.
+#[test]
+fn verify_proof_rejects_action_shared_with_adjunct() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let bundle = build_autonome(rng, &wallet, 1000, 700);
+
+    // An adjunct carrying the same actions as the bundle: the combined multiset
+    // repeats every descriptor. The pointer is irrelevant to `verify_proof`.
+    let adjunct = bundle.clone().strip(mock_wtxid(&bundle));
+
+    let err = bundle
+        .verify_proof(rng, &[adjunct.as_dyn()])
+        .expect_err("an action shared across self and adjunct must be rejected");
+    let VerifyProofError::DuplicateActions = err else {
+        panic!("expected DuplicateActions, got {err:?}");
+    };
+}
+
+/// A unique but uncovered adjunct action clears the duplicate check yet fails
+/// the proof: `verify_proof` reconstructs the action polynomial over the
+/// combined set, which the bundle's stamp — proving only its own actions — does
+/// not commit to. This is the bundle-level route to `Disproved`, distinct from
+/// the `DuplicateActions` path (here the combined set stays a set).
+#[test]
+fn verify_proof_disproves_uncovered_adjunct() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let bundle = build_autonome(rng, &wallet, 1000, 700);
+
+    // A foreign autonome with disjoint actions, stripped to an adjunct the bundle
+    // does not cover.
+    let foreign = build_autonome(rng, &wallet, 500, 300);
+    let adjunct = foreign.strip(mock_wtxid(&bundle));
+
+    let err = bundle
+        .verify_proof(rng, &[adjunct.as_dyn()])
+        .expect_err("a unique but uncovered adjunct action must not verify");
+    let VerifyProofError::Disproved = err else {
+        panic!("expected Disproved, got {err:?}");
+    };
+}
+
+/// A more obfuscated double spend: the same note spent under two independent
+/// randomizations yields distinct descriptors, so the cheap bundle checks
+/// (descriptor-uniqueness and signatures) pass. It is still caught elsewhere —
+/// the proof refuses to aggregate the shared nullifiers (the stamp-level
+/// `double_spend_cannot_aggregate`) and the pool nullifier set rejects reuse
+/// across transactions — this test covers only that the cheap checks alone do
+/// not catch it.
 #[test]
 fn double_spend_secret() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -997,8 +973,9 @@ fn based_aggregate_with_two_adjuncts() {
 
     becomes_based.stamp = based_stamp;
 
-    let adjunct_a = autonome_a.strip(mock_wtxid(&becomes_based));
-    let adjunct_b = autonome_b.strip(mock_wtxid(&becomes_based));
+    let wtxid = mock_wtxid(&becomes_based);
+    let adjunct_a = autonome_a.strip(wtxid);
+    let adjunct_b = autonome_b.strip(wtxid);
 
     becomes_based
         .verify_signatures(&sighash)
@@ -1007,21 +984,67 @@ fn based_aggregate_with_two_adjuncts() {
     becomes_based
         .verify_proof(rng, &[adjunct_a.as_dyn(), adjunct_b.as_dyn()])
         .expect("based aggregate proof verifies against its adjuncts");
+
+    // Outer `verify` composes the pointer, coverage, signature, and proof checks
+    // against the covering wtxid the adjuncts were stripped with.
+    assert!(
+        becomes_based.is_aggregate(),
+        "a based aggregate does not cover its own actions alone"
+    );
+    becomes_based
+        .verify(rng, &sighash, wtxid, &[&adjunct_a, &adjunct_b])
+        .expect("based aggregate fully verifies against its adjuncts");
+
+    // A wtxid the adjuncts were not stripped with: the pointer check fails first.
+    {
+        let foreign = PointerStamp::try_from([0x5au8; 64]).expect("nonzero");
+        let err = becomes_based
+            .verify(rng, &sighash, foreign, &[&adjunct_a, &adjunct_b])
+            .expect_err("adjuncts pointing to another aggregate must be rejected");
+        let VerificationError::PointerStampMismatch = err else {
+            panic!("expected PointerStampMismatch, got {err:?}");
+        };
+    }
+
+    // Pointers match but an adjunct is missing: coverage no longer reconstructs.
+    {
+        let err = becomes_based
+            .verify(rng, &sighash, wtxid, &[&adjunct_a])
+            .expect_err("a missing adjunct must mismatch coverage");
+        let VerificationError::StampActionsMismatch = err else {
+            panic!("expected StampActionsMismatch, got {err:?}");
+        };
+    }
+
+    // A corrupted action signature surfaces through the composed check.
+    {
+        let mut tampered = becomes_based.clone();
+        let mut sig_bytes: [u8; 64] = tampered.actions[0].sig.0.into();
+        sig_bytes[0] ^= 0xFF;
+        tampered.actions[0].sig = action::Signature(sig_bytes.into());
+        let err = tampered
+            .verify(rng, &sighash, wtxid, &[&adjunct_a, &adjunct_b])
+            .expect_err("a corrupted action signature must fail verification");
+        let VerificationError::Signatures(VerifySignaturesError::Action(_)) = err else {
+            panic!("expected Signatures(Action), got {err:?}");
+        };
+    }
 }
 
 /// The outer `verify` composes coverage, signatures, and proof for an autonome
 /// bundle with no adjuncts: the honest bundle passes, and a corrupted binding
-/// signature surfaces as `VerificationError::Signatures`.
+/// signature surfaces as `VerificationError::Signatures`. With no adjuncts the
+/// `wtxid` is never compared, so any nonzero value serves.
 #[test]
 fn autonome_verify_composes_all_checks() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
     let bundle = build_autonome(rng, &wallet, 1000, 700);
     let sighash = mock_sighash(bundle.commitment());
-    let auth_digest = bundle.auth_digest();
+    let wtxid = mock_wtxid(&bundle);
 
     bundle
-        .verify(rng, &sighash, &auth_digest, &[])
+        .verify(rng, &sighash, wtxid, &[])
         .expect("honest autonome bundle verifies");
 
     let mut tampered = bundle.clone();
@@ -1030,7 +1053,7 @@ fn autonome_verify_composes_all_checks() {
     tampered.binding_sig = Signature(sig_bytes.into());
 
     let err = tampered
-        .verify(rng, &sighash, &auth_digest, &[])
+        .verify(rng, &sighash, wtxid, &[])
         .expect_err("a corrupted binding signature must fail verification");
     let VerificationError::Signatures(VerifySignaturesError::Binding(_)) = err else {
         panic!("expected Signatures(Binding), got {err:?}");
@@ -1074,6 +1097,74 @@ fn stamped_read_write_round_trip() {
     deserialized
         .verify_signatures(&sighash)
         .expect("deserialized bundle must verify");
+}
+
+/// Actions are an ordered multiset: their wire order is significant and `read`
+/// reproduces it exactly, without reordering. There is no canonical order to
+/// enforce (the planner happens to emit sorted, but that is not a consensus
+/// rule), and an arbitrary order is fully valid: assembled in descending
+/// descriptor order with signatures over that order's commitment, the bundle
+/// round-trips unchanged and its signatures verify. Order still binds:
+/// [`permuted_actions_change_commitment`] shows a different order is a
+/// different commitment, so reordering after signing would break the
+/// signatures.
+#[test]
+fn read_preserves_action_order() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+
+    // Two outputs, assembled in descending descriptor order — the opposite of
+    // what the planner emits — so a canonicalizing read would be caught.
+    let (rcv_a, alpha_a, plan_a) = build_output_plan(rng, wallet.random_note(200));
+    let (rcv_b, alpha_b, plan_b) = build_output_plan(rng, wallet.random_note(300));
+    let mut items = [
+        (plan_a.descriptor(), alpha_a, rcv_a),
+        (plan_b.descriptor(), alpha_b, rcv_b),
+    ];
+    items.sort_by_key(|item| Reverse(item.0));
+    assert!(
+        items[0].0 > items[1].0,
+        "assembled in non-canonical (descending) order"
+    );
+
+    // Sign for this exact order: the commitment, and hence the sighash, depends
+    // on it.
+    let value_balance = value::Balance::try_from(-500i64).expect("in range");
+    let descriptors: Vec<[u8; 64]> = items.iter().map(|item| item.0).collect();
+    let sighash = mock_sighash(bundle_commitment(
+        &action_descriptor_digest(&descriptors),
+        value_balance.into(),
+    ));
+    let actions: Vec<Action> = items
+        .iter()
+        .map(|item| {
+            Action::from((
+                item.0,
+                private::ActionSigningKey::new(&item.1).sign(rng, &sighash),
+            ))
+        })
+        .collect();
+    let binding_sig =
+        private::BindingSigningKey::from(items.iter().map(|item| item.2)).sign(rng, &sighash);
+
+    let bundle = Bundle {
+        actions,
+        value_balance,
+        binding_sig,
+        stamp: PointerStamp::try_from([0x11u8; 64]).expect("nonzero wtxid"),
+    };
+
+    let mut buf = Vec::new();
+    bundle.write(&mut buf).expect("write");
+    let decoded = Bundle::<PointerStamp>::read(&*buf).expect("any action order is wire-valid");
+
+    assert_eq!(
+        bundle.actions, decoded.actions,
+        "read reproduces the wire order, it does not reorder"
+    );
+    decoded
+        .verify_signatures(&sighash)
+        .expect("signatures are valid for the constructed order");
 }
 
 #[test]

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -477,8 +477,8 @@ fn stamp_verify_action_multiset_invariants() {
         let mut dropped = descriptors.clone();
         dropped.pop();
         let err = stamped.stamp.verify(rng, &dropped).unwrap_err();
-        let VerificationError::ActionsMismatch = err else {
-            panic!("drop: expected ActionsMismatch, got {err:?}");
+        let VerificationError::Disproved = err else {
+            panic!("drop: expected Disproved, got {err:?}");
         };
     }
 
@@ -487,8 +487,8 @@ fn stamp_verify_action_multiset_invariants() {
         let mut duplicated = descriptors.clone();
         duplicated.push(duplicated[0]);
         let err = stamped.stamp.verify(rng, &duplicated).unwrap_err();
-        let VerificationError::ActionsMismatch = err else {
-            panic!("duplicate: expected ActionsMismatch, got {err:?}");
+        let VerificationError::Disproved = err else {
+            panic!("duplicate: expected Disproved, got {err:?}");
         };
     }
 
@@ -497,8 +497,8 @@ fn stamp_verify_action_multiset_invariants() {
         let mut extended = descriptors.clone();
         extended.push(random_action(rng).descriptor());
         let err = stamped.stamp.verify(rng, &extended).unwrap_err();
-        let VerificationError::ActionsMismatch = err else {
-            panic!("extra: expected ActionsMismatch, got {err:?}");
+        let VerificationError::Disproved = err else {
+            panic!("extra: expected Disproved, got {err:?}");
         };
     }
 
@@ -507,8 +507,8 @@ fn stamp_verify_action_multiset_invariants() {
         let mut replaced = descriptors;
         replaced[0] = random_action(rng).descriptor();
         let err = stamped.stamp.verify(rng, &replaced).unwrap_err();
-        let VerificationError::ActionsMismatch = err else {
-            panic!("replaced: expected ActionsMismatch, got {err:?}");
+        let VerificationError::Disproved = err else {
+            panic!("replaced: expected Disproved, got {err:?}");
         };
     }
 }
@@ -653,9 +653,9 @@ fn innocent_aggregate_from_two_autonomes() {
         alloc::vec![output_b],
     );
 
-    let descriptors_a: Vec<action::Descriptor> =
+    let descriptors_a: BTreeSet<action::Descriptor> =
         autonome_a.actions.iter().map(Action::descriptor).collect();
-    let descriptors_b: Vec<action::Descriptor> =
+    let descriptors_b: BTreeSet<action::Descriptor> =
         autonome_b.actions.iter().map(Action::descriptor).collect();
     let stamp_a = autonome_a.stamp.clone();
     let stamp_b = autonome_b.stamp.clone();
@@ -754,20 +754,21 @@ fn based_aggregate_with_two_adjuncts() {
 
     let sighash = mock_sighash(becomes_based.commitment());
 
-    let based_descriptors: Vec<action::Descriptor> = becomes_based
+    let based_descriptors: BTreeSet<action::Descriptor> = becomes_based
         .actions
         .iter()
         .map(Action::descriptor)
         .collect();
-    let descriptors_a: Vec<action::Descriptor> =
+    let descriptors_a: BTreeSet<action::Descriptor> =
         autonome_a.actions.iter().map(Action::descriptor).collect();
-    let descriptors_b: Vec<action::Descriptor> =
+    let descriptors_b: BTreeSet<action::Descriptor> =
         autonome_b.actions.iter().map(Action::descriptor).collect();
 
     let stamp_a = autonome_a.stamp.clone();
     let stamp_b = autonome_b.stamp.clone();
 
-    let innocent_descriptors = [descriptors_a.as_slice(), descriptors_b.as_slice()].concat();
+    let innocent_descriptors: BTreeSet<action::Descriptor> =
+        descriptors_a.union(&descriptors_b).copied().collect();
     let innocent_stamp = ProofStamp::merge(rng, (stamp_a, descriptors_a), (stamp_b, descriptors_b))
         .expect("innocent merge");
 
@@ -1224,20 +1225,21 @@ fn coverage_check_matches_stamp_actions() {
         alloc::vec![b_output],
     );
 
-    let based_descriptors: Vec<action::Descriptor> = becomes_based
+    let based_descriptors: BTreeSet<action::Descriptor> = becomes_based
         .actions
         .iter()
         .map(Action::descriptor)
         .collect();
-    let descriptors_a: Vec<action::Descriptor> =
+    let descriptors_a: BTreeSet<action::Descriptor> =
         autonome_a.actions.iter().map(Action::descriptor).collect();
-    let descriptors_b: Vec<action::Descriptor> =
+    let descriptors_b: BTreeSet<action::Descriptor> =
         autonome_b.actions.iter().map(Action::descriptor).collect();
 
     let stamp_a = autonome_a.stamp.clone();
     let stamp_b = autonome_b.stamp.clone();
 
-    let innocent_descriptors = [descriptors_a.as_slice(), descriptors_b.as_slice()].concat();
+    let innocent_descriptors: BTreeSet<action::Descriptor> =
+        descriptors_a.union(&descriptors_b).copied().collect();
     let innocent_stamp = ProofStamp::merge(rng, (stamp_a, descriptors_a), (stamp_b, descriptors_b))
         .expect("innocent merge");
 

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -456,8 +456,8 @@ fn payment_bundle_verifies() {
         .expect("payment bundle must verify");
 }
 
-/// An obvious double spend, two actions with identical descriptors, clears the
-/// signature check yet fails coverage verification on its uniqueness check.
+/// Two actions with identical descriptors clear the signature check but fail
+/// `verify_coverage` on uniqueness.
 #[test]
 fn double_spend_obvious() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -543,8 +543,8 @@ fn double_spend_obvious() {
         "the actions are identical"
     );
 
-    // Coverage verification rejects the duplicate outright: the descriptors dedup
-    // into a `BTreeSet`, collapsing the repeat, so the count shrinks.
+    // `verify_coverage` rejects the duplicate; deduplicating the descriptors
+    // shrinks the count below the wire multiset.
     let dup_err = decoded
         .verify_coverage(&[])
         .expect_err("duplicated actions must be rejected");
@@ -668,8 +668,8 @@ fn duplicated_spend_cannot_inflate() {
     let backed = i64::try_from(u64::from(note.value)).expect("note value fits i64");
     assert_eq!(withdrawn, 2 * backed, "the bundle balances two spends");
 
-    // Coverage verification rejects the duplicate outright: the descriptors dedup
-    // into a `BTreeSet`, collapsing the repeat, so the count shrinks.
+    // `verify_coverage` rejects the duplicate; deduplicating the descriptors
+    // shrinks the count below the wire multiset.
     let dup_err = decoded
         .verify_coverage(&[])
         .expect_err("the duplicated spend must be rejected");
@@ -693,10 +693,8 @@ fn duplicated_spend_cannot_inflate() {
         "the doubled action must not verify against the single-spend proof"
     );
 
-    // The same failure surfaces through the composed `verify` (autonome, no
-    // adjuncts): the forged coverage digest matches the duplicated action set, and
-    // the duplicate is caught at the coverage step's uniqueness check. (`verify`
-    // does not check signatures; that is done separately above.)
+    // `verify` catches the same duplicate at its coverage step. It does not
+    // check signatures; those are verified separately above.
     let err = decoded
         .verify(rng, &mock_wtxid(&decoded).into(), &[])
         .expect_err("the duplicated spend must fail full verification");
@@ -705,9 +703,8 @@ fn duplicated_spend_cannot_inflate() {
     };
 }
 
-/// `verify_coverage` deduplicates across the self+adjunct boundary: an
-/// aggregate and an adjunct claiming the same action are rejected as
-/// `DuplicateActions`. `verify_proof` independently returns `false` on the
+/// An action shared between the aggregate and an adjunct is rejected by
+/// `verify_coverage` as a duplicate; `verify_proof` also returns `false` on the
 /// repeated multiset.
 #[test]
 fn verify_proof_rejects_action_shared_with_adjunct() {
@@ -734,9 +731,9 @@ fn verify_proof_rejects_action_shared_with_adjunct() {
     );
 }
 
-/// A unique but uncovered adjunct action passes the duplicate check but fails
-/// the proof: the combined action set is not what the bundle's stamp commits
-/// to, so `verify_proof` returns `false`.
+/// A unique but uncovered adjunct action passes the duplicate check, but
+/// `verify_proof` returns `false` since the combined action set is not what the
+/// stamp commits to.
 #[test]
 fn verify_proof_disproves_uncovered_adjunct() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -983,9 +980,8 @@ fn based_aggregate_with_two_adjuncts() {
         "based aggregate proof must verify against its adjuncts"
     );
 
-    // Outer `verify` composes the pointer, coverage, and proof checks against the
-    // covering wtxid the adjuncts were stripped with. Signatures are verified
-    // separately (above).
+    // `verify` composes the pointer, coverage, and proof checks against the
+    // covering wtxid. Signatures are verified separately above.
     assert!(
         becomes_based.is_aggregate(),
         "a based aggregate does not cover its own actions alone"
@@ -1015,8 +1011,7 @@ fn based_aggregate_with_two_adjuncts() {
         };
     }
 
-    // A corrupted action signature is caught by `verify_signatures`, the caller's
-    // responsibility alongside `verify`.
+    // A corrupted action signature is caught by `verify_signatures`, not `verify`.
     {
         let mut tampered = becomes_based.clone();
         let mut sig_bytes: [u8; 64] = tampered.actions[0].sig.0.into();
@@ -1031,10 +1026,9 @@ fn based_aggregate_with_two_adjuncts() {
     }
 }
 
-/// The outer `verify` on an autonome (no adjuncts): the honest bundle passes,
-/// with signatures verified separately via `verify_signatures`, which also
-/// catches a corrupted binding signature. Without adjuncts there is nothing to
-/// match the `wtxid` against, though it must still be a valid (nonzero)
+/// `verify` on an autonome (no adjuncts). Signatures are checked separately by
+/// `verify_signatures`, which also catches a corrupted binding signature. With
+/// no adjuncts the `wtxid` is not matched, but must still be a valid nonzero
 /// aggregate id.
 #[test]
 fn autonome_verify_composes_all_checks() {

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -542,10 +542,10 @@ fn is_aggregate_independent_of_action_order() {
     );
 }
 
-/// An obvious double spend, two actions carrying identical descriptors, is
-/// rejected at deserialization by the parser's uniqueness check. The `Plan`
-/// API cannot express this shape (it keys actions by descriptor), so the
-/// duplicate is forced by hand.
+/// Even an obvious double spend, two actions carrying identical descriptors, is
+/// not rejected by the parser, but no verifier will accept a proof for such a
+/// bundle. The `Plan` API cannot express this shape (it keys actions by
+/// descriptor), so the duplicate is forced by hand.
 #[test]
 fn double_spend_obvious() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -561,10 +561,17 @@ fn double_spend_obvious() {
     let mut buf = Vec::new();
     bundle.write(&mut buf).expect("write");
 
-    let err =
-        Bundle::<ProofStamp>::read(&*buf).expect_err("duplicate descriptors must be rejected");
-    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-    assert_eq!(err.to_string(), "action descriptors are not unique");
+    // The parser accepts the duplicate: the double spend is wire-valid.
+    let decoded = Bundle::<ProofStamp>::read(&*buf).expect("duplicate descriptors are wire-valid");
+
+    // But the proof does not verify against the duplicated action set.
+    let err = decoded
+        .stamp
+        .verify(rng, &decoded.descriptors())
+        .expect_err("duplicated actions must not verify");
+    let VerificationError::Disproved = err else {
+        panic!("expected Disproved, got {err:?}");
+    };
 }
 
 /// A more obfuscated double spend, the same note spent under two independent

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -572,23 +572,12 @@ fn double_spend_obvious() {
     );
 }
 
-/// A duplicated *spend* would mint value, and `verify` catches it by
-/// reconstructing the action multiset from the wire.
-///
-/// The attacker holds one real spendable note worth `v` and its honest
-/// single-spend stamp (covering `{d}`, one nullifier pair). By hand they build
-/// an autonome whose action list is `[d, d]` — the same spend twice — with
-/// `value_balance = 2v` (a valid binding signature over the doubled `cv` and
-/// `bsk = 2·rcv`) and `coverage` forged to `digest([d, d])`. Signatures verify
-/// and `is_autonome` accepts the forged coverage; the stamp evidences one spent
-/// note against a balance that withdraws `2v`, so accepting it would mint `v`.
-///
-/// It dies at the proof: `verify` reconstructs `(x−d)²` from the wire's
-/// `[d, d]`, which the honest single-spend `(x−d)` proof does not commit to →
-/// `Disproved`. This defense relies on `verify` seeing the full multiset. A
-/// `verify` that deduplicated its input would collapse `[d, d]` to `{d}`, which
-/// the honest proof satisfies, and the distinctness check would have to be
-/// hoisted to the caller.
+/// A duplicated spend would mint value: one honest single-spend stamp,
+/// republished by hand as an autonome with action list `[d, d]`,
+/// `value_balance = 2v`, `bsk = 2·rcv`, and `coverage` forged to `digest([d, d])`.
+/// Signatures and coverage pass, but `verify_proof` rejects the repeat as
+/// `DuplicateActions`, and the proof reconstructs `(x−d)²`, which the honest
+/// `(x−d)` proof does not commit to.
 #[test]
 fn duplicated_spend_cannot_inflate() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -715,11 +704,9 @@ fn duplicated_spend_cannot_inflate() {
     };
 }
 
-/// `verify_proof` deduplicates across the self+adjunct boundary, not just
-/// within one bundle: an aggregate and one of its adjuncts claiming the same
-/// action is the cross-bundle double-cover, and the count check rejects it
-/// before the proof. Every other duplicate test passes `&[]`, exercising only
-/// the self-only path; this drives the chained adjunct descriptors.
+/// `verify_proof` deduplicates across the self+adjunct boundary: an aggregate
+/// and an adjunct claiming the same action are rejected as `DuplicateActions`
+/// before the proof.
 #[test]
 fn verify_proof_rejects_action_shared_with_adjunct() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -738,11 +725,9 @@ fn verify_proof_rejects_action_shared_with_adjunct() {
     };
 }
 
-/// A unique but uncovered adjunct action clears the duplicate check yet fails
-/// the proof: `verify_proof` reconstructs the action polynomial over the
-/// combined set, which the bundle's stamp — proving only its own actions — does
-/// not commit to. This is the bundle-level route to `Disproved`, distinct from
-/// the `DuplicateActions` path (here the combined set stays a set).
+/// A unique but uncovered adjunct action passes the duplicate check but fails
+/// the proof: the combined action set is not what the bundle's stamp commits to,
+/// so `verify_proof` returns `Disproved`.
 #[test]
 fn verify_proof_disproves_uncovered_adjunct() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -762,13 +747,10 @@ fn verify_proof_disproves_uncovered_adjunct() {
     };
 }
 
-/// A more obfuscated double spend: the same note spent under two independent
-/// randomizations yields distinct descriptors, so the cheap bundle checks
-/// (descriptor-uniqueness and signatures) pass. It is still caught elsewhere —
-/// the proof refuses to aggregate the shared nullifiers (the stamp-level
-/// `double_spend_cannot_aggregate`) and the pool nullifier set rejects reuse
-/// across transactions — this test covers only that the cheap checks alone do
-/// not catch it.
+/// The same note spent under two independent randomizations yields distinct
+/// descriptors, so the cheap bundle checks (descriptor-uniqueness, signatures)
+/// pass. It is caught at the proof (shared nullifiers, see
+/// `double_spend_cannot_aggregate`) and by the pool nullifier set, not here.
 #[test]
 fn double_spend_secret() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -1031,10 +1013,9 @@ fn based_aggregate_with_two_adjuncts() {
     }
 }
 
-/// The outer `verify` composes coverage, signatures, and proof for an autonome
-/// bundle with no adjuncts: the honest bundle passes, and a corrupted binding
-/// signature surfaces as `VerificationError::Signatures`. With no adjuncts the
-/// `wtxid` is never compared, so any nonzero value serves.
+/// The outer `verify` on an autonome (no adjuncts): the honest bundle passes,
+/// and a corrupted binding signature surfaces as `Signatures`. Without adjuncts
+/// the `wtxid` is unchecked, so any nonzero value serves.
 #[test]
 fn autonome_verify_composes_all_checks() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -1099,15 +1080,11 @@ fn stamped_read_write_round_trip() {
         .expect("deserialized bundle must verify");
 }
 
-/// Actions are an ordered multiset: their wire order is significant and `read`
-/// reproduces it exactly, without reordering. There is no canonical order to
-/// enforce (the planner happens to emit sorted, but that is not a consensus
-/// rule), and an arbitrary order is fully valid: assembled in descending
-/// descriptor order with signatures over that order's commitment, the bundle
-/// round-trips unchanged and its signatures verify. Order still binds:
-/// [`permuted_actions_change_commitment`] shows a different order is a
-/// different commitment, so reordering after signing would break the
-/// signatures.
+/// Actions are an ordered multiset: `read` reproduces the wire order exactly,
+/// without reordering, and any order is valid. Assembled in descending
+/// descriptor order (non-canonical) with signatures over that order's
+/// commitment, the bundle round-trips unchanged and verifies. Order binds
+/// through the commitment; see [`permuted_actions_change_commitment`].
 #[test]
 fn read_preserves_action_order() {
     let rng = &mut StdRng::seed_from_u64(0);

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -516,6 +516,35 @@ fn stamp_verify_action_multiset_invariants() {
     }
 }
 
+/// `is_aggregate` digests the bundle's own action descriptors and compares
+/// against the stamp's covered-actions digest, which is built from canonically
+/// sorted descriptors. It must therefore sort its own descriptors too: a
+/// validly-signed bundle whose actions are in non-canonical order is still its
+/// own aggregate.
+#[test]
+fn is_aggregate_independent_of_action_order() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let stamped = build_autonome(rng, &wallet, 1000, 700);
+    assert!(
+        stamped.actions.len() >= 2,
+        "need at least two actions to permute"
+    );
+    assert_ne!(stamped.actions[0], stamped.actions[1]);
+
+    assert!(
+        stamped.is_aggregate(),
+        "a self-covering bundle is its own aggregate"
+    );
+
+    let mut permuted = stamped;
+    permuted.actions.swap(0, 1);
+    assert!(
+        permuted.is_aggregate(),
+        "is_aggregate must hold regardless of action order"
+    );
+}
+
 #[test]
 fn innocent_aggregate_from_two_autonomes() {
     let rng = &mut StdRng::seed_from_u64(0);

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -760,7 +760,8 @@ fn stripped_read_write_round_trip() {
     stripped.write(&mut buf).expect("write");
     let deserialized = Bundle::<PointerStamp>::read(&*buf).expect("read");
 
-    assert_eq!(stripped, deserialized);
+    assert_eq!(stripped.commitment(), deserialized.commitment());
+    assert_eq!(stripped.auth_digest(), deserialized.auth_digest());
     assert_eq!(deserialized.stamp, wtxid);
 }
 
@@ -791,7 +792,8 @@ fn tachyon_bundle_conversions() {
         let erased: TachyonBundle = stripped.clone().into();
         let back = Bundle::<PointerStamp>::try_from(erased).expect("stripped variant");
 
-        assert_eq!(stripped, back);
+        assert_eq!(stripped.commitment(), back.commitment());
+        assert_eq!(stripped.auth_digest(), back.auth_digest());
         assert_eq!(back.stamp, wtxid);
     }
 
@@ -841,7 +843,8 @@ fn tachyon_bundle_wire_round_trip() {
         let decoded = TachyonBundle::read(&*buf).expect("read");
         let back = Bundle::<PointerStamp>::try_from(decoded).expect("stripped variant");
 
-        assert_eq!(stripped, back);
+        assert_eq!(stripped.commitment(), back.commitment());
+        assert_eq!(stripped.auth_digest(), back.auth_digest());
     }
 }
 
@@ -981,11 +984,13 @@ fn innocent_round_trips_with_nonzero_wtxid() {
     innocent.write(&mut buf).expect("write innocent");
 
     let via_adjunct = Bundle::<PointerStamp>::read(&*buf).expect("Adjunct::read innocent");
-    assert_eq!(innocent, via_adjunct);
+    assert_eq!(innocent.commitment(), via_adjunct.commitment());
+    assert_eq!(innocent.auth_digest(), via_adjunct.auth_digest());
 
     let decoded = TachyonBundle::read(&*buf).expect("TachyonBundle::read");
     let via_enum = Bundle::<PointerStamp>::try_from(decoded).expect("adjunct variant");
-    assert_eq!(innocent, via_enum);
+    assert_eq!(innocent.commitment(), via_enum.commitment());
+    assert_eq!(innocent.auth_digest(), via_enum.auth_digest());
 }
 
 #[test]
@@ -996,11 +1001,12 @@ fn auth_digest_invariants() {
         let rng = &mut StdRng::seed_from_u64(0);
         let wallet = WalletSim::new(shared_sk());
         let stamped = build_autonome(rng, &wallet, 1000, 700);
-        let stamped_digest = stamped.auth_digest();
 
         let covering = build_autonome(rng, &wallet, 500, 300);
-        let stripped = stamped.strip(mock_wtxid(&covering));
-        assert_ne!(stamped_digest, stripped.auth_digest());
+        let stripped = stamped.clone().strip(mock_wtxid(&covering));
+
+        assert_eq!(stamped.commitment(), stripped.commitment());
+        assert_ne!(stamped.auth_digest(), stripped.auth_digest());
     }
 
     // wtxid binds: distinct wtxids on otherwise-identical stripped bundles
@@ -1046,9 +1052,12 @@ fn auth_digest_invariants() {
         let wallet = WalletSim::new(shared_sk());
         let stamped = build_autonome(rng, &wallet, 1000, 700);
         let baseline = stamped.auth_digest();
+        let baseline_commitment = stamped.commitment();
 
         let mut altered_actions = stamped.clone();
         altered_actions.stamp.coverage[0] ^= 0x01;
+        // the commitment does not reach into the stamp: only auth_digest moves.
+        assert_eq!(baseline_commitment, altered_actions.commitment());
         assert_ne!(baseline, altered_actions.auth_digest());
 
         let mut extra_tachygram = stamped;
@@ -1058,6 +1067,7 @@ fn auth_digest_invariants() {
             .push(Tachygram::from(Fp::from(7u64)));
         // Tachygrams must stay canonically sorted for the stamp digest.
         extra_tachygram.stamp.tachygrams.sort_unstable();
+        assert_eq!(baseline_commitment, extra_tachygram.commitment());
         assert_ne!(baseline, extra_tachygram.auth_digest());
     }
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -456,6 +456,10 @@ fn payment_bundle_verifies() {
         .expect("payment bundle must verify");
 }
 
+/// `verify` reconstructs the action polynomial from the descriptors it is
+/// given, as a multiset: the exact covered actions verify (in any order), and
+/// any deviation — a dropped, duplicated, extra, or substituted action —
+/// reconstructs a different polynomial and is `Disproved`.
 #[test]
 fn stamp_verify_action_multiset_invariants() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -601,13 +605,129 @@ fn double_spend_obvious() {
         "the actions are identical"
     );
 
-    // Proof verification rejects it: the doubled action set reconstructs to
-    // match the proof, but the collapsed tachygram set cannot reconstruct the
-    // doubled commitment the merge proof holds.
+    // Proof verification rejects it: the doubled action set reconstructs to a
+    // polynomial the forged merge proof does not commit to.
     let err = decoded
         .stamp
         .verify(rng, &decoded.descriptors())
         .expect_err("duplicated actions must not verify");
+    let VerificationError::Disproved = err else {
+        panic!("expected Disproved, got {err:?}");
+    };
+}
+
+/// A duplicated *spend* would mint value, and `verify` catches it by
+/// reconstructing the action multiset from the wire.
+///
+/// The attacker holds one real spendable note worth `v` and its honest
+/// single-spend stamp (covering `{d}`, one nullifier pair). By hand they build
+/// an autonome whose action list is `[d, d]` — the same spend twice — with
+/// `value_balance = 2v` (a valid binding signature over the doubled `cv` and
+/// `bsk = 2·rcv`) and `coverage` forged to `digest([d, d])`. Signatures verify
+/// and `is_autonome` accepts the forged coverage; the stamp evidences one spent
+/// note against a balance that withdraws `2v`, so accepting it would mint `v`.
+///
+/// It dies at the proof: `verify` reconstructs `(x−d)²` from the wire's
+/// `[d, d]`, which the honest single-spend `(x−d)` proof does not commit to →
+/// `Disproved`. This defense relies on `verify` seeing the full multiset. A
+/// `verify` that deduplicated its input would collapse `[d, d]` to `{d}`, which
+/// the honest proof satisfies, and the distinctness check would have to be
+/// hoisted to the caller.
+#[test]
+fn duplicated_spend_cannot_inflate() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let note = wallet.random_note(200);
+
+    let mut pool = PoolSim::genesis(rng);
+    pool.mine(random_block_with(rng, &[vec![note.commitment()]], 50));
+    let cm_height = pool.height();
+    while pool.height() < BlockHeight(EPOCH_SIZE) {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+    let init = wallet.spendable_init(rng, &note, &pool, cm_height);
+    let spendable = wallet.lift_over_creation_epoch(rng, &pool, &note, cm_height, init);
+    let anchor = spendable.data().2;
+    let spend_epoch = cm_height.epoch().next();
+
+    // Build one honest spend with a trapdoor and randomizer we control, so the
+    // duplicated bundle's binding and action signatures can be reproduced.
+    let range = wallet.derived_range(rng, &note, spend_epoch, 2);
+    let rcv = value::Trapdoor::random(rng);
+    let theta = ActionEntropy::random(rng);
+    let plan = action::Plan::spend(note, theta, rcv, |alpha| {
+        wallet.pak.ak.derive_action_public(&alpha)
+    });
+    let descriptor = plan.descriptor();
+    let honest_stamp = Plan::new(alloc::vec![plan], alloc::vec![])
+        .stamp_plan(anchor)
+        .prove(rng, &wallet.pak, alloc::vec![(range, spendable)])
+        .expect("prove the honest single spend");
+
+    // Assemble the duplicated-spend bundle by hand: two identical spend actions,
+    // a value balance and binding key doubled to match, and coverage forged over
+    // the doubled action set.
+    let doubled = 2 * i64::try_from(u64::from(note.value)).expect("note value fits i64");
+    let value_balance = value::Balance::try_from(doubled).expect("doubled balance in range");
+    let action_bytes: Vec<[u8; 64]> = vec![descriptor, descriptor].into_iter().collect();
+    let sighash = mock_sighash(bundle_commitment(
+        &action_descriptor_digest(&action_bytes),
+        doubled,
+    ));
+    let alpha = theta.randomizer::<effect::Spend>(note.commitment());
+    let sig = wallet
+        .sk
+        .derive_auth_private()
+        .derive_action_private(&alpha)
+        .sign(rng, &sighash);
+    let action = Action::from((descriptor, sig));
+    let binding_sig = private::BindingSigningKey::from([rcv, rcv]).sign(rng, &sighash);
+    let coverage = {
+        let mut desc_bytes = Vec::<[u8; 64]>::from_iter([descriptor, descriptor]);
+        desc_bytes.sort_unstable();
+        action_descriptor_digest(&desc_bytes)
+    };
+    let bundle = Bundle {
+        actions: vec![action, action],
+        value_balance,
+        binding_sig,
+        stamp: ProofStamp {
+            coverage,
+            anchor: honest_stamp.anchor,
+            tachygrams: honest_stamp.tachygrams,
+            proof: honest_stamp.proof,
+        },
+    };
+
+    let mut buf = Vec::new();
+    bundle.write(&mut buf).expect("write");
+    let decoded = Bundle::<ProofStamp>::read(&*buf).expect("duplicated spend is wire-valid");
+
+    // The cheap checks pass, and the balance would mint: one spent note (one
+    // present/next nullifier pair) against a balance that withdraws twice its
+    // value.
+    decoded
+        .verify_signatures(&mock_sighash(decoded.commitment()))
+        .expect("binding and action signatures verify");
+    assert!(
+        decoded.is_autonome(),
+        "the forged coverage matches the duplicated action set"
+    );
+    assert_eq!(
+        decoded.stamp.tachygrams.len(),
+        2,
+        "a single spend contributes exactly one present/next nullifier pair"
+    );
+    let withdrawn: i64 = decoded.value_balance.into();
+    let backed = i64::try_from(u64::from(note.value)).expect("note value fits i64");
+    assert_eq!(withdrawn, 2 * backed, "the bundle balances two spends");
+
+    // The proof rejects it: reconstructing the [d, d] multiset yields an action
+    // polynomial the honest single-spend proof does not commit to.
+    let err = decoded
+        .stamp
+        .verify(rng, &decoded.descriptors())
+        .expect_err("the doubled action must not verify against the single-spend proof");
     let VerificationError::Disproved = err else {
         panic!("expected Disproved, got {err:?}");
     };

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -234,9 +234,7 @@ fn apply_signatures_rejects_wrong_sig_count() {
             BTreeMap::from([(spend_a.descriptor(), sig_a)]),
         )
         .unwrap_err();
-    let FinalizePlanError::ActionsMismatch = too_few else {
-        panic!("expected ActionsMismatch, got {too_few:?}");
-    };
+    assert_eq!(too_few, PlanError::ActionSigMismatch);
 
     let too_many = plan
         .apply_signatures(
@@ -249,9 +247,7 @@ fn apply_signatures_rejects_wrong_sig_count() {
             ]),
         )
         .unwrap_err();
-    let FinalizePlanError::ActionsMismatch = too_many else {
-        panic!("expected ActionsMismatch, got {too_many:?}");
-    };
+    assert_eq!(too_many, PlanError::ActionSigMismatch);
 }
 
 #[test]
@@ -1285,16 +1281,12 @@ fn plan_value_balance_rejects_overflow_above_max_money() {
     assert_eq!(bundle_plan.value_balance(), Err(value::OutOfRange));
     {
         let err = bundle_plan.commitment().unwrap_err();
-        let CommitError::BalanceOverflow(_) = err else {
-            panic!("expected CommitError::BalanceOverflow, got {err:?}");
-        };
+        assert_eq!(err, value::OutOfRange);
     }
     let sighash = [0u8; 32];
     {
         let err = bundle_plan.sign(rng, &sighash, &ask).unwrap_err();
-        let FinalizePlanError::BalanceOverflow = err else {
-            panic!("expected SignError::BalanceOverflow, got {err:?}");
-        };
+        assert_eq!(err, PlanError::BalanceOverflow);
     }
 }
 
@@ -1312,16 +1304,12 @@ fn plan_value_balance_rejects_overflow_below_negative_max_money() {
     assert_eq!(bundle_plan.value_balance(), Err(value::OutOfRange));
     {
         let err = bundle_plan.commitment().unwrap_err();
-        let CommitError::BalanceOverflow(_) = err else {
-            panic!("expected CommitError::BalanceOverflow, got {err:?}");
-        };
+        assert_eq!(err, value::OutOfRange);
     }
     let sighash = [0u8; 32];
     {
         let err = bundle_plan.sign(rng, &sighash, &ask).unwrap_err();
-        let FinalizePlanError::BalanceOverflow = err else {
-            panic!("expected SignError::BalanceOverflow, got {err:?}");
-        };
+        assert_eq!(err, PlanError::BalanceOverflow);
     }
 }
 

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -17,7 +17,6 @@ use crate::{
         random_block_with, shared_sk, spend_witness,
     },
     primitives::{BlockHeight, Tachygram},
-    stamp::VerificationError,
     value,
 };
 
@@ -46,7 +45,7 @@ fn wrong_value_balance_fails_verification() {
 
     bundle.value_balance = value::Balance::try_from(999).unwrap();
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let SignatureError::Binding(_) = err else {
+    let VerifySignaturesError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
     };
 }
@@ -66,7 +65,7 @@ fn verify_signatures_rejects_out_of_range_value_balance_mutation() {
 
     bundle.value_balance = value::Balance::new_unchecked(i64::MAX);
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let SignatureError::Binding(_) = err else {
+    let VerifySignaturesError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
     };
 }
@@ -147,7 +146,7 @@ fn actions_signed_despite_wrong_rk_fail_verification() {
     let err = bundle
         .verify_signatures(&mock_sighash(bundle.commitment()))
         .unwrap_err();
-    let SignatureError::Action(_) = err else {
+    let VerifySignaturesError::Action(_) = err else {
         panic!("expected SignatureError::Action, got {err:?}");
     };
 }
@@ -190,7 +189,7 @@ fn actions_signed_by_wrong_rsk_fail_verification() {
     let err = bundle
         .verify_signatures(&mock_sighash(bundle.commitment()))
         .unwrap_err();
-    let SignatureError::Action(_) = err else {
+    let VerifySignaturesError::Action(_) = err else {
         panic!("expected SignatureError::Action, got {err:?}");
     };
 }
@@ -284,7 +283,7 @@ fn apply_signatures_with_shuffled_sigs_fails_verification() {
     let err = bundle
         .verify_signatures(&mock_sighash(bundle.commitment()))
         .unwrap_err();
-    let SignatureError::Action(_) = err else {
+    let VerifySignaturesError::Action(_) = err else {
         panic!("expected SignatureError::Action, got {err:?}");
     };
 }
@@ -317,7 +316,7 @@ fn permuted_actions_change_commitment() {
     let sig_err = permuted
         .verify_signatures(&mock_sighash(permuted.commitment()))
         .unwrap_err();
-    let SignatureError::Binding(_) = sig_err else {
+    let VerifySignaturesError::Binding(_) = sig_err else {
         panic!("expected SignatureError::Binding, got {sig_err:?}");
     };
 }
@@ -342,7 +341,7 @@ fn tampered_value_balance_fails_verification() {
     let bind_err = tampered
         .verify_signatures(&mock_sighash(tampered.commitment()))
         .unwrap_err();
-    let SignatureError::Binding(_) = bind_err else {
+    let VerifySignaturesError::Binding(_) = bind_err else {
         panic!("expected SignatureError::Binding, got {bind_err:?}");
     };
 
@@ -350,7 +349,7 @@ fn tampered_value_balance_fails_verification() {
     let also_err = tampered
         .verify_signatures(&mock_sighash(original.commitment()))
         .unwrap_err();
-    let SignatureError::Binding(_) = also_err else {
+    let VerifySignaturesError::Binding(_) = also_err else {
         panic!("expected SignatureError::Binding, got {also_err:?}");
     };
 }
@@ -456,65 +455,89 @@ fn payment_bundle_verifies() {
         .expect("payment bundle must verify");
 }
 
-/// `verify` reconstructs the action polynomial from the descriptors it is
-/// given, as a multiset: the exact covered actions verify (in any order), and
-/// any deviation — a dropped, duplicated, extra, or substituted action —
-/// reconstructs a different polynomial and is `Disproved`.
+/// `verify_proof` reconstructs the action polynomial from the action digests it
+/// is given, as a multiset: the exact covered actions verify (in any order),
+/// and any deviation — a dropped, duplicated, extra, or substituted action —
+/// reconstructs a different polynomial and does not verify.
 #[test]
 fn stamp_verify_action_multiset_invariants() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
     let stamped = build_autonome(rng, &wallet, 1000, 700);
 
-    let descriptors: Vec<action::Descriptor> =
-        stamped.actions.iter().map(Action::descriptor).collect();
+    let digests: Vec<ActionDigest> = stamped
+        .actions
+        .iter()
+        .map(|action| action.descriptor().digest().expect("action digest"))
+        .collect();
 
     // Permutation accepts.
-    {
+    assert!(
         stamped
             .stamp
-            .verify(rng, &[descriptors[1], descriptors[0]])
-            .expect("permuted actions must verify");
-    }
+            .verify_proof(rng, &[digests[1], digests[0]])
+            .expect("proof system verification"),
+        "permuted actions must verify"
+    );
 
     // Drop rejects.
     {
-        let mut dropped = descriptors.clone();
+        let mut dropped = digests.clone();
         dropped.pop();
-        let err = stamped.stamp.verify(rng, &dropped).unwrap_err();
-        let VerificationError::Disproved = err else {
-            panic!("drop: expected Disproved, got {err:?}");
-        };
+        assert!(
+            !stamped
+                .stamp
+                .verify_proof(rng, &dropped)
+                .expect("proof system verification"),
+            "dropped action must not verify"
+        );
     }
 
     // Duplicate rejects.
     {
-        let mut duplicated = descriptors.clone();
-        duplicated.push(duplicated[0]);
-        let err = stamped.stamp.verify(rng, &duplicated).unwrap_err();
-        let VerificationError::Disproved = err else {
-            panic!("duplicate: expected Disproved, got {err:?}");
-        };
+        let mut duplicated = digests.clone();
+        duplicated.push(digests[0]);
+        assert!(
+            !stamped
+                .stamp
+                .verify_proof(rng, &duplicated)
+                .expect("proof system verification"),
+            "duplicated action must not verify"
+        );
     }
 
     // Foreign-extra rejects.
     {
-        let mut extended = descriptors.clone();
-        extended.push(random_action(rng).descriptor());
-        let err = stamped.stamp.verify(rng, &extended).unwrap_err();
-        let VerificationError::Disproved = err else {
-            panic!("extra: expected Disproved, got {err:?}");
-        };
+        let mut extended = digests.clone();
+        extended.push(
+            random_action(rng)
+                .descriptor()
+                .digest()
+                .expect("action digest"),
+        );
+        assert!(
+            !stamped
+                .stamp
+                .verify_proof(rng, &extended)
+                .expect("proof system verification"),
+            "extra action must not verify"
+        );
     }
 
     // Replace-with-foreign rejects.
     {
-        let mut replaced = descriptors;
-        replaced[0] = random_action(rng).descriptor();
-        let err = stamped.stamp.verify(rng, &replaced).unwrap_err();
-        let VerificationError::Disproved = err else {
-            panic!("replaced: expected Disproved, got {err:?}");
-        };
+        let mut replaced = digests;
+        replaced[0] = random_action(rng)
+            .descriptor()
+            .digest()
+            .expect("action digest");
+        assert!(
+            !stamped
+                .stamp
+                .verify_proof(rng, &replaced)
+                .expect("proof system verification"),
+            "replaced action must not verify"
+        );
     }
 }
 
@@ -605,15 +628,33 @@ fn double_spend_obvious() {
         "the actions are identical"
     );
 
-    // Proof verification rejects it: the doubled action set reconstructs to a
-    // polynomial the forged merge proof does not commit to.
-    let err = decoded
-        .stamp
-        .verify(rng, &decoded.descriptors())
-        .expect_err("duplicated actions must not verify");
-    let VerificationError::Disproved = err else {
-        panic!("expected Disproved, got {err:?}");
+    // Bundle-level proof verification rejects the duplicate outright: the action
+    // set digests into a `BTreeSet`, collapsing the repeat, so the count shrinks.
+    let dup_err = decoded
+        .verify_proof(rng, &[])
+        .expect_err("duplicated actions must be rejected");
+    let VerifyProofError::DuplicateActions = dup_err else {
+        panic!("expected DuplicateActions, got {dup_err:?}");
     };
+
+    // The proof independently rejects it, but on the tachygram accumulator, not
+    // the action one: the forged merge commits to the doubled action multiset
+    // (x-d)^2 AND the doubled tachygram (x-cm)^2, so reconstructing the action
+    // set from [d, d] matches. A wire-valid stamp must carry a canonical
+    // deduplicated tachygram set (see `read_rejects_duplicate_tachygrams`),
+    // whose (x-cm) cannot reconstruct the doubled tachygram the proof commits to.
+    let digests: Vec<ActionDigest> = decoded
+        .descriptors()
+        .iter()
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect();
+    assert!(
+        !decoded
+            .stamp
+            .verify_proof(rng, &digests)
+            .expect("proof system verification"),
+        "the deduplicated tachygram set cannot reconstruct the doubled proof"
+    );
 }
 
 /// A duplicated *spend* would mint value, and `verify` catches it by
@@ -722,15 +763,30 @@ fn duplicated_spend_cannot_inflate() {
     let backed = i64::try_from(u64::from(note.value)).expect("note value fits i64");
     assert_eq!(withdrawn, 2 * backed, "the bundle balances two spends");
 
-    // The proof rejects it: reconstructing the [d, d] multiset yields an action
-    // polynomial the honest single-spend proof does not commit to.
-    let err = decoded
-        .stamp
-        .verify(rng, &decoded.descriptors())
-        .expect_err("the doubled action must not verify against the single-spend proof");
-    let VerificationError::Disproved = err else {
-        panic!("expected Disproved, got {err:?}");
+    // Bundle-level proof verification rejects the duplicate outright: the action
+    // set digests into a `BTreeSet`, collapsing the repeat, so the count shrinks.
+    let dup_err = decoded
+        .verify_proof(rng, &[])
+        .expect_err("the duplicated spend must be rejected");
+    let VerifyProofError::DuplicateActions = dup_err else {
+        panic!("expected DuplicateActions, got {dup_err:?}");
     };
+
+    // The proof independently rejects it: reconstructing the [d, d] multiset
+    // yields an action polynomial the honest single-spend proof does not commit
+    // to.
+    let digests: Vec<ActionDigest> = decoded
+        .descriptors()
+        .iter()
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect();
+    assert!(
+        !decoded
+            .stamp
+            .verify_proof(rng, &digests)
+            .expect("proof system verification"),
+        "the doubled action must not verify against the single-spend proof"
+    );
 }
 
 /// A more obfuscated double spend, the same note spent under two independent
@@ -850,15 +906,9 @@ fn innocent_aggregate_from_two_autonomes() {
         .verify_signatures(&mock_sighash(innocent.commitment()))
         .expect("innocent binding sig should verify");
 
-    let adjunct_descriptors: Vec<action::Descriptor> = [adjunct_a.actions, adjunct_b.actions]
-        .concat()
-        .iter()
-        .map(Action::descriptor)
-        .collect();
     innocent
-        .stamp
-        .verify(rng, &adjunct_descriptors)
-        .expect("innocent stamp should verify against adjunct actions");
+        .verify_proof(rng, &[adjunct_a.as_dyn(), adjunct_b.as_dyn()])
+        .expect("innocent aggregate proof verifies against its adjuncts");
 }
 
 #[test]
@@ -954,20 +1004,37 @@ fn based_aggregate_with_two_adjuncts() {
         .verify_signatures(&sighash)
         .expect("based aggregate binding sig should verify");
 
-    let all_descriptors: Vec<action::Descriptor> = [
-        becomes_based.actions.clone(),
-        adjunct_a.actions,
-        adjunct_b.actions,
-    ]
-    .concat()
-    .iter()
-    .map(Action::descriptor)
-    .collect();
-
     becomes_based
-        .stamp
-        .verify(rng, &all_descriptors)
-        .expect("based aggregate stamp should verify against all actions");
+        .verify_proof(rng, &[adjunct_a.as_dyn(), adjunct_b.as_dyn()])
+        .expect("based aggregate proof verifies against its adjuncts");
+}
+
+/// The outer `verify` composes coverage, signatures, and proof for an autonome
+/// bundle with no adjuncts: the honest bundle passes, and a corrupted binding
+/// signature surfaces as `VerificationError::Signatures`.
+#[test]
+fn autonome_verify_composes_all_checks() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let bundle = build_autonome(rng, &wallet, 1000, 700);
+    let sighash = mock_sighash(bundle.commitment());
+    let auth_digest = bundle.auth_digest();
+
+    bundle
+        .verify(rng, &sighash, &auth_digest, &[])
+        .expect("honest autonome bundle verifies");
+
+    let mut tampered = bundle.clone();
+    let mut sig_bytes: [u8; 64] = tampered.binding_sig.0.into();
+    sig_bytes[0] ^= 0xFF;
+    tampered.binding_sig = Signature(sig_bytes.into());
+
+    let err = tampered
+        .verify(rng, &sighash, &auth_digest, &[])
+        .expect_err("a corrupted binding signature must fail verification");
+    let VerificationError::Signatures(VerifySignaturesError::Binding(_)) = err else {
+        panic!("expected Signatures(Binding), got {err:?}");
+    };
 }
 
 #[test]
@@ -983,7 +1050,7 @@ fn invalid_action_sig_fails_verification() {
     bundle.actions[0].sig = bad_sig;
 
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let SignatureError::Action(sig) = err else {
+    let VerifySignaturesError::Action(sig) = err else {
         panic!("expected SignatureError::Action, got {err:?}");
     };
     assert_eq!(sig, bad_sig);
@@ -1659,7 +1726,7 @@ fn zero_action_bundle_rejects_nonzero_balance() {
     };
 
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let SignatureError::Binding(_) = err else {
+    let VerifySignaturesError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
     };
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -46,7 +46,7 @@ fn wrong_value_balance_fails_verification() {
 
     bundle.value_balance = value::Balance::try_from(999).unwrap();
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let VerifySignaturesError::Binding(_) = err else {
+    let SignatureError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
     };
 }
@@ -66,7 +66,7 @@ fn verify_signatures_rejects_out_of_range_value_balance_mutation() {
 
     bundle.value_balance = value::Balance::new_unchecked(i64::MAX);
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let VerifySignaturesError::Binding(_) = err else {
+    let SignatureError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
     };
 }
@@ -147,7 +147,7 @@ fn actions_signed_despite_wrong_rk_fail_verification() {
     let err = bundle
         .verify_signatures(&mock_sighash(bundle.commitment()))
         .unwrap_err();
-    let VerifySignaturesError::Action(_) = err else {
+    let SignatureError::Action(_) = err else {
         panic!("expected SignatureError::Action, got {err:?}");
     };
 }
@@ -190,7 +190,7 @@ fn actions_signed_by_wrong_rsk_fail_verification() {
     let err = bundle
         .verify_signatures(&mock_sighash(bundle.commitment()))
         .unwrap_err();
-    let VerifySignaturesError::Action(_) = err else {
+    let SignatureError::Action(_) = err else {
         panic!("expected SignatureError::Action, got {err:?}");
     };
 }
@@ -284,7 +284,7 @@ fn apply_signatures_with_shuffled_sigs_fails_verification() {
     let err = bundle
         .verify_signatures(&mock_sighash(bundle.commitment()))
         .unwrap_err();
-    let VerifySignaturesError::Action(_) = err else {
+    let SignatureError::Action(_) = err else {
         panic!("expected SignatureError::Action, got {err:?}");
     };
 }
@@ -317,7 +317,7 @@ fn permuted_actions_change_commitment() {
     let sig_err = permuted
         .verify_signatures(&mock_sighash(permuted.commitment()))
         .unwrap_err();
-    let VerifySignaturesError::Binding(_) = sig_err else {
+    let SignatureError::Binding(_) = sig_err else {
         panic!("expected SignatureError::Binding, got {sig_err:?}");
     };
 }
@@ -342,7 +342,7 @@ fn tampered_value_balance_fails_verification() {
     let bind_err = tampered
         .verify_signatures(&mock_sighash(tampered.commitment()))
         .unwrap_err();
-    let VerifySignaturesError::Binding(_) = bind_err else {
+    let SignatureError::Binding(_) = bind_err else {
         panic!("expected SignatureError::Binding, got {bind_err:?}");
     };
 
@@ -350,7 +350,7 @@ fn tampered_value_balance_fails_verification() {
     let also_err = tampered
         .verify_signatures(&mock_sighash(original.commitment()))
         .unwrap_err();
-    let VerifySignaturesError::Binding(_) = also_err else {
+    let SignatureError::Binding(_) = also_err else {
         panic!("expected SignatureError::Binding, got {also_err:?}");
     };
 }
@@ -456,8 +456,8 @@ fn payment_bundle_verifies() {
         .expect("payment bundle must verify");
 }
 
-/// An obvious double spend, two actions with identical descriptors, clears
-/// every cheap validator check yet fails proof verification.
+/// An obvious double spend, two actions with identical descriptors, clears the
+/// signature check yet fails coverage verification on its uniqueness check.
 #[test]
 fn double_spend_obvious() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -543,12 +543,12 @@ fn double_spend_obvious() {
         "the actions are identical"
     );
 
-    // Bundle-level proof verification rejects the duplicate outright: the action
-    // set digests into a `BTreeSet`, collapsing the repeat, so the count shrinks.
+    // Coverage verification rejects the duplicate outright: the descriptors dedup
+    // into a `BTreeSet`, collapsing the repeat, so the count shrinks.
     let dup_err = decoded
-        .verify_proof(rng, &[])
+        .verify_coverage(&[])
         .expect_err("duplicated actions must be rejected");
-    let VerifyProofError::DuplicateActions = dup_err else {
+    let VerifyCoverageError::DuplicateActions = dup_err else {
         panic!("expected DuplicateActions, got {dup_err:?}");
     };
 
@@ -566,7 +566,7 @@ fn double_spend_obvious() {
     assert!(
         !decoded
             .stamp
-            .verify_proof(rng, &digests)
+            .verify_proof(rng, digests)
             .expect("proof system verification"),
         "the deduplicated tachygram set cannot reconstruct the doubled proof"
     );
@@ -574,10 +574,11 @@ fn double_spend_obvious() {
 
 /// A duplicated spend would mint value: one honest single-spend stamp,
 /// republished by hand as an autonome with action list `[d, d]`,
-/// `value_balance = 2v`, `bsk = 2·rcv`, and `coverage` forged to `digest([d, d])`.
-/// Signatures and coverage pass, but `verify_proof` rejects the repeat as
-/// `DuplicateActions`, and the proof reconstructs `(x−d)²`, which the honest
-/// `(x−d)` proof does not commit to.
+/// `value_balance = 2v`, `bsk = 2·rcv`, and `coverage` forged to `digest([d,
+/// d])`. Signatures pass and the forged coverage digest matches, but
+/// `verify_coverage` rejects the repeat as `DuplicateActions`, and
+/// `verify_proof` reconstructs `(x−d)²`, which the honest `(x−d)` proof does
+/// not commit to.
 #[test]
 fn duplicated_spend_cannot_inflate() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -667,12 +668,12 @@ fn duplicated_spend_cannot_inflate() {
     let backed = i64::try_from(u64::from(note.value)).expect("note value fits i64");
     assert_eq!(withdrawn, 2 * backed, "the bundle balances two spends");
 
-    // Bundle-level proof verification rejects the duplicate outright: the action
-    // set digests into a `BTreeSet`, collapsing the repeat, so the count shrinks.
+    // Coverage verification rejects the duplicate outright: the descriptors dedup
+    // into a `BTreeSet`, collapsing the repeat, so the count shrinks.
     let dup_err = decoded
-        .verify_proof(rng, &[])
+        .verify_coverage(&[])
         .expect_err("the duplicated spend must be rejected");
-    let VerifyProofError::DuplicateActions = dup_err else {
+    let VerifyCoverageError::DuplicateActions = dup_err else {
         panic!("expected DuplicateActions, got {dup_err:?}");
     };
 
@@ -687,26 +688,27 @@ fn duplicated_spend_cannot_inflate() {
     assert!(
         !decoded
             .stamp
-            .verify_proof(rng, &digests)
+            .verify_proof(rng, digests)
             .expect("proof system verification"),
         "the doubled action must not verify against the single-spend proof"
     );
 
     // The same failure surfaces through the composed `verify` (autonome, no
-    // adjuncts): the pointer is unchecked, coverage matches the forged digest,
-    // signatures verify (over the same `sighash`), and the duplicate is caught at
-    // the proof step.
+    // adjuncts): the forged coverage digest matches the duplicated action set, and
+    // the duplicate is caught at the coverage step's uniqueness check. (`verify`
+    // does not check signatures; that is done separately above.)
     let err = decoded
-        .verify(rng, &sighash, mock_wtxid(&decoded), &[])
+        .verify(rng, &mock_wtxid(&decoded).into(), &[])
         .expect_err("the duplicated spend must fail full verification");
-    let VerificationError::Proof(VerifyProofError::DuplicateActions) = err else {
-        panic!("expected Proof(DuplicateActions), got {err:?}");
+    let VerificationError::Coverage(VerifyCoverageError::DuplicateActions) = err else {
+        panic!("expected Coverage(DuplicateActions), got {err:?}");
     };
 }
 
-/// `verify_proof` deduplicates across the self+adjunct boundary: an aggregate
-/// and an adjunct claiming the same action are rejected as `DuplicateActions`
-/// before the proof.
+/// `verify_coverage` deduplicates across the self+adjunct boundary: an
+/// aggregate and an adjunct claiming the same action are rejected as
+/// `DuplicateActions`. `verify_proof` independently returns `false` on the
+/// repeated multiset.
 #[test]
 fn verify_proof_rejects_action_shared_with_adjunct() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -714,20 +716,27 @@ fn verify_proof_rejects_action_shared_with_adjunct() {
     let bundle = build_autonome(rng, &wallet, 1000, 700);
 
     // An adjunct carrying the same actions as the bundle: the combined multiset
-    // repeats every descriptor. The pointer is irrelevant to `verify_proof`.
+    // repeats every descriptor. The pointer is irrelevant to coverage.
     let adjunct = bundle.clone().strip(mock_wtxid(&bundle));
 
     let err = bundle
-        .verify_proof(rng, &[adjunct.as_dyn()])
+        .verify_coverage(&[&adjunct])
         .expect_err("an action shared across self and adjunct must be rejected");
-    let VerifyProofError::DuplicateActions = err else {
+    let VerifyCoverageError::DuplicateActions = err else {
         panic!("expected DuplicateActions, got {err:?}");
     };
+
+    assert!(
+        !bundle
+            .verify_proof(rng, &[&adjunct])
+            .expect("proof system verification"),
+        "the repeated multiset must not verify against the single-set proof"
+    );
 }
 
 /// A unique but uncovered adjunct action passes the duplicate check but fails
-/// the proof: the combined action set is not what the bundle's stamp commits to,
-/// so `verify_proof` returns `Disproved`.
+/// the proof: the combined action set is not what the bundle's stamp commits
+/// to, so `verify_proof` returns `false`.
 #[test]
 fn verify_proof_disproves_uncovered_adjunct() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -739,12 +748,12 @@ fn verify_proof_disproves_uncovered_adjunct() {
     let foreign = build_autonome(rng, &wallet, 500, 300);
     let adjunct = foreign.strip(mock_wtxid(&bundle));
 
-    let err = bundle
-        .verify_proof(rng, &[adjunct.as_dyn()])
-        .expect_err("a unique but uncovered adjunct action must not verify");
-    let VerifyProofError::Disproved = err else {
-        panic!("expected Disproved, got {err:?}");
-    };
+    assert!(
+        !bundle
+            .verify_proof(rng, &[&adjunct])
+            .expect("proof system verification"),
+        "a unique but uncovered adjunct action must not verify"
+    );
 }
 
 /// The same note spent under two independent randomizations yields distinct
@@ -864,9 +873,12 @@ fn innocent_aggregate_from_two_autonomes() {
         .verify_signatures(&mock_sighash(innocent.commitment()))
         .expect("innocent binding sig should verify");
 
-    innocent
-        .verify_proof(rng, &[adjunct_a.as_dyn(), adjunct_b.as_dyn()])
-        .expect("innocent aggregate proof verifies against its adjuncts");
+    assert!(
+        innocent
+            .verify_proof(rng, &[&adjunct_a, &adjunct_b])
+            .expect("innocent aggregate proof verifies against its adjuncts"),
+        "innocent aggregate proof must verify against its adjuncts"
+    );
 }
 
 #[test]
@@ -956,6 +968,7 @@ fn based_aggregate_with_two_adjuncts() {
     becomes_based.stamp = based_stamp;
 
     let wtxid = mock_wtxid(&becomes_based);
+    let wtxid_bytes: [u8; 64] = wtxid.into();
     let adjunct_a = autonome_a.strip(wtxid);
     let adjunct_b = autonome_b.strip(wtxid);
 
@@ -963,69 +976,79 @@ fn based_aggregate_with_two_adjuncts() {
         .verify_signatures(&sighash)
         .expect("based aggregate binding sig should verify");
 
-    becomes_based
-        .verify_proof(rng, &[adjunct_a.as_dyn(), adjunct_b.as_dyn()])
-        .expect("based aggregate proof verifies against its adjuncts");
+    assert!(
+        becomes_based
+            .verify_proof(rng, &[&adjunct_a, &adjunct_b])
+            .expect("based aggregate proof verifies against its adjuncts"),
+        "based aggregate proof must verify against its adjuncts"
+    );
 
-    // Outer `verify` composes the pointer, coverage, signature, and proof checks
-    // against the covering wtxid the adjuncts were stripped with.
+    // Outer `verify` composes the pointer, coverage, and proof checks against the
+    // covering wtxid the adjuncts were stripped with. Signatures are verified
+    // separately (above).
     assert!(
         becomes_based.is_aggregate(),
         "a based aggregate does not cover its own actions alone"
     );
     becomes_based
-        .verify(rng, &sighash, wtxid, &[&adjunct_a, &adjunct_b])
+        .verify(rng, &wtxid_bytes, &[&adjunct_a, &adjunct_b])
         .expect("based aggregate fully verifies against its adjuncts");
 
     // A wtxid the adjuncts were not stripped with: the pointer check fails first.
     {
-        let foreign = PointerStamp::try_from([0x5au8; 64]).expect("nonzero");
+        let foreign = [0x5au8; 64];
         let err = becomes_based
-            .verify(rng, &sighash, foreign, &[&adjunct_a, &adjunct_b])
+            .verify(rng, &foreign, &[&adjunct_a, &adjunct_b])
             .expect_err("adjuncts pointing to another aggregate must be rejected");
-        let VerificationError::PointerStampMismatch = err else {
-            panic!("expected PointerStampMismatch, got {err:?}");
+        let VerificationError::Pointers(VerifyPointersError::AdjunctPointerMismatch) = err else {
+            panic!("expected AdjunctPointerMismatch, got {err:?}");
         };
     }
 
     // Pointers match but an adjunct is missing: coverage no longer reconstructs.
     {
         let err = becomes_based
-            .verify(rng, &sighash, wtxid, &[&adjunct_a])
+            .verify(rng, &wtxid_bytes, &[&adjunct_a])
             .expect_err("a missing adjunct must mismatch coverage");
-        let VerificationError::StampActionsMismatch = err else {
-            panic!("expected StampActionsMismatch, got {err:?}");
+        let VerificationError::Coverage(VerifyCoverageError::StampActionsMismatch) = err else {
+            panic!("expected Coverage(StampActionsMismatch), got {err:?}");
         };
     }
 
-    // A corrupted action signature surfaces through the composed check.
+    // A corrupted action signature is caught by `verify_signatures`, the caller's
+    // responsibility alongside `verify`.
     {
         let mut tampered = becomes_based.clone();
         let mut sig_bytes: [u8; 64] = tampered.actions[0].sig.0.into();
         sig_bytes[0] ^= 0xFF;
         tampered.actions[0].sig = action::Signature(sig_bytes.into());
         let err = tampered
-            .verify(rng, &sighash, wtxid, &[&adjunct_a, &adjunct_b])
-            .expect_err("a corrupted action signature must fail verification");
-        let VerificationError::Signatures(VerifySignaturesError::Action(_)) = err else {
-            panic!("expected Signatures(Action), got {err:?}");
+            .verify_signatures(&sighash)
+            .expect_err("a corrupted action signature must fail signature verification");
+        let SignatureError::Action(_) = err else {
+            panic!("expected SignatureError::Action, got {err:?}");
         };
     }
 }
 
 /// The outer `verify` on an autonome (no adjuncts): the honest bundle passes,
-/// and a corrupted binding signature surfaces as `Signatures`. Without adjuncts
-/// the `wtxid` is unchecked, so any nonzero value serves.
+/// with signatures verified separately via `verify_signatures`, which also
+/// catches a corrupted binding signature. Without adjuncts there is nothing to
+/// match the `wtxid` against, though it must still be a valid (nonzero)
+/// aggregate id.
 #[test]
 fn autonome_verify_composes_all_checks() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
     let bundle = build_autonome(rng, &wallet, 1000, 700);
     let sighash = mock_sighash(bundle.commitment());
-    let wtxid = mock_wtxid(&bundle);
+    let wtxid: [u8; 64] = mock_wtxid(&bundle).into();
 
     bundle
-        .verify(rng, &sighash, wtxid, &[])
+        .verify_signatures(&sighash)
+        .expect("honest autonome signatures verify");
+    bundle
+        .verify(rng, &wtxid, &[])
         .expect("honest autonome bundle verifies");
 
     let mut tampered = bundle.clone();
@@ -1034,10 +1057,10 @@ fn autonome_verify_composes_all_checks() {
     tampered.binding_sig = Signature(sig_bytes.into());
 
     let err = tampered
-        .verify(rng, &sighash, wtxid, &[])
-        .expect_err("a corrupted binding signature must fail verification");
-    let VerificationError::Signatures(VerifySignaturesError::Binding(_)) = err else {
-        panic!("expected Signatures(Binding), got {err:?}");
+        .verify_signatures(&sighash)
+        .expect_err("a corrupted binding signature must fail signature verification");
+    let SignatureError::Binding(_) = err else {
+        panic!("expected SignatureError::Binding, got {err:?}");
     };
 }
 
@@ -1054,7 +1077,7 @@ fn invalid_action_sig_fails_verification() {
     bundle.actions[0].sig = bad_sig;
 
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let VerifySignaturesError::Action(sig) = err else {
+    let SignatureError::Action(sig) = err else {
         panic!("expected SignatureError::Action, got {err:?}");
     };
     assert_eq!(sig, bad_sig);
@@ -1794,7 +1817,7 @@ fn zero_action_bundle_rejects_nonzero_balance() {
     };
 
     let err = bundle.verify_signatures(&sighash).unwrap_err();
-    let VerifySignaturesError::Binding(_) = err else {
+    let SignatureError::Binding(_) = err else {
         panic!("expected SignatureError::Binding, got {err:?}");
     };
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -1558,19 +1558,19 @@ fn coverage_check_matches_stamp_actions() {
     // Coverage confirmation: the based aggregate's carried digest matches
     // its own actions plus both covered adjuncts'.
     assert!(
-        becomes_based.covers(&[&adjunct_a, &adjunct_b]),
+        becomes_based.is_covering(&[&adjunct_a, &adjunct_b]),
         "full covered set matches hStampActionsTachyon"
     );
 
     // Missing an adjunct: fewer descriptors, no match.
     assert!(
-        !becomes_based.covers(&[&adjunct_a]),
+        !becomes_based.is_covering(&[&adjunct_a]),
         "missing adjunct must mismatch"
     );
 
     // Extra (duplicated) adjunct: more descriptors, no match.
     assert!(
-        !becomes_based.covers(&[&adjunct_a, &adjunct_b, &adjunct_a]),
+        !becomes_based.is_covering(&[&adjunct_a, &adjunct_b, &adjunct_a]),
         "extra adjunct must mismatch"
     );
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -3,6 +3,7 @@
 use alloc::{string::ToString as _, vec, vec::Vec};
 
 use pasta_curves::Fp;
+use ragu::proof::PROOF_SIZE_COMPRESSED;
 use rand::{SeedableRng as _, rngs::StdRng};
 
 use super::*;
@@ -1157,9 +1158,8 @@ fn auth_digest_invariants() {
         extra_tachygram
             .stamp
             .tachygrams
-            .push(Tachygram::from(Fp::from(7u64)));
+            .insert(Tachygram::from(Fp::from(7u64)));
         // Tachygrams must stay canonically sorted for the stamp digest.
-        extra_tachygram.stamp.tachygrams.sort_unstable();
         assert_eq!(baseline_commitment, extra_tachygram.commitment());
         assert_ne!(baseline, extra_tachygram.auth_digest());
     }
@@ -1282,10 +1282,18 @@ fn read_rejects_noncanonical_tachygrams() {
     let n = bundle.stamp.tachygrams.len();
     assert!(n >= 2, "need at least two tachygrams to permute");
 
-    let mut permuted = bundle;
-    permuted.stamp.tachygrams.swap(0, n - 1);
     let mut buf = Vec::new();
-    permuted.write(&mut buf).expect("write");
+    bundle.write(&mut buf).expect("write");
+
+    // The stamp's proof is the constant-size trailer; the n 32-byte tachygrams
+    // sit immediately before it. A BTreeSet always serializes canonically, so
+    // forge a non-canonical encoding by swapping the first and last tachygram
+    // blocks directly in the buffer.
+    let end = buf.len() - PROOF_SIZE_COMPRESSED;
+    let first = end - n * 32;
+    let last = end - 32;
+    let (head, tail) = buf.split_at_mut(last);
+    head[first..first + 32].swap_with_slice(&mut tail[..32]);
 
     let err =
         Bundle::<ProofStamp>::read(&*buf).expect_err("non-canonical tachygrams must be rejected");

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -200,38 +200,58 @@ fn apply_signatures_rejects_wrong_sig_count() {
     let ask = wallet.sk.derive_auth_private();
     let spend_a = spend_plan_at(rng, &wallet, &ask, 200);
     let spend_b = spend_plan_at(rng, &wallet, &ask, 100);
+    let spend_c = spend_plan_at(rng, &wallet, &ask, 300);
     let plan = Plan::new(alloc::vec![spend_a, spend_b], alloc::vec![]);
 
-    let alpha = spend_a
-        .theta
-        .randomizer::<effect::Spend>(spend_a.note.commitment());
-    let sig = ask
-        .derive_action_private(&alpha)
-        .sign(rng, &mock_sighash(plan.commitment().unwrap()));
+    let sig_a = {
+        let alpha = spend_a
+            .theta
+            .randomizer::<effect::Spend>(spend_a.note.commitment());
+        ask.derive_action_private(&alpha)
+            .sign(rng, &mock_sighash(plan.commitment().unwrap()))
+    };
+
+    let sig_b = {
+        let alpha = spend_b
+            .theta
+            .randomizer::<effect::Spend>(spend_b.note.commitment());
+        ask.derive_action_private(&alpha)
+            .sign(rng, &mock_sighash(plan.commitment().unwrap()))
+    };
+
+    let sig_c = {
+        let alpha = spend_c
+            .theta
+            .randomizer::<effect::Spend>(spend_c.note.commitment());
+        ask.derive_action_private(&alpha)
+            .sign(rng, &mock_sighash(plan.commitment().unwrap()))
+    };
 
     let too_few = plan
         .apply_signatures(
             rng,
             &mock_sighash(plan.commitment().unwrap()),
-            alloc::vec![sig],
+            BTreeMap::from([(spend_a.descriptor(), sig_a)]),
         )
         .unwrap_err();
-    let SignError::SigCountMismatch(expected_for_too_few) = too_few else {
-        panic!("expected SigCountMismatch, got {too_few:?}");
+    let FinalizePlanError::ActionsMismatch = too_few else {
+        panic!("expected ActionsMismatch, got {too_few:?}");
     };
-    assert_eq!(expected_for_too_few, 2);
 
     let too_many = plan
         .apply_signatures(
             rng,
             &mock_sighash(plan.commitment().unwrap()),
-            alloc::vec![sig, sig, sig],
+            BTreeMap::from([
+                (spend_a.descriptor(), sig_a),
+                (spend_b.descriptor(), sig_b),
+                (spend_c.descriptor(), sig_c),
+            ]),
         )
         .unwrap_err();
-    let SignError::SigCountMismatch(expected_for_too_many) = too_many else {
-        panic!("expected SigCountMismatch, got {too_many:?}");
+    let FinalizePlanError::ActionsMismatch = too_many else {
+        panic!("expected ActionsMismatch, got {too_many:?}");
     };
-    assert_eq!(expected_for_too_many, 2);
 }
 
 #[test]
@@ -256,8 +276,10 @@ fn apply_signatures_with_shuffled_sigs_fails_verification() {
 
     // shuffled assembly still succeeds
     sigs.reverse();
+    let authorized = plan.descriptors().into_iter().zip(sigs).collect();
+
     let bundle = plan
-        .apply_signatures(rng, &mock_sighash(plan.commitment().unwrap()), sigs)
+        .apply_signatures(rng, &mock_sighash(plan.commitment().unwrap()), authorized)
         .expect("assembly succeeds regardless of sig order");
 
     // but the mismatched pairing fails verification.
@@ -300,19 +322,6 @@ fn permuted_actions_change_commitment() {
     let SignatureError::Binding(_) = sig_err else {
         panic!("expected SignatureError::Binding, got {sig_err:?}");
     };
-
-    // the original sighash can still verify.
-    // always use a sighash corresponding to the bundle's actual state.
-    permuted
-        .verify_signatures(&mock_sighash(original.commitment()))
-        .unwrap();
-
-    // the invalid bundle is detected at deserialization.
-    let mut buf = Vec::new();
-    permuted.write(&mut buf).expect("write");
-    let read_err = Bundle::<ProofStamp>::read(&*buf).unwrap_err();
-    assert_eq!(read_err.kind(), io::ErrorKind::InvalidData);
-    assert_eq!(read_err.to_string(), "actions are not canonically sorted");
 }
 
 /// Mutating a bundle's `value_balance` breaks verification.
@@ -346,78 +355,6 @@ fn tampered_value_balance_fails_verification() {
     let SignatureError::Binding(_) = also_err else {
         panic!("expected SignatureError::Binding, got {also_err:?}");
     };
-}
-
-/// Duplicate actions are detected at deserialization.
-#[test]
-fn double_spend_obvious() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let wallet = WalletSim::random(rng);
-    let ask = wallet.sk.derive_auth_private();
-    let spend = spend_plan_at(rng, &wallet, &ask, 200);
-
-    let plan = Plan::new(alloc::vec![spend, spend], alloc::vec![]);
-    let bundle = plan
-        .sign(rng, &mock_sighash(plan.commitment().unwrap()), &ask)
-        .expect("signing works");
-
-    bundle
-        .verify_signatures(&mock_sighash(bundle.commitment()))
-        .expect("duplicate spend of the same note still verifies at the bundle level");
-
-    let mut buf = Vec::new();
-    Bundle::<PointerStamp> {
-        actions: bundle.actions,
-        value_balance: bundle.value_balance,
-        binding_sig: bundle.binding_sig,
-        stamp: PointerStamp::try_from([1u8; 64]).expect("not checked"),
-    }
-    .write(&mut buf)
-    .unwrap();
-    let read_err = Bundle::<PointerStamp>::read(&*buf).unwrap_err();
-    assert_eq!(read_err.kind(), io::ErrorKind::InvalidData);
-    assert_eq!(read_err.to_string(), "action descriptors are not unique");
-}
-
-/// This double spend is more obfuscated, so we can't detect it. True double
-/// spend prevention is a nullifier/pool-level concern.
-#[test]
-fn double_spend_secret() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let wallet = WalletSim::random(rng);
-    let ask = wallet.sk.derive_auth_private();
-    let note = wallet.random_note(200);
-
-    let spend_a = action::Plan::spend(
-        note,
-        ActionEntropy::random(rng),
-        value::Trapdoor::random(rng),
-        |alpha| ask.derive_action_private(&alpha).derive_action_public(),
-    );
-    let spend_b = action::Plan::spend(
-        note,
-        ActionEntropy::random(rng),
-        value::Trapdoor::random(rng),
-        |alpha| ask.derive_action_private(&alpha).derive_action_public(),
-    );
-    assert_ne!(
-        spend_a.cv(),
-        spend_b.cv(),
-        "independent rcv gives distinct cv"
-    );
-    assert_ne!(
-        spend_a.rk, spend_b.rk,
-        "independent theta gives distinct rk"
-    );
-
-    let plan = Plan::new(alloc::vec![spend_a, spend_b], alloc::vec![]);
-    let bundle = plan
-        .sign(rng, &mock_sighash(plan.commitment().unwrap()), &ask)
-        .expect("signing works");
-
-    bundle
-        .verify_signatures(&mock_sighash(bundle.commitment()))
-        .expect("two independently-randomized spends of the same note still verify");
 }
 
 /// `sign` and `apply_signatures` go through the real API (not a hand-built
@@ -458,7 +395,7 @@ fn sign_and_apply_signatures_handle_one_sided_and_empty_plans() {
         .apply_signatures(
             rng,
             &mock_sighash(empty_plan.commitment().unwrap()),
-            alloc::vec![],
+            BTreeMap::new(),
         )
         .expect("apply_signatures accepts zero sigs for an empty plan")
         .verify_signatures(&mock_sighash(empty_plan.commitment().unwrap()))
@@ -1232,38 +1169,6 @@ fn coverage_check_matches_stamp_actions() {
     );
 }
 
-/// A bundle whose actions are not in canonical order is rejected on read: the
-/// order-committing sighash plus this check close action reordering as a
-/// malleability vector.
-#[test]
-fn read_rejects_noncanonical_actions() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let wallet = WalletSim::new(shared_sk());
-    let bundle = build_autonome(rng, &wallet, 1000, 700);
-    assert!(
-        bundle.actions.len() >= 2,
-        "need at least two actions to permute"
-    );
-    assert_ne!(bundle.actions[0], bundle.actions[1]);
-
-    // A canonical (signed) bundle round-trips.
-    let mut buf = Vec::new();
-    bundle.write(&mut buf).expect("write");
-    Bundle::<ProofStamp>::read(&*buf).expect("canonical bundle reads");
-
-    // Permuting the stored actions and re-serializing produces a non-canonical
-    // encoding, which read must reject.
-    let mut permuted = bundle;
-    permuted.actions.swap(0, 1);
-    let mut permuted_buf = Vec::new();
-    permuted.write(&mut permuted_buf).expect("write permuted");
-
-    let err = Bundle::<ProofStamp>::read(&*permuted_buf)
-        .expect_err("non-canonical actions must be rejected");
-    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-    assert_eq!(err.to_string(), "actions are not canonically sorted");
-}
-
 /// A stamp whose tachygrams are not in canonical order is rejected on read,
 /// matching the order the stamp digest commits to.
 #[test]
@@ -1348,7 +1253,7 @@ fn plan_value_balance_rejects_overflow_above_max_money() {
     let sighash = [0u8; 32];
     {
         let err = bundle_plan.sign(rng, &sighash, &ask).unwrap_err();
-        let SignError::BalanceOverflow = err else {
+        let FinalizePlanError::BalanceOverflow = err else {
             panic!("expected SignError::BalanceOverflow, got {err:?}");
         };
     }
@@ -1375,7 +1280,7 @@ fn plan_value_balance_rejects_overflow_below_negative_max_money() {
     let sighash = [0u8; 32];
     {
         let err = bundle_plan.sign(rng, &sighash, &ask).unwrap_err();
-        let SignError::BalanceOverflow = err else {
+        let FinalizePlanError::BalanceOverflow = err else {
             panic!("expected SignError::BalanceOverflow, got {err:?}");
         };
     }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -541,6 +541,74 @@ fn is_aggregate_independent_of_action_order() {
     );
 }
 
+/// An obvious double spend, two actions carrying identical descriptors, is
+/// rejected at deserialization by the parser's uniqueness check. The `Plan`
+/// API cannot express this shape (it keys actions by descriptor), so the
+/// duplicate is forced by hand.
+#[test]
+fn double_spend_obvious() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let mut bundle = build_autonome(rng, &wallet, 1000, 700);
+    assert!(
+        bundle.actions.len() >= 2,
+        "need at least two actions to duplicate"
+    );
+
+    bundle.actions[1] = bundle.actions[0];
+
+    let mut buf = Vec::new();
+    bundle.write(&mut buf).expect("write");
+
+    let err =
+        Bundle::<ProofStamp>::read(&*buf).expect_err("duplicate descriptors must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(err.to_string(), "action descriptors are not unique");
+}
+
+/// A more obfuscated double spend, the same note spent under two independent
+/// randomizations, produces distinct descriptors and is not caught at the
+/// bundle level. True double-spend prevention is a nullifier/pool-level
+/// concern.
+#[test]
+fn double_spend_secret() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let ask = wallet.sk.derive_auth_private();
+    let note = wallet.random_note(200);
+
+    let spend_a = action::Plan::spend(
+        note,
+        ActionEntropy::random(rng),
+        value::Trapdoor::random(rng),
+        |alpha| ask.derive_action_private(&alpha).derive_action_public(),
+    );
+    let spend_b = action::Plan::spend(
+        note,
+        ActionEntropy::random(rng),
+        value::Trapdoor::random(rng),
+        |alpha| ask.derive_action_private(&alpha).derive_action_public(),
+    );
+    assert_ne!(
+        spend_a.cv(),
+        spend_b.cv(),
+        "independent rcv gives distinct cv"
+    );
+    assert_ne!(
+        spend_a.rk, spend_b.rk,
+        "independent theta gives distinct rk"
+    );
+
+    let plan = Plan::new(alloc::vec![spend_a, spend_b], alloc::vec![]);
+    let bundle = plan
+        .sign(rng, &mock_sighash(plan.commitment().unwrap()), &ask)
+        .expect("signing works");
+
+    bundle
+        .verify_signatures(&mock_sighash(bundle.commitment()))
+        .expect("two independently-randomized spends of the same note still verify");
+}
+
 #[test]
 fn innocent_aggregate_from_two_autonomes() {
     let rng = &mut StdRng::seed_from_u64(0);

--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -213,7 +213,8 @@ pub(crate) fn stamp_data_digest(
 ///   )
 /// $$
 ///
-/// $\mathsf{tachyonBundleState}$ is one byte indicating format of $\mathsf{tachyonStampState}$
+/// $\mathsf{tachyonBundleState}$ is one byte indicating format of
+/// $\mathsf{tachyonStampState}$
 ///
 /// | $\mathsf{tachyonBundleState}$ | Impl | $\mathsf{tachyonStampState}$ |
 /// | ----------------------------- | ---- | ---------------------------- |

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -37,7 +37,7 @@ use crate::{
         TachygramSetPoly, effect,
     },
     stamp::{
-        PointerStamp, ProofStamp,
+        PointerStamp, ProofStamp, StampState,
         proof::{
             PROOF_SYSTEM, delegation, pool, spendable,
             stamp::{MergeStamp, StampHeader},
@@ -59,19 +59,43 @@ pub fn mock_sighash(bundle_digest: [u8; 32]) -> [u8; 32] {
     out
 }
 
-/// A stand-in for the covering aggregate's `wtxid = txid || auth_digest`:
-/// a mock txid over the bundle commitment, beside the real `auth_digest`.
-pub fn mock_wtxid(bundle: &Bundle<ProofStamp>) -> PointerStamp {
-    let txid = blake2b_simd::Params::new()
+pub fn mock_txid(bundle_commitment: [u8; 32]) -> [u8; 32] {
+    let hash = blake2b_simd::Params::new()
         .hash_length(32)
         .personal(b"pretend txid")
         .to_state()
-        .update(&bundle.commitment())
+        .update(&bundle_commitment)
         .finalize();
 
+    let mut out = [0u8; 32];
+    out.copy_from_slice(hash.as_bytes());
+    out
+}
+
+pub fn mock_auth_digest(bundle_auth_digest: [u8; 32]) -> [u8; 32] {
+    let hash = blake2b_simd::Params::new()
+        .hash_length(32)
+        .personal(b"pretend auth")
+        .to_state()
+        .update(&bundle_auth_digest)
+        .finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(hash.as_bytes());
+    out
+}
+
+/// A stand-in for the covering aggregate's `wtxid = txid || auth_digest`.
+///
+/// Kept distinct from [`mock_sighash`] on purpose: the transaction sighash
+/// equals the txid only for a fully shielded transaction, and `Bundle::verify`
+/// takes the sighash and the covering wtxid as independent inputs. Deriving the
+/// txid half from a separate transform lets tests catch any regression that
+/// conflates the two.
+pub fn mock_wtxid<S: StampState + 'static>(bundle: &Bundle<S>) -> PointerStamp {
     let mut wtxid = [0u8; 64];
-    wtxid[..32].copy_from_slice(txid.as_bytes());
-    wtxid[32..].copy_from_slice(&bundle.auth_digest());
+    wtxid[..32].copy_from_slice(&mock_txid(bundle.commitment()));
+    wtxid[32..].copy_from_slice(&mock_auth_digest(bundle.auth_digest()));
+
     PointerStamp::try_from(wtxid).expect("nonzero wtxid")
 }
 

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -187,7 +187,7 @@ pub fn build_autonome(
 ///
 /// However, `MergeStamp` actually handles a commitment scheme that represents a
 /// multiset, and proves a relationship equivalent to a multiset union. So, a
-/// dishonest prover can feasibly prove a merge violates consensus rules.
+/// dishonest prover can feasibly prove a merge that violates consensus rules.
 ///
 /// Normal tools in this crate don't allow you to carry out such operations, so
 /// this utility will fuse a `MergeStamp` without checking for intersection.

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -122,7 +122,7 @@ pub fn build_output_stamp(
     let (tachygrams, stamp_anchor, proof) =
         ProofStamp::prove_output(rng, rcv, alpha, note, anchor).expect("prove_output");
     let stamp = ProofStamp {
-        actions: blake2b::action_descriptor_digest(
+        coverage: blake2b::action_descriptor_digest(
             &iter::once(plan.descriptor()).collect::<Vec<[u8; 64]>>(),
         ),
         tachygrams,

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -33,11 +33,15 @@ use crate::{
     keys::{NoteMasterKey, PaymentKey, ProofAuthorizingKey, private},
     note::{self, Note, Nullifier, NullifierTrapdoor},
     primitives::{
-        Anchor, BlockHeight, EpochIndex, Tachygram, TachygramSetCommit, TachygramSetPoly, effect,
+        ActionSetPoly, Anchor, BlockHeight, EpochIndex, Tachygram, TachygramSetCommit,
+        TachygramSetPoly, effect,
     },
     stamp::{
         PointerStamp, ProofStamp,
-        proof::{PROOF_SYSTEM, delegation, pool, spendable},
+        proof::{
+            PROOF_SYSTEM, delegation, pool, spendable,
+            stamp::{MergeStamp, StampHeader},
+        },
     },
     value, witness,
 };
@@ -153,6 +157,78 @@ pub fn build_autonome(
         alloc::vec![(spend_note, spendable_pcd, spend_epoch)],
         alloc::vec![output_note],
     )
+}
+
+/// An honest prover will not merge intersecting stamps.
+///
+/// However, `MergeStamp` actually handles a commitment scheme that represents a
+/// multiset, and proves a relationship equivalent to a multiset union. So, a
+/// dishonest prover can feasibly prove a merge violates consensus rules.
+///
+/// Normal tools in this crate don't allow you to carry out such operations, so
+/// this utility will fuse a `MergeStamp` without checking for intersection.
+pub fn forge_overlapping_merge(
+    rng: &mut (impl RngCore + CryptoRng),
+    (stamp_a, descriptors_a): (&ProofStamp, &Vec<action::Descriptor>),
+    (stamp_b, descriptors_b): (&ProofStamp, &Vec<action::Descriptor>),
+) -> Pcd<StampHeader> {
+    let left_acts = descriptors_a
+        .iter()
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect::<ActionSetPoly>();
+    let right_acts = descriptors_b
+        .iter()
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect::<ActionSetPoly>();
+    let left_tg = stamp_a
+        .tachygrams
+        .iter()
+        .copied()
+        .collect::<TachygramSetPoly>();
+    let right_tg = stamp_b
+        .tachygrams
+        .iter()
+        .copied()
+        .collect::<TachygramSetPoly>();
+
+    let left_pcd = stamp_a.proof.clone().carry::<StampHeader>((
+        left_acts.commit(),
+        left_tg.commit(),
+        stamp_a.anchor,
+    ));
+    let right_pcd = stamp_b.proof.clone().carry::<StampHeader>((
+        right_acts.commit(),
+        right_tg.commit(),
+        stamp_b.anchor,
+    ));
+
+    let merged_acts = descriptors_a
+        .iter()
+        .chain(descriptors_b.iter())
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect::<ActionSetPoly>();
+    let merged_tg = stamp_a
+        .tachygrams
+        .iter()
+        .chain(stamp_b.tachygrams.iter())
+        .copied()
+        .collect::<TachygramSetPoly>();
+
+    let (pcd, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            MergeStamp,
+            (
+                (left_acts, left_tg),
+                (merged_acts, merged_tg),
+                (right_acts, right_tg),
+            ),
+            left_pcd,
+            right_pcd,
+        )
+        .expect("multiset merge must prove");
+
+    pcd
 }
 
 pub fn random_block(

--- a/crates/tachyon/src/keys/private.rs
+++ b/crates/tachyon/src/keys/private.rs
@@ -234,14 +234,6 @@ impl ActionSigningKey<effect::Output> {
 #[derive(Clone, Copy, Debug)]
 pub struct BindingSigningKey(#[debug(skip)] reddsa::SigningKey<reddsa::BindingAuth>);
 
-impl TryFrom<[u8; 32]> for BindingSigningKey {
-    type Error = reddsa::Error;
-
-    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        reddsa::SigningKey::<reddsa::BindingAuth>::try_from(bytes).map(Self)
-    }
-}
-
 impl BindingSigningKey {
     /// Sign a transaction sighash with this binding key.
     pub fn sign<RNG: RngCore + CryptoRng>(
@@ -260,16 +252,17 @@ impl BindingSigningKey {
     }
 }
 
-impl From<&[value::Trapdoor]> for BindingSigningKey {
+impl<I: IntoIterator<Item = value::Trapdoor>> From<I> for BindingSigningKey {
     /// BindingAuth signing key is the scalar sum of all value commitment
     /// trapdoors.
     ///
     /// Every Pallas scalar field element, including zero, is a valid binding
     /// signing key. See Zcash protocol §4.14.
-    fn from(trapdoors: &[value::Trapdoor]) -> Self {
+    fn from(trapdoors: I) -> Self {
         let sum: Fq = trapdoors
-            .iter()
-            .fold(Fq::ZERO, |acc, rcv| acc + Into::<Fq>::into(*rcv));
+            .into_iter()
+            .fold(Fq::ZERO, |acc, rcv| acc + Fq::from(rcv));
+
         #[expect(
             clippy::expect_used,
             reason = "all Fq are valid RedPallas signing keys"

--- a/crates/tachyon/src/keys/public.rs
+++ b/crates/tachyon/src/keys/public.rs
@@ -2,7 +2,7 @@
 
 use core::cmp::Eq as CoreTotalEq;
 
-use derive_more::{Debug, Display, PartialEq};
+use derive_more::{Debug, Display};
 use pasta_curves::{EpAffine, group::GroupEncoding as _};
 
 use crate::{
@@ -26,11 +26,18 @@ use crate::{
 ///
 /// This unification lets consensus treat all actions identically while
 /// the type system enforces the authority boundary at construction time.
-#[derive(Clone, Copy, Debug, Display, PartialEq)]
+#[derive(Clone, Copy, Debug, Display)]
 #[display("ActionVerificationKey({:?})", reddsa::VerificationKeyBytes::from(self.0))]
 pub struct ActionVerificationKey(pub(crate) reddsa::VerificationKey<reddsa::ActionAuth>);
 
 impl CoreTotalEq for ActionVerificationKey {}
+impl PartialEq for ActionVerificationKey {
+    fn eq(&self, other: &Self) -> bool {
+        let bytes: [u8; 32] = self.0.into();
+        let other_bytes: [u8; 32] = other.0.into();
+        bytes == other_bytes
+    }
+}
 
 impl ActionVerificationKey {
     /// Verify an action signature against a transaction sighash.
@@ -81,11 +88,18 @@ impl From<ActionVerificationKey> for EpAffine {
 ///
 /// Wraps `reddsa::VerificationKey<reddsa::BindingAuth>`, which internally
 /// stores a Pallas curve point (EpAffine, encoded as 32 compressed bytes).
-#[derive(Clone, Copy, Debug, Display, PartialEq)]
+#[derive(Clone, Copy, Debug, Display)]
 #[display("BindingVerificationKey({:?})", reddsa::VerificationKeyBytes::from(self.0))]
 pub struct BindingVerificationKey(pub(super) reddsa::VerificationKey<reddsa::BindingAuth>);
 
 impl CoreTotalEq for BindingVerificationKey {}
+impl PartialEq for BindingVerificationKey {
+    fn eq(&self, other: &Self) -> bool {
+        let bytes: [u8; 32] = self.0.into();
+        let other_bytes: [u8; 32] = other.0.into();
+        bytes == other_bytes
+    }
+}
 
 impl BindingVerificationKey {
     /// Derive the binding verification key from public action data.

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -31,7 +31,10 @@ mod serialization;
 pub(crate) mod fixtures;
 
 pub use action::{Action, Plan as ActionPlan};
-pub use bundle::{Bundle, Plan as BundlePlan, TachyonBundle};
+pub use bundle::{
+    Bundle, Plan as BundlePlan, TachyonBundle, VerificationError, VerifyProofError,
+    VerifySignaturesError,
+};
 pub use note::Note;
 pub use primitives::*;
 pub use stamp::{PointerStamp, ProofStamp, Unproven};

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -32,9 +32,9 @@ pub(crate) mod fixtures;
 
 pub use action::{Action, Plan as ActionPlan};
 pub use bundle::{
-    Bundle, Plan as BundlePlan, TachyonBundle, VerificationError, VerifyProofError,
-    VerifySignaturesError,
+    Bundle, Plan as BundlePlan, SignatureError, TachyonBundle, VerificationError,
+    VerifyCoverageError, VerifyPointersError, VerifyProofError,
 };
 pub use note::Note;
 pub use primitives::*;
-pub use stamp::{PointerStamp, ProofStamp, Unproven};
+pub use stamp::{AggregateIdError, Plan as StampPlan, PointerStamp, ProofStamp, Unproven};

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -8,7 +8,7 @@ use crate::{digest::poseidon, keys::public, value};
 /// Each action produces one digest, which serves as a root in the
 /// accumulator polynomial. Multiple actions are accumulated via
 /// polynomial commitment, not on this type.
-#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
+#[derive(Clone, Copy, Debug, From, Into, Ord, PartialEq, PartialOrd, TotalEq)]
 pub struct ActionDigest(Fp);
 
 /// Errors from action digest computation.

--- a/crates/tachyon/src/primitives/effect.rs
+++ b/crates/tachyon/src/primitives/effect.rs
@@ -18,7 +18,7 @@ mod sealed {
 }
 
 /// Sealed trait marking an action effect (spend or output).
-pub trait Effect: sealed::Sealed + 'static {
+pub trait Effect: sealed::Sealed {
     /// Derive this effect's $\alpha$ scalar from per-action entropy and a note
     /// commitment.
     ///

--- a/crates/tachyon/src/relations/enforce.rs
+++ b/crates/tachyon/src/relations/enforce.rs
@@ -62,6 +62,7 @@ pub(crate) fn enforce_poly_product(
     multiplicand: &Polynomial,
     multiplier: &Polynomial,
     product: &Polynomial,
+    err: &'static str,
 ) -> Result<()> {
     let multiplicand_com = multiplicand.commit();
     let multiplier_com = multiplier.commit();
@@ -69,9 +70,7 @@ pub(crate) fn enforce_poly_product(
     let z = ctx.derive_challenge(&[multiplicand_com, multiplier_com, product_com])?;
 
     if product.eval(z) != multiplicand.eval(z) * multiplier.eval(z) {
-        return Err(Error::InvalidWitness(
-            "poly product: product identity fails at challenge".into(),
-        ));
+        return Err(Error::InvalidWitness(err.into()));
     }
 
     ctx.enforce_poly_query(multiplicand_com, z, multiplicand.eval(z))?;
@@ -130,6 +129,7 @@ pub(crate) fn enforce_shifted_combination<const SHIFTED_POLYS: usize, const MONO
     shifted_polys: [(&Polynomial, usize); SHIFTED_POLYS],
     monomials: [(Fp, usize); MONOMIALS],
     result: &Polynomial,
+    err: &'static str,
 ) -> Result<()> {
     let poly_coms = shifted_polys.map(|(poly, _)| poly.commit());
     let result_com = result.commit();
@@ -145,9 +145,7 @@ pub(crate) fn enforce_shifted_combination<const SHIFTED_POLYS: usize, const MONO
         )
         .sum::<Fp>();
     if result.eval(z) != combination {
-        return Err(Error::InvalidWitness(
-            "shifted combination: identity fails at challenge".into(),
-        ));
+        return Err(Error::InvalidWitness(err.into()));
     }
 
     for (&(poly, _), com) in shifted_polys.iter().zip(poly_coms) {

--- a/crates/tachyon/src/serialization/mod.rs
+++ b/crates/tachyon/src/serialization/mod.rs
@@ -6,8 +6,6 @@
 
 #![allow(dead_code, reason = "may not be used")]
 
-use alloc::vec::Vec;
-
 use corez::io::{self, Read, Write};
 use ff::PrimeField as _;
 use pasta_curves::{EpAffine, EqAffine, Fp, Fq, group::GroupEncoding as _};
@@ -44,34 +42,6 @@ pub(crate) fn read_fp<R: Read>(mut reader: R) -> io::Result<Fp> {
     reader.read_exact(&mut bytes)?;
     Option::from(Fp::from_repr(bytes))
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid Fp encoding"))
-}
-
-pub(crate) fn read_fp_list<R: Read>(mut reader: R) -> io::Result<Vec<Fp>> {
-    let n = usize::try_from(read_compactsize(&mut reader)?).map_err(|_err| {
-        io::Error::new(io::ErrorKind::InvalidData, "vector length exceeds usize")
-    })?;
-    // TODO: `n` is attacker-controlled up to MAX_COMPACT_SIZE (2^25), so do
-    // not pre-allocate from it; growth on push hits EOF and errors before any
-    // dangerous allocation.
-    let mut fp_list = Vec::new();
-    for _ in 0..n {
-        let fp = read_fp(&mut reader)?;
-        fp_list.push(fp);
-    }
-    Ok(fp_list)
-}
-
-pub(crate) fn write_fp_list<W: Write>(mut writer: W, fp_list: &[Fp]) -> io::Result<()> {
-    write_compactsize(
-        &mut writer,
-        u64::try_from(fp_list.len()).map_err(|_err| {
-            io::Error::new(io::ErrorKind::InvalidData, "vector length exceeds u64")
-        })?,
-    )?;
-    for fp in fp_list {
-        write_fp(&mut writer, fp)?;
-    }
-    Ok(())
 }
 
 /// Write a Pallas base field element (`Fp`) as 32 bytes.

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -497,11 +497,10 @@ impl ProofStamp {
         note: Note,
         anchor: Anchor,
     ) -> Result<(BTreeSet<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
-        let app = &*PROOF_SYSTEM;
-
-        let (pcd, ()) = app.seed(rng, OutputStamp, (rcv, alpha, note, anchor))?;
+        let (pcd, ()) = PROOF_SYSTEM.seed(rng, OutputStamp, (rcv, alpha, note, anchor))?;
         let tachygrams = BTreeSet::from_iter([Tachygram::from(note.commitment())]);
-        let rerand = app.rerandomize(pcd, rng)?;
+
+        let rerand = PROOF_SYSTEM.rerandomize(pcd, rng)?;
 
         Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))
     }
@@ -546,8 +545,6 @@ impl ProofStamp {
         (left_digests, left_tachygrams, left_anchor, left_proof): StampComponents,
         (right_digests, right_tachygrams, right_anchor, right_proof): StampComponents,
     ) -> Result<StampComponents, ragu::Error> {
-        let app = &*PROOF_SYSTEM;
-
         let (left_acts_poly, left_tg_poly) = (
             left_digests.iter().copied().collect::<ActionSetPoly>(),
             left_tachygrams
@@ -580,7 +577,7 @@ impl ProofStamp {
         let tachygrams: BTreeSet<Tachygram> =
             left_tachygrams.union(&right_tachygrams).copied().collect();
 
-        let (pcd, ()) = app.fuse(
+        let (pcd, ()) = PROOF_SYSTEM.fuse(
             rng,
             MergeStamp,
             (
@@ -595,7 +592,7 @@ impl ProofStamp {
             right_pcd,
         )?;
         let anchor = pcd.data().2;
-        let rerand = app.rerandomize(pcd, rng)?;
+        let rerand = PROOF_SYSTEM.rerandomize(pcd, rng)?;
 
         Ok((
             merged_digests,
@@ -647,11 +644,10 @@ impl ProofStamp {
         .map_err(ProveError::MergeFailed)?;
 
         let coverage = blake2b::action_descriptor_digest(
-            left_desc
+            &left_desc
                 .union(&right_desc)
                 .copied()
-                .collect::<Vec<[u8; 64]>>()
-                .as_slice(),
+                .collect::<Vec<[u8; 64]>>(),
         );
 
         Ok(Self {
@@ -683,8 +679,6 @@ impl ProofStamp {
         rng: &mut RNG,
         actions: &[action::Descriptor],
     ) -> Result<(), VerificationError> {
-        let app = &*PROOF_SYSTEM;
-
         let action_set = actions
             .iter()
             .map(action::Descriptor::digest)
@@ -703,7 +697,7 @@ impl ProofStamp {
             self.anchor,
         ));
 
-        let valid = app
+        let valid = PROOF_SYSTEM
             .verify(&pcd, rng)
             .map_err(VerificationError::ProofSystem)?;
 

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -662,8 +662,8 @@ impl ProofStamp {
     ///
     /// The parameter is a multiset: order does not matter, multiplicity does.
     #[must_use]
-    pub fn covers(&self, action_descs: &[action::Descriptor]) -> bool {
-        let mut desc_bytes = action_descs.iter().copied().collect::<Vec<[u8; 64]>>();
+    pub fn covers(&self, action_descs: impl IntoIterator<Item = action::Descriptor>) -> bool {
+        let mut desc_bytes = action_descs.into_iter().collect::<Vec<[u8; 64]>>();
         desc_bytes.sort_unstable();
         blake2b::action_descriptor_digest(&desc_bytes) == self.coverage
     }
@@ -677,9 +677,9 @@ impl ProofStamp {
     pub fn verify_proof<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,
-        action_digests: &[ActionDigest],
+        action_digests: impl IntoIterator<Item = ActionDigest>,
     ) -> Result<bool, ragu::Error> {
-        let action_set = action_digests.iter().copied().collect::<ActionSetPoly>();
+        let action_set = action_digests.into_iter().collect::<ActionSetPoly>();
 
         let tachygram_set = self
             .tachygrams

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -672,8 +672,25 @@ impl ProofStamp {
     /// Verifies this stamp's proof by reconstructing the PCD header from
     /// public data.
     ///
+    /// This is a multiset. The commitment is reconstructed as a product of
+    /// roots, so order does not matter but multiplicity does. A deduplicated or
+    /// otherwise altered set reconstructs a different polynomial.
+    ///
     /// You might want to call [`ProofStamp::covers`] first, to check if the
     /// verification may be expected to fail.
+    ///
+    /// # TODO
+    ///
+    /// Presently, this method *requires that action descriptors must not be
+    /// deduplicated by the caller*. Instead of requiring a difficult-to-enforce
+    /// precondition, it should either
+    ///
+    /// 1. become pub(crate) so callers may be controlled, and a verification
+    ///    method should be added to Bundle<ProofStamp>, or
+    /// 2. a case should be added to VerificationError about action duplication,
+    ///    and a duplication check should be performed.
+    ///
+    /// I prefer (1) but I'm calling it out of scope for the present changeset.
     pub fn verify<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -246,20 +246,17 @@ impl StampState for ProofStamp {
 }
 
 /// Error during stamp verification.
-#[derive(Clone, Debug, Display, Error)]
+#[derive(Debug, Display, Error)]
 pub enum VerificationError {
     /// An action's cv or rk is the identity point.
     #[display("action digest error: {_0}")]
     ActionDigest(ActionDigestError),
     /// The proof system returned an error.
     #[display("proof system error")]
-    ProofSystem,
+    ProofSystem(ragu::Error),
     /// The proof did not verify against the reconstructed header.
     #[display("proof did not verify")]
     Disproved,
-    /// The carried `hStampActionsTachyon` indicator does not match the actions.
-    #[display("covered actions indicator mismatch")]
-    ActionsMismatch,
 }
 
 /// Everything needed to produce a [`ProofStamp`].
@@ -614,8 +611,8 @@ impl ProofStamp {
     /// system, but we might want to fail early.
     pub fn merge<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
-        (left_stamp, left_desc): (Self, Vec<action::Descriptor>),
-        (right_stamp, right_desc): (Self, Vec<action::Descriptor>),
+        (left_stamp, left_desc): (Self, BTreeSet<action::Descriptor>),
+        (right_stamp, right_desc): (Self, BTreeSet<action::Descriptor>),
     ) -> Result<Self, ProveError> {
         let left_actions_digest = left_desc
             .iter()
@@ -645,11 +642,13 @@ impl ProofStamp {
         )
         .map_err(ProveError::MergeFailed)?;
 
-        let coverage = {
-            let mut desc_bytes = Vec::<[u8; 64]>::from_iter([left_desc, right_desc].concat());
-            desc_bytes.sort_unstable();
-            blake2b::action_descriptor_digest(&desc_bytes)
-        };
+        let coverage = blake2b::action_descriptor_digest(
+            left_desc
+                .union(&right_desc)
+                .copied()
+                .collect::<Vec<[u8; 64]>>()
+                .as_slice(),
+        );
 
         Ok(Self {
             coverage,
@@ -659,9 +658,10 @@ impl ProofStamp {
         })
     }
 
-    /// Checks if this stamp covers the given action descriptors. The
-    /// descriptors are sorted into canonical order before hashing, so the
-    /// check is independent of the order the caller presents them in.
+    /// Confirm `hStampActionsTachyon` represents the given action descriptors.
+    ///
+    /// Action descriptors will be sorted but not deduplicated, so that a caller
+    /// checking a collection which contains duplicates can detect the mismatch.
     #[must_use]
     pub fn covers(&self, descs: &[action::Descriptor]) -> bool {
         let mut desc_bytes = descs.iter().copied().collect::<Vec<[u8; 64]>>();
@@ -672,9 +672,8 @@ impl ProofStamp {
     /// Verifies this stamp's proof by reconstructing the PCD header from
     /// public data.
     ///
-    /// The verifier recomputes the covered-actions digest, fails early if
-    /// it disagrees with the carried `hStampActionsTachyon`, then reconstructs
-    /// the action and tachygram accumulators and calls Ragu `verify()`.
+    /// You might want to call [`ProofStamp::covers`] first, to check if the
+    /// verification may be expected to fail.
     pub fn verify<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,
@@ -682,34 +681,27 @@ impl ProofStamp {
     ) -> Result<(), VerificationError> {
         let app = &*PROOF_SYSTEM;
 
-        if !self.covers(actions) {
-            return Err(VerificationError::ActionsMismatch);
-        }
-
-        let action_digests = actions
+        let action_set = actions
             .iter()
             .map(action::Descriptor::digest)
-            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
+            .collect::<Result<ActionSetPoly, ActionDigestError>>()
             .map_err(VerificationError::ActionDigest)?;
-        let action_set = action_digests
-            .into_iter()
-            .collect::<ActionSetPoly>()
-            .commit();
-        let header = (
-            action_set,
-            self.tachygrams
-                .iter()
-                .copied()
-                .collect::<TachygramSetPoly>()
-                .commit(),
-            self.anchor,
-        );
 
-        let pcd = self.proof.clone().carry::<StampHeader>(header);
+        let tachygram_set = self
+            .tachygrams
+            .iter()
+            .copied()
+            .collect::<TachygramSetPoly>();
+
+        let pcd = self.proof.clone().carry::<StampHeader>((
+            action_set.commit(),
+            tachygram_set.commit(),
+            self.anchor,
+        ));
 
         let valid = app
             .verify(&pcd, rng)
-            .map_err(|_err| VerificationError::ProofSystem)?;
+            .map_err(VerificationError::ProofSystem)?;
 
         if valid {
             Ok(())

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -73,6 +73,17 @@ pub enum AggregateIdError {
     Zero,
 }
 
+impl TryFrom<(&[u8; 32], &[u8; 32])> for PointerStamp {
+    type Error = AggregateIdError;
+
+    fn try_from((sighash, auth_digest): (&[u8; 32], &[u8; 32])) -> Result<Self, Self::Error> {
+        let mut wtxid = [0u8; 64];
+        wtxid[..32].copy_from_slice(sighash);
+        wtxid[32..].copy_from_slice(auth_digest);
+        Self::try_from(wtxid)
+    }
+}
+
 impl TryFrom<[u8; 64]> for PointerStamp {
     type Error = AggregateIdError;
 
@@ -249,20 +260,6 @@ impl StampState for ProofStamp {
     }
 }
 
-/// Error during stamp verification.
-#[derive(Debug, Display, Error)]
-pub enum VerificationError {
-    /// An action's cv or rk is the identity point.
-    #[display("action digest error: {_0}")]
-    ActionDigest(ActionDigestError),
-    /// The proof system returned an error.
-    #[display("proof system error")]
-    ProofSystem(ragu::Error),
-    /// The proof did not verify against the reconstructed header.
-    #[display("proof did not verify")]
-    Disproved,
-}
-
 /// Everything needed to produce a [`ProofStamp`].
 ///
 /// Each action is described by a public descriptor `(cv, rk)` and a
@@ -328,6 +325,7 @@ impl Plan {
     /// order.
     ///
     /// TODO: nf_next parameter may need to come back
+    /// TODO: provide a way to lift spend stamps when necessary to merge
     pub fn prove<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,
@@ -660,11 +658,14 @@ impl ProofStamp {
 
     /// Confirm `hStampActionsTachyon` represents the given action descriptors.
     ///
-    /// Action descriptors will be sorted but not deduplicated, so that a caller
-    /// checking a collection which contains duplicates can detect the mismatch.
+    /// # Soundness
+    ///
+    /// The input parameter represents a multiset. Order does not matter, but
+    /// multiplicity does. A set containing duplicate members is not the same as
+    /// a similar set without duplicates.
     #[must_use]
-    pub fn covers(&self, descs: &[action::Descriptor]) -> bool {
-        let mut desc_bytes = descs.iter().copied().collect::<Vec<[u8; 64]>>();
+    pub fn covers(&self, action_descs: &[action::Descriptor]) -> bool {
+        let mut desc_bytes = action_descs.iter().copied().collect::<Vec<[u8; 64]>>();
         desc_bytes.sort_unstable();
         blake2b::action_descriptor_digest(&desc_bytes) == self.coverage
     }
@@ -672,35 +673,20 @@ impl ProofStamp {
     /// Verifies this stamp's proof by reconstructing the PCD header from
     /// public data.
     ///
-    /// This is a multiset. The commitment is reconstructed as a product of
-    /// roots, so order does not matter but multiplicity does. A deduplicated or
-    /// otherwise altered set reconstructs a different polynomial.
-    ///
     /// You might want to call [`ProofStamp::covers`] first, to check if the
     /// verification may be expected to fail.
     ///
-    /// # TODO
+    /// # Soundness
     ///
-    /// Presently, this method *requires that action descriptors must not be
-    /// deduplicated by the caller*. Instead of requiring a difficult-to-enforce
-    /// precondition, it should either
-    ///
-    /// 1. become pub(crate) so callers may be controlled, and a verification
-    ///    method should be added to Bundle<ProofStamp>, or
-    /// 2. a case should be added to VerificationError about action duplication,
-    ///    and a duplication check should be performed.
-    ///
-    /// I prefer (1) but I'm calling it out of scope for the present changeset.
-    pub fn verify<RNG: RngCore + CryptoRng>(
+    /// The input parameter represents a multiset. Order does not matter, but
+    /// multiplicity does. A set containing duplicate members is not the same as
+    /// a similar set without duplicates.
+    pub fn verify_proof<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,
-        actions: &[action::Descriptor],
-    ) -> Result<(), VerificationError> {
-        let action_set = actions
-            .iter()
-            .map(action::Descriptor::digest)
-            .collect::<Result<ActionSetPoly, ActionDigestError>>()
-            .map_err(VerificationError::ActionDigest)?;
+        action_digests: &[ActionDigest],
+    ) -> Result<bool, ragu::Error> {
+        let action_set = action_digests.iter().copied().collect::<ActionSetPoly>();
 
         let tachygram_set = self
             .tachygrams
@@ -714,15 +700,7 @@ impl ProofStamp {
             self.anchor,
         ));
 
-        let valid = PROOF_SYSTEM
-            .verify(&pcd, rng)
-            .map_err(VerificationError::ProofSystem)?;
-
-        if valid {
-            Ok(())
-        } else {
-            Err(VerificationError::Disproved)
-        }
+        PROOF_SYSTEM.verify(&pcd, rng)
     }
 }
 

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -660,9 +660,7 @@ impl ProofStamp {
     ///
     /// # Soundness
     ///
-    /// The input parameter represents a multiset. Order does not matter, but
-    /// multiplicity does. A set containing duplicate members is not the same as
-    /// a similar set without duplicates.
+    /// The parameter is a multiset: order does not matter, multiplicity does.
     #[must_use]
     pub fn covers(&self, action_descs: &[action::Descriptor]) -> bool {
         let mut desc_bytes = action_descs.iter().copied().collect::<Vec<[u8; 64]>>();
@@ -670,17 +668,12 @@ impl ProofStamp {
         blake2b::action_descriptor_digest(&desc_bytes) == self.coverage
     }
 
-    /// Verifies this stamp's proof by reconstructing the PCD header from
-    /// public data.
-    ///
-    /// You might want to call [`ProofStamp::covers`] first, to check if the
-    /// verification may be expected to fail.
+    /// Verify this stamp's proof, reconstructing the PCD header from public data.
+    /// Call [`ProofStamp::covers`] first to cheaply predict a mismatch.
     ///
     /// # Soundness
     ///
-    /// The input parameter represents a multiset. Order does not matter, but
-    /// multiplicity does. A set containing duplicate members is not the same as
-    /// a similar set without duplicates.
+    /// The parameter is a multiset: order does not matter, multiplicity does.
     pub fn verify_proof<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 pub mod proof;
 
 use alloc::{boxed::Box, vec, vec::Vec};
+use core::cmp::Ordering;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, Into, PartialEq};
@@ -180,25 +181,47 @@ impl StampState for ProofStamp {
 
         let anchor = Anchor::read(&mut reader)?;
 
-        let tachygrams: Vec<Tachygram> = serialization::read_fp_list(&mut reader)?
-            .into_iter()
-            .map(Tachygram::from)
-            .collect();
-        if !tachygrams.is_sorted() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "tachygrams are not canonically sorted",
-            ));
+        // `n_tachygrams` is attacker-controlled up to MAX_COMPACT_SIZE (2^25), so
+        // do not pre-allocate vector capacity. vector reads are ASSUMED to hit
+        // invalid data or EOF before significant problems occur.
+        // TODO: assert a reasonable maximum, to allow pre-allocation?
+        let n_tachygrams = usize::try_from(serialization::read_compactsize(&mut reader)?)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+        let mut tachygrams: Vec<Tachygram> = Vec::new();
+        for _ in 0..n_tachygrams {
+            let tg = Tachygram::from(serialization::read_fp(&mut reader)?);
+
+            match tachygrams.last().map(|last| last.cmp(&tg)) {
+                None | Some(Ordering::Less) => tachygrams.push(tg),
+                Some(Ordering::Greater) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "tachygrams are not canonically sorted",
+                    ));
+                },
+                Some(Ordering::Equal) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "tachygrams are not unique",
+                    ));
+                },
+            }
         }
 
-        let mut bytes = vec![0u8; PROOF_SIZE_COMPRESSED];
-        reader.read_exact(&mut bytes)?;
-        let arr: Box<[u8; PROOF_SIZE_COMPRESSED]> =
-            bytes.into_boxed_slice().try_into().map_err(|_err| {
-                io::Error::new(io::ErrorKind::InvalidData, "proof buffer wrong size")
-            })?;
-        let proof = ragu::Proof::try_from(arr.as_ref())
-            .map_err(|_err| io::Error::new(io::ErrorKind::InvalidData, "invalid proof encoding"))?;
+        let proof = {
+            let mut bytes = vec![0u8; PROOF_SIZE_COMPRESSED];
+            reader.read_exact(&mut bytes)?;
+
+            let proof_bytes: &[u8; PROOF_SIZE_COMPRESSED] =
+                bytes.as_slice().try_into().map_err(|_err| {
+                    io::Error::new(io::ErrorKind::InvalidData, "failed to read proof")
+                })?;
+
+            ragu::Proof::try_from(proof_bytes).map_err(|_err| {
+                io::Error::new(io::ErrorKind::InvalidData, "invalid proof encoding")
+            })?
+        };
 
         Ok(Self {
             actions: covered_actions,

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -176,6 +176,7 @@ impl StampState for ProofStamp {
         let mut stamp_digest = [0u8; 64];
         stamp_digest[..32].copy_from_slice(&self.coverage);
         stamp_digest[32..].copy_from_slice(&stamp_data_digest);
+
         stamp_digest
     }
 
@@ -662,19 +663,22 @@ impl ProofStamp {
     ///
     /// The parameter is a multiset: order does not matter, multiplicity does.
     #[must_use]
-    pub fn covers(&self, action_descs: impl IntoIterator<Item = action::Descriptor>) -> bool {
+    pub(crate) fn is_covering(
+        &self,
+        action_descs: impl IntoIterator<Item = action::Descriptor>,
+    ) -> bool {
         let mut desc_bytes = action_descs.into_iter().collect::<Vec<[u8; 64]>>();
         desc_bytes.sort_unstable();
         blake2b::action_descriptor_digest(&desc_bytes) == self.coverage
     }
 
-    /// Verify this stamp's proof, reconstructing the PCD header from public data.
-    /// Call [`ProofStamp::covers`] first to cheaply predict a mismatch.
+    /// Reconstruct the PCD header and verify the proof. Call
+    /// [`ProofStamp::is_covering`] first to cheaply predict a mismatch.
     ///
     /// # Soundness
     ///
     /// The parameter is a multiset: order does not matter, multiplicity does.
-    pub fn verify_proof<RNG: RngCore + CryptoRng>(
+    pub(crate) fn verify_proof<RNG: RngCore + CryptoRng>(
         &self,
         rng: &mut RNG,
         action_digests: impl IntoIterator<Item = ActionDigest>,

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -6,8 +6,7 @@ extern crate alloc;
 
 pub mod proof;
 
-use alloc::{boxed::Box, vec, vec::Vec};
-use core::cmp::Ordering;
+use alloc::{boxed::Box, collections::BTreeSet, vec, vec::Vec};
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, Into, PartialEq};
@@ -188,24 +187,22 @@ impl StampState for ProofStamp {
         let n_tachygrams = usize::try_from(serialization::read_compactsize(&mut reader)?)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
-        let mut tachygrams: Vec<Tachygram> = Vec::new();
+        let mut tachygrams: BTreeSet<Tachygram> = BTreeSet::new();
         for _ in 0..n_tachygrams {
             let tg = Tachygram::from(serialization::read_fp(&mut reader)?);
 
-            match tachygrams.last().map(|last| last.cmp(&tg)) {
-                None | Some(Ordering::Less) => tachygrams.push(tg),
-                Some(Ordering::Greater) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "tachygrams are not canonically sorted",
-                    ));
-                },
-                Some(Ordering::Equal) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "tachygrams are not unique",
-                    ));
-                },
+            if !tachygrams.insert(tg) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "tachygrams are not unique",
+                ));
+            }
+
+            if tachygrams.last().is_none_or(|&last| last != tg) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "tachygrams are not canonically sorted",
+                ));
             }
         }
 
@@ -353,9 +350,7 @@ impl Plan {
         for ((desc, alpha, note, rcv), (nf_pcd, spendable_pcd)) in
             self.spends.into_iter().zip(spendbind_inputs)
         {
-            let app = &*PROOF_SYSTEM;
-
-            let (bind_pcd, ()) = app
+            let (bind_pcd, ()) = PROOF_SYSTEM
                 .fuse(
                     rng,
                     spend::SpendBind,
@@ -370,7 +365,13 @@ impl Plan {
                 ProofStamp::prove_spend(rng, bind_pcd, nf_pcd).map_err(ProveError::ProofFailed)?;
 
             let digest = desc.digest().map_err(ProveError::ActionDigest)?;
-            entries.push((vec![desc], vec![digest], tachygrams, anchor, proof));
+            entries.push((
+                BTreeSet::from_iter([desc]),
+                BTreeSet::from_iter([digest]),
+                tachygrams,
+                anchor,
+                proof,
+            ));
         }
 
         for (desc, alpha, note, rcv) in self.outputs {
@@ -379,10 +380,16 @@ impl Plan {
                     .map_err(ProveError::ProofFailed)?;
 
             let digest = desc.digest().map_err(ProveError::ActionDigest)?;
-            entries.push((vec![desc], vec![digest], tachygrams, anchor, proof));
+            entries.push((
+                BTreeSet::from_iter([desc]),
+                BTreeSet::from_iter([digest]),
+                tachygrams,
+                anchor,
+                proof,
+            ));
         }
 
-        let (mut descriptors, _digests, mut tachygrams, anchor, proof) = entries
+        let (descriptors, _digests, tachygrams, anchor, proof) = entries
             .into_iter()
             .map(Ok::<_, ProveError>)
             .reduce(|acc, next| {
@@ -398,8 +405,10 @@ impl Plan {
                     )
                     .map_err(ProveError::MergeFailed)?;
 
+                let merged_descs = left_desc.union(&right_desc).copied().collect();
+
                 Ok((
-                    [left_desc, right_desc].concat(),
+                    merged_descs,
                     merged_digests,
                     merged_tachygrams,
                     merged_anchor,
@@ -407,9 +416,6 @@ impl Plan {
                 ))
             })
             .ok_or(ProveError::NoActions)??;
-
-        descriptors.sort_unstable();
-        tachygrams.sort_unstable();
 
         let coverage = blake2b::action_descriptor_digest(&Vec::<[u8; 64]>::from_iter(descriptors));
 
@@ -461,7 +467,7 @@ pub struct ProofStamp {
     pub anchor: Anchor,
 
     /// Tachygrams (nullifiers and note commitments) for data availability.
-    pub tachygrams: Vec<Tachygram>,
+    pub tachygrams: BTreeSet<Tachygram>,
 
     /// The Ragu proof bytes.
     #[debug(skip)]
@@ -470,7 +476,12 @@ pub struct ProofStamp {
 
 /// Stamp components threaded through the merge fold: the covered actions'
 /// digests, the tachygrams, the shared anchor, and the proof.
-type StampComponents = (Vec<ActionDigest>, Vec<Tachygram>, Anchor, Box<ragu::Proof>);
+type StampComponents = (
+    BTreeSet<ActionDigest>,
+    BTreeSet<Tachygram>,
+    Anchor,
+    Box<ragu::Proof>,
+);
 
 impl ProofStamp {
     /// Proves a single output action, returning the stamp components
@@ -484,11 +495,11 @@ impl ProofStamp {
         alpha: ActionRandomizer<effect::Output>,
         note: Note,
         anchor: Anchor,
-    ) -> Result<(Vec<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
+    ) -> Result<(BTreeSet<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
         let app = &*PROOF_SYSTEM;
 
         let (pcd, ()) = app.seed(rng, OutputStamp, (rcv, alpha, note, anchor))?;
-        let tachygrams = vec![Tachygram::from(note.commitment())];
+        let tachygrams = BTreeSet::from_iter([Tachygram::from(note.commitment())]);
         let rerand = app.rerandomize(pcd, rng)?;
 
         Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))
@@ -504,17 +515,16 @@ impl ProofStamp {
         rng: &mut RNG,
         bind_pcd: ragu::Pcd<spend::SpendHeader>,
         nf_pcd: ragu::Pcd<delegation::NullifierHeader>,
-    ) -> Result<(Vec<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
-        let app = &*PROOF_SYSTEM;
-
+    ) -> Result<(BTreeSet<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
         let (_, _, nf_present, anchor) = *bind_pcd.data();
         let (_, _, _, (_, nf_next)) = *nf_pcd.data();
 
-        let tachygrams = vec![Tachygram::from(nf_present), Tachygram::from(nf_next)];
+        let tachygrams =
+            BTreeSet::from_iter([Tachygram::from(nf_present), Tachygram::from(nf_next)]);
 
-        let (pcd, ()) = app.fuse(rng, SpendStamp, (nf_next,), bind_pcd, nf_pcd)?;
+        let (pcd, ()) = PROOF_SYSTEM.fuse(rng, SpendStamp, (nf_next,), bind_pcd, nf_pcd)?;
 
-        let rerand = app.rerandomize(pcd, rng)?;
+        let rerand = PROOF_SYSTEM.rerandomize(pcd, rng)?;
 
         Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))
     }
@@ -564,17 +574,20 @@ impl ProofStamp {
             right_anchor,
         ));
 
-        let merged_digests = [left_digests, right_digests].concat();
-        let tachygrams = [left_tachygrams, right_tachygrams].concat();
-        let merged_tg_poly = TachygramSetPoly::from_iter(tachygrams.clone());
-        let merged_acts_poly = ActionSetPoly::from_iter(merged_digests.clone());
+        let merged_digests: BTreeSet<ActionDigest> =
+            left_digests.union(&right_digests).copied().collect();
+        let tachygrams: BTreeSet<Tachygram> =
+            left_tachygrams.union(&right_tachygrams).copied().collect();
 
         let (pcd, ()) = app.fuse(
             rng,
             MergeStamp,
             (
                 (left_acts_poly, left_tg_poly),
-                (merged_acts_poly, merged_tg_poly),
+                (
+                    ActionSetPoly::from_iter(merged_digests.clone()),
+                    TachygramSetPoly::from_iter(tachygrams.clone()),
+                ),
                 (right_acts_poly, right_tg_poly),
             ),
             left_pcd,
@@ -607,15 +620,15 @@ impl ProofStamp {
         let left_actions_digest = left_desc
             .iter()
             .map(action::Descriptor::digest)
-            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
+            .collect::<Result<BTreeSet<ActionDigest>, ActionDigestError>>()
             .map_err(ProveError::ActionDigest)?;
         let right_actions_digest = right_desc
             .iter()
             .map(action::Descriptor::digest)
-            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
+            .collect::<Result<BTreeSet<ActionDigest>, ActionDigestError>>()
             .map_err(ProveError::ActionDigest)?;
 
-        let (_merged_digests, mut tachygrams, anchor, proof) = Self::prove_merge(
+        let (_merged_digests, tachygrams, anchor, proof) = Self::prove_merge(
             rng,
             (
                 left_actions_digest,
@@ -631,7 +644,6 @@ impl ProofStamp {
             ),
         )
         .map_err(ProveError::MergeFailed)?;
-        tachygrams.sort_unstable();
 
         let coverage = {
             let mut desc_bytes = Vec::<[u8; 64]>::from_iter([left_desc, right_desc].concat());

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -233,14 +233,18 @@ impl StampState for ProofStamp {
     fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.coverage)?;
         self.anchor.write(&mut writer)?;
-        serialization::write_fp_list(
+        serialization::write_compactsize(
             &mut writer,
-            &self
-                .tachygrams
-                .iter()
-                .map(|&tg| Fp::from(tg))
-                .collect::<Vec<Fp>>(),
+            u64::try_from(self.tachygrams.len()).map_err(|_err| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "tachygram vector length exceeds u64",
+                )
+            })?,
         )?;
+        for &tg in &self.tachygrams {
+            serialization::write_fp(&mut writer, &Fp::from(tg))?;
+        }
         writer.write_all(self.proof.serialize().as_ref())
     }
 }

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -164,7 +164,7 @@ impl StampState for ProofStamp {
         };
 
         let mut stamp_digest = [0u8; 64];
-        stamp_digest[..32].copy_from_slice(&self.actions);
+        stamp_digest[..32].copy_from_slice(&self.coverage);
         stamp_digest[32..].copy_from_slice(&stamp_data_digest);
         stamp_digest
     }
@@ -224,9 +224,9 @@ impl StampState for ProofStamp {
         };
 
         Ok(Self {
-            actions: covered_actions,
-            tachygrams,
+            coverage: covered_actions,
             anchor,
+            tachygrams,
             proof: Box::new(proof),
         })
     }
@@ -234,7 +234,7 @@ impl StampState for ProofStamp {
     /// Write a stamp to the consensus wire format. The proof blob has a
     /// known constant size.
     fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        writer.write_all(&self.actions)?;
+        writer.write_all(&self.coverage)?;
         self.anchor.write(&mut writer)?;
         serialization::write_fp_list(
             &mut writer,
@@ -411,10 +411,12 @@ impl Plan {
         descriptors.sort_unstable();
         tachygrams.sort_unstable();
 
+        let coverage = blake2b::action_descriptor_digest(&Vec::<[u8; 64]>::from_iter(descriptors));
+
         Ok(ProofStamp {
-            actions: blake2b::action_descriptor_digest(&Vec::<[u8; 64]>::from_iter(descriptors)),
-            tachygrams,
+            coverage,
             anchor,
+            tachygrams,
             proof,
         })
     }
@@ -453,13 +455,13 @@ pub struct ProofStamp {
     /// descriptors from this stamp's bundle and all covered bundles.
     ///
     /// See [`blake2b::action_descriptor_digest`]
-    pub actions: [u8; 32],
-
-    /// Tachygrams (nullifiers and note commitments) for data availability.
-    pub tachygrams: Vec<Tachygram>,
+    pub coverage: [u8; 32],
 
     /// Pool state at the anchor block.
     pub anchor: Anchor,
+
+    /// Tachygrams (nullifiers and note commitments) for data availability.
+    pub tachygrams: Vec<Tachygram>,
 
     /// The Ragu proof bytes.
     #[debug(skip)]
@@ -631,13 +633,16 @@ impl ProofStamp {
         .map_err(ProveError::MergeFailed)?;
         tachygrams.sort_unstable();
 
-        let mut covered_actions = Vec::<[u8; 64]>::from_iter([left_desc, right_desc].concat());
-        covered_actions.sort_unstable();
+        let coverage = {
+            let mut desc_bytes = Vec::<[u8; 64]>::from_iter([left_desc, right_desc].concat());
+            desc_bytes.sort_unstable();
+            blake2b::action_descriptor_digest(&desc_bytes)
+        };
 
         Ok(Self {
-            actions: blake2b::action_descriptor_digest(&covered_actions),
-            tachygrams,
+            coverage,
             anchor,
+            tachygrams,
             proof,
         })
     }
@@ -649,7 +654,7 @@ impl ProofStamp {
     pub fn covers(&self, descs: &[action::Descriptor]) -> bool {
         let mut desc_bytes = descs.iter().copied().collect::<Vec<[u8; 64]>>();
         desc_bytes.sort_unstable();
-        blake2b::action_descriptor_digest(&desc_bytes) == self.actions
+        blake2b::action_descriptor_digest(&desc_bytes) == self.coverage
     }
 
     /// Verifies this stamp's proof by reconstructing the PCD header from

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -279,12 +279,8 @@ impl Step for NullifierFuse {
             ],
             [(-Fp::ONE, offset)],
             &Polynomial::from(merged_seq),
-        )
-        .map_err(|_relation_err| {
-            ragu::Error::InvalidWitness(
-                "NullifierFuse: merged is not the concat of the halves".into(),
-            )
-        })?;
+            "NullifierFuse: merged is not the concat of the halves",
+        )?;
         // Pin the boundary nullifiers that sit at a queryable degree-0 position:
         // the merged sequence opens to `left_nf_start` (its first leaf), and the
         // right half opens to `right_nf_start`. Each ties a witnessed sequence to

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -440,12 +440,8 @@ impl Step for UnspentFuse {
             ],
             [(-Fp::ONE, offset)],
             &Polynomial::from(combined_elapsed_seq),
-        )
-        .map_err(|_relation_err| {
-            ragu::Error::InvalidWitness(
-                "UnspentFuse: combined is not the concatenation of the halves".into(),
-            )
-        })?;
+            "UnspentFuse: combined is not the concatenation of the halves",
+        )?;
         Ok((
             (
                 left_anchor_prev,
@@ -536,12 +532,8 @@ impl Step for UnspentEpochFuse {
             ],
             [(Fp::from(left_nf_end) - Fp::ONE, offset)],
             &Polynomial::from(combined_elapsed_seq),
-        )
-        .map_err(|_relation_err| {
-            ragu::Error::InvalidWitness(
-                "UnspentEpochFuse: combined is not the splice of the halves".into(),
-            )
-        })?;
+            "UnspentEpochFuse: combined is not the splice of the halves",
+        )?;
         Ok((
             (
                 left_anchor_prev,
@@ -628,12 +620,8 @@ impl Step for VerifyUnspent {
                 (Fp::ONE, offset + 1),
             ],
             &Polynomial::from(nf_seq),
-        )
-        .map_err(|_relation_err| {
-            ragu::Error::InvalidWitness(
-                "VerifyUnspent: range is not elapsed followed by the tip".into(),
-            )
-        })?;
+            "VerifyUnspent: range is not elapsed followed by the tip",
+        )?;
         // Bind the unspent's free-witness boundary nullifiers to the range's
         // genuine boundary leaves, which the derivation header proved by
         // construction.

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -278,12 +278,14 @@ impl Step for MergeStamp {
             &left_action_set.into(),
             &right_action_set.into(),
             &merged_action_set.into(),
+            "MergeStamp: merged action set must be the product of left and right action sets",
         )?;
         enforce_poly_product(
             ctx,
             &left_tachygram_set.into(),
             &right_tachygram_set.into(),
             &merged_tachygram_set.into(),
+            "MergeStamp: merged tachygram set must be the product of left and right tachygram sets",
         )?;
 
         Ok((

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -176,43 +176,30 @@ fn merge_populates_covered_actions() {
     assert_eq!(merged.coverage, expected);
 }
 
-/// The honest merge workflow refuses to combine two stamps whose tachygram
-/// sets intersect. `MergeStamp` encodes the merged set as the polynomial
-/// product of its inputs (a multiset union), but `prove_merge` witnesses the
-/// deduplicated set union; the two coincide only for disjoint inputs. An
-/// overlap makes `merged == left · right` unsatisfiable, so the product
-/// relation fails and no proof is produced.
-#[test]
-fn merge_rejects_overlapping_tachygrams() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let wallet = WalletSim::random(rng);
-    let pool = PoolSim::genesis(rng);
-    let anchor = pool.anchor();
-
-    // Two output stamps for the same note share their sole tachygram (the note
-    // commitment) but carry distinct descriptors (independent trapdoors), so
-    // the action sets stay disjoint and the failure isolates to the tachygram
-    // product relation.
-    let note = wallet.random_note(200);
-    let (stamp_a, plan_a) = build_output_stamp(rng, anchor, note);
-    let (stamp_b, plan_b) = build_output_stamp(rng, anchor, note);
-    assert_eq!(
-        stamp_a.tachygrams, stamp_b.tachygrams,
-        "tachygram sets must overlap"
-    );
-    assert_ne!(
-        plan_a.descriptor(),
-        plan_b.descriptor(),
-        "action sets must stay disjoint"
-    );
-
+/// Force-fuse a `MergeStamp` over two stamps that share a set element,
+/// returning the stamp a malicious prover would publish.
+///
+/// First confirms the honest merge refuses the overlap: `MergeStamp` binds each
+/// merged accumulator as the polynomial product of its inputs (a multiset
+/// union), but `prove_merge` witnesses the deduplicated set union, so any
+/// shared element makes `merged == left · right` unsatisfiable. The forgery
+/// instead witnesses the multiset union of both accumulators directly, so both
+/// product relations hold and a proof is produced. The published stamp bears
+/// canonical deduplicated sets, so it is wire-valid — but those sets no longer
+/// reconstruct the multiset accumulators the proof commits to. Applies whether
+/// the shared element is a tachygram (a reused note) or an action digest (a
+/// duplicated contributor).
+fn forge_overlapping_merge(
+    rng: &mut StdRng,
+    (stamp_a, descriptors_a): (&ProofStamp, &BTreeSet<action::Descriptor>),
+    (stamp_b, descriptors_b): (&ProofStamp, &BTreeSet<action::Descriptor>),
+) -> ProofStamp {
     let err = ProofStamp::merge(
         rng,
-        (stamp_a, BTreeSet::from_iter([plan_a.descriptor()])),
-        (stamp_b, BTreeSet::from_iter([plan_b.descriptor()])),
+        (stamp_a.clone(), descriptors_a.clone()),
+        (stamp_b.clone(), descriptors_b.clone()),
     )
     .expect_err("overlapping tachygram sets must not merge");
-
     let ProveError::MergeFailed(ragu::Error::InvalidWitness(inner)) = err else {
         panic!("expected MergeFailed(InvalidWitness), got {err:?}");
     };
@@ -220,32 +207,17 @@ fn merge_rejects_overlapping_tachygrams() {
         inner.to_string(),
         "poly product: product identity fails at challenge"
     );
-}
-
-/// A malicious prover could execute `MergeStamp` to prove a merge of
-/// intersecting sets, but no verifier will accept such a proof.
-#[test]
-fn verify_rejects_maliciously_merged_overlapping_tachygrams() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let wallet = WalletSim::random(rng);
-    let pool = PoolSim::genesis(rng);
-    let anchor = pool.anchor();
-
-    let note = wallet.random_note(200);
-    let (stamp_a, plan_a) = build_output_stamp(rng, anchor, note);
-    let (stamp_b, plan_b) = build_output_stamp(rng, anchor, note);
-    assert_eq!(
-        stamp_a.tachygrams, stamp_b.tachygrams,
-        "tachygram sets must overlap"
-    );
 
     let app = &*PROOF_SYSTEM;
 
-    let digest_a = plan_a.descriptor().digest().expect("action digest");
-    let digest_b = plan_b.descriptor().digest().expect("action digest");
-
-    let left_acts = ActionSetPoly::from_iter([digest_a]);
-    let right_acts = ActionSetPoly::from_iter([digest_b]);
+    let left_acts = descriptors_a
+        .iter()
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect::<ActionSetPoly>();
+    let right_acts = descriptors_b
+        .iter()
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect::<ActionSetPoly>();
     let left_tg = stamp_a
         .tachygrams
         .iter()
@@ -257,56 +229,58 @@ fn verify_rejects_maliciously_merged_overlapping_tachygrams() {
         .copied()
         .collect::<TachygramSetPoly>();
 
-    let left_pcd =
-        stamp_a
-            .proof
-            .carry::<StampHeader>((left_acts.commit(), left_tg.commit(), stamp_a.anchor));
-    let right_pcd = stamp_b.proof.carry::<StampHeader>((
+    let left_pcd = stamp_a.proof.clone().carry::<StampHeader>((
+        left_acts.commit(),
+        left_tg.commit(),
+        stamp_a.anchor,
+    ));
+    let right_pcd = stamp_b.proof.clone().carry::<StampHeader>((
         right_acts.commit(),
         right_tg.commit(),
         stamp_b.anchor,
     ));
 
-    // The malicious witness: the shared tachygram appears twice, so the merged
-    // set polynomial equals `left · right` and the product relation holds. The
-    // action sets are disjoint, so their set and multiset unions coincide.
-    let merged_acts = ActionSetPoly::from_iter([digest_a, digest_b]);
-    let malicious_merged_tg = stamp_a
+    let merged_acts = descriptors_a
+        .iter()
+        .chain(descriptors_b.iter())
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect::<ActionSetPoly>();
+    let merged_tg = stamp_a
         .tachygrams
         .iter()
         .chain(stamp_b.tachygrams.iter())
         .copied()
         .collect::<TachygramSetPoly>();
 
-    let proof = {
-        let (pcd, ()) = app
-            .fuse(
-                rng,
-                MergeStamp,
-                (
-                    (left_acts, left_tg),
-                    (merged_acts, malicious_merged_tg),
-                    (right_acts, right_tg),
-                ),
-                left_pcd,
-                right_pcd,
-            )
-            .expect("multiset merge must prove");
-        Box::new(
-            app.rerandomize(pcd, rng)
-                .expect("rerandomize")
-                .proof()
-                .clone(),
+    let (pcd, ()) = app
+        .fuse(
+            rng,
+            MergeStamp,
+            (
+                (left_acts, left_tg),
+                (merged_acts, merged_tg),
+                (right_acts, right_tg),
+            ),
+            left_pcd,
+            right_pcd,
         )
-    };
+        .expect("multiset merge must prove");
+    let merged_anchor = pcd.data().2;
+    let proof = Box::new(
+        app.rerandomize(pcd, rng)
+            .expect("rerandomize")
+            .proof()
+            .clone(),
+    );
 
-    // The published stamp must bear a canonical deduplicated tachygram vector,
-    // or it will be rejected at deserialization.
     let malicious_stamp = ProofStamp {
-        coverage: blake2b::action_descriptor_digest(&Vec::<[u8; 64]>::from_iter(
-            BTreeSet::from_iter([plan_a.descriptor(), plan_b.descriptor()]),
-        )),
-        anchor,
+        coverage: blake2b::action_descriptor_digest(
+            &descriptors_a
+                .union(descriptors_b)
+                .copied()
+                .collect::<Vec<[u8; 64]>>(),
+        ),
+        anchor: merged_anchor,
         tachygrams: stamp_a
             .tachygrams
             .union(&stamp_b.tachygrams)
@@ -315,21 +289,169 @@ fn verify_rejects_maliciously_merged_overlapping_tachygrams() {
         proof,
     };
 
-    let read_malicious_stamp = {
-        let mut buf = Vec::new();
-        malicious_stamp
-            .write(&mut buf)
-            .expect("write malicious stamp");
-        ProofStamp::read(&*buf).expect("malicious stamp is wire-valid")
-    };
-    assert_eq!(read_malicious_stamp.tachygrams, malicious_stamp.tachygrams);
+    // The deduplicated set is canonical, so the forgery survives deserialization
+    // untouched; only verification catches the mismatch.
+    let mut buf = Vec::new();
+    malicious_stamp
+        .write(&mut buf)
+        .expect("write malicious stamp");
+    ProofStamp::read(&*buf).expect("malicious stamp is wire-valid")
+}
 
-    // The malicious stamp will be rejected at verification, since the canonical
-    // tachygram vector does not represent the multiset union necessary to
-    // verify the malicious proof.
-    let err = read_malicious_stamp
-        .verify(rng, &[plan_a.descriptor(), plan_b.descriptor()])
+/// Reusing a note as an output collides on the note commitment: each
+/// `OutputStamp`'s sole tachygram is that commitment. The nullifier-side analog
+/// is [`double_spend_cannot_aggregate`] — both reuse modes are caught the same
+/// way once the collision lands in the tachygram set.
+#[test]
+fn output_reuse_cannot_aggregate() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let anchor = pool.anchor();
+
+    // Two output stamps for the same note carry the same commitment tachygram
+    // but distinct descriptors (independent trapdoors), so the action sets stay
+    // disjoint and the collision isolates to the tachygrams.
+    let note = wallet.random_note(200);
+    let (stamp_a, plan_a) = build_output_stamp(rng, anchor, note);
+    let (stamp_b, plan_b) = build_output_stamp(rng, anchor, note);
+    assert_eq!(
+        stamp_a.tachygrams, stamp_b.tachygrams,
+        "reused output commitment must collide"
+    );
+    assert_ne!(
+        plan_a.descriptor(),
+        plan_b.descriptor(),
+        "action descriptors stay distinct"
+    );
+
+    let descriptors_a = BTreeSet::from_iter([plan_a.descriptor()]);
+    let descriptors_b = BTreeSet::from_iter([plan_b.descriptor()]);
+    let malicious_stamp =
+        forge_overlapping_merge(rng, (&stamp_a, &descriptors_a), (&stamp_b, &descriptors_b));
+
+    let all_descriptors: Vec<action::Descriptor> =
+        descriptors_a.union(&descriptors_b).copied().collect();
+    let err = malicious_stamp
+        .verify(rng, &all_descriptors)
         .expect_err("multiset-backed proof must not verify against the deduplicated set");
+    let VerificationError::Disproved = err else {
+        panic!("expected Disproved, got {err:?}");
+    };
+}
+
+/// Reusing a note as a spend collides on the nullifiers: nullifiers are
+/// independent of the spend randomization, so two autonome bundles spending one
+/// note carry distinct action descriptors yet identical spend nullifiers. The
+/// nullifier-side analog of [`output_reuse_cannot_aggregate`]: the collision is
+/// caught by the tachygram set, not by action-descriptor uniqueness.
+#[test]
+fn double_spend_cannot_aggregate() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+
+    let spend = wallet.random_note(1000);
+    let output_a = wallet.random_note(700);
+    let output_b = wallet.random_note(600);
+
+    let mut pool = PoolSim::genesis(rng);
+    pool.mine(random_block_with(rng, &[vec![spend.commitment()]], 50));
+    let cm_height = pool.height();
+    while pool.height() < BlockHeight(EPOCH_SIZE) {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+
+    // Two spendable lineages for the SAME note produce identical nullifiers.
+    let init_a = wallet.spendable_init(rng, &spend, &pool, cm_height);
+    let sp_a = wallet.lift_over_creation_epoch(rng, &pool, &spend, cm_height, init_a);
+    let init_b = wallet.spendable_init(rng, &spend, &pool, cm_height);
+    let sp_b = wallet.lift_over_creation_epoch(rng, &pool, &spend, cm_height, init_b);
+    let anchor = sp_a.data().2;
+    assert_eq!(anchor, sp_b.data().2, "same-note lifts share an anchor");
+
+    let spend_epoch = cm_height.epoch().next();
+    let autonome_a = wallet.autonome(
+        rng,
+        anchor,
+        vec![(spend, sp_a, spend_epoch)],
+        vec![output_a],
+    );
+    let autonome_b = wallet.autonome(
+        rng,
+        anchor,
+        vec![(spend, sp_b, spend_epoch)],
+        vec![output_b],
+    );
+
+    let stamp_a = autonome_a.stamp.clone();
+    let stamp_b = autonome_b.stamp.clone();
+
+    let descriptors_a: BTreeSet<action::Descriptor> = autonome_a
+        .actions
+        .iter()
+        .map(action::Action::descriptor)
+        .collect();
+    let descriptors_b: BTreeSet<action::Descriptor> = autonome_b
+        .actions
+        .iter()
+        .map(action::Action::descriptor)
+        .collect();
+    assert!(
+        descriptors_a.is_disjoint(&descriptors_b),
+        "independent randomization gives distinct descriptors"
+    );
+    assert!(
+        !stamp_a.tachygrams.is_disjoint(&stamp_b.tachygrams),
+        "same-note spends share their nullifiers"
+    );
+
+    let malicious_stamp =
+        forge_overlapping_merge(rng, (&stamp_a, &descriptors_a), (&stamp_b, &descriptors_b));
+
+    // The published stamp bears the canonical deduplicated nullifier set, so it
+    // cannot reconstruct the doubled multiset the proof commits to: Disproved.
+    let all_descriptors: Vec<action::Descriptor> =
+        descriptors_a.union(&descriptors_b).copied().collect();
+    let err = malicious_stamp
+        .verify(rng, &all_descriptors)
+        .expect_err("doubled-nullifier proof must not verify");
+    let VerificationError::Disproved = err else {
+        panic!("expected Disproved, got {err:?}");
+    };
+}
+
+/// A stamp cannot cover the same action twice, and the duplicate-tachygram
+/// constraint is what forbids it. Every action carries a tachygram (a spend's
+/// nullifiers, an output's commitment), so covering an action twice doubles its
+/// tachygram. A forged multiset merge commits to the doubled tachygram, but the
+/// published stamp can only bear the canonical deduplicated set.
+///
+/// The forgery is verified here against the *doubled* action descriptors, so
+/// the (also doubled) action accumulator reconstructs to match the proof —
+/// isolating the failure to the tachygram accumulator, which the deduplicated
+/// set cannot reconstruct. A prover who instead published the duplicate on the
+/// wire is caught earlier by [`read_rejects_duplicate_tachygrams`]. This is the
+/// shape of merging two aggregates that share a covered contributor.
+#[test]
+fn cannot_forge_stamp_covering_duplicated_action() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let anchor = pool.anchor();
+
+    let note = wallet.random_note(200);
+    let (stamp, plan) = build_output_stamp(rng, anchor, note);
+    let descriptors = BTreeSet::from_iter([plan.descriptor()]);
+
+    // Two contributors covering the same action: the stamp counted twice.
+    let forged = forge_overlapping_merge(rng, (&stamp, &descriptors), (&stamp, &descriptors));
+
+    // Present the duplicated action honestly, so the action accumulator matches;
+    // only the deduplicated tachygram set fails to reconstruct the doubled
+    // tachygram the proof commits to.
+    let err = forged
+        .verify(rng, &[plan.descriptor(), plan.descriptor()])
+        .expect_err("a stamp covering a duplicated action must not verify");
     let VerificationError::Disproved = err else {
         panic!("expected Disproved, got {err:?}");
     };

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -345,8 +345,9 @@ fn read_rejects_duplicate_tachygrams() {
     let mut buf = Vec::new();
     buf.extend_from_slice(&[0u8; 32]); // covered actions digest
     Anchor(Fp::ZERO).write(&mut buf).expect("write anchor");
-    serialization::write_fp_list(&mut buf, &[Fp::from(tg), Fp::from(tg)])
-        .expect("write tachygrams");
+    serialization::write_compactsize(&mut buf, 2).expect("write tachygram count");
+    serialization::write_fp(&mut buf, &Fp::from(tg)).expect("write tachygram");
+    serialization::write_fp(&mut buf, &Fp::from(tg)).expect("write tachygram");
 
     let err = ProofStamp::read(&*buf).expect_err("duplicate tachygrams must be rejected");
     assert_eq!(err.to_string(), "tachygrams are not unique");

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -173,7 +173,7 @@ fn merge_populates_covered_actions() {
     .expect("merge");
     // `merge` sorts the concatenated descriptors into canonical order, so the
     // covered-actions digest is independent of the order they were passed in.
-    assert_eq!(merged.actions, expected);
+    assert_eq!(merged.coverage, expected);
 }
 
 /// Bundle-validity rule 9 requires a proof stamp's tachygrams to be
@@ -221,7 +221,7 @@ fn covered_actions_round_trip() {
     stamp.write(&mut buf).expect("write");
     let decoded = ProofStamp::read(&*buf).expect("read");
 
-    assert_eq!(decoded.actions, stamp.actions);
+    assert_eq!(decoded.coverage, stamp.coverage);
     assert_eq!(decoded.anchor, stamp.anchor);
     assert_eq!(decoded.tachygrams, stamp.tachygrams);
 }

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -181,7 +181,7 @@ fn merge_populates_covered_actions() {
 /// is [`double_spend_cannot_aggregate`] — both reuse modes are caught the same
 /// way once the collision lands in the tachygram set.
 #[test]
-fn output_reuse_cannot_aggregate() {
+fn double_output_cannot_aggregate() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);
     let pool = PoolSim::genesis(rng);
@@ -261,8 +261,8 @@ fn output_reuse_cannot_aggregate() {
 /// Reusing a note as a spend collides on the nullifiers: nullifiers are
 /// independent of the spend randomization, so two autonome bundles spending one
 /// note carry distinct action descriptors yet identical spend nullifiers. The
-/// nullifier-side analog of [`output_reuse_cannot_aggregate`]: the collision is
-/// caught by the tachygram set, not by action-descriptor uniqueness.
+/// nullifier-side analog of [`double_output_cannot_aggregate`]: the collision
+/// is caught by the tachygram set, not by action-descriptor uniqueness.
 #[test]
 fn double_spend_cannot_aggregate() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -385,8 +385,7 @@ fn double_spend_cannot_aggregate() {
 /// reconstruct it. Verifying against the *doubled* action descriptors makes the
 /// action accumulator match, leaving the tachygram accumulator as the mismatch,
 /// so the forgery is `Disproved`. Publishing the duplicate tachygram on the
-/// wire is instead caught by [`read_rejects_duplicate_tachygrams`]. This is the
-/// shape of merging two aggregates that share a covered contributor.
+/// wire is instead caught by [`read_rejects_duplicate_tachygrams`].
 #[test]
 fn cannot_forge_stamp_covering_duplicated_action() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -450,6 +449,38 @@ fn cannot_forge_stamp_covering_duplicated_action() {
     let err = stamp
         .verify(rng, &all_descriptors)
         .expect_err("a stamp covering a duplicated action must not verify");
+    let VerificationError::Disproved = err else {
+        panic!("expected Disproved, got {err:?}");
+    };
+}
+
+/// `verify` characterization: it checks the proof against exactly the
+/// descriptor multiset it is handed, and nothing more. A duplicated action that
+/// a caller deduplicated to `{d}` verifies against the single-action proof; the
+/// true multiset `[d, d]` reconstructs `(x−d)²` and does not. So `verify`
+/// cannot distinguish a deduplicated duplicate from a genuine single action —
+/// detecting the duplicate is the caller's responsibility, which is why it must
+/// pass the full multiset.
+#[test]
+fn verify_cannot_distinguish_a_deduplicated_duplicate() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let anchor = pool.anchor();
+
+    let note = wallet.random_note(200);
+    let (stamp, plan) = build_output_stamp(rng, anchor, note);
+    let descriptor = plan.descriptor();
+
+    // Deduplicated to one action, it matches the single-action proof.
+    stamp
+        .verify(rng, &[descriptor])
+        .expect("the single covered action verifies");
+
+    // The true multiset is a different action polynomial: (x−d)² ≠ (x−d).
+    let err = stamp
+        .verify(rng, &[descriptor, descriptor])
+        .expect_err("the doubled action must not verify");
     let VerificationError::Disproved = err else {
         panic!("expected Disproved, got {err:?}");
     };

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -10,8 +10,8 @@ use crate::{
     action,
     constants::EPOCH_SIZE,
     fixtures::{
-        PoolSim, WalletSim, build_output_stamp, random_block, random_block_with, shared_sk,
-        spend_witness,
+        PoolSim, WalletSim, build_output_stamp, forge_overlapping_merge, random_block,
+        random_block_with, shared_sk, spend_witness,
     },
     primitives::BlockHeight,
 };
@@ -176,128 +176,6 @@ fn merge_populates_covered_actions() {
     assert_eq!(merged.coverage, expected);
 }
 
-/// Force-fuse a `MergeStamp` over two stamps that share a set element,
-/// returning the stamp a malicious prover would publish.
-///
-/// First confirms the honest merge refuses the overlap: `MergeStamp` binds each
-/// merged accumulator as the polynomial product of its inputs (a multiset
-/// union), but `prove_merge` witnesses the deduplicated set union, so any
-/// shared element makes `merged == left · right` unsatisfiable. The forgery
-/// instead witnesses the multiset union of both accumulators directly, so both
-/// product relations hold and a proof is produced. The published stamp bears
-/// canonical deduplicated sets, so it is wire-valid — but those sets no longer
-/// reconstruct the multiset accumulators the proof commits to. Applies whether
-/// the shared element is a tachygram (a reused note) or an action digest (a
-/// duplicated contributor).
-fn forge_overlapping_merge(
-    rng: &mut StdRng,
-    (stamp_a, descriptors_a): (&ProofStamp, &BTreeSet<action::Descriptor>),
-    (stamp_b, descriptors_b): (&ProofStamp, &BTreeSet<action::Descriptor>),
-) -> ProofStamp {
-    let err = ProofStamp::merge(
-        rng,
-        (stamp_a.clone(), descriptors_a.clone()),
-        (stamp_b.clone(), descriptors_b.clone()),
-    )
-    .expect_err("overlapping tachygram sets must not merge");
-    let ProveError::MergeFailed(ragu::Error::InvalidWitness(inner)) = err else {
-        panic!("expected MergeFailed(InvalidWitness), got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "poly product: product identity fails at challenge"
-    );
-
-    let app = &*PROOF_SYSTEM;
-
-    let left_acts = descriptors_a
-        .iter()
-        .map(|desc| desc.digest().expect("action digest"))
-        .collect::<ActionSetPoly>();
-    let right_acts = descriptors_b
-        .iter()
-        .map(|desc| desc.digest().expect("action digest"))
-        .collect::<ActionSetPoly>();
-    let left_tg = stamp_a
-        .tachygrams
-        .iter()
-        .copied()
-        .collect::<TachygramSetPoly>();
-    let right_tg = stamp_b
-        .tachygrams
-        .iter()
-        .copied()
-        .collect::<TachygramSetPoly>();
-
-    let left_pcd = stamp_a.proof.clone().carry::<StampHeader>((
-        left_acts.commit(),
-        left_tg.commit(),
-        stamp_a.anchor,
-    ));
-    let right_pcd = stamp_b.proof.clone().carry::<StampHeader>((
-        right_acts.commit(),
-        right_tg.commit(),
-        stamp_b.anchor,
-    ));
-
-    let merged_acts = descriptors_a
-        .iter()
-        .chain(descriptors_b.iter())
-        .map(|desc| desc.digest().expect("action digest"))
-        .collect::<ActionSetPoly>();
-    let merged_tg = stamp_a
-        .tachygrams
-        .iter()
-        .chain(stamp_b.tachygrams.iter())
-        .copied()
-        .collect::<TachygramSetPoly>();
-
-    let (pcd, ()) = app
-        .fuse(
-            rng,
-            MergeStamp,
-            (
-                (left_acts, left_tg),
-                (merged_acts, merged_tg),
-                (right_acts, right_tg),
-            ),
-            left_pcd,
-            right_pcd,
-        )
-        .expect("multiset merge must prove");
-    let merged_anchor = pcd.data().2;
-    let proof = Box::new(
-        app.rerandomize(pcd, rng)
-            .expect("rerandomize")
-            .proof()
-            .clone(),
-    );
-
-    let malicious_stamp = ProofStamp {
-        coverage: blake2b::action_descriptor_digest(
-            &descriptors_a
-                .union(descriptors_b)
-                .copied()
-                .collect::<Vec<[u8; 64]>>(),
-        ),
-        anchor: merged_anchor,
-        tachygrams: stamp_a
-            .tachygrams
-            .union(&stamp_b.tachygrams)
-            .copied()
-            .collect(),
-        proof,
-    };
-
-    // The deduplicated set is canonical, so the forgery survives deserialization
-    // untouched; only verification catches the mismatch.
-    let mut buf = Vec::new();
-    malicious_stamp
-        .write(&mut buf)
-        .expect("write malicious stamp");
-    ProofStamp::read(&*buf).expect("malicious stamp is wire-valid")
-}
-
 /// Reusing a note as an output collides on the note commitment: each
 /// `OutputStamp`'s sole tachygram is that commitment. The nullifier-side analog
 /// is [`double_spend_cannot_aggregate`] — both reuse modes are caught the same
@@ -327,12 +205,52 @@ fn output_reuse_cannot_aggregate() {
 
     let descriptors_a = BTreeSet::from_iter([plan_a.descriptor()]);
     let descriptors_b = BTreeSet::from_iter([plan_b.descriptor()]);
-    let malicious_stamp =
-        forge_overlapping_merge(rng, (&stamp_a, &descriptors_a), (&stamp_b, &descriptors_b));
+
+    // The honest merge refuses the overlap on the tachygram-set product relation.
+    {
+        let merge_err = ProofStamp::merge(
+            rng,
+            (stamp_a.clone(), descriptors_a.clone()),
+            (stamp_b.clone(), descriptors_b.clone()),
+        )
+        .expect_err("overlapping tachygrams must not merge");
+        let ProveError::MergeFailed(ragu::Error::InvalidWitness(inner)) = merge_err else {
+            panic!("expected MergeFailed(InvalidWitness), got {merge_err:?}");
+        };
+        assert_eq!(
+            inner.to_string(),
+            "MergeStamp: merged tachygram set must be the product of left and right tachygram sets"
+        );
+    }
+
+    let evil_pcd = forge_overlapping_merge(
+        rng,
+        (&stamp_a, &Vec::from_iter(descriptors_a.clone())),
+        (&stamp_b, &Vec::from_iter(descriptors_b.clone())),
+    );
 
     let all_descriptors: Vec<action::Descriptor> =
         descriptors_a.union(&descriptors_b).copied().collect();
-    let err = malicious_stamp
+
+    // Publish the forgery as a coherent stamp: canonical deduplicated tachygrams
+    // and the covered-actions digest over the merged descriptors, so `covers`
+    // accepts it and only proof verification rejects it.
+    let coverage = {
+        let mut desc_bytes: Vec<[u8; 64]> = all_descriptors.iter().copied().collect();
+        desc_bytes.sort_unstable();
+        blake2b::action_descriptor_digest(&desc_bytes)
+    };
+    let stamp = ProofStamp {
+        coverage,
+        anchor: evil_pcd.data().2,
+        tachygrams: stamp_a
+            .tachygrams
+            .union(&stamp_b.tachygrams)
+            .copied()
+            .collect(),
+        proof: Box::new(evil_pcd.proof().clone()),
+    };
+    let err = stamp
         .verify(rng, &all_descriptors)
         .expect_err("multiset-backed proof must not verify against the deduplicated set");
     let VerificationError::Disproved = err else {
@@ -405,14 +323,52 @@ fn double_spend_cannot_aggregate() {
         "same-note spends share their nullifiers"
     );
 
-    let malicious_stamp =
-        forge_overlapping_merge(rng, (&stamp_a, &descriptors_a), (&stamp_b, &descriptors_b));
+    // The honest merge refuses the overlap on the tachygram-set product relation.
+    {
+        let merge_err = ProofStamp::merge(
+            rng,
+            (stamp_a.clone(), descriptors_a.clone()),
+            (stamp_b.clone(), descriptors_b.clone()),
+        )
+        .expect_err("shared nullifiers must not merge");
+        let ProveError::MergeFailed(ragu::Error::InvalidWitness(inner)) = merge_err else {
+            panic!("expected MergeFailed(InvalidWitness), got {merge_err:?}");
+        };
+        assert_eq!(
+            inner.to_string(),
+            "MergeStamp: merged tachygram set must be the product of left and right tachygram sets"
+        );
+    }
 
-    // The published stamp bears the canonical deduplicated nullifier set, so it
-    // cannot reconstruct the doubled multiset the proof commits to: Disproved.
+    let evil_pcd = forge_overlapping_merge(
+        rng,
+        (&stamp_a, &Vec::from_iter(descriptors_a.clone())),
+        (&stamp_b, &Vec::from_iter(descriptors_b.clone())),
+    );
+
     let all_descriptors: Vec<action::Descriptor> =
         descriptors_a.union(&descriptors_b).copied().collect();
-    let err = malicious_stamp
+
+    // Publish the forgery as a coherent stamp: the covered-actions digest over
+    // the merged descriptors, and the canonical deduplicated nullifier set that
+    // cannot reconstruct the doubled multiset the proof commits to.
+    let coverage = {
+        let mut desc_bytes: Vec<[u8; 64]> = all_descriptors.iter().copied().collect();
+        desc_bytes.sort_unstable();
+        blake2b::action_descriptor_digest(&desc_bytes)
+    };
+    let stamp = ProofStamp {
+        coverage,
+        anchor: evil_pcd.data().2,
+        tachygrams: stamp_a
+            .tachygrams
+            .union(&stamp_b.tachygrams)
+            .copied()
+            .collect(),
+        proof: Box::new(evil_pcd.proof().clone()),
+    };
+
+    let err = stamp
         .verify(rng, &all_descriptors)
         .expect_err("doubled-nullifier proof must not verify");
     let VerificationError::Disproved = err else {
@@ -420,17 +376,16 @@ fn double_spend_cannot_aggregate() {
     };
 }
 
-/// A stamp cannot cover the same action twice, and the duplicate-tachygram
-/// constraint is what forbids it. Every action carries a tachygram (a spend's
-/// nullifiers, an output's commitment), so covering an action twice doubles its
-/// tachygram. A forged multiset merge commits to the doubled tachygram, but the
-/// published stamp can only bear the canonical deduplicated set.
-///
-/// The forgery is verified here against the *doubled* action descriptors, so
-/// the (also doubled) action accumulator reconstructs to match the proof —
-/// isolating the failure to the tachygram accumulator, which the deduplicated
-/// set cannot reconstruct. A prover who instead published the duplicate on the
-/// wire is caught earlier by [`read_rejects_duplicate_tachygrams`]. This is the
+/// A stamp cannot cover the same action twice. The honest merge refuses it on
+/// the action-set product relation (asserted below), since the two contributors
+/// share the action's descriptor. A malicious prover who force-fuses the
+/// multiset union bypasses that — but every action carries a tachygram (a
+/// spend's nullifiers, an output's commitment), so the doubled action doubles
+/// its tachygram, and the published stamp's canonical deduplicated set cannot
+/// reconstruct it. Verifying against the *doubled* action descriptors makes the
+/// action accumulator match, leaving the tachygram accumulator as the mismatch,
+/// so the forgery is `Disproved`. Publishing the duplicate tachygram on the
+/// wire is instead caught by [`read_rejects_duplicate_tachygrams`]. This is the
 /// shape of merging two aggregates that share a covered contributor.
 #[test]
 fn cannot_forge_stamp_covering_duplicated_action() {
@@ -439,18 +394,61 @@ fn cannot_forge_stamp_covering_duplicated_action() {
     let pool = PoolSim::genesis(rng);
     let anchor = pool.anchor();
 
+    // One output stamp counted twice: both contributors share the descriptor.
     let note = wallet.random_note(200);
-    let (stamp, plan) = build_output_stamp(rng, anchor, note);
+    let (output_stamp, plan) = build_output_stamp(rng, anchor, note);
     let descriptors = BTreeSet::from_iter([plan.descriptor()]);
 
-    // Two contributors covering the same action: the stamp counted twice.
-    let forged = forge_overlapping_merge(rng, (&stamp, &descriptors), (&stamp, &descriptors));
+    // The honest merge refuses the shared action on the action-set product
+    // relation (checked before the tachygram product).
+    {
+        let merge_err = ProofStamp::merge(
+            rng,
+            (output_stamp.clone(), descriptors.clone()),
+            (output_stamp.clone(), descriptors.clone()),
+        )
+        .expect_err("a duplicated action must not merge");
+        let ProveError::MergeFailed(ragu::Error::InvalidWitness(inner)) = merge_err else {
+            panic!("expected MergeFailed(InvalidWitness), got {merge_err:?}");
+        };
+        assert_eq!(
+            inner.to_string(),
+            "MergeStamp: merged action set must be the product of left and right action sets"
+        );
+    }
 
-    // Present the duplicated action honestly, so the action accumulator matches;
-    // only the deduplicated tachygram set fails to reconstruct the doubled
-    // tachygram the proof commits to.
-    let err = forged
-        .verify(rng, &[plan.descriptor(), plan.descriptor()])
+    let evil_pcd = forge_overlapping_merge(
+        rng,
+        (&output_stamp, &Vec::from_iter(descriptors.clone())),
+        (&output_stamp, &Vec::from_iter(descriptors.clone())),
+    );
+
+    let all_descriptors: Vec<action::Descriptor> = descriptors
+        .iter()
+        .chain(descriptors.iter())
+        .copied()
+        .collect();
+
+    // Publish the forgery as a coherent stamp: the covered-actions digest over
+    // the duplicated action, and the canonical deduplicated tachygram set that
+    // cannot reconstruct the doubled multiset the proof commits to.
+    let coverage = {
+        let mut desc_bytes: Vec<[u8; 64]> = all_descriptors.iter().copied().collect();
+        desc_bytes.sort_unstable();
+        blake2b::action_descriptor_digest(&desc_bytes)
+    };
+    let stamp = ProofStamp {
+        coverage,
+        anchor: evil_pcd.data().2,
+        tachygrams: output_stamp.tachygrams.iter().copied().collect(),
+        proof: Box::new(evil_pcd.proof().clone()),
+    };
+
+    // Verifying against the doubled descriptors makes the action accumulator
+    // match; only the deduplicated tachygram set fails to reconstruct the
+    // doubled tachygram the proof commits to.
+    let err = stamp
+        .verify(rng, &all_descriptors)
         .expect_err("a stamp covering a duplicated action must not verify");
     let VerificationError::Disproved = err else {
         panic!("expected Disproved, got {err:?}");

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -10,8 +10,8 @@ use crate::{
     action,
     constants::EPOCH_SIZE,
     fixtures::{
-        PoolSim, WalletSim, build_output_stamp, forge_overlapping_merge, random_block,
-        random_block_with, shared_sk, spend_witness,
+        PoolSim, WalletSim, build_autonome, build_output_stamp, forge_overlapping_merge,
+        random_action, random_block, random_block_with, shared_sk, spend_witness,
     },
     primitives::BlockHeight,
 };
@@ -500,6 +500,92 @@ fn verify_cannot_distinguish_a_deduplicated_duplicate() {
             .expect("proof system verification"),
         "the doubled action must not verify"
     );
+}
+
+/// `verify_proof` reconstructs the action polynomial from the action digests it
+/// is given, as a multiset: the exact covered actions verify (in any order),
+/// and any deviation — a dropped, duplicated, extra, or substituted action —
+/// reconstructs a different polynomial and does not verify.
+#[test]
+fn verify_proof_action_multiset_invariants() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let stamped = build_autonome(rng, &wallet, 1000, 700);
+
+    let digests: Vec<ActionDigest> = stamped
+        .actions
+        .iter()
+        .map(|action| action.descriptor().digest().expect("action digest"))
+        .collect();
+
+    // Permutation accepts.
+    assert!(
+        stamped
+            .stamp
+            .verify_proof(rng, &[digests[1], digests[0]])
+            .expect("proof system verification"),
+        "permuted actions must verify"
+    );
+
+    // Drop rejects.
+    {
+        let mut dropped = digests.clone();
+        dropped.pop();
+        assert!(
+            !stamped
+                .stamp
+                .verify_proof(rng, &dropped)
+                .expect("proof system verification"),
+            "dropped action must not verify"
+        );
+    }
+
+    // Duplicate rejects.
+    {
+        let mut duplicated = digests.clone();
+        duplicated.push(digests[0]);
+        assert!(
+            !stamped
+                .stamp
+                .verify_proof(rng, &duplicated)
+                .expect("proof system verification"),
+            "duplicated action must not verify"
+        );
+    }
+
+    // Foreign-extra rejects.
+    {
+        let mut extended = digests.clone();
+        extended.push(
+            random_action(rng)
+                .descriptor()
+                .digest()
+                .expect("action digest"),
+        );
+        assert!(
+            !stamped
+                .stamp
+                .verify_proof(rng, &extended)
+                .expect("proof system verification"),
+            "extra action must not verify"
+        );
+    }
+
+    // Replace-with-foreign rejects.
+    {
+        let mut replaced = digests;
+        replaced[0] = random_action(rng)
+            .descriptor()
+            .digest()
+            .expect("action digest");
+        assert!(
+            !stamped
+                .stamp
+                .verify_proof(rng, &replaced)
+                .expect("proof system verification"),
+            "replaced action must not verify"
+        );
+    }
 }
 
 /// Bundle-validity rule 9 requires a proof stamp's tachygrams to be

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -2,6 +2,7 @@
 
 use alloc::{string::ToString as _, vec, vec::Vec};
 
+use ff::Field as _;
 use rand::{SeedableRng as _, rngs::StdRng};
 
 use super::*;
@@ -173,6 +174,38 @@ fn merge_populates_covered_actions() {
     // `merge` sorts the concatenated descriptors into canonical order, so the
     // covered-actions digest is independent of the order they were passed in.
     assert_eq!(merged.actions, expected);
+}
+
+/// Bundle-validity rule 9 requires a proof stamp's tachygrams to be
+/// distinct, not merely sorted; `read` must reject an adjacent duplicate
+/// even though the sequence is non-decreasing.
+#[test]
+fn read_rejects_duplicate_tachygrams() {
+    let tg = Tachygram::from(Fp::ONE);
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0u8; 32]); // covered actions digest
+    Anchor(Fp::ZERO).write(&mut buf).expect("write anchor");
+    serialization::write_fp_list(&mut buf, &[Fp::from(tg), Fp::from(tg)])
+        .expect("write tachygrams");
+
+    let err = ProofStamp::read(&*buf).expect_err("duplicate tachygrams must be rejected");
+    assert_eq!(err.to_string(), "tachygrams are not unique");
+}
+
+/// A strictly increasing tachygram sequence is unaffected by the
+/// distinctness check.
+#[test]
+fn read_accepts_distinct_sorted_tachygrams() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let note = wallet.random_note(200);
+    let (stamp, _plan) = build_output_stamp(rng, pool.anchor(), note);
+
+    let mut buf = Vec::new();
+    stamp.write(&mut buf).expect("write");
+    ProofStamp::read(&*buf).expect("distinct sorted tachygrams must be accepted");
 }
 
 /// `hStampActionsTachyon` survives a `write`/`read` round-trip.

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::panic, reason = "test code")]
 
-use alloc::{string::ToString as _, vec, vec::Vec};
+use alloc::{boxed::Box, string::ToString as _, vec, vec::Vec};
 
 use ff::Field as _;
 use rand::{SeedableRng as _, rngs::StdRng};
@@ -49,8 +49,8 @@ fn merge_stamp_iff_matching_anchors() {
 
         let result = ProofStamp::merge(
             rng,
-            (stamp_a, vec![plan_a.descriptor()]),
-            (stamp_b, vec![plan_b.descriptor()]),
+            (stamp_a, BTreeSet::from_iter([plan_a.descriptor()])),
+            (stamp_b, BTreeSet::from_iter([plan_b.descriptor()])),
         );
         assert_eq!(
             result.is_ok(),
@@ -167,13 +167,172 @@ fn merge_populates_covered_actions() {
 
     let merged = ProofStamp::merge(
         rng,
-        (stamp_a, vec![plan_a.descriptor()]),
-        (stamp_b, vec![plan_b.descriptor()]),
+        (stamp_a, BTreeSet::from_iter([plan_a.descriptor()])),
+        (stamp_b, BTreeSet::from_iter([plan_b.descriptor()])),
     )
     .expect("merge");
     // `merge` sorts the concatenated descriptors into canonical order, so the
     // covered-actions digest is independent of the order they were passed in.
     assert_eq!(merged.coverage, expected);
+}
+
+/// The honest merge workflow refuses to combine two stamps whose tachygram
+/// sets intersect. `MergeStamp` encodes the merged set as the polynomial
+/// product of its inputs (a multiset union), but `prove_merge` witnesses the
+/// deduplicated set union; the two coincide only for disjoint inputs. An
+/// overlap makes `merged == left · right` unsatisfiable, so the product
+/// relation fails and no proof is produced.
+#[test]
+fn merge_rejects_overlapping_tachygrams() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let anchor = pool.anchor();
+
+    // Two output stamps for the same note share their sole tachygram (the note
+    // commitment) but carry distinct descriptors (independent trapdoors), so
+    // the action sets stay disjoint and the failure isolates to the tachygram
+    // product relation.
+    let note = wallet.random_note(200);
+    let (stamp_a, plan_a) = build_output_stamp(rng, anchor, note);
+    let (stamp_b, plan_b) = build_output_stamp(rng, anchor, note);
+    assert_eq!(
+        stamp_a.tachygrams, stamp_b.tachygrams,
+        "tachygram sets must overlap"
+    );
+    assert_ne!(
+        plan_a.descriptor(),
+        plan_b.descriptor(),
+        "action sets must stay disjoint"
+    );
+
+    let err = ProofStamp::merge(
+        rng,
+        (stamp_a, BTreeSet::from_iter([plan_a.descriptor()])),
+        (stamp_b, BTreeSet::from_iter([plan_b.descriptor()])),
+    )
+    .expect_err("overlapping tachygram sets must not merge");
+
+    let ProveError::MergeFailed(ragu::Error::InvalidWitness(inner)) = err else {
+        panic!("expected MergeFailed(InvalidWitness), got {err:?}");
+    };
+    assert_eq!(
+        inner.to_string(),
+        "poly product: product identity fails at challenge"
+    );
+}
+
+/// A malicious prover could execute `MergeStamp` to prove a merge of
+/// intersecting sets, but no verifier will accept such a proof.
+#[test]
+fn verify_rejects_maliciously_merged_overlapping_tachygrams() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let anchor = pool.anchor();
+
+    let note = wallet.random_note(200);
+    let (stamp_a, plan_a) = build_output_stamp(rng, anchor, note);
+    let (stamp_b, plan_b) = build_output_stamp(rng, anchor, note);
+    assert_eq!(
+        stamp_a.tachygrams, stamp_b.tachygrams,
+        "tachygram sets must overlap"
+    );
+
+    let app = &*PROOF_SYSTEM;
+
+    let digest_a = plan_a.descriptor().digest().expect("action digest");
+    let digest_b = plan_b.descriptor().digest().expect("action digest");
+
+    let left_acts = ActionSetPoly::from_iter([digest_a]);
+    let right_acts = ActionSetPoly::from_iter([digest_b]);
+    let left_tg = stamp_a
+        .tachygrams
+        .iter()
+        .copied()
+        .collect::<TachygramSetPoly>();
+    let right_tg = stamp_b
+        .tachygrams
+        .iter()
+        .copied()
+        .collect::<TachygramSetPoly>();
+
+    let left_pcd =
+        stamp_a
+            .proof
+            .carry::<StampHeader>((left_acts.commit(), left_tg.commit(), stamp_a.anchor));
+    let right_pcd = stamp_b.proof.carry::<StampHeader>((
+        right_acts.commit(),
+        right_tg.commit(),
+        stamp_b.anchor,
+    ));
+
+    // The malicious witness: the shared tachygram appears twice, so the merged
+    // set polynomial equals `left · right` and the product relation holds. The
+    // action sets are disjoint, so their set and multiset unions coincide.
+    let merged_acts = ActionSetPoly::from_iter([digest_a, digest_b]);
+    let malicious_merged_tg = stamp_a
+        .tachygrams
+        .iter()
+        .chain(stamp_b.tachygrams.iter())
+        .copied()
+        .collect::<TachygramSetPoly>();
+
+    let proof = {
+        let (pcd, ()) = app
+            .fuse(
+                rng,
+                MergeStamp,
+                (
+                    (left_acts, left_tg),
+                    (merged_acts, malicious_merged_tg),
+                    (right_acts, right_tg),
+                ),
+                left_pcd,
+                right_pcd,
+            )
+            .expect("multiset merge must prove");
+        Box::new(
+            app.rerandomize(pcd, rng)
+                .expect("rerandomize")
+                .proof()
+                .clone(),
+        )
+    };
+
+    // The published stamp must bear a canonical deduplicated tachygram vector,
+    // or it will be rejected at deserialization.
+    let malicious_stamp = ProofStamp {
+        coverage: blake2b::action_descriptor_digest(&Vec::<[u8; 64]>::from_iter(
+            BTreeSet::from_iter([plan_a.descriptor(), plan_b.descriptor()]),
+        )),
+        anchor,
+        tachygrams: stamp_a
+            .tachygrams
+            .union(&stamp_b.tachygrams)
+            .copied()
+            .collect(),
+        proof,
+    };
+
+    let read_malicious_stamp = {
+        let mut buf = Vec::new();
+        malicious_stamp
+            .write(&mut buf)
+            .expect("write malicious stamp");
+        ProofStamp::read(&*buf).expect("malicious stamp is wire-valid")
+    };
+    assert_eq!(read_malicious_stamp.tachygrams, malicious_stamp.tachygrams);
+
+    // The malicious stamp will be rejected at verification, since the canonical
+    // tachygram vector does not represent the multiset union necessary to
+    // verify the malicious proof.
+    let err = read_malicious_stamp
+        .verify(rng, &[plan_a.descriptor(), plan_b.descriptor()])
+        .expect_err("multiset-backed proof must not verify against the deduplicated set");
+    let VerificationError::Disproved = err else {
+        panic!("expected Disproved, got {err:?}");
+    };
 }
 
 /// Bundle-validity rule 9 requires a proof stamp's tachygrams to be

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -385,15 +385,12 @@ fn double_spend_cannot_aggregate() {
 }
 
 /// A stamp cannot cover the same action twice. The honest merge refuses it on
-/// the action-set product relation (asserted below), since the two contributors
-/// share the action's descriptor. A malicious prover who force-fuses the
-/// multiset union bypasses that — but every action carries a tachygram (a
-/// spend's nullifiers, an output's commitment), so the doubled action doubles
-/// its tachygram, and the published stamp's canonical deduplicated set cannot
-/// reconstruct it. Verifying against the *doubled* action descriptors makes the
-/// action accumulator match, leaving the tachygram accumulator as the mismatch,
-/// so the forgery is `Disproved`. Publishing the duplicate tachygram on the
-/// wire is instead caught by [`read_rejects_duplicate_tachygrams`].
+/// the action-set product relation (the two contributors share the descriptor).
+/// A forced-fuse forgery bypasses that, but every action carries a tachygram, so
+/// the doubled action doubles its tachygram: verifying against `[d, d]` matches
+/// the action accumulator while the published deduplicated tachygram set fails
+/// to reconstruct the doubled one, so the proof is `Disproved`. The wire-level
+/// duplicate tachygram is caught by [`read_rejects_duplicate_tachygrams`].
 #[test]
 fn cannot_forge_stamp_covering_duplicated_action() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -466,13 +463,10 @@ fn cannot_forge_stamp_covering_duplicated_action() {
     );
 }
 
-/// `verify` characterization: it checks the proof against exactly the
-/// descriptor multiset it is handed, and nothing more. A duplicated action that
-/// a caller deduplicated to `{d}` verifies against the single-action proof; the
-/// true multiset `[d, d]` reconstructs `(x−d)²` and does not. So `verify`
-/// cannot distinguish a deduplicated duplicate from a genuine single action —
-/// detecting the duplicate is the caller's responsibility, which is why it must
-/// pass the full multiset.
+/// `verify_proof` checks the proof against exactly the multiset it is handed:
+/// the deduplicated `{d}` matches the single-action proof, while the true
+/// `[d, d]` reconstructs `(x−d)²` and does not. Detecting a duplicate is the
+/// caller's obligation.
 #[test]
 fn verify_cannot_distinguish_a_deduplicated_duplicate() {
     let rng = &mut StdRng::seed_from_u64(0);

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -256,7 +256,7 @@ fn double_output_cannot_aggregate() {
         .collect();
     assert!(
         !stamp
-            .verify_proof(rng, &digests)
+            .verify_proof(rng, digests)
             .expect("proof system verification"),
         "multiset-backed proof must not verify against the deduplicated set"
     );
@@ -378,7 +378,7 @@ fn double_spend_cannot_aggregate() {
         .collect();
     assert!(
         !stamp
-            .verify_proof(rng, &digests)
+            .verify_proof(rng, digests)
             .expect("proof system verification"),
         "doubled-nullifier proof must not verify"
     );
@@ -386,11 +386,12 @@ fn double_spend_cannot_aggregate() {
 
 /// A stamp cannot cover the same action twice. The honest merge refuses it on
 /// the action-set product relation (the two contributors share the descriptor).
-/// A forced-fuse forgery bypasses that, but every action carries a tachygram, so
-/// the doubled action doubles its tachygram: verifying against `[d, d]` matches
-/// the action accumulator while the published deduplicated tachygram set fails
-/// to reconstruct the doubled one, so the proof is `Disproved`. The wire-level
-/// duplicate tachygram is caught by [`read_rejects_duplicate_tachygrams`].
+/// A forced-fuse forgery bypasses that, but every action carries a tachygram,
+/// so the doubled action doubles its tachygram: verifying against `[d, d]`
+/// matches the action accumulator while the published deduplicated tachygram
+/// set fails to reconstruct the doubled one, so the proof is `Disproved`. The
+/// wire-level duplicate tachygram is caught by
+/// [`read_rejects_duplicate_tachygrams`].
 #[test]
 fn cannot_forge_stamp_covering_duplicated_action() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -457,7 +458,7 @@ fn cannot_forge_stamp_covering_duplicated_action() {
         .collect();
     assert!(
         !stamp
-            .verify_proof(rng, &digests)
+            .verify_proof(rng, digests)
             .expect("proof system verification"),
         "a stamp covering a duplicated action must not verify"
     );
@@ -482,7 +483,7 @@ fn verify_cannot_distinguish_a_deduplicated_duplicate() {
     let single = descriptor.digest().expect("action digest");
     assert!(
         stamp
-            .verify_proof(rng, &[single])
+            .verify_proof(rng, [single])
             .expect("proof system verification"),
         "the single covered action verifies"
     );
@@ -490,7 +491,7 @@ fn verify_cannot_distinguish_a_deduplicated_duplicate() {
     // The true multiset is a different action polynomial: (x−d)² ≠ (x−d).
     assert!(
         !stamp
-            .verify_proof(rng, &[single, single])
+            .verify_proof(rng, [single, single])
             .expect("proof system verification"),
         "the doubled action must not verify"
     );
@@ -516,7 +517,7 @@ fn verify_proof_action_multiset_invariants() {
     assert!(
         stamped
             .stamp
-            .verify_proof(rng, &[digests[1], digests[0]])
+            .verify_proof(rng, [digests[1], digests[0]])
             .expect("proof system verification"),
         "permuted actions must verify"
     );
@@ -528,7 +529,7 @@ fn verify_proof_action_multiset_invariants() {
         assert!(
             !stamped
                 .stamp
-                .verify_proof(rng, &dropped)
+                .verify_proof(rng, dropped)
                 .expect("proof system verification"),
             "dropped action must not verify"
         );
@@ -541,7 +542,7 @@ fn verify_proof_action_multiset_invariants() {
         assert!(
             !stamped
                 .stamp
-                .verify_proof(rng, &duplicated)
+                .verify_proof(rng, duplicated)
                 .expect("proof system verification"),
             "duplicated action must not verify"
         );
@@ -559,7 +560,7 @@ fn verify_proof_action_multiset_invariants() {
         assert!(
             !stamped
                 .stamp
-                .verify_proof(rng, &extended)
+                .verify_proof(rng, extended)
                 .expect("proof system verification"),
             "extra action must not verify"
         );
@@ -575,7 +576,7 @@ fn verify_proof_action_multiset_invariants() {
         assert!(
             !stamped
                 .stamp
-                .verify_proof(rng, &replaced)
+                .verify_proof(rng, replaced)
                 .expect("proof system verification"),
             "replaced action must not verify"
         );

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -250,12 +250,16 @@ fn double_output_cannot_aggregate() {
             .collect(),
         proof: Box::new(evil_pcd.proof().clone()),
     };
-    let err = stamp
-        .verify(rng, &all_descriptors)
-        .expect_err("multiset-backed proof must not verify against the deduplicated set");
-    let VerificationError::Disproved = err else {
-        panic!("expected Disproved, got {err:?}");
-    };
+    let digests: Vec<ActionDigest> = all_descriptors
+        .iter()
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect();
+    assert!(
+        !stamp
+            .verify_proof(rng, &digests)
+            .expect("proof system verification"),
+        "multiset-backed proof must not verify against the deduplicated set"
+    );
 }
 
 /// Reusing a note as a spend collides on the nullifiers: nullifiers are
@@ -368,12 +372,16 @@ fn double_spend_cannot_aggregate() {
         proof: Box::new(evil_pcd.proof().clone()),
     };
 
-    let err = stamp
-        .verify(rng, &all_descriptors)
-        .expect_err("doubled-nullifier proof must not verify");
-    let VerificationError::Disproved = err else {
-        panic!("expected Disproved, got {err:?}");
-    };
+    let digests: Vec<ActionDigest> = all_descriptors
+        .iter()
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect();
+    assert!(
+        !stamp
+            .verify_proof(rng, &digests)
+            .expect("proof system verification"),
+        "doubled-nullifier proof must not verify"
+    );
 }
 
 /// A stamp cannot cover the same action twice. The honest merge refuses it on
@@ -446,12 +454,16 @@ fn cannot_forge_stamp_covering_duplicated_action() {
     // Verifying against the doubled descriptors makes the action accumulator
     // match; only the deduplicated tachygram set fails to reconstruct the
     // doubled tachygram the proof commits to.
-    let err = stamp
-        .verify(rng, &all_descriptors)
-        .expect_err("a stamp covering a duplicated action must not verify");
-    let VerificationError::Disproved = err else {
-        panic!("expected Disproved, got {err:?}");
-    };
+    let digests: Vec<ActionDigest> = all_descriptors
+        .iter()
+        .map(|desc| desc.digest().expect("action digest"))
+        .collect();
+    assert!(
+        !stamp
+            .verify_proof(rng, &digests)
+            .expect("proof system verification"),
+        "a stamp covering a duplicated action must not verify"
+    );
 }
 
 /// `verify` characterization: it checks the proof against exactly the
@@ -473,17 +485,21 @@ fn verify_cannot_distinguish_a_deduplicated_duplicate() {
     let descriptor = plan.descriptor();
 
     // Deduplicated to one action, it matches the single-action proof.
-    stamp
-        .verify(rng, &[descriptor])
-        .expect("the single covered action verifies");
+    let single = descriptor.digest().expect("action digest");
+    assert!(
+        stamp
+            .verify_proof(rng, &[single])
+            .expect("proof system verification"),
+        "the single covered action verifies"
+    );
 
     // The true multiset is a different action polynomial: (x−d)² ≠ (x−d).
-    let err = stamp
-        .verify(rng, &[descriptor, descriptor])
-        .expect_err("the doubled action must not verify");
-    let VerificationError::Disproved = err else {
-        panic!("expected Disproved, got {err:?}");
-    };
+    assert!(
+        !stamp
+            .verify_proof(rng, &[single, single])
+            .expect("proof system verification"),
+        "the doubled action must not verify"
+    );
 }
 
 /// Bundle-validity rule 9 requires a proof stamp's tachygrams to be

--- a/crates/tachyon/src/value.rs
+++ b/crates/tachyon/src/value.rs
@@ -1,9 +1,6 @@
 //! Value commitments and bounded value types.
 
-use core::{
-    cmp,
-    ops::{self, Neg as _},
-};
+use core::{cmp, ops};
 
 use derive_more::{Add, Debug, Display, Eq as TotalEq, Error, From, Into, PartialEq, Sub, Sum};
 use ff::Field as _;


### PR DESCRIPTION

After #166, bundle deserialization required actions to be canonically sorted.
That check is redundant: order is already bound cryptographically. `Bundle::commitment`
hashes descriptors in wire order and feeds the sighash, so a signed bundle cannot
be reordered without breaking its signatures. This drops the sort requirement
(any order may be a valid, faithfully-committed encoding; `Plan` still emits
sorted bundles) and moves real double-spend prevention to where it belongs, the
stamp's proof.

## Wire and commitment

- `read` preserves action wire order and any duplicates. Multiplicity is
  significant to both the commitment and the proof, so it is carried faithfully
  rather than filtered at the parser.
- `Bundle::commitment` / `Bundle::descriptors` are documented order-sensitive and
  no longer sort.
- `ProofStamp` tachygram read stays strictly increasing (sorted and unique), the
  one canonical serialization of an unordered set.

## Verification

`Bundle<ProofStamp>::verify(rng, wtxid, adjuncts)` composes the full check and
returns `VerificationError`:

- `verify_pointers`: each adjunct's stamp digest equals the expected `wtxid`.
- `verify_coverage`: this bundle's and the adjuncts' descriptors are collectively
  unique (`DuplicateActions` otherwise), and `hStampActionsTachyon` matches that
  set. Duplicate detection now lives here, at verification, not at the parser.
- `verify_proof`: reconstructs the PCD header from public data and runs the Ragu
  verifier over the combined action multiset.

Coverage predicates are the cheap, proof-free pre-checks: `is_covering` (stamp
covers exactly the given descriptor multiset), `is_autonome` (covers exactly its
own actions), `is_aggregate` (does not). `covers` is renamed `is_covering` and
takes an `IntoIterator` multiset.

## Types

- `ProofStamp` coverage and tachygrams are `BTreeSet`, threaded as sets through
  the merge fold; `Plan::descriptors` returns a `BTreeSet` (the prover-side set),
  and `apply_signatures` takes a `BTreeMap<Descriptor, Signature>` matched against
  the descriptor set.
- Verification errors live on the bundle: `VerificationError`, `VerifyProofError`,
  `VerifyCoverageError`, `VerifyPointersError`. The stamp's own `verify` splits
  into crate-private `is_covering` + `verify_proof`.
- `Bundle` and `TachyonBundle` compare by `commitment` + `auth_digest`;
  `TachyonBundle` also orders by them. `as_dyn` borrows any stamped bundle as
  `&Bundle<dyn StampState>`.

## Tests

- `read_preserves_action_order`, `permuted_actions_change_commitment`: wire order
  survives round-trip and drives the commitment.
- `double_spend_obvious` / `double_spend_secret`: an obvious duplicate is caught
  at coverage; independently-randomized spends of one note pass the bundle layer,
  marking the bundle-vs-proof boundary.
- `double_spend_cannot_aggregate`, `duplicated_spend_cannot_inflate`,
  `cannot_forge_stamp_covering_duplicated_action`,
  `verify_cannot_distinguish_a_deduplicated_duplicate`: the proof, not the parser,
  rejects duplicated coverage.
- `autonome_verify_composes_all_checks`, `based_aggregate_with_two_adjuncts`,
  `verify_proof_disproves_uncovered_adjunct`,
  `verify_proof_rejects_action_shared_with_adjunct`: the composed verify flow over
  adjuncts.
- `auth_digest_invariants`: commitment held invariant while `auth_digest` moves.
