### PR TITLE
test: guard digest domain seperator reuse

### DIFF
--- a/crates/tachyon/src/digest/blake2b.rs
+++ b/crates/tachyon/src/digest/blake2b.rs
@@ -236,6 +236,114 @@ pub(crate) fn bundle_auth_digest(
     })
 }
 
+#[cfg(test)]
+mod domain_separation {
+    //! Registry of every BLAKE2b hash context and a check that they are
+    //! mutually domain-separated.
+    //!
+    //! Separation comes from the fixed 16-byte `personal` field, optionally
+    //! refined by a trailing in-preimage domain byte. BLAKE2b zero-pads
+    //! shorter tags to 16 bytes, so distinctness is checked on the padded
+    //! block — the form the hash actually sees — not the source literal
+    //! (`b"foo"` and `b"foo\0"` are the same personalization). Two contexts
+    //! are separated whenever their `(personal_block, domain_byte)` pair
+    //! differs. `prf_expand_ask`/`prf_expand_nk` deliberately share the
+    //! global `Zcash_ExpandSeed` personalization and are separated by that
+    //! trailing byte (the standard Zcash PRF^expand pattern), so no reuse is
+    //! unseparated here.
+
+    use super::{
+        ACTION_DESCRIPTOR_PERSONALIZATION, AUTH_DIGEST_PERSONALIZATION,
+        BUNDLE_COMMITMENT_PERSONALIZATION, OUTPUT_ALPHA_PERSONALIZATION, PRF_EXPAND_DOMAIN_ASK,
+        PRF_EXPAND_DOMAIN_NK, PRF_EXPAND_PERSONALIZATION, SPEND_ALPHA_PERSONALIZATION,
+        STAMP_DATA_PERSONALIZATION, STAMP_PROOF_PERSONALIZATION,
+    };
+
+    /// A BLAKE2b hash context: its `personal` field and any trailing in-preimage
+    /// domain byte. `(personal_block(personal), domain_byte)` is the separation
+    /// key.
+    struct Context {
+        name: &'static str,
+        personal: &'static [u8],
+        domain_byte: Option<u8>,
+    }
+
+    /// The 16-byte `personal` block BLAKE2b actually keys on: shorter tags are
+    /// zero-padded, so distinctness must be compared on this form.
+    fn personal_block(personal: &[u8]) -> [u8; 16] {
+        assert!(personal.len() <= 16, "personalization exceeds 16 bytes");
+        let mut block = [0u8; 16];
+        for (dst, src) in block.iter_mut().zip(personal) {
+            *dst = *src;
+        }
+        block
+    }
+
+    const REGISTRY: &[Context] = &[
+        Context {
+            name: "alpha_spend",
+            personal: SPEND_ALPHA_PERSONALIZATION,
+            domain_byte: None,
+        },
+        Context {
+            name: "alpha_output",
+            personal: OUTPUT_ALPHA_PERSONALIZATION,
+            domain_byte: None,
+        },
+        Context {
+            name: "prf_expand_ask",
+            personal: PRF_EXPAND_PERSONALIZATION,
+            domain_byte: Some(PRF_EXPAND_DOMAIN_ASK),
+        },
+        Context {
+            name: "prf_expand_nk",
+            personal: PRF_EXPAND_PERSONALIZATION,
+            domain_byte: Some(PRF_EXPAND_DOMAIN_NK),
+        },
+        Context {
+            name: "action_descriptor_digest",
+            personal: ACTION_DESCRIPTOR_PERSONALIZATION,
+            domain_byte: None,
+        },
+        Context {
+            name: "bundle_commitment",
+            personal: BUNDLE_COMMITMENT_PERSONALIZATION,
+            domain_byte: None,
+        },
+        Context {
+            name: "bundle_auth_digest",
+            personal: AUTH_DIGEST_PERSONALIZATION,
+            domain_byte: None,
+        },
+        Context {
+            name: "stamp_proof_digest",
+            personal: STAMP_PROOF_PERSONALIZATION,
+            domain_byte: None,
+        },
+        Context {
+            name: "stamp_data_digest",
+            personal: STAMP_DATA_PERSONALIZATION,
+            domain_byte: None,
+        },
+    ];
+
+    #[test]
+    fn every_blake2b_context_is_domain_separated() {
+        for (index, a) in REGISTRY.iter().enumerate() {
+            for b in REGISTRY.iter().skip(index + 1) {
+                let collides = personal_block(a.personal) == personal_block(b.personal)
+                    && a.domain_byte == b.domain_byte;
+                assert!(
+                    !collides,
+                    "BLAKE2b contexts `{}` and `{}` share a personalization and domain \
+                     byte — they are not domain-separated",
+                    a.name, b.name,
+                );
+            }
+        }
+    }
+}
+
 lazy_static! {
     /// A non-Tachyon transaction's contribution to the transaction sighash.
     ///

--- a/crates/tachyon/src/digest/poseidon.rs
+++ b/crates/tachyon/src/digest/poseidon.rs
@@ -136,3 +136,109 @@ pub(crate) fn anchor_epoch_step(anchor_prev: Fp, new_epoch: EpochIndex) -> Fp {
         Fp::from(new_epoch),
     ])
 }
