### PR TITLE
refactor: `SpendBind` and `SpendStamp`

### DIFF
--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -48,15 +48,15 @@ A single lift can consume an arbitrarily long composed `Unspent`, including one 
 ### Spending
 
 To spend, the wallet runs `SpendBind`.
-It consumes the `SpendableHeader` and witnesses the note and the action fields.
-It derives `cm` from the note and requires `spendable.cm == cm`, so the witnessed note is the spendable lineage's note: the value commitment `cv` then commits to the minted value[^notes].
-The output `SpendHeader` carries `cm`, the value commitment and action verification key `(cv, rk)`, the lineage's current nullifier `present_nf`, and the threaded anchor.
-
-`SpendStamp` composes that `SpendHeader` with a length-2 `NullifierHeader` range (the live pair for the current and next epochs) and witnesses the next-epoch nullifier `nf_next`.
-It requires `range.epoch_end == range.epoch_start + 2` and `range.cm == cm`, then binds the published pair to the range's boundary leaves by equality: `present_nf == range.nf_start` and `nf_next == range.nf_end`.
+It consumes the `SpendableHeader` and a length-2 `NullifierHeader` range (the live pair for the current and next epochs), and witnesses the next-epoch nullifier `nf_next`.
+It requires `range.epoch_end == range.epoch_start + 2` and `range.cm == spendable.cm`, then binds the published pair to the range's boundary leaves by equality: `present_nf == range.nf_start` and `nf_next == range.nf_end`.
 Because `present_nf` is threaded from the lineage, the `nf_start` equality forces the range to start at the lineage's current epoch, while `nf_next` is pinned to the genuine end leaf $N_{e+1}$.
 Nonzero guards close the `nf == 0` degenerate.
-It derives the action digest from the value commitment and verification key, and emits a `StampHeader` whose tachygram set contains both nullifiers and whose anchor is threaded from the spend.
+The output `SpendHeader` carries `cm`, the confirmed pair `(present_nf, nf_next)`, and the threaded anchor; it carries no curve points.
+
+`SpendStamp` consumes that `SpendHeader` and witnesses the note and the action fields.
+It requires `note.commitment() == cm`, so the witnessed note is the spendable lineage's note: the value commitment `cv` then commits to the minted value[^notes].
+It derives the action digest from `cv` and the randomized action key `rk`, and emits a `StampHeader` whose tachygram set contains both nullifiers and whose anchor is threaded from the spend.
 
 An output operation runs `OutputStamp` directly.
 The step witnesses the new note, value-randomness, action-randomness, and an anchor; the wallet typically anchors each output at the same height as the transaction's spends so the merge can proceed without an intervening lift.
@@ -173,15 +173,15 @@ The anchor adjacency check (`verified.anchor_prev == spendable.anchor`) welds th
 ### Spend binding
 
 Spending a note publishes two nullifiers, one for the current epoch and one for the next, both pinned to the note's genuine leaves.
-`SpendBind` witnesses the note's fields and the action material and consumes the `SpendableHeader`.
-It derives `cm` from the note and requires `spendable.cm == cm`: the witnessed note is the lineage's note, so a phantom note reusing the same `psi` (and so the same nullifiers) but carrying a different value, and hence a different `cm`, is rejected.
-The value commitment binds to `value`, which `cm` digests, so the spent value is the minted value[^notes].
-The output `SpendHeader` threads the lineage's `present_nf`, anchor, and `cm`; `SpendBind` is an intermediate step, its `SpendHeader` consumed only by `SpendStamp`, so the note never propagates.
-
-`SpendStamp` completes the publication: it composes the `SpendHeader` with a length-2 `NullifierHeader` range, witnesses `nf_next`, and requires the range to span exactly two epochs with `range.cm == cm`.
+`SpendBind` consumes the `SpendableHeader` and a length-2 `NullifierHeader` range, witnesses `nf_next`, and requires the range to span exactly two epochs with `range.cm == spendable.cm`.
 It binds the published pair to the range's boundary leaves by equality (`present_nf == range.nf_start`, `nf_next == range.nf_end`): `present_nf` is threaded from the lineage, so the `nf_start` equality forces the range to start at the lineage's current epoch, and `nf_next` is pinned to the genuine `nf_end` leaf.
 Each published nullifier must be nonzero, or it would collide with the note's own `cm` in the tachygram scan.
