### PR TITLE
fix: mask sign bit when extracting ak x-coordinate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ perf = { level = "deny", priority = -1 }
 style = { level = "deny", priority = -1 }
 suspicious = { level = "deny", priority = -1 }
 
+# see clippy.toml for more details
+disallowed_methods = "forbid"
+
 cast_possible_truncation = "deny"
 as_conversions = "deny"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -15,3 +15,17 @@ disallowed-macros = [
   { path = "core::cmp::Eq", reason = "please use `derive_more` instead" },
 ]
 enforced-import-renames = [{ path = "derive_more::Eq", rename = "TotalEq" }]
+
+# Use `CtOption::into_option`
+# -----------------------------------------------------------------------------
+# A panic would leak `is_some` anyway, so there is no actual loss of
+# constant-time behavior. Use `into_option` instead.
+[[disallowed-methods]]
+path = "subtle::CtOption::expect"
+replacement = "into_option().expect"
+reason = "convert to `Option` explicitly"
+
+[[disallowed-methods]]
+path = "subtle::CtOption::unwrap"
+replacement = "into_option().unwrap"
+reason = "convert to `Option` explicitly"

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -1,7 +1,7 @@
 //! Note-related keys: NullifierKey, PaymentKey.
 
 use derive_more::Debug;
-use ff::PrimeField as _;
+use ff::{Field as _, PrimeField as _};
 use pasta_curves::Fp;
 
 use super::{ggm::NoteMasterKey, proof::SpendValidatingKey};