+
+#[cfg(test)]
+mod domain_separation {
+    //! Registry of every Poseidon hash context and a check that they are
+    //! mutually domain-separated.
+    //!
+    //! Each [`hash`] call absorbs a 16-byte domain tag first, so two contexts
+    //! are separated whenever their `(tag, arity)` pair differs. The single
+    //! unseparated reuse is legacy GGM (`nf_master`/`nf_prefix`, see
+    //! `KNOWN_SHARED`); the flat-MiMC nullifier rework (#171) removes that path.
+    //! New code must not introduce another shared `(tag, arity)` without an
+    //! in-preimage discriminator.
+
+    use super::{
+        ACTION_DIGEST_DOMAIN, ANCHOR_EMPTY_DOMAIN, ANCHOR_EPOCH_DOMAIN, ANCHOR_STAMP_DOMAIN,
+        NOTE_COMMITMENT_DOMAIN, NULLIFIER_DOMAIN, NULLIFIER_PREFIX_DOMAIN, PAYMENT_KEY_DOMAIN,
+    };
+
+    /// A Poseidon hash context: the domain tag it absorbs first and its total
+    /// arity (tag element included). `(tag, arity)` is the separation key.
+    struct Context {
+        name: &'static str,
+        tag: &'static [u8; 16],
+        arity: usize,
+    }
+
+    const REGISTRY: &[Context] = &[
+        Context {
+            name: "action_digest",
+            tag: ACTION_DIGEST_DOMAIN,
+            arity: 5,
+        },
+        Context {
+            name: "payment_key",
+            tag: PAYMENT_KEY_DOMAIN,
+            arity: 3,
+        },
+        Context {
+            name: "note_commitment",
+            tag: NOTE_COMMITMENT_DOMAIN,
+            arity: 5,
+        },
+        Context {
+            name: "nf_master",
+            tag: NULLIFIER_PREFIX_DOMAIN,
+            arity: 3,
+        },
+        Context {
+            name: "nf_prefix",
+            tag: NULLIFIER_PREFIX_DOMAIN,
+            arity: 3,
+        },
+        Context {
+            name: "nullifier",
+            tag: NULLIFIER_DOMAIN,
+            arity: 2,
+        },
+        Context {
+            name: "anchor_stamp_step",
+            tag: ANCHOR_STAMP_DOMAIN,
+            arity: 6,
+        },
+        Context {
+            name: "anchor_empty_step",
+            tag: ANCHOR_EMPTY_DOMAIN,
+            arity: 2,
+        },
+        Context {
+            name: "anchor_epoch_step",
+            tag: ANCHOR_EPOCH_DOMAIN,
+            arity: 3,
+        },
+    ];
+
+    /// Context pairs that intentionally share `(tag, arity)` with no in-preimage
+    /// discriminator. Legacy GGM: `nf_master(psi, nk)` and
+    /// `nf_prefix(prefix_prev, step)` both absorb `Tachyon-NfPrefix` at arity 3,
+    /// separated only by the meaning of their second field. The flat-MiMC
+    /// nullifier rework (#171) deletes this path; until it lands the reuse is
+    /// documented here rather than treated as a fresh collision.
+    const KNOWN_SHARED: &[[&str; 2]] = &[["nf_master", "nf_prefix"]];
+
+    fn is_known_shared(a: &str, b: &str) -> bool {
+        KNOWN_SHARED
+            .iter()
+            .any(|pair| *pair == [a, b] || *pair == [b, a])
+    }
+
+    #[test]
+    fn every_poseidon_context_is_domain_separated() {
+        for (index, a) in REGISTRY.iter().enumerate() {
+            for b in REGISTRY.iter().skip(index + 1) {
+                let collides = a.tag == b.tag && a.arity == b.arity;
+                assert!(
+                    !collides || is_known_shared(a.name, b.name),
+                    "Poseidon contexts `{}` and `{}` share a domain tag at arity {} \
+                     with no discriminator — add a discriminator or a justified \
+                     KNOWN_SHARED entry",
+                    a.name,
+                    b.name,
+                    a.arity,
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
adds executable distinctness checks for the current digest contexts
-a registry of every Poseidon (tag, arity) and BLAKE2b (personal, domain byte) hash context, with a pairwise-separation test in each digest module. BLAKE2b tags are compared as the zero-padded 16-byte block the hash actually keys on.

also documents the known `nf_master/nf_prefix` GGM reuse (shared `Tachyon-NfPrefix` at arity 3) as an explicit allowlist entry rather than a failure. #171 removes that path, and should update the registry when it lands (drop the allowlist, add the MiMC domains).

~ this is a guard ahead of the full registry/spec work.