-Deferring the boundary-leaf binding and the action digest to `SpendStamp` keeps each step within its per-step gate budget.
+No note witness is needed here: the range and the lineage are already tied to the same note by their two `cm` fields, bound where the range was derived and at `SpendableInit` respectively.
+The output `SpendHeader` threads `cm`, the confirmed pair, and the anchor, and carries no curve points.
+
+`SpendStamp` completes the publication: it re-witnesses the note against the header's `cm`, derives the value commitment `cv` and the randomized action key `rk`, and commits the one-action set alongside the two-element tachygram set.
+Requiring `note.commitment() == cm` rejects a phantom note reusing the same `psi`, and so the same nullifiers, while carrying a different value and hence a different `cm`.
+The note is witnessed only in this terminal step, so it never propagates.
 
 The two complementary `cm` checks pin value two independent ways. `cm == note.commitment()` ties `cm` to the note by `Poseidon` collision-resistance (the spender must know `rcm`, `pk`, `value`, `psi`). `spendable.cm == cm` ties it to the lineage, which the creation stamp proved minted. Together they bind the action's value commitment to the note actually being spent. Publishing both nullifiers lets consensus apply the spend across an epoch transition that may occur between proof construction and inclusion.
 
@@ -191,7 +191,7 @@ The note's age never becomes public. The lineage carries only a single current n
 
 A stamp commits to two multisets, an action-digest set and a tachygram set[^tachygrams].
 `OutputStamp` derives a value commitment, action verification key, and action digest from a witnessed note, value-randomness, and action-randomness; constraints reject zero or over-range note values and require the note's payment key to match the witnessed key material[^keys].
-`SpendStamp` composes a `SpendHeader` (carrying value commitment, action verification key, `present_nf`, anchor, and `cm`) with the note's length-2 `NullifierHeader` range, binds the published pair to the range, derives the action digest, and emits a stamp whose action digest, two-nullifier tachygram set, and threaded anchor follow.
+`SpendStamp` mirrors it on the spend side: it re-witnesses the note against the `SpendHeader`'s `cm`, derives the value commitment, action verification key, and action digest, and emits a stamp whose one-action digest set, two-nullifier tachygram set, and threaded anchor follow. The nullifier pair it publishes was already confirmed against the covering range at `SpendBind`.
 `MergeStamp` fuses two stamps by checking anchor equality and confirming each output set is the union of the two inputs': it witnesses the merged sets and enforces, for each, that the merged set polynomial is the product of the input set polynomials.
 
 ### Stamp anchor
@@ -225,12 +225,12 @@ flowchart TB
   end
 
   subgraph spend_action [spend action]
-    w_bind[/note, rcv, alpha, pak/]
+    w_bind[/nf_next/]
     s_bind[SpendBind]
   end
 
   subgraph merge [transaction assembly]
-    w_stamp[/nf_next/]
+    w_stamp[/note, rcv, alpha, pak/]
     s_spendstamp[SpendStamp]
     w_output[/rcv, alpha, note, anchor/]
     s_output[OutputStamp]
@@ -255,8 +255,8 @@ flowchart TB
   s_lift -->|SpendableHeader| s_bind
 
   w_bind --> s_bind
+  nf_range -->|NullifierHeader| s_bind
   s_bind -->|SpendHeader| s_spendstamp
-  nf_range -->|NullifierHeader| s_spendstamp
   w_stamp --> s_spendstamp
 
   w_output --> s_output
@@ -323,7 +323,7 @@ flowchart LR
 | NfPrefixHeader | (cm, node, depth, index) |
 | NullifierHeader | (cm, (epoch_start, nf_start), nf_seq_commit, (epoch_end, nf_end)) |
 | SpendableHeader | (cm, present_nf, anchor) |
-| SpendHeader | (cm, (cv, rk), present_nf, anchor) |
+| SpendHeader | (cm, present_nf, nf_next, anchor) |
 | StampHeader | (action_commit, tachygram_commit, anchor) |
 
 ## Steps
@@ -344,9 +344,9 @@ flowchart LR
 | NullifierFuse | NullifierHeader | NullifierHeader | left_seq, merged_seq, right_seq | NullifierHeader |
 | SpendableInit | AnchorChain | NullifierHeader | (pre_epoch_anchor, pre_cm_anchor), creation_set, present_nf | SpendableHeader |
 | SpendableLift | SpendableHeader | VerifiedUnspent | — | SpendableHeader |
-| SpendBind | SpendableHeader | — | note, rcv, alpha, pak | SpendHeader |
+| SpendBind | SpendableHeader | NullifierHeader | nf_next | SpendHeader |
 | OutputStamp | — | — | rcv, alpha, note, anchor | StampHeader |
-| SpendStamp | SpendHeader | NullifierHeader | nf_next | StampHeader |
+| SpendStamp | SpendHeader | — | note, rcv, alpha, pak | StampHeader |
 | MergeStamp | StampHeader | StampHeader | (action_set, tachygram_set) × left, merged, right | StampHeader |
 | StampLift | StampHeader | AnchorChain | — | StampHeader |
 

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -350,19 +350,16 @@ impl Plan {
         for ((desc, alpha, note, rcv), (nf_pcd, spendable_pcd)) in
             self.spends.into_iter().zip(spendbind_inputs)
         {
+            // SpendBind: confirm the live pair against the derived range.
+            let (_, _, _, (_, nf_next)) = *nf_pcd.data();
             let (bind_pcd, ()) = PROOF_SYSTEM
-                .fuse(
-                    rng,
-                    spend::SpendBind,
-                    (note, rcv, alpha, *pak),
-                    spendable_pcd,
-                    ragu::Proof::trivial().carry::<()>(()),
-                )
+                .fuse(rng, spend::SpendBind, (nf_next,), spendable_pcd, nf_pcd)
                 .map_err(ProveError::ProofFailed)?;
 
-            // SpendStamp: bind the live pair to the derived range and publish.
+            // SpendStamp: prove the action and publish.
             let (tachygrams, anchor, proof) =
-                ProofStamp::prove_spend(rng, bind_pcd, nf_pcd).map_err(ProveError::ProofFailed)?;
+                ProofStamp::prove_spend(rng, bind_pcd, note, rcv, alpha, *pak)
+                    .map_err(ProveError::ProofFailed)?;
 
             let digest = desc.digest().map_err(ProveError::ActionDigest)?;
             entries.push((
@@ -504,25 +501,30 @@ impl ProofStamp {
         Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))
     }
 
-    /// Proves a single spend action from pre-built spend and
-    /// nullifier-range PCDs, returning the stamp components
-    /// `(tachygrams, anchor, proof)`.
+    /// Proves a single spend action from a pre-built [`spend::SpendBind`]
+    /// PCD, returning the stamp components `(tachygrams, anchor, proof)`.
     ///
     /// The spend's `anchor` is taken as the stamp's anchor — chain
     /// validation lives inside the spendable lineage, not here.
     pub fn prove_spend<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
         bind_pcd: ragu::Pcd<spend::SpendHeader>,
-        nf_pcd: ragu::Pcd<delegation::NullifierHeader>,
+        note: Note,
+        rcv: value::Trapdoor,
+        alpha: ActionRandomizer<effect::Spend>,
+        pak: ProofAuthorizingKey,
     ) -> Result<(BTreeSet<Tachygram>, Anchor, Box<ragu::Proof>), ragu::Error> {
-        let (_, _, nf_present, anchor) = *bind_pcd.data();
-        let (_, _, _, (_, nf_next)) = *nf_pcd.data();
-
+        let (_cm, present_nf, nf_next, anchor) = *bind_pcd.data();
         let tachygrams =
-            BTreeSet::from_iter([Tachygram::from(nf_present), Tachygram::from(nf_next)]);
+            BTreeSet::from_iter([Tachygram::from(present_nf), Tachygram::from(nf_next)]);
 
-        let (pcd, ()) = PROOF_SYSTEM.fuse(rng, SpendStamp, (nf_next,), bind_pcd, nf_pcd)?;
-
+        let (pcd, ()) = PROOF_SYSTEM.fuse(
+            rng,
+            SpendStamp,
+            (note, rcv, alpha, pak),
+            bind_pcd,
+            ragu::Proof::trivial().carry::<()>(()),
+        )?;
         let rerand = PROOF_SYSTEM.rerandomize(pcd, rng)?;
 
         Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -1,61 +1,62 @@
-//! Spend action-binding header and step.
+//! Spend nullifier-binding header and step.
 
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
 
-use pasta_curves::{Ep, EpAffine, Eq, Fp, Fq};
+use pasta_curves::{Ep, Eq, Fp, Fq};
 use ragu::{
     Header, Index, Step, Suffix,
     constraint::{enforce_nonzero, enforce_zero},
 };
 
-use super::spendable::SpendableHeader;
-use crate::{
-    action,
-    constants::MAX_MONEY,
-    entropy::ActionRandomizer,
-    keys::ProofAuthorizingKey,
-    note::{self, Note},
-    nullifier::Nullifier,
-    primitives::{Anchor, effect},
-    value,
-};
+use super::{delegation::NullifierHeader, spendable::SpendableHeader};
+use crate::{note, nullifier::Nullifier, primitives::Anchor};
 
-/// Header binding an action to its spendable lineage.
+/// Header binding a spend to its lineage note and epoch nullifier pair.
 ///
-/// Carries `cv`, `rk`, the lineage's `present_nf`, the pool `anchor`, and the
-/// note commitment `cm`; the nullifier pair is completed and published at
+/// Carries the note commitment `cm`, the present and next nullifiers
+/// `(present_nf, nf_next)` confirmed against the covering range, and the pool
+/// `anchor`. The action pair `(cv, rk)` is produced downstream at
 /// [`SpendStamp`](super::stamp::SpendStamp).
 #[derive(Debug)]
 pub struct SpendHeader;
 
 impl Header for SpendHeader {
-    /// `(cm, (cv, rk), present_nf, anchor)`. `cm` leads; `(cv, rk)` are the
-    /// spend's published action pair, derived together at [`SpendBind`];
-    /// `present_nf` and `anchor` thread from the spendable lineage that
-    /// [`SpendBind`] consumed.
-    type Data = (note::Commitment, action::Descriptor, Nullifier, Anchor);
+    /// `(cm, present_nf, nf_next, anchor)`. `cm` binds the spent note;
+    /// `present_nf`/`nf_next` are the confirmed epoch pair; `anchor` threads
+    /// the spendable lineage's pool position.
+    type Data = (note::Commitment, Nullifier, Nullifier, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(10);
 
     fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
-        let (cm, act, present_nf, anchor) = *data;
+        let (cm, present_nf, nf_next, anchor) = *data;
         (
-            vec![Fp::from(cm), Fp::from(present_nf), Fp::from(anchor)],
+            vec![
+                Fp::from(cm),
+                Fp::from(present_nf),
+                Fp::from(nf_next),
+                Fp::from(anchor),
+            ],
             Vec::new(),
-            vec![Ep::from(act.cv), EpAffine::from(act.rk).into()],
+            Vec::new(),
             Vec::new(),
         )
     }
 }
 
-/// Binds an action to its spendable lineage's note.
+/// Confirms a spend's epoch nullifier pair against a covering two-leaf
+/// [`NullifierHeader`] range and binds it to the spendable lineage.
 ///
-/// Witnesses the `note` and `pak`, plus the action randomizers (`rcv`,
-/// `alpha`); checks `cm == spendable.cm` (so `cv` commits to the proven-minted
-/// value) and threads `present_nf`, `anchor`, and `cm` onto the output. The
-/// live pair is completed at [`SpendStamp`](super::stamp::SpendStamp).
+/// The range is tied to the lineage's note by `nf_cm == spendable_cm` (both
+/// are the note commitment, bound where the range was derived and at
+/// [`SpendableInit`](super::spendable::SpendableInit) respectively), so no
+/// note witness is needed here. Witnesses `nf_next` and binds the published
+/// pair to the range's genuine `GGM(mk, ·)` boundary leaves: the range spans
+/// exactly two epochs, `present_nf` is its start leaf, and `nf_next` its end
+/// leaf. Both nullifiers are emitted on the [`SpendHeader`] for the
+/// action-producing step to publish.
 #[derive(Debug)]
 pub struct SpendBind;
 
@@ -63,47 +64,45 @@ impl Step for SpendBind {
     type Aux<'source> = ();
     type Left = SpendableHeader;
     type Output = SpendHeader;
-    type Right = ();
-    /// `(note, rcv, alpha, pak)`.
-    type Witness<'source> = (
-        Note,
-        value::Trapdoor,
-        ActionRandomizer<effect::Spend>,
-        ProofAuthorizingKey,
-    );
+    type Right = NullifierHeader;
+    /// `(nf_next,)`.
+    type Witness<'source> = (Nullifier,);
 
     const INDEX: Index = Index::new(15);
 
     fn witness<'source>(
         &self,
         _ctx: &mut ragu::StepCtx<'_>,
-        (note, rcv, alpha, pak): Self::Witness<'source>,
+        (nf_next,): Self::Witness<'source>,
         (spendable_cm, present_nf, anchor): <Self::Left as Header>::Data,
-        _right: <Self::Right as Header>::Data,
+        (nf_cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, nf_end)): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        enforce_zero(
+            Fp::from(nf_epoch_end) - (Fp::from(nf_epoch_start) + Fp::from(2u64)),
+            "SpendBind: live range must span two epochs",
+        )?;
+        enforce_zero(
+            Fp::from(nf_cm) - Fp::from(spendable_cm),
+            "SpendBind: derived range does not match note",
+        )?;
+
+        // Bind the published nullifiers to the range's genuine boundary leaves.
+        enforce_zero(
+            Fp::from(present_nf) - Fp::from(nf_start),
+            "SpendBind: present nullifier is not the range's start leaf",
+        )?;
+        enforce_zero(
+            Fp::from(nf_next) - Fp::from(nf_end),
+            "SpendBind: next nullifier is not the range's end leaf",
+        )?;
+
+        // A zero nullifier would collide with the note's own cm tachygram.
         enforce_nonzero(
-            Fp::from(u64::from(note.value)),
-            "SpendBind: zero-value note",
+            Fp::from(present_nf),
+            "SpendBind: present-epoch nullifier is zero",
         )?;
-        if u64::from(note.value) > MAX_MONEY {
-            return Err(ragu::Error::InvalidWitness(
-                "SpendBind: note value exceeds maximum".into(),
-            ));
-        }
-        enforce_zero(
-            Fp::from(note.pk) - Fp::from(pak.derive_payment_key()),
-            "SpendBind: pak not related to note",
-        )?;
-        let cm = note.commitment();
+        enforce_nonzero(Fp::from(nf_next), "SpendBind: next-epoch nullifier is zero")?;
 
-        enforce_zero(
-            Fp::from(spendable_cm) - Fp::from(cm),
-            "SpendBind: note does not match the spendable lineage",
-        )?;
-
-        let cv = rcv.commit(note.value);
-        let rk = pak.ak.derive_action_public(&alpha);
-
-        Ok(((cm, action::Descriptor { cv, rk }, present_nf, anchor), ()))
+        Ok(((spendable_cm, present_nf, nf_next, anchor), ()))
     }
 }

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -10,14 +10,13 @@ use ragu::{
     constraint::{enforce_equal_point, enforce_nonzero, enforce_zero},
 };
 
-use super::{delegation::NullifierHeader, pool::AnchorChain, spend::SpendHeader};
+use super::{pool::AnchorChain, spend::SpendHeader};
 use crate::{
     ActionSetPoly, TachygramSetPoly,
     constants::MAX_MONEY,
     entropy::ActionRandomizer,
-    keys::private,
+    keys::{ProofAuthorizingKey, private},
     note::Note,
-    nullifier::Nullifier,
     primitives::{ActionDigest, ActionSetCommit, Anchor, TachygramSetCommit, effect},
     relations::enforce::enforce_poly_product,
     value,
@@ -125,13 +124,14 @@ impl Step for OutputStamp {
     }
 }
 
-/// Composes a [`SpendHeader`] with the live two-leaf [`NullifierHeader`] range
-/// and stamps the spend.
+/// Proves a spend's action and publishes its stamp.
 ///
-/// Witnesses `nf_next` and binds the published pair to the note's genuine
-/// `GGM(mk, ·)` leaves: consumes the two-leaf range (`range.end ==
-/// range.start + 2`, `range.cm == cm`) and checks
-/// `[present_nf]G_0 + [nf_next]G_1 == nf_seq_commit`.
+/// Focused like [`OutputStamp`] on the action: re-witnesses the spent note
+/// (bound to the [`SpendHeader`]'s `cm`), derives the value commitment `cv` and
+/// the randomized action key `rk`, and commits the one-action set plus the
+/// two-element tachygram set `{present_nf, nf_next}` (the pair
+/// [`SpendBind`](super::spend::SpendBind) already confirmed against the
+/// covering range).
 #[derive(Debug)]
 pub struct SpendStamp;
 
@@ -139,18 +139,23 @@ impl Step for SpendStamp {
     type Aux<'source> = ();
     type Left = SpendHeader;
     type Output = StampHeader;
-    type Right = NullifierHeader;
-    /// `(nf_next,)`.
-    type Witness<'source> = (Nullifier,);
+    type Right = ();
+    /// `(note, rcv, alpha, pak)`.
+    type Witness<'source> = (
+        Note,
+        value::Trapdoor,
+        ActionRandomizer<effect::Spend>,
+        ProofAuthorizingKey,
+    );
 
     const INDEX: Index = Index::new(16);
 
     fn witness<'source>(
         &self,
         _ctx: &mut ragu::StepCtx<'_>,
-        (nf_next,): Self::Witness<'source>,
-        (cm, act, present_nf, anchor): <Self::Left as Header>::Data,
-        (nf_cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, nf_end)): <Self::Right as Header>::Data,
+        (note, rcv, alpha, pak): Self::Witness<'source>,
+        (cm, present_nf, nf_next, anchor): <Self::Left as Header>::Data,
+        _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         #[expect(clippy::expect_used, reason = "constant size")]
         let &[g0, g1, g2] = Pasta::host_generators(Pasta::baked())
@@ -159,36 +164,27 @@ impl Step for SpendStamp {
             .expect("at least three generators")
             .0;
 
-        enforce_zero(
-            Fp::from(nf_epoch_end) - (Fp::from(nf_epoch_start) + Fp::from(2u64)),
-            "SpendStamp: live range must span two epochs",
-        )?;
-        enforce_zero(
-            Fp::from(nf_cm) - Fp::from(cm),
-            "SpendStamp: derived range does not match note",
-        )?;
-
-        // Bind the published nullifiers to the range's genuine boundary leaves.
-        enforce_zero(
-            Fp::from(present_nf) - Fp::from(nf_start),
-            "SpendStamp: present nullifier is not the range's start leaf",
-        )?;
-        enforce_zero(
-            Fp::from(nf_next) - Fp::from(nf_end),
-            "SpendStamp: next nullifier is not the range's end leaf",
-        )?;
-
-        // A zero nullifier would collide with the note's own cm tachygram.
         enforce_nonzero(
-            Fp::from(present_nf),
-            "SpendStamp: present-epoch nullifier is zero",
+            Fp::from(u64::from(note.value)),
+            "SpendStamp: zero-value note",
         )?;
-        enforce_nonzero(
-            Fp::from(nf_next),
-            "SpendStamp: next-epoch nullifier is zero",
+        if u64::from(note.value) > MAX_MONEY {
+            return Err(ragu::Error::InvalidWitness(
+                "SpendStamp: note value exceeds maximum".into(),
+            ));
+        }
+        enforce_zero(
+            Fp::from(note.pk) - Fp::from(pak.derive_payment_key()),
+            "SpendStamp: pak not related to note",
+        )?;
+        enforce_zero(
+            Fp::from(note.commitment()) - Fp::from(cm),
+            "SpendStamp: note does not match the spend",
         )?;
 
-        let action_digest = act.digest().map_err(|_err| {
+        let cv = rcv.commit(note.value);
+        let rk = pak.ak.derive_action_public(&alpha);
+        let action_digest = ActionDigest::new(cv, rk).map_err(|_err| {
             ragu::Error::InvalidWitness("SpendStamp: action digest construction failed".into())
         })?;
 

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -16,7 +16,7 @@ use rand_core::{CryptoRng, RngCore};
 
 use super::{PROOF_SYSTEM, delegation, pool, spend, spendable, stamp};
 use crate::{
-    ActionSetPoly, NfSeqPoly, Note, TachygramSetPoly, action,
+    ActionSetPoly, NfSeqPoly, Note, TachygramSetPoly,
     constants::EPOCH_SIZE,
     entropy::ActionEntropy,
     fixtures::{
@@ -56,31 +56,31 @@ fn honest_spend_bind(
     user: &WalletSim,
     note: &Note,
     spendable: Pcd<spendable::SpendableHeader>,
+    spend_epoch: EpochIndex,
 ) -> Pcd<spend::SpendHeader> {
-    let (rcv, _theta, alpha) = spend_witness(rng, note);
-    let (spend_pcd, ()) = PROOF_SYSTEM
-        .fuse(
-            rng,
-            spend::SpendBind,
-            (*note, rcv, alpha, user.pak),
-            spendable,
-            Proof::trivial().carry::<()>(()),
-        )
+    let derived = user.derived_range(rng, note, spend_epoch, 2);
+    let nf_next = user.nf_at(note, spend_epoch.next());
+    let (bind_pcd, ()) = PROOF_SYSTEM
+        .fuse(rng, spend::SpendBind, (nf_next,), spendable, derived)
         .expect("SpendBind honest");
-    spend_pcd
+    bind_pcd
 }
 
 fn honest_spend_stamp(
     rng: &mut StdRng,
     user: &WalletSim,
     note: &Note,
-    spend_pcd: Pcd<spend::SpendHeader>,
-    spend_epoch: EpochIndex,
+    bind_pcd: Pcd<spend::SpendHeader>,
 ) -> Pcd<stamp::StampHeader> {
-    let derived = user.derived_range(rng, note, spend_epoch, 2);
-    let nf_next = user.nf_at(note, spend_epoch.next());
+    let (rcv, _theta, alpha) = spend_witness(rng, note);
     let (stamp, ()) = PROOF_SYSTEM
-        .fuse(rng, stamp::SpendStamp, (nf_next,), spend_pcd, derived)
+        .fuse(
+            rng,
+            stamp::SpendStamp,
+            (*note, rcv, alpha, user.pak),
+            bind_pcd,
+            Proof::trivial().carry::<()>(()),
+        )
         .expect("SpendStamp honest");
     stamp
 }
@@ -95,8 +95,8 @@ fn same_epoch_honest_spend_accepted() {
     let epoch = cm_height.epoch();
 
     let spendable = user.spendable_init(rng, &note, &pool, cm_height);
-    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable);
-    let stamp = honest_spend_stamp(rng, &user, &note, spend_pcd, epoch);
+    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable, epoch);
+    let stamp = honest_spend_stamp(rng, &user, &note, spend_pcd);
 
     let expected = TachygramSetPoly::from_iter([
         user.nf_at(&note, epoch).into(),
@@ -467,13 +467,13 @@ fn spend_bind_honest() {
     let spend_epoch = height.epoch();
     let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
 
-    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd);
-    let (_cm, _desc, present_nf, _anchor) = *spend_pcd.data();
+    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd, spend_epoch);
+    let (_cm, present_nf, _nf_next, _anchor) = *spend_pcd.data();
     assert_eq!(present_nf, user.nf_at(&note, spend_epoch));
 }
 
 #[test]
-fn spend_bind_rejects_invalid_inputs() {
+fn spend_stamp_rejects_invalid_note() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::random(rng);
     let other = WalletSim::random(rng);
@@ -499,12 +499,17 @@ fn spend_bind_rejects_invalid_inputs() {
     let wrong_value = value::Positive::try_from(999_999u64).expect("test value in range");
     assert_ne!(u64::from(wrong_value), u64::from(note.value));
 
+    // The nullifier pair binds honestly at SpendBind; the note-level checks
+    // (value, pak, cm) now live at SpendStamp, which proves the action.
+    let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
+    let bind_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd, spend_epoch);
+
     let cases = [
         (
             "value inflation",
             phantom,
             user.pak,
-            "SpendBind: note does not match the spendable lineage",
+            "SpendStamp: note does not match the spend",
         ),
         (
             "wrong value",
@@ -513,25 +518,24 @@ fn spend_bind_rejects_invalid_inputs() {
                 ..note
             },
             user.pak,
-            "SpendBind: note does not match the spendable lineage",
+            "SpendStamp: note does not match the spend",
         ),
         (
             "unrelated pak",
             note,
             other.pak,
-            "SpendBind: pak not related to note",
+            "SpendStamp: pak not related to note",
         ),
     ];
 
     for (label, spend_note, pak, expected) in cases {
-        let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
         let (rcv, _theta, alpha) = spend_witness(rng, &note);
         let err = PROOF_SYSTEM
             .fuse(
                 rng,
-                spend::SpendBind,
+                stamp::SpendStamp,
                 (spend_note, rcv, alpha, pak),
-                spendable_pcd,
+                bind_pcd.clone(),
                 Proof::trivial().carry::<()>(()),
             )
             .err()
@@ -544,7 +548,7 @@ fn spend_bind_rejects_invalid_inputs() {
 }
 
 #[test]
-fn spend_stamp_rejects_forged_next() {
+fn spend_bind_rejects_forged_next() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
@@ -554,12 +558,17 @@ fn spend_stamp_rejects_forged_next() {
     let spend_epoch = height.epoch();
     let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
 
-    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd);
     let derived = user.derived_range(rng, &note, spend_epoch, 2);
     let forged_next = Nullifier::from(Fp::random(&mut *rng));
 
     let err = PROOF_SYSTEM
-        .fuse(rng, stamp::SpendStamp, (forged_next,), spend_pcd, derived)
+        .fuse(
+            rng,
+            spend::SpendBind,
+            (forged_next,),
+            spendable_pcd,
+            derived,
+        )
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {
@@ -567,12 +576,12 @@ fn spend_stamp_rejects_forged_next() {
     };
     assert_eq!(
         inner.to_string(),
-        "SpendStamp: next nullifier is not the range's end leaf"
+        "SpendBind: next nullifier is not the range's end leaf"
     );
 }
 
 #[test]
-fn spend_stamp_rejects_zero_next_nullifier() {
+fn spend_bind_rejects_zero_next_nullifier() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
@@ -582,12 +591,11 @@ fn spend_stamp_rejects_zero_next_nullifier() {
     let spend_epoch = height.epoch();
     let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
 
-    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd);
     let derived = user.derived_range(rng, &note, spend_epoch, 2);
     let zero_next = Nullifier::from(Fp::ZERO);
 
     let err = PROOF_SYSTEM
-        .fuse(rng, stamp::SpendStamp, (zero_next,), spend_pcd, derived)
+        .fuse(rng, spend::SpendBind, (zero_next,), spendable_pcd, derived)
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {
@@ -595,48 +603,8 @@ fn spend_stamp_rejects_zero_next_nullifier() {
     };
     assert_eq!(
         inner.to_string(),
-        "SpendStamp: next nullifier is not the range's end leaf"
+        "SpendBind: next nullifier is not the range's end leaf"
     );
-}
-
-#[test]
-fn spend_stamp_rejects_identity_cv() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    pool.mine(random_block_with(rng, &[vec![note.commitment()]], 4));
-    let height = pool.height();
-    let spend_epoch = height.epoch();
-    let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
-
-    let real_spend = honest_spend_bind(rng, &user, &note, spendable_pcd);
-    let (cm, real_desc, present_nf, anchor) = *real_spend.data();
-    let identity_cv = value::Commitment::default();
-    let forged_spend = real_spend.proof().clone().carry::<spend::SpendHeader>((
-        cm,
-        action::Descriptor {
-            cv: identity_cv,
-            rk: real_desc.rk,
-        },
-        present_nf,
-        anchor,
-    ));
-
-    let derived = user.derived_range(rng, &note, spend_epoch, 2);
-    let nf_next = user.nf_at(&note, spend_epoch.next());
-    let err = PROOF_SYSTEM
-        .fuse(rng, stamp::SpendStamp, (nf_next,), forged_spend, derived)
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    // The identity cv dies at the header boundary: the header's points are
-    // hashed on the way into the step and the identity is unrepresentable.
-    // `ActionDigest`'s own identity rejection remains as defense in depth
-    // behind this structural check.
-    assert_eq!(inner.to_string(), "point at infinity cannot be witnessed");
 }
 
 #[test]
@@ -675,14 +643,16 @@ fn step_rejects_zero_value_note() {
         let note = user.random_note(500);
         pool.mine(random_block_with(rng, &[vec![note.commitment()]], 4));
         let height = pool.height();
+        let spend_epoch = height.epoch();
         let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
+        let bind_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd, spend_epoch);
 
         let (rcv, _theta, alpha) = spend_witness(rng, &note);
 
         let err = PROOF_SYSTEM
             .fuse(
                 rng,
-                spend::SpendBind,
+                stamp::SpendStamp,
                 (
                     Note {
                         value: value::Positive::new_unchecked(0),
@@ -692,7 +662,7 @@ fn step_rejects_zero_value_note() {
                     alpha,
                     user.pak,
                 ),
-                spendable_pcd,
+                bind_pcd,
                 Proof::trivial().carry::<()>(()),
             )
             .err()
@@ -700,7 +670,7 @@ fn step_rejects_zero_value_note() {
         let ragu::Error::InvalidWitness(inner) = err else {
             panic!("expected InvalidWitness, got {err:?}");
         };
-        assert_eq!(inner.to_string(), "SpendBind: zero-value note");
+        assert_eq!(inner.to_string(), "SpendStamp: zero-value note");
     }
 }
 
@@ -732,8 +702,8 @@ fn spend_after_lift_publishes_anchor_epoch_nullifiers() {
     let unspent = sync.build_next_unspent(rng, 0, &pool, target_height);
     let lifted = user.lift(rng, spendable, unspent, &note, EpochIndex(0), EpochIndex(1));
 
-    let spend_pcd = honest_spend_bind(rng, &user, &note, lifted);
-    let (_cm, _desc, present_nf, _anchor) = *spend_pcd.data();
+    let spend_pcd = honest_spend_bind(rng, &user, &note, lifted, EpochIndex(1));
+    let (_cm, present_nf, _nf_next, _anchor) = *spend_pcd.data();
     assert_eq!(
         present_nf,
         user.nf_at(&note, EpochIndex(1)),
@@ -745,7 +715,7 @@ fn spend_after_lift_publishes_anchor_epoch_nullifiers() {
         "nf_0 was consumed by the lift"
     );
 
-    let stamp = honest_spend_stamp(rng, &user, &note, spend_pcd, EpochIndex(1));
+    let stamp = honest_spend_stamp(rng, &user, &note, spend_pcd);
     let expected = TachygramSetPoly::from_iter([
         user.nf_at(&note, EpochIndex(1)).into(),
         user.nf_at(&note, EpochIndex(2)).into(),
@@ -765,8 +735,8 @@ fn spend_stamp_assembles_tachygrams() {
     let spend_epoch = height.epoch();
     let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
 
-    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd);
-    let stamp_pcd = honest_spend_stamp(rng, &user, &note, spend_pcd, spend_epoch);
+    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd, spend_epoch);
+    let stamp_pcd = honest_spend_stamp(rng, &user, &note, spend_pcd);
     let (_actions, tg_commit, _anchor) = *stamp_pcd.data();
     let expected = TachygramSetPoly::from_iter([
         Tachygram::from(user.nf_at(&note, spend_epoch)),

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -126,8 +126,10 @@ fn plan_prove_rejects_invalid_inputs() {
         );
     }
 
-    // Correspondence swap: lengths match, pairing is wrong. SpendBind's
-    // `spendable.cm == note.commitment()` check rejects the mismatched lineage.
+    // Correspondence swap: lengths match, pairing is wrong. Each pair is
+    // internally consistent, so SpendBind binds it; the plan's note is the
+    // odd one out, and SpendStamp's `note.commitment() == cm` check catches
+    // it when the action is proven.
     {
         let plan = Plan::new(two_spends(), alloc::vec![], anchor);
         let pcds = alloc::vec![bundle_b(), bundle_a()];
@@ -137,7 +139,7 @@ fn plan_prove_rejects_invalid_inputs() {
         };
         assert_eq!(
             inner.to_string(),
-            "SpendBind: note does not match the spendable lineage"
+            "SpendStamp: note does not match the spend"
         );
     }
 }


### PR DESCRIPTION
`SpendBind` and `SpendStamp` are refactored. This reduces diff in later PRs.

Now, `SpendBind` binds the nullifier derivation, and `SpendStamp` proves the action.

- `spend_stamp_rejects_identity_cv` is eliminated since `SpendHeader` no longer carries `cv`
- `digest_rejects_identity_cv` still covers rejection where `cv` folds into `ActionDigest`
