### PR TITLE
fix: fail fast on stamp merge coverage mismatch

### DIFF
--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -607,13 +607,24 @@ impl ProofStamp {
     /// The action digests for the merge proof and the merged
     /// `covered_actions` are both derived from the descriptor lists.
     ///
-    /// TODO: confirm desc list against stamp? it's forbidden by the proof
-    /// system, but we might want to fail early.
+    /// In debug builds, asserts that each descriptor list matches its stamp's
+    /// covered-actions digest. The proof system rejects a mismatched merge
+    /// regardless, but only after the merge proving work has been spent; a
+    /// caller that hits these assertions has selected the wrong inputs.
     pub fn merge<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
         (left_stamp, left_desc): (Self, BTreeSet<action::Descriptor>),
         (right_stamp, right_desc): (Self, BTreeSet<action::Descriptor>),
     ) -> Result<Self, ProveError> {
+        debug_assert!(
+            left_stamp.is_covering(left_desc.iter().copied()),
+            "merge: left descriptor list does not match stamp coverage",
+        );
+        debug_assert!(
+            right_stamp.is_covering(right_desc.iter().copied()),
+            "merge: right descriptor list does not match stamp coverage",
+        );
+
         let left_actions_digest = left_desc
             .iter()
             .map(action::Descriptor::digest)

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -753,13 +753,24 @@ impl ProofStamp {
     /// The action digests for the merge proof and the merged
     /// `covered_actions` are both derived from the descriptor lists.
     ///
-    /// TODO: confirm desc list against stamp? it's forbidden by the proof
-    /// system, but we might want to fail early.
+    /// In debug builds, asserts that each descriptor list matches its stamp's
+    /// covered-actions digest. The proof system rejects a mismatched merge
+    /// regardless, but only after the merge proving work has been spent; a
+    /// caller that hits these assertions has selected the wrong inputs.
     pub fn merge<RNG: CryptoRng>(
         rng: &mut RNG,
         (left_stamp, left_desc): (Self, BTreeSet<action::Descriptor>),
         (right_stamp, right_desc): (Self, BTreeSet<action::Descriptor>),
     ) -> Result<Self, ProveError> {
+        debug_assert!(
+            left_stamp.is_covering(left_desc.iter().copied()),
+            "merge: left descriptor list does not match stamp coverage",
+        );
+        debug_assert!(
+            right_stamp.is_covering(right_desc.iter().copied()),
+            "merge: right descriptor list does not match stamp coverage",
+        );
+
         let left_actions_digest = left_desc
             .iter()
             .map(action::Descriptor::digest)

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -616,6 +616,48 @@ fn read_accepts_distinct_sorted_tachygrams() {
     ProofStamp::read(&*buf).expect("distinct sorted tachygrams must be accepted");
 }
 
+/// In debug builds, `merge` asserts when the left descriptor list does not
+/// match the left stamp's covered-actions digest, before any proving work.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "left descriptor list does not match stamp coverage")]
+fn merge_asserts_left_coverage() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user_a = WalletSim::random(rng);
+    let user_b = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let anchor = pool.anchor();
+    let (stamp_a, _plan_a) = build_output_stamp(rng, anchor, user_a.random_note(200));
+    let (stamp_b, plan_b) = build_output_stamp(rng, anchor, user_b.random_note(300));
+
+    let _unused = ProofStamp::merge(
+        rng,
+        (stamp_a, BTreeSet::from_iter([plan_b.descriptor()])),
+        (stamp_b, BTreeSet::from_iter([plan_b.descriptor()])),
+    );
+}
+
+/// In debug builds, `merge` asserts when the right descriptor list does not
+/// match the right stamp's covered-actions digest, before any proving work.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "right descriptor list does not match stamp coverage")]
+fn merge_asserts_right_coverage() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user_a = WalletSim::random(rng);
+    let user_b = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let anchor = pool.anchor();
+    let (stamp_a, plan_a) = build_output_stamp(rng, anchor, user_a.random_note(200));
+    let (stamp_b, _plan_b) = build_output_stamp(rng, anchor, user_b.random_note(300));
+
+    let _unused = ProofStamp::merge(
+        rng,
+        (stamp_a, BTreeSet::from_iter([plan_a.descriptor()])),
+        (stamp_b, BTreeSet::from_iter([plan_a.descriptor()])),
+    );
+}
+
 /// `hStampActionsTachyon` survives a `write`/`read` round-trip.
 #[test]
 fn covered_actions_round_trip() {

--- a/crates/tachyon/tests/integration/stamp.rs
+++ b/crates/tachyon/tests/integration/stamp.rs
@@ -661,6 +661,48 @@ fn read_accepts_distinct_sorted_tachygrams() {
     ProofStamp::read(&*buf).expect("distinct sorted tachygrams must be accepted");
 }
 
+/// In debug builds, `merge` asserts when the left descriptor list does not
+/// match the left stamp's covered-actions digest, before any proving work.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "left descriptor list does not match stamp coverage")]
+fn merge_asserts_left_coverage() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user_a = WalletSim::random(rng);
+    let user_b = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let anchor = pool.anchor();
+    let (stamp_a, _plan_a) = build_output_stamp(rng, anchor, user_a.random_note(200));
+    let (stamp_b, plan_b) = build_output_stamp(rng, anchor, user_b.random_note(300));
+
+    let _unused = ProofStamp::merge(
+        rng,
+        (stamp_a, BTreeSet::from_iter([plan_b.descriptor()])),
+        (stamp_b, BTreeSet::from_iter([plan_b.descriptor()])),
+    );
+}
+
+/// In debug builds, `merge` asserts when the right descriptor list does not
+/// match the right stamp's covered-actions digest, before any proving work.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "right descriptor list does not match stamp coverage")]
+fn merge_asserts_right_coverage() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user_a = WalletSim::random(rng);
+    let user_b = WalletSim::random(rng);
+    let pool = PoolSim::genesis(rng);
+    let anchor = pool.anchor();
+    let (stamp_a, plan_a) = build_output_stamp(rng, anchor, user_a.random_note(200));
+    let (stamp_b, _plan_b) = build_output_stamp(rng, anchor, user_b.random_note(300));
+
+    let _unused = ProofStamp::merge(
+        rng,
+        (stamp_a, BTreeSet::from_iter([plan_a.descriptor()])),
+        (stamp_b, BTreeSet::from_iter([plan_a.descriptor()])),
+    );
+}
+
 /// `hStampActionsTachyon` survives a `write`/`read` round-trip.
 #[test]
 fn covered_actions_round_trip() {


### PR DESCRIPTION
avoids wasted merge proving work when an aggregator is given descriptor lists that do not match the input stamps: `ProofStamp::merge` now compares each side's descriptors against the stamp's covered-actions digest and fails fast with `CoverageMismatch` (carrying both digests) before proving. 

resolves the in-code TODO; the proof system still enforces the same property, this just moves the rejection before the expensive work.

~refs #52 and also touches `stamp/mod.rs` so anticipates a small rebase if #173 lands first