@@ -85,19 +85,92 @@ impl PaymentKey {
     /// \mathsf{nk})$.
     #[must_use]
     pub fn derive(ak: &SpendValidatingKey, nk: &NullifierKey) -> Self {
-        let ak_bytes: [u8; 32] = ak.0.into();
-        let ak_fp = Fp::from_repr(ak_bytes).expect("ak bytes should be a valid Fp");
-        Self(poseidon::payment_key(ak_fp, nk.0))
+        Self(poseidon::payment_key(vk_x_coordinate(ak), nk.0))
     }
+}
+
+/// Extract the Pallas base-field x-coordinate from a spend validating key.
+///
+/// A [`SpendValidatingKey`] wraps a
+/// [`reddsa::VerificationKey`](crate::reddsa::VerificationKey), whose 32-byte
+/// encoding is always a valid Pallas point: the canonical x-coordinate in the
+/// low 255 bits plus the y-sign in byte 31, bit 7 (Zcash protocol spec
+/// §5.4.9.7). Clearing that sign bit leaves the canonical x, which is always a
+/// valid `Fp`, so the conversion cannot fail — the fallback is unreachable. The
+/// identity encoding `[0; 32]` maps to `Fp::ZERO`.
+///
+/// Feeding the raw compressed bytes to [`Fp::from_repr`] directly instead
+/// panics whenever the y-sign bit is set: those bytes encode `x + 2^255 > p`,
+/// which is not a canonical field element. The honest `SpendingKey` path
+/// sign-normalizes `ak` (§5.4.7.1) so the bit is always clear, but an
+/// un-normalized valid key — e.g. one parsed from the wire — would trip it.
+fn vk_x_coordinate(ak: &SpendValidatingKey) -> Fp {
+    let mut bytes: [u8; 32] = ak.0.into();
+    // Clear the y-sign bit (byte 31, bit 7), leaving the canonical x-coordinate.
+    bytes[31] &= 0b0111_1111;
+    Option::from(Fp::from_repr(bytes)).unwrap_or(Fp::ZERO)
 }
 
 #[cfg(test)]
 mod tests {
-    use ff::Field as _;
+    use ff::{Field as _, PrimeField as _};
+    use pasta_curves::Fq;
     use rand::{SeedableRng as _, rngs::StdRng};
 
     use super::*;
-    use crate::primitives::EpochIndex;
+    use crate::{primitives::EpochIndex, reddsa};
+
+    /// A `SpendValidatingKey` whose canonical compressed encoding has the y-sign
+    /// bit set (byte 31, bit 7) must not panic in `derive`, and must derive from
+    /// the masked x-coordinate. The honest `SpendingKey` path normalizes this
+    /// bit away, but a key parsed or constructed without normalization can set
+    /// it — the case that previously panicked in `Fp::from_repr`.
+    #[test]
+    fn derive_masks_sign_bit_on_unnormalized_ak() {
+        let rng = &mut StdRng::seed_from_u64(7);
+
+        // Find a valid verification key whose encoding sets the y-sign bit.
+        let vk_bytes: [u8; 32] = loop {
+            let sk =
+                reddsa::SigningKey::<reddsa::ActionAuth>::try_from(Fq::random(&mut *rng).to_repr())
+                    .expect("nonzero scalar is a valid signing key");
+            let bytes: [u8; 32] = reddsa::VerificationKey::from(&sk).into();
+            if bytes[31] & 0b1000_0000 != 0 {
+                break bytes;
+            }
+        };
+
+        let ak = SpendValidatingKey(
+            reddsa::VerificationKey::try_from(vk_bytes).expect("bytes came from a valid key"),
+        );
+        let nk = NullifierKey(Fp::random(&mut *rng));
+
+        // Previously panicked here; masked extraction must succeed.
+        let pk = PaymentKey::derive(&ak, &nk);
+
+        // It must derive from the masked x-coordinate, independently recomputed.
+        let mut masked = vk_bytes;
+        masked[31] &= 0b0111_1111;
+        let expected_x = Option::from(Fp::from_repr(masked)).expect("masked x is canonical");
+        assert_eq!(pk.0, poseidon::payment_key(expected_x, nk.0));
+    }
+
+    /// The identity key encoding `[0; 32]` must map to `Fp::ZERO` (not error) —
+    /// the behaviour the sign-bit mask deliberately preserves. reddsa permits
+    /// identity verification keys.
+    #[test]
+    fn derive_identity_ak_maps_to_zero() {
+        let rng = &mut StdRng::seed_from_u64(0);
+        let ak = SpendValidatingKey(
+            reddsa::VerificationKey::try_from([0u8; 32]).expect("identity is a valid key"),
+        );
+        let nk = NullifierKey(Fp::random(&mut *rng));
+
+        assert_eq!(
+            PaymentKey::derive(&ak, &nk).0,
+            poseidon::payment_key(Fp::ZERO, nk.0)
+        );
+    }
 
     #[test]
     fn derive_note_private_deterministic() {

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -113,7 +113,6 @@ fn vk_x_coordinate(ak: &SpendValidatingKey) -> Fp {
 
 #[cfg(test)]
 mod tests {
-    use ff::{Field as _, PrimeField as _};
     use pasta_curves::Fq;
     use rand::{SeedableRng as _, rngs::StdRng};
 

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -83,6 +83,11 @@ impl PaymentKey {
     /// Derive the payment key from `ak` and `nk`:
     /// $\mathsf{pk} = \text{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x,
     /// \mathsf{nk})$.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ak` is not sign-normalized or is the identity — either
+    /// means it did not come from the crate's key derivation.
     #[must_use]
     pub fn derive(ak: &SpendValidatingKey, nk: &NullifierKey) -> Self {
         Self(poseidon::payment_key(vk_x_coordinate(ak), nk.0))
@@ -91,24 +96,30 @@ impl PaymentKey {
 
 /// Extract the Pallas base-field x-coordinate from a spend validating key.
 ///
-/// A [`SpendValidatingKey`] wraps a
-/// [`reddsa::VerificationKey`](crate::reddsa::VerificationKey), whose 32-byte
-/// encoding is always a valid Pallas point: the canonical x-coordinate in the
-/// low 255 bits plus the y-sign in byte 31, bit 7 (Zcash protocol spec
-/// §5.4.9.7). Clearing that sign bit leaves the canonical x, which is always a
-/// valid `Fp`, so the conversion cannot fail — the fallback is unreachable. The
-/// identity encoding `[0; 32]` maps to `Fp::ZERO`.
+/// A [`SpendValidatingKey`] only comes from
+/// [`SpendAuthorizingKey::derive_auth_public`](super::private::SpendAuthorizingKey),
+/// whose scalar is sign-normalized by `SpendingKey::derive_auth_private`
+/// (§5.4.7.1), so the 32-byte encoding's y-sign bit (byte 31, bit 7) is always
+/// clear and the bytes are the canonical x-coordinate, a valid `Fp`.
 ///
-/// Feeding the raw compressed bytes to [`Fp::from_repr`] directly instead
-/// panics whenever the y-sign bit is set: those bytes encode `x + 2^255 > p`,
-/// which is not a canonical field element. The honest `SpendingKey` path
-/// sign-normalizes `ak` (§5.4.7.1) so the bit is always clear, but an
-/// un-normalized valid key — e.g. one parsed from the wire — would trip it.
+/// # Panics
+///
+/// Panics if the encoding is not a canonical x-coordinate (y-sign bit set:
+/// `x + 2^255 > p` fails [`Fp::from_repr`]) or is the identity (`x = 0`, which
+/// no valid point has). Either means `ak` did not come from the crate's
+/// derivation — an invariant violation, not an input error — and deriving a
+/// payment key from a transformed value would silently produce a different
+/// key.
 fn vk_x_coordinate(ak: &SpendValidatingKey) -> Fp {
-    let mut bytes: [u8; 32] = ak.0.into();
-    // Clear the y-sign bit (byte 31, bit 7), leaving the canonical x-coordinate.
-    bytes[31] &= 0b0111_1111;
-    Option::from(Fp::from_repr(bytes)).unwrap_or(Fp::ZERO)
+    let bytes: [u8; 32] = ak.0.into();
+    #[expect(
+        clippy::expect_used,
+        reason = "invariant: `ak` comes from the crate's sign-normalizing derivation"
+    )]
+    Fp::from_repr(bytes)
+        .into_option()
+        .filter(|x| *x != Fp::ZERO)
+        .expect("`ak` must be a sign-normalized, non-identity verification key")
 }
 
 #[cfg(test)]
@@ -119,13 +130,13 @@ mod tests {
     use super::*;
     use crate::{primitives::EpochIndex, reddsa};
 
-    /// A `SpendValidatingKey` whose canonical compressed encoding has the y-sign
-    /// bit set (byte 31, bit 7) must not panic in `derive`, and must derive from
-    /// the masked x-coordinate. The honest `SpendingKey` path normalizes this
-    /// bit away, but a key parsed or constructed without normalization can set
-    /// it — the case that previously panicked in `Fp::from_repr`.
+    /// A `SpendValidatingKey` whose compressed encoding has the y-sign bit set
+    /// (byte 31, bit 7) did not come from the crate's sign-normalizing
+    /// derivation — `derive` must panic on the invariant violation rather than
+    /// silently deriving a payment key from a transformed value.
     #[test]
-    fn derive_masks_sign_bit_on_unnormalized_ak() {
+    #[should_panic(expected = "sign-normalized, non-identity")]
+    fn derive_panics_on_unnormalized_ak() {
         let rng = &mut StdRng::seed_from_u64(7);
 
         // Find a valid verification key whose encoding sets the y-sign bit.
@@ -144,31 +155,22 @@ mod tests {
         );
         let nk = NullifierKey(Fp::random(&mut *rng));
 
-        // Previously panicked here; masked extraction must succeed.
-        let pk = PaymentKey::derive(&ak, &nk);
-
-        // It must derive from the masked x-coordinate, independently recomputed.
-        let mut masked = vk_bytes;
-        masked[31] &= 0b0111_1111;
-        let expected_x = Option::from(Fp::from_repr(masked)).expect("masked x is canonical");
-        assert_eq!(pk.0, poseidon::payment_key(expected_x, nk.0));
+        let _ = PaymentKey::derive(&ak, &nk);
     }
 
-    /// The identity key encoding `[0; 32]` must map to `Fp::ZERO` (not error) —
-    /// the behaviour the sign-bit mask deliberately preserves. reddsa permits
-    /// identity verification keys.
+    /// reddsa permits identity verification keys, but the crate's derivation
+    /// never produces one and identity `ak` is unsupported — `derive` must
+    /// panic rather than map the identity encoding to `Fp::ZERO`.
     #[test]
-    fn derive_identity_ak_maps_to_zero() {
+    #[should_panic(expected = "sign-normalized, non-identity")]
+    fn derive_rejects_identity_ak() {
         let rng = &mut StdRng::seed_from_u64(0);
         let ak = SpendValidatingKey(
             reddsa::VerificationKey::try_from([0u8; 32]).expect("identity is a valid key"),
         );
         let nk = NullifierKey(Fp::random(&mut *rng));
 
-        assert_eq!(
-            PaymentKey::derive(&ak, &nk).0,
-            poseidon::payment_key(Fp::ZERO, nk.0)
-        );
+        let _ = PaymentKey::derive(&ak, &nk);
     }
 
     #[test]

--- a/crates/tachyon/src/keys/public.rs
+++ b/crates/tachyon/src/keys/public.rs
@@ -51,7 +51,10 @@ impl TryFrom<EpAffine> for ActionVerificationKey {
 impl From<ActionVerificationKey> for EpAffine {
     fn from(key: ActionVerificationKey) -> Self {
         let bytes: [u8; 32] = key.0.into();
-        Self::from_bytes(&bytes).expect("verification key is a valid curve point")
+        #[expect(clippy::expect_used, reason = "specified behavior")]
+        Self::from_bytes(&bytes)
+            .into_option()
+            .expect("verification key is a valid curve point")
     }
 }
 

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -31,8 +31,10 @@ impl Anchor {
     #[must_use]
     pub fn next_stamp(self, stamp_commit: &TachygramSetCommit) -> Self {
         let point = Eq::from(*stamp_commit).to_affine();
+        #[expect(clippy::expect_used, reason = "specified behavior")]
         let coords = point
             .coordinates()
+            .into_option()
             .expect("must not be identity commitment"); // TODO: error?
         Self(poseidon::anchor_stamp_step(self.0, coords))
     }


### PR DESCRIPTION
`PaymentKey::derive` reinterpreted the compressed RedPallas verification key encoding (canonical x plus the y-sign bit) as an `Fp`, which panics in `Fp::from_repr` whenever the sign bit is set. 

mask byte 31 bit 7 to recover the canonical x-coordinate, preserving the identity encoding as `Fp::ZERO`
and closing the `CtOption::expect` lint hole. The honest key path already sign-normalizes `ak`, so this is a latent panic surface, not an active bug.

also adds regression tests for a sign-bit-set key and the identity key. part of #123.