### PR TITLE
refactor: indexed multiset

### DIFF
--- a/book/src/domain-separators.md
+++ b/book/src/domain-separators.md
@@ -63,7 +63,7 @@ These are all Tachyon-specific digests, performed in-circuit.
 | Nullifier master key | `Tachyon-NfMaster` |
 | Nullifier derivation | `Tachyon-NfDerive` |
 | Note commitment | `Tachyon-CmDerive` |
-| Output padding tachygram | `Tachyon-PadDeriv` |
+| Output padding tachygram | `Tachyon-CmOutPad` |
 | Action digest | `Tachyon-ActionDg` |
 | Payment key derivation | `Tachyon-PkDerive` |
 | Anchor stamp step | `Tachyon-AnchorSt` |

--- a/book/src/nullifiers.md
+++ b/book/src/nullifiers.md
@@ -2,64 +2,79 @@
 
 A nullifier is a secret bound at note creation, and published later to destroy the note. Each note has a distinct nullifier per epoch.
 
-To spend a note, a transaction author must prove that no valid nullifier for it has been published in the pool between the note's creation and some anchor[^anchor]. Spending a note publishes two of its nullifiers to the pool, for the anchor epoch and the next epoch, making such a proof impossible to produce afterward.
+To spend a note, a transaction author must prove that no valid nullifier for the note has been published in the pool between the note's creation and some anchor[^anchor].
+Spending a note publishes two of its nullifiers to the pool, for the anchor epoch and the next epoch, making such a proof impossible to produce for later anchors.
 
 Pool state is likely to advance between proof creation and mining, so consensus closes the gap by confirming the nullifiers did not enter the pool in the interim.[^tachygrams] The second nullifier allows consensus to tolerate an epoch transition in that interim.
 
 ## Derivation
 
-The note's master key $\mathsf{mk}$ is derived from the note's trapdoor $\psi$ and the wallet's nullifier key $\mathsf{nk}$, and should be kept secret.
+A nullifier is the output of a Poseidon sponge. Abstractly,
 
 $$
-\mathsf{mk} =
-    \mathsf{Poseidon}_\texttt{Tachyon-NfMaster}\!(
-        \psi, \mathsf{nk}
-    )
+  \mathsf{nf}_e = \mathsf{PRF}^{\mathsf{nfTachyon}}_{\mathsf{mk}}(e)
 $$
 
-Nullifiers come in groups of the sponge rate $r$: one sponge keyed on $\mathsf{mk}$ and the window start $w = e - (e \bmod r)$ squeezes the $r$ consecutive nullifiers starting at epoch $w$.
+Because $\mathsf{nf}_e$ is the output of a pseudo-random function of master key $\mathsf{mk}$ and epoch $e$, distinct epochs have unrelated nullifiers.
+
+Epochs are grouped at sponge rate $r$ for proof efficiency.
+One sponge squeezes $r$ consecutive nullifiers starting at base epoch $w = e - (e \bmod r)$
 
 $$
-\mathsf{Poseidon}_\texttt{Tachyon-NfDerive}\!\left(
-    \mathsf{mk},\ w
-\right) = (\mathsf{nf}_{w},\ \ldots,\ \mathsf{nf}_{w + r - 1})
+    \mathsf{Poseidon}_\texttt{Tachyon-NfDerive}\!(
+      \mathsf{mk}, w
+    ) = (\mathsf{nf}_w, \ldots,\ \mathsf{nf}_{w + r - 1})
 $$
 
-$\mathsf{nf}_e$ is the member at position $e - w$ in its group. Because $\mathsf{nf}_e$ is a pseudo-random function of $\mathsf{mk}$ and the epoch $e$, distinct epochs yield unrelated nullifiers, and an author cannot steer a nullifier toward a chosen value.
+So $\mathsf{nf}_e$ is the member at position $e - w$ in its group.
 
 ## Binding
 
-$\psi$ is carried in the note and digested into the note commitment $\mathsf{cm}$, alongside the payment key $\mathsf{pk}$, which itself pins $\mathsf{nk}$[^pk]. So $\mathsf{cm}$ fixes both $\psi$ and $\mathsf{nk}$, hence $\mathsf{mk}$, hence the entire nullifier sequence. A note has exactly one nullifier sequence, frozen when its commitment enters the pool as a tachygram.
+The master key $\mathsf{mk}$ is derived from the note trapdoor $\psi$ and nullifier key $\mathsf{nk}$.
 
-The proof tree never trusts a freely witnessed nullifier. Wherever a nullifier is consumed, a derivation chain proves in-circuit that it is a genuine sponge output of the note's $\mathsf{mk}$, and binds that derivation to the note by $\mathsf{cm}$.[^derive]
+The note commitment $\mathsf{cm}$ digests $\psi$ and the payment key $\mathsf{pk}$, which transitively binds $\mathsf{nk}$ via its own derivation, closing the circle with $\mathsf{mk}$.
 
-$\psi$ must be unique per note. Two notes that reuse the same $\psi$ share $\mathsf{mk}$ and therefore the same nullifier sequence, so spending one publishes the other's nullifiers.
+Distinct notes under the same $\mathsf{nk}$ should not re-use $\psi$ because the pair $(\psi, \mathsf{nk})$ produce an identical $\mathsf{mk}$ and identical sequence of nullifiers.
 
-### Spendable
+## Delegation
 
-A spendable tracks an unspent note as the pool advances. It carries the note's current nullifier, its pool anchor, and the note commitment:
+A delegate may observe pool state and prove the absence of nullifiers without holding key material or any information about a note.
 
-$$(\,\mathsf{nf}_e,\;\; \mathsf{anchor},\;\; \mathsf{cm}\,)$$
+The delegate is provided an arbitrary sequence of values $\delta_{e..e+d}$ to prove absent from epochs $e..e+d$ and these tested values are committed as a contiguous sequence.
 
-$\mathsf{nf}_e$ is the nullifier the wallet would publish to spend now, at the lineage's current epoch $e$. Advancing the spendable (a lift) proves every nullifier from epoch $e$ up to the new epoch absent from the pool, then moves $\mathsf{nf}_e$ and the anchor forward together. $\mathsf{cm}$ rides along unchanged, binding the whole lineage to one note, and so to one value: the spend commits to the value inside $\mathsf{cm}$, which the creation stamp proved minted.
+$$
+  \Delta(X) =
+    \prod_{i = e}^{e+d} \Bigl(
+        ((i+1)X + \delta_{i})^3 - 2
+    \Bigr)
+$$
 
-A lift advances the current nullifier only to a genuine next derived nullifier, and the next lift's starting nullifier must equal the current one. Because both are PRF outputs, that equality forces the same note and the same epoch, so a lineage cannot skip an epoch or splice in another note.
+In parallel, $\mathsf{mk}$ proves derivation of a nullifier sequence for a range at least covering the delegated sequence.
 
-### Delegation
+$$
+  N(X) = \prod_{j} \Bigl(
+      ((j+1)X + \mathsf{nf}_{j})^3 - 2
+    \Bigr)
+$$
 
-The holder of $\mathsf{mk}$ can outsource the search for its nullifiers in the pool.[^delegation] It hands a delegate the next window of values $\Delta_{e..e+d}$, which should be the nullifiers $\mathsf{nf}_{e..e+d}$ but which the delegate treats as opaque. The delegate proves them absent from the pool across stamps and epochs, oblivious to $\mathsf{mk}$, $\psi$, $\mathsf{cm}$, and the note, and commits the sequence on the coefficient generators, terminated by a sentinel $1$ one position above the window:
+Witness material $ C = N \setminus \Delta $ is prepared for the expected complement.
 
-$$\delta = \sum_{i} [\Delta_{e+i}]\,\mathcal{G}_i + \mathcal{G}_d$$
+$$
+  C(X) = \prod_{j \notin e..e+d} \Bigl(
+      ((j+1)X + \mathsf{nf}_{j})^3 - 2
+    \Bigr)
+$$
 
-The sentinel keeps every committed sequence nonzero (an empty window is the constant $1$), so $\delta$ is never the identity point, and it pins the window's exact length.
+The delegate returns its proof of absence, and the relationship is verified by challenge.
 
-At the lift the wallet binds $\delta$ to genuine derived nullifiers: it proves a contiguous derived range commits to the same sequence, so each $\Delta_{e+i}$ is the real $\mathsf{nf}_{e+i}$. The window is measured in epoch-boundary crossings: $d$ is the crossing count and $\delta$ holds one nullifier per crossing, plus the nullifier of the epoch in progress at the span's tip, which is carried separately because that epoch is not yet complete. The wallet binds the tip too, so the lineage's new current nullifier is itself a genuine derived nullifier rather than a free value.
+$$
+  N = C \uplus \Delta
+   \quad \iff \quad
+  N(X) = C(X) \cdot \Delta(X)
+$$
 
-Re-basing is what lets a window be arbitrary. Any run of nullifiers shifts down to a degree-zero polynomial that stands as a witness on its own, so the wallet can delegate any window from any epoch, and only the wallet, holding the note, can fold the proven absence into the lineage.[^lift]
+The delegate's values are arbitrary until bound to a proven derivation. If the delegate constructed a proof diverging from the correct sequence, no relationship can be established with $N$ and the delegate's proof is useless.
 
 [^anchor]: [Anchor](./anchor.md) describes the pool state commitment.
+
 [^tachygrams]: See [Tachygrams](./tachygrams.md) for the unified consensus rule covering all published tachygrams.
-[^pk]: $\mathsf{pk} = \mathrm{Poseidon}(\text{PK\_DOMAIN}, \mathsf{ak}_x, \mathsf{nk})$ binds $\mathsf{nk}$ into the commitment, so a wrong $\mathsf{nk}$ yields a wrong $\mathsf{cm}$.
-[^derive]: The derivation chain and its consumers; see [Proof Tree](./proof-tree.md).
-[^delegation]: The delegate composes the absence proofs the wallet later lifts onto its own lineage; see [Proof Tree](./proof-tree.md).
-[^lift]: This fold is the `SpendableLift` proof step; see [Proof Tree](./proof-tree.md).

--- a/book/src/nullifiers.md
+++ b/book/src/nullifiers.md
@@ -45,7 +45,7 @@ The delegate is provided an arbitrary sequence of values $\delta_{e..e+d}$ to pr
 $$
   \Delta(X) =
     \prod_{i = e}^{e+d} \Bigl(
-        ((i+1)X + \delta_{i})^3 - 2
+        \bigl( \delta_{i} + (i+1)X \bigr)^3 - 2
     \Bigr)
 $$
 
@@ -53,7 +53,7 @@ In parallel, $\mathsf{mk}$ proves derivation of a nullifier sequence for a range
 
 $$
   N(X) = \prod_{j} \Bigl(
-      ((j+1)X + \mathsf{nf}_{j})^3 - 2
+      \bigl( \mathsf{nf}_{j} + (j+1)X \bigr)^3 - 2
     \Bigr)
 $$
 
@@ -61,7 +61,7 @@ Witness material $ C = N \setminus \Delta $ is prepared for the expected complem
 
 $$
   C(X) = \prod_{j \notin e..e+d} \Bigl(
-      ((j+1)X + \mathsf{nf}_{j})^3 - 2
+      \bigl( \mathsf{nf}_{j} + (j+1)X \bigr)^3 - 2
     \Bigr)
 $$
 

--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -13,45 +13,43 @@ Multiple parties execute the proof tree.
 
 ### Deriving nullifiers
 
-A wallet proves a contiguous run of its note's nullifiers were correctly derived[^nullifiers].
-`NfMasterSeed` witnesses the note and the proof-authorizing key `pak`, checks `note.pk == pak.derive_payment_key()` (which pins `nk`, and through `nk` the commitment `cm`), derives the master key `mk` and `cm`, and emits an `NfMasterHeader` carrying `(cm, mk)`.
-`NfDerive` runs one sponge over `(mk, group)` to derive the group's nullifiers, and witnesses a boolean mask selecting a contiguous run of them: the emitted `NullifierHeader` carries `cm`, the boundary `(epoch, nf)` pairs of the run, and an `nf_seq_commit` over the run's half-open epoch range, with `epoch_start` shifted past the leading unselected epochs.
+A wallet proves a window of its note's nullifiers were correctly derived[^nullifiers].
+`NfMasterSeed` witnesses the note and the proof-authorizing key `pak`, checks `note.pk == pak.derive_payment_key()` (which pins `nk`, and through `nk` the commitment `cm`), derives the master key `mk` and `cm`, and emits an `NfMasterHeader` carrying `(cm, mk)`. `nk` never leaves the step.
+`NfDerive` consumes that seed. It witnesses the window's start epoch (constrained group-aligned) and its sequence, runs four sponges over $(\texttt{Tachyon-NfDerive}, \mathsf{mk}, w)$ to squeeze the window's 16 nullifiers natively, and binds the sequence to them with one opening at a free challenge (below). It exports the whole window, so the range it announces is derived rather than witnessed.
 `NullifierFuse` concatenates two adjacent nullifier sequences into one, requiring the same `cm` and contiguity (`right.epoch_start == left.epoch_end`).
-The result is a `NullifierHeader` proving the range `[epoch_start, epoch_end)` commits to the genuine derived nullifiers `PRF(mk, ·)` of the note identified by `cm`, surfacing `nf_start` and `nf_end` as its boundary members.
+The result is a `NullifierDerivation` proving the range `[epoch_start, epoch_end)` commits to the genuine nullifiers of the note identified by `cm`, one factor per covered epoch.
 
 ### Bootstrapping a spendable
 
-A spendable starts when `SpendableInit` consumes the wallet's single-epoch `NullifierHeader` for the starting epoch.
-It witnesses `(pre_cm_anchor, creation_set, present_nf)`: it binds `present_nf` to the proven member by equality (`present_nf == nf_start`, the range spanning the single epoch `[epoch_start, epoch_start + 1)`), takes `cm` from the range header, checks `cm` is among the creation stamp's tachygrams[^tachygrams], and emits a `SpendableHeader` carrying `(cm, (epoch, present_nf), anchor)` with `anchor = pre_cm_anchor.next_stamp(epoch, creation_commit)`, the position immediately after the creation stamp, advanced by each lift.
-`pre_cm_anchor` is a free witness, so the anchor binds only downstream: lift adjacency threads it to the eventual spend anchor, which consensus checks for chain membership, and a chain node's preimage fixes the real predecessor, the real creation epoch (pinning the starting derivation epoch), and the real cm-stamp.
+A spendable starts when `SpendableInit` consumes a `NullifierDerivation` covering the creation epoch.
+It witnesses `(pre_cm_anchor, creation_set, creation_epoch, present_nf)` along with the derivation's sequence and a complement: dividing the creation epoch's factor out of the sequence forces `present_nf` to the range's genuine member there. It takes `cm` from the range header, checks `cm` is among the creation stamp's tachygrams[^tachygrams], and emits a `SpendableHeader` carrying `(cm, (creation_epoch, present_nf), anchor)` with `anchor = pre_cm_anchor.next_stamp(creation_epoch, creation_commit)`, the position immediately after the creation stamp, advanced by each lift.
+`pre_cm_anchor` is a free witness, so the anchor binds only downstream: lift adjacency threads it to the eventual spend anchor, which consensus checks for chain membership, and a chain node's preimage fixes the real predecessor, the real creation epoch, and the real cm-stamp.
 
 ### Maintaining a spendable
 
 Maintaining the spendable means advancing its anchor forward over `ArbitraryUnspent` segments while proving the crossed nullifiers absent.
-The sync service produces `ArbitraryUnspent` segments without ever holding the note, its `cm`, or `psi`.
-The values a segment tests are arbitrary field elements as far as its own proof is concerned, which is why the segment can be built by a party that knows nothing about the note; only `UnspentBind` attributes them to a derivation.
-`UnspentSeed` absorbs one stamp at a given absolute epoch and proves a wallet-supplied nullifier was absent from that stamp's tachygram set; the resulting `ArbitraryUnspent` has crossed no epoch boundary, so its `elapsed` is empty and `epoch_start == epoch_end` with `nf_start == nf_end` the tested nullifier.
+The sync service produces `ArbitraryUnspent` segments without ever holding the note, its `cm`, or `psi`: the values a segment tests are arbitrary field elements as far as its own proof is concerned, and only `UnspentBind` attributes them to a derivation.
+`UnspentSeed` absorbs one stamp at a given absolute epoch and proves a wallet-supplied nullifier was absent from that stamp's tachygram set; the resulting `ArbitraryUnspent` crosses no epoch boundary, so `epoch_start == epoch_last` and the tested nullifier is its single `elapsed` member.
 A block that publishes no stamp advances no anchor, so a stampless span needs no segment and no proof work.
-`UnspentFuse` composes two contiguous ranges that share a junction epoch (`right.epoch_start == left.epoch_end`): it concatenates their `elapsed` histories and seam-binds the junction nullifier (`left.nf_end == right.nf_start`) at adjacent anchors.
-`EndEpochUnspentSeed` is the segment for the boundary itself: it folds the epoch tick from a witnessed epoch-terminal anchor and records the epoch it leaves as the one member of its `elapsed`, so `epoch_end == epoch_start + 1`.
+`UnspentFuse` composes two contiguous ranges that share a junction epoch (`right.epoch_start == left.epoch_last`): it concatenates their `elapsed` histories, keeping the junction member once, at adjacent anchors.
+`EndEpochUnspentSeed` is the segment for the boundary itself: it folds the epoch tick from a witnessed epoch-terminal anchor, its two `elapsed` members being the epochs it leaves and enters, so `epoch_last == epoch_start + 1`.
 A boundary is therefore a link like any other, and `UnspentFuse` composes it with its neighbours on both sides; an epoch that published nothing is simply two crossings with no stamp segment between them.
-An `ArbitraryUnspent` records its span as two absolute epoch endpoints, `epoch_start` and `epoch_end`; the crossing count is their difference.
 
-`UnspentBind` binds a sync-built `ArbitraryUnspent` to genuine derivation. It is wallet-side: it consumes the `ArbitraryUnspent` and a wallet `NullifierHeader` range, and proves the range commits to exactly the `elapsed` crossings followed by the tip `nf_end`, with the range's epochs equal to the `ArbitraryUnspent`'s span. So every crossed nullifier and the tip are proven `PRF(mk, ·)` outputs.
+`UnspentBind` is wallet-side. It consumes the sync-built `ArbitraryUnspent` and a `NullifierDerivation`, and divides `elapsed` out of the derivation's sequence, so every factor of `elapsed` is a genuine nullifier of the note at its own epoch.
 It emits an `Unspent` carrying the span's boundary nullifiers, anchors and epochs, and the note's `cm`.
 
 `SpendableLift` is wallet-side and witness-free: it consumes a `SpendableHeader` and an `Unspent`.
 It checks the verified segment's `cm` equals the spendable's (so the absence-proven nullifiers are this note's, and the value cannot drift), the segment's `nf_start` equals the spendable's `present_nf` (continuity), and the segment's `anchor_prev` equals the spendable's anchor (adjacency).
-It advances to the segment's `nf_end` and `anchor_last`, threading `cm` unchanged.
+It advances to the segment's `nf_last` and `anchor_last`, threading `cm` unchanged.
 A single lift can consume an arbitrarily long composed `ArbitraryUnspent`, including one that crosses many epoch boundaries.
 A lineage resting on its epoch's terminal anchor lifts the same way: the boundary tick is a link, so a segment can open on it.
 
 ### Spending
 
 To spend, the wallet runs `SpendBind`.
-It consumes the `SpendableHeader` and a length-2 `NullifierHeader` range (the live pair for the current and next epochs), and witnesses the next-epoch nullifier `nf_next`.
-It requires `range.epoch_end == range.epoch_start + 2` and `range.cm == spendable.cm`, then binds the published pair to the range's boundary leaves by equality: `present_nf == range.nf_start` and `nf_next == range.nf_end`.
-Because `present_nf` is threaded from the lineage, the `nf_start` equality forces the range to start at the lineage's current epoch, while `nf_next` is pinned to the genuine end member $N_{e+1}$.
+It consumes the `SpendableHeader` and a `NullifierDerivation` covering the current and next epochs, and witnesses the next-epoch nullifier `nf_next`.
+It requires `range.cm == spendable.cm`, then confirms the published pair by dividing two adjacent factors out of the derivation's sequence, one indexed at the lineage's epoch and one at the next.
+Because `present_nf` is threaded from the lineage, its factor is fixed before the challenge, and `nf_next` is forced to the genuine nullifier of the epoch after it.
 Nonzero guards close the `nf == 0` degenerate.
 The output `SpendHeader` carries `cm`, the confirmed pair `(present_nf, nf_next)`, and the threaded anchor; it carries no curve points.
 
@@ -79,7 +77,7 @@ The aggregated stamp has the same shape as any other, so it is itself eligible f
 ## Roles
 
 The wallet runs every step that touches the note's commitment or master key.
-It seeds and derives the private nullifier ranges (`NfMasterSeed`, `NfDerive`, `NullifierFuse`), derives spendable status from its own derivation (`SpendableInit`), binds and lifts over sync-built segments (`UnspentBind`, `SpendableLift`), and produces spend and output stamps (`SpendBind`, `SpendStamp`, `OutputBind`, `OutputStamp`).
+It derives its nullifier windows (`NfMasterSeed`, `NfDerive`, `NullifierFuse`), derives spendable status from its own derivation (`SpendableInit`), binds and lifts over sync-built segments (`UnspentBind`, `SpendableLift`), and produces spend and output stamps (`SpendBind`, `SpendStamp`, `OutputBind`, `OutputStamp`).
 
 The sync service holds the per-epoch nullifier values the wallet shared and pool history.
 It produces the `ArbitraryUnspent` segments that carry the spendable forward (`UnspentSeed`, `EndEpochUnspentSeed`, `UnspentFuse`) and hands the composed segment to the wallet to bind and lift over; it never sees a note, `cm`, `psi`, or `mk`.
@@ -109,61 +107,63 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `A
 
 ## Soundness
 
-The subsections below walk each subtree bottom-up: the chain segments that act as primitives, then the `ArbitraryUnspent` segments and the derivation chain that consume them, then the binding at `UnspentBind`, the spendable lineage, then spend binding and stamps.
+The subsections below walk each subtree bottom-up.
 
 ### Anchor segments
 
-`AnchorSeed`, `UnspentSeed`, and `EndEpochUnspentSeed` each witness a predecessor anchor and prove one anchor step from it.
-`AnchorFuse` composes adjacent segments by checking endpoint equality; `UnspentFuse` additionally concatenates the two halves' `elapsed` histories.
+`AnchorSeed`, `UnspentSeed`, and `EndEpochUnspentSeed` each witness a predecessor anchor and prove one anchor step from it, and the fuses compose adjacent segments by checking endpoint equality.
 A segment ties to real chain history only through a consensus-published stamp whose anchor matches an end-of-block value, emitted at `StampLift`. `SpendableInit`'s anchor closes the same way without a segment: the private spendable's anchor reaches consensus once it is spent into a stamp.
 
 ### ArbitraryUnspent composition
 
-An `ArbitraryUnspent` is a contiguous range bracketed by `anchor_prev` and `anchor_last`, with boundary pairs `(epoch_start, nf_start)` and `(epoch_end, nf_end)`, plus `elapsed` (one nullifier coefficient per epoch-boundary crossing in its span, forward-chronological, terminated by a sentinel coefficient $1$ at the crossing count)[^nullifiers]. `nf_start`/`nf_end` are the nullifiers at `epoch_start`/`epoch_end`; the crossing count is `epoch_end - epoch_start`.
-The sentinel keeps the committed polynomial nonzero for every sequence, so the commitment never falls on the identity point, which the in-circuit point representation cannot hold; it also pins the sequence's exact length, which commit-equality alone bounds only from above.
-`UnspentSeed` produces a within-epoch `ArbitraryUnspent` for one stamp's worth of anchor advance: `elapsed` is empty (the sentinel constant $1$, committing to $\mathcal{G}_0$), `epoch_start == epoch_end`, and the nullifier it just non-membership-checked is both `nf_start` and `nf_end`.
-`EndEpochUnspentSeed` produces the other base case, the epoch boundary itself. It folds a witnessed epoch-terminal anchor through the cross-epoch domain and emits the tick's output as `anchor_last`, with `epoch_end == epoch_start + 1` and a one-member `elapsed` holding the nullifier tested in the epoch being left. It is the only step that adds a member, so the invariant that `elapsed` holds exactly `epoch_end - epoch_start` of them holds by induction: the other seed establishes it at zero and the fuse preserves it additively. There is no exclusion to prove; that the witnessed predecessor really is its epoch's terminal anchor rests on consensus anchor membership of the eventual spend, since the tick of a short anchor is not a value consensus recomputes.
-`UnspentFuse` composes two contiguous ranges sharing a junction epoch (`right.epoch_start == left.epoch_end`) at adjacent anchors (`left.anchor_last == right.anchor_prev`): it concatenates their histories and seam-binds the junction nullifier (`left.nf_end == right.nf_start`). Writing $s$ for the left crossing count, the concat confirms
+An `ArbitraryUnspent` is a contiguous range bracketed by `anchor_prev` and `anchor_last`, with boundary pairs `(epoch_start, nf_start)` and `(epoch_last, nf_last)`, plus `elapsed`: the product of one indexed cubic factor per epoch covered over `[epoch_start, epoch_last]`[^nullifiers].
+Each factor carries its own epoch, so the product is a multiset of `(epoch, nullifier)` pairs and needs no degree pin. Every producer holds three properties that `UnspentBind` relies on: each factor's epoch lies inside the span, each epoch has exactly one factor, and the boundary caches name factors the product holds.
+`UnspentSeed` produces a within-epoch `ArbitraryUnspent` for one stamp's worth of anchor advance: `epoch_start == epoch_last`, and the nullifier it just non-membership-checked is the single factor, hence both `nf_start` and `nf_last`.
+`EndEpochUnspentSeed` produces the other base case, the epoch boundary itself. It folds a witnessed epoch-terminal anchor through the cross-epoch domain and emits the tick's output as `anchor_last`, with `epoch_last == epoch_start + 1` and two factors, the epoch being left and the epoch entered. There is no exclusion to prove; that the witnessed predecessor really is its epoch's terminal anchor rests on consensus anchor membership of the eventual spend, since the tick of a short anchor is not a value consensus recomputes.
+Each seed pins its own product against the pair it emits. The challenge absorbs the sequence commitment and a scalar-binding point of the free nullifiers, so a witnessed sequence cannot disagree with the header scalars.
+`UnspentFuse` composes two contiguous ranges sharing a junction epoch (`right.epoch_start == left.epoch_last`) at adjacent anchors (`left.anchor_last == right.anchor_prev`), confirming
 
-$$C(X) = L(X) + X^{s}\,(R(X) - 1)$$
+$$C(X) \cdot F_{\text{junction}}(X) = L(X) \cdot R(X)$$
 
-for the witnessed `combined` $C$, left $L$, and right $R$, at a Fiat-Shamir challenge: the $-1$ cancels the left half's sentinel at degree $s$, the right half's first crossing takes its slot, and the right half's sentinel re-terminates the combined sequence; the seam-bind makes the shared junction epoch's nullifier unambiguous across the merge.
-Every seam is intra-epoch, because a crossing arrives as a segment of its own rather than as a property of the merge, so this concatenation is the only sequence relation the composition needs and its shift $s$ is the only header-fixed quantity in it.
-$L$ and $R$ are bound by the recursive verification of the two input PCDs before the challenge, and $s$ is a left-header value bound likewise; because the identity is linear in $L$ and $R$ with a constant coefficient, that prior binding is what makes the concatenation sound.
-A crossing's absolute epoch is consensus-tied where the crossing is built rather than where it merges: `EndEpochUnspentSeed` folds its witnessed epoch through the cross-epoch domain, and a wrong epoch yields an anchor the published sequence does not contain.
+for the witnessed `combined` $C$, left $L$, and right $R$. Both halves hold the junction epoch's factor, and dividing it out leaves each epoch represented once. The recursive verification of the two input PCDs binds $L$ and $R$ before the challenge.
+The junction agreement (`left.nf_last == right.nf_start`) is well-formedness only, since a consistent pair of lies yields a wrong `elapsed` that `UnspentBind` rejects.
 
-### Derivation chain
+### Derivation window
 
-`NfMasterSeed` is the chain's only seed. It binds the master key to the note: `note.pk == pak.derive_payment_key()` pins `nk`, and the note commitment digests `nk` (through `pk`) and `psi`, so the derived `mk = Poseidon(psi, nk)` is consistent with the `cm` the seed threads forward.
-`NfDerive` derives one sponge group of nullifiers from the threaded `mk` and witnesses a boolean mask: in-circuit it enforces the mask is one contiguous nonempty run, shifts `epoch_start` past the leading unselected epochs, edge-selects the boundary nullifiers, and binds the witnessed run sequence to the selected sponge outputs by a single opening at a Fiat-Shamir challenge over its commitment. The window start (constrained group-aligned in-step) and the mask are free witnesses pinned by the emitted span: `epoch_start` decomposes injectively into the window start plus the mask's lead, and the span length is the run's size.
-`NullifierFuse` witnesses the two nullifier sequences and their concatenation, binds each by commit-equality, and confirms the concat at the constant offset `left.epoch_end - left.epoch_start`, requiring the same `cm` and contiguity.
-So a `NullifierHeader` is a sound proof that a contiguous epoch range commits to the genuine derived nullifiers of the note identified by `cm`.
+`NfMasterSeed` is the only seed. It binds the master key to the note: `note.pk == pak.derive_payment_key()` pins `nk`, and the note commitment digests `nk` (through `pk`) and `psi`, so the derived `mk = Poseidon(psi, nk)` is consistent with the `cm` the seed threads forward.
+`NfDerive` threads `mk` from that header, squeezes the window's nullifiers natively, and binds the witnessed sequence to them at a fresh challenge $z$:
+
+$$g(z) = \prod_{j < K} F_{\texttt{base}+j,\ \mathsf{nf}_{\texttt{base}+j}}(z)$$
+
+for $K$ the window width. The sequence is committed before $z$ exists, and every factor's scalars are pinned in-circuit: each epoch index is `epoch_start` plus a constant, and each nullifier is a sponge output of the threaded `mk`. `epoch_start` is a free witness constrained group-aligned in-step, pinned by the header it produces because it is emitted on the header directly.
+`NullifierFuse` binds both sequences and their product by commit-equality and confirms $M(X) = L(X) \cdot R(X)$, requiring the same `cm` and contiguity, which keeps the product squarefree.
 
 ### Binding unspent to derivation
 
-`UnspentBind` consumes the sync's `ArbitraryUnspent` and the wallet's `NullifierHeader`.
-It witnesses the `elapsed` sequence and the range sequence, binds each by commit-equality (`elapsed` to the `ArbitraryUnspent` header, the range to the `NullifierHeader`), and appends the header's tip scalar `nf_end`, confirming
+`UnspentBind` consumes the sync's `ArbitraryUnspent` and any `NullifierDerivation`, comparing no bounds against the unspent span.
+It binds `elapsed` and the derivation's sequence $g$ to their headers by commit-equality, then confirms the divisibility
 
-$$R(X) = E(X) + X^{s}\,(\texttt{nf\_end} - 1) + X^{s+1}$$
+$$g(X) = \texttt{elapsed}(X) \cdot \texttt{complement}(X)$$
 
-for the range $R$, elapsed $E$, and crossing count $s$, at a Fiat-Shamir challenge: the appended tip overwrites `elapsed`'s sentinel and the trailing term re-terminates the range. The tip scalar is a left-header value, fixed by the recursive verification of the `ArbitraryUnspent` PCD before the challenge.
-With the range epochs pinned to the `ArbitraryUnspent`'s span (`range.epoch_start == epoch_start`, `range.epoch_end == epoch_end + 1`), this proves the crossings and the tip are exactly the derived `PRF(mk, ·)` outputs: the tip nullifier is a genuine derived member, not a free value.
-It binds the span's boundary nullifiers to the range's genuine boundary members by equality (`nf_start` and `nf_end`), and threads the range's `cm`.
+where the witnessed complement holds the derivation's factors outside the lineage. Every factor is irreducible, so divisibility is multiset containment: each `elapsed` factor, its epoch included, is a genuine derived pair, and an epoch the derivation lacks has no factor to divide out.
+With the provenance properties above, every epoch of the span was therefore tested with its own genuine nullifier. The boundary caches inherit their genuineness from the same identity, so they need no separate check.
+The derivation's `cm` is stamped onto the `Unspent`.
 
 ### Spendable lineage
 
 `SpendableInit` is the lineage's only seed and is wallet-only.
-It witnesses the creation stamp's tachygrams, the anchor running into the creation stamp, and the starting-epoch nullifier `present_nf`.
+It witnesses the creation stamp's tachygrams, the anchor running into the creation stamp, the creation epoch, and the starting-epoch nullifier `present_nf`.
 It takes `cm` from the range header and binds the note to the pool (`cm` in `creation_set`), which pins the whole note to the real minted note.
-It emits `SpendableHeader(cm, (epoch, present_nf), anchor)`, where `epoch` is the range header's starting epoch and `anchor` folds that epoch onto the free-witnessed `pre_cm_anchor`; a wrong epoch or predecessor lands the anchor off the published sequence, so consensus anchor membership of the eventual spend forces both.
-`present_nf` is bound to the range's single derived member here; each lift then requires an `Unspent`'s `nf_start` to equal it, a genuine derived nullifier, keeping the lineage on the note's derived nullifiers.
+It emits `SpendableHeader(cm, (creation_epoch, present_nf), anchor)`, where `anchor` folds the creation epoch onto the free-witnessed `pre_cm_anchor`; a wrong epoch or predecessor lands the anchor off the published sequence, so consensus anchor membership of the eventual spend forces both.
+`present_nf` is forced to the range's member at the creation epoch by dividing its factor out of the derivation's sequence, the challenge absorbing a scalar-binding point of the free nullifier; each lift then requires an `Unspent`'s `nf_start` to equal it, keeping the lineage on the note's derived nullifiers.
+`creation_epoch` needs no bound check, since divisibility forces its factor to be one the derivation actually holds.
 
 `SpendableLift` advances the lineage over an `Unspent`.
 It threads `cm` by equality (`unspent.cm == spendable.cm`), so every consumed segment belongs to the lineage's one note and the spent value cannot drift to a different same-`mk` note.
-Combined with the tip binding at `UnspentBind` (which makes each new `present_nf` itself a genuine derived member), a lineage cannot skip an epoch or splice in another note.
+Every `Unspent` factor is genuine by `UnspentBind`, so a lineage cannot skip an epoch or splice in another note.
 
 Continuity holds through the boundary pair: `unspent.nf_start == spendable.present_nf` and `unspent.epoch_start == spendable.epoch`.
-The nullifiers are both `PRF(mk, ·)` outputs, so value-equality alone already forces the same note and the same epoch; carrying the epoch makes that a checked equality per lift rather than one inferred from the PRF, and it is what lets the lineage state its position without a derivation in hand.
+Both nullifiers are PRF outputs of the note's sponge, so value-equality alone forces the same note and epoch. Carrying the epoch makes that a checked equality per lift, and lets the lineage state its position without a derivation in hand.
 The anchor adjacency check (`unspent.anchor_prev == spendable.anchor`) welds the segment to the lineage's current position.
 
 A lineage resting on its epoch's terminal anchor is not a special position: the segment it lifts over opens with the boundary tick, so adjacency holds against the anchor it already sits on.
@@ -174,9 +174,9 @@ No coverage is skipped: the crossing leaves the epoch at its terminal anchor, an
 
 ### Spend binding
 
-Spending a note publishes two nullifiers, one for the current epoch and one for the next, both pinned to the note's genuine leaves.
-`SpendBind` consumes the `SpendableHeader` and a length-2 `NullifierHeader` range, witnesses `nf_next`, and requires the range to span exactly two epochs starting at the lineage's epoch, with `range.cm == spendable.cm`.
-It binds the published pair to the range's boundary members by equality (`present_nf == range.nf_start`, `nf_next == range.nf_end`): `present_nf` is threaded from the lineage, so the `nf_start` equality forces the range to start at the lineage's current epoch, and `nf_next` is pinned to the genuine `nf_end` member.
+Spending a note publishes two nullifiers, one for the current epoch and one for the next, both pinned to the note's genuine derivation.
+`SpendBind` consumes the `SpendableHeader` and a `NullifierDerivation` covering the current and next epochs, witnesses `nf_next`, and requires `range.cm == spendable.cm`.
+Dividing two adjacent factors out of the derivation's sequence confirms the pair. `present_nf`'s factor is native from left-header scalars, fixed before the challenge; the free `nf_next` is pinned by its scalar-binding point, absorbed into the challenge. Adjacency is the factor indices $e$ and $e+1$.
 Each published nullifier must be nonzero, or it would collide with the note's own `cm` in the tachygram scan.
 No note witness is needed here: the range and the lineage are already tied to the same note by their two `cm` fields, bound where the range was derived and at `SpendableInit` respectively.
 The output `SpendHeader` threads `cm`, the confirmed pair, and the anchor, and carries no curve points.
@@ -222,13 +222,14 @@ flowchart TB
   subgraph derive [nullifier derivation]
     w_seed[/note, pak/]
     s_seed[NfMasterSeed]
-    s_derive[NfDerive]
+    w_window[/epoch_start, seq/]
+    s_window[NfDerive]
     s_dfuse[NullifierFuse]
-    nf_range((NullifierHeader))
+    nf_range((NullifierDerivation))
   end
 
   subgraph spendable [spendable advance]
-    w_init[/pre_cm_anchor, creation_set, present_nf/]
+    w_init[/pre_cm_anchor, creation_set, creation_epoch, present_nf/]
     s_init[SpendableInit]
     unspent_in((ArbitraryUnspent))
     s_unspentbind[UnspentBind]
@@ -253,11 +254,12 @@ flowchart TB
   stamp_out((StampHeader))
 
   w_seed --> s_seed
-  s_seed -->|NfMasterHeader| s_derive
-  s_derive -->|NullifierHeader| s_dfuse
+  s_seed -->|NfMasterHeader| s_window
+  w_window --> s_window
+  s_window -->|NullifierDerivation| s_dfuse
   s_dfuse --> nf_range
 
-  nf_range -->|NullifierHeader| s_init
+  nf_range -->|NullifierDerivation| s_init
   w_init --> s_init
   nf_range --> s_unspentbind
   unspent_in --> s_unspentbind
@@ -266,7 +268,7 @@ flowchart TB
   s_lift -->|SpendableHeader| s_bind
 
   w_bind --> s_bind
-  nf_range -->|NullifierHeader| s_bind
+  nf_range -->|NullifierDerivation| s_bind
   s_bind -->|SpendHeader| s_spendstamp
   w_stamp --> s_spendstamp
 
@@ -337,10 +339,10 @@ flowchart LR
 | Header | Fields |
 | ------ | ------ |
 | AnchorChain | (start, end) |
-| ArbitraryUnspent | (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_end, nf_end), anchor_last) |
-| Unspent | (cm, anchor_prev, (epoch_start, nf_start), (epoch_end, nf_end), anchor_last) |
+| ArbitraryUnspent | (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_last, nf_last), anchor_last) |
+| Unspent | (cm, anchor_prev, (epoch_start, nf_start), (epoch_last, nf_last), anchor_last) |
 | NfMasterHeader | (cm, mk) |
-| NullifierHeader | (cm, (epoch_start, nf_start), nf_seq_commit, (epoch_end, nf_end)) |
+| NullifierDerivation | (cm, epoch_start, nf_commit, epoch_end) |
 | SpendableHeader | (cm, (epoch, present_nf), anchor) |
 | OutputHeader | (cm, pad) |
 | SpendHeader | (cm, present_nf, nf_next, anchor) |
@@ -352,23 +354,23 @@ flowchart LR
 | ---- | ---- | ----- | ------- | ------ |
 | AnchorSeed | — | — | start, epoch, stamp_commit | AnchorChain |
 | AnchorFuse | AnchorChain | AnchorChain | — | AnchorChain |
-| UnspentSeed | — | — | anchor_prev, (epoch, nf), stamp_tg_set | ArbitraryUnspent |
-| EndEpochUnspentSeed | — | — | anchor_prev, (epoch_prev, nf_prev), nf | ArbitraryUnspent |
+| UnspentSeed | — | — | anchor_prev, (epoch, nf), stamp_tg_set, elapsed_seq | ArbitraryUnspent |
+| EndEpochUnspentSeed | — | — | anchor_prev, (epoch_prev, nf_prev), nf, elapsed_seq | ArbitraryUnspent |
 | UnspentFuse | ArbitraryUnspent | ArbitraryUnspent | left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq | ArbitraryUnspent |
-| UnspentBind | ArbitraryUnspent | NullifierHeader | elapsed_seq, nf_seq | Unspent |
+| UnspentBind | ArbitraryUnspent | NullifierDerivation | elapsed_seq, nf_seq, complement_seq | Unspent |
 | NfMasterSeed | — | — | note, pak | NfMasterHeader |
-| NfDerive | NfMasterHeader | — | group, mask, seq | NullifierHeader |
-| NullifierFuse | NullifierHeader | NullifierHeader | left_seq, merged_seq, right_seq | NullifierHeader |
-| SpendableInit | NullifierHeader | — | pre_cm_anchor, creation_set, present_nf | SpendableHeader |
+| NfDerive | NfMasterHeader | — | epoch_start, seq | NullifierDerivation |
+| NullifierFuse | NullifierDerivation | NullifierDerivation | left_seq, merged_seq, right_seq | NullifierDerivation |
+| SpendableInit | NullifierDerivation | — | pre_cm_anchor, creation_set, creation_epoch, present_nf, nf_seq, complement_seq | SpendableHeader |
 | SpendableLift | SpendableHeader | Unspent | — | SpendableHeader |
-| SpendBind | SpendableHeader | NullifierHeader | nf_next | SpendHeader |
+| SpendBind | SpendableHeader | NullifierDerivation | nf_seq, complement_seq, nf_next | SpendHeader |
 | OutputBind | — | — | note | OutputHeader |
 | OutputStamp | OutputHeader | — | rcv, alpha, note, anchor | StampHeader |
 | SpendStamp | SpendHeader | — | note, rcv, alpha, pak | StampHeader |
 | MergeStamp | StampHeader | StampHeader | (action_set, tachygram_set) × left, merged, right | StampHeader |
 | StampLift | StampHeader | AnchorChain | — | StampHeader |
 
-[^nullifiers]: See [Nullifiers](./nullifiers.md) for the sponge derivation, the scalar `psi` seed, and the re-based absence sequence.
+[^nullifiers]: See [Nullifiers](./nullifiers.md) for the nullifier sponge, the scalar `psi` seed, and the delegated absence sequence.
 [^tachygrams]: See [Tachygrams](./tachygrams.md) for the per-stamp multiset polynomial and its Pedersen commitment.
 [^notes]: See [Notes](./notes.md) for the four-field note structure and its commitment.
 [^keys]: See [Keys](./keys.md) for the wallet key hierarchy and the per-action derivations.

--- a/book/src/tachygrams.md
+++ b/book/src/tachygrams.md
@@ -17,7 +17,7 @@ $$
 
 $$
 \mathsf{tg}_1 = \mathsf{tg}_\bot =
-    \mathsf{Poseidon}_\texttt{Tachyon-PadDeriv}(
+    \mathsf{Poseidon}_\texttt{Tachyon-CmOutPad}(
         \mathsf{rcm}, \mathsf{pk}, v, \psi
     )
 $$

--- a/crates/tachyon/src/collections/indexed_multiset.rs
+++ b/crates/tachyon/src/collections/indexed_multiset.rs
@@ -1,21 +1,20 @@
 //! # Indexed multiset
 //!
-//! An indexed multiset may contain any number of unique or repeated nonzero
-//! members at each nonzero index. It is a multiset of `(index, member)`
-//! tuples.
+//! An indexed multiset may contain any number of unique or repeated members at
+//! each index. Conceptually, it is a multiset of `(index, member)` tuples.
 //!
 //! ## Irreducible encoding
 //!
-//! Construct a single-member indexed multiset of member $m$ at index
-//! $i$ as the polynomial
+//! Construct a single-member indexed multiset of member $m$ at index $i$ as the
+//! polynomial
 //!
 //! $$
-//!   F_{i,m}(X) = (iX + m)^3 - c
+//!   F_{i,m}(X) = (m + (i+1)X)^3 - c
 //! $$
 //!
 //! where $c = 2$ is selected because it is the smallest cubic non-residue.
 //!
-//! Since $(iX + m)^3 \neq c$ the encoding is irreducible.
+//! Since $(m + (i+1)X)^3 \neq c$ the encoding is irreducible.
 //!
 //! ## Product composition
 //!
@@ -60,14 +59,14 @@
 //! Precisely, if
 //!
 //! $$
-//!   \frac{i_1X + m_1}{i_2X + m_2} \in \{1, \zeta, \zeta^2\}
+//!   \frac{m_1 + (i_1+1)X}{m_2 + (i_2+1)X} \in \{1, \zeta, \zeta^2\}
 //! $$
 //!
 //! then $(i_1, m_1)$ cannot be distinguished from $(i_2, m_2)$ in an
 //! indexed multiset.
 //!
-//! Specifying $i_\mathsf{max}$ below $\lfloor\sqrt{p/3}\rfloor$ is sufficient
-//! to prevent collisions.
+//! Specifying $i_\mathsf{max} + 1$ below $\lfloor\sqrt{p/3}\rfloor$ is
+//! sufficient to prevent collisions.
 
 #![allow(clippy::min_ident_chars, reason = "just for fun")]
 

--- a/crates/tachyon/src/collections/indexed_multiset.rs
+++ b/crates/tachyon/src/collections/indexed_multiset.rs
@@ -73,8 +73,6 @@
 
 extern crate alloc;
 
-use core::{iter, num::NonZero};
-
 use ff::Field as _;
 use pasta_curves::Fp;
 use ragu::Polynomial;
@@ -85,7 +83,8 @@ use super::poly_mul;
 const NON_RESIDUE: Fp = fp!(0x02);
 
 #[must_use]
-fn encode_single(i: Fp, m: Fp) -> Polynomial {
+fn encode_single(idx: u64, m: Fp) -> Polynomial {
+    let i = Fp::from(idx) + Fp::ONE;
     // writing out expanded coefficients for $F(X) = (iX + m)^3 - c$ is
     // cheaper than constructing a linear $f(X) = iX + m$ and then cubing it.
     Polynomial::from_coeffs(
@@ -100,39 +99,29 @@ fn encode_single(i: Fp, m: Fp) -> Polynomial {
 }
 
 #[must_use]
-fn direct_eval_single(i: Fp, m: Fp, x: Fp) -> Fp {
+fn direct_eval_single(idx: u64, m: Fp, x: Fp) -> Fp {
+    let i = Fp::from(idx) + Fp::ONE;
     ((i * x) + m).pow([3]) - NON_RESIDUE
 }
 
-/// Encode the provided members consecutively.
-pub(crate) fn encode(start_idx: NonZero<u64>, members: impl IntoIterator<Item = Fp>) -> Polynomial {
-    let i_m = iter::successors(Some(start_idx), |idx| idx.checked_add(1))
-        .map(|idx| Fp::from(idx.get()))
-        .zip(members);
-
-    i_m.fold(
+/// Encode the provided indexed members.
+pub(crate) fn encode(members: impl IntoIterator<Item = (u64, Fp)>) -> Polynomial {
+    members.into_iter().fold(
         Polynomial::from_coeffs([Fp::ONE].to_vec()),
-        |acc, (i, m)| poly_mul(&acc, &encode_single(i, m)),
+        |acc, (idx, m)| poly_mul(&acc, &encode_single(idx, m)),
     )
 }
 
 /// Evaluate the indexed multiset without building the polynomial.
-pub(crate) fn direct_eval(
-    start_idx: NonZero<u64>,
-    members: impl IntoIterator<Item = Fp>,
-    x: Fp,
-) -> Fp {
-    let i_m = iter::successors(Some(start_idx), |idx| idx.checked_add(1))
-        .map(|idx| Fp::from(idx.get()))
-        .zip(members);
-
-    i_m.fold(Fp::ONE, |acc, (i, m)| acc * direct_eval_single(i, m, x))
+pub(crate) fn direct_eval(members: impl IntoIterator<Item = (u64, Fp)>, x: Fp) -> Fp {
+    members
+        .into_iter()
+        .fold(Fp::ONE, |acc, (idx, m)| acc * direct_eval_single(idx, m, x))
 }
 
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
-    use core::iter;
 
     use rand::{RngExt as _, SeedableRng as _, rngs::StdRng};
 
@@ -142,12 +131,12 @@ mod tests {
     fn member_encoding_matches_manual_evaluation() {
         let rng = &mut StdRng::seed_from_u64(3);
         for _ in 0..8 {
-            let idx = NonZero::new(u64::from(rng.random_range(1..u32::MAX))).expect("nonzero");
+            let idx = u64::from(rng.random_range(0..u32::MAX));
             let member = Fp::random(&mut *rng);
             let x = Fp::random(&mut *rng);
             assert_eq!(
-                encode_single(Fp::from(idx.get()), member).eval(x),
-                direct_eval(idx, [member], x)
+                encode_single(idx, member).eval(x),
+                direct_eval([(idx, member)], x)
             );
         }
     }
@@ -155,12 +144,12 @@ mod tests {
     #[test]
     fn member_encoding_matches_manual_construction() {
         let rng = &mut StdRng::seed_from_u64(6);
-        let idx = NonZero::new(u64::from(rng.random_range(1..u32::MAX))).expect("nonzero");
+        let idx = u64::from(rng.random_range(0..u32::MAX));
         let member = Fp::random(&mut *rng);
         let x = Fp::random(&mut *rng);
 
         let manual_poly = {
-            let m_ix = Polynomial::from_coeffs([member, Fp::from(idx.get())].to_vec());
+            let m_ix = Polynomial::from_coeffs([member, Fp::from(idx) + Fp::ONE].to_vec());
 
             let m_ix_cube = poly_mul(&poly_mul(&m_ix, &m_ix), &m_ix);
 
@@ -171,25 +160,21 @@ mod tests {
             }
         };
 
-        assert_eq!(
-            encode_single(Fp::from(idx.get()), member).eval(x),
-            manual_poly.eval(x)
-        );
+        assert_eq!(encode_single(idx, member).eval(x), manual_poly.eval(x));
     }
 
     #[test]
     fn sequence_evaluation_matches_the_encoding() {
         let rng = &mut StdRng::seed_from_u64(12);
-        for len in 0..6 {
-            let start_idx =
-                NonZero::new(1 + u64::from(rng.random_range(0..u32::MAX))).expect("nonzero");
-            let members: Vec<Fp> = iter::repeat_with(|| Fp::random(&mut *rng))
-                .take(len)
+        for len in 0..6u64 {
+            let start_idx = u64::from(rng.random_range(0..u32::MAX));
+            let members: Vec<(u64, Fp)> = (start_idx..start_idx + len)
+                .map(|idx| (idx, Fp::random(&mut *rng)))
                 .collect();
             let x = Fp::random(&mut *rng);
             assert_eq!(
-                direct_eval(start_idx, members.iter().copied(), x),
-                encode(start_idx, members).eval(x)
+                direct_eval(members.iter().copied(), x),
+                encode(members).eval(x)
             );
         }
     }

--- a/crates/tachyon/src/collections/indexed_multiset.rs
+++ b/crates/tachyon/src/collections/indexed_multiset.rs
@@ -1,0 +1,196 @@
+//! # Indexed multiset
+//!
+//! An indexed multiset may contain any number of unique or repeated nonzero
+//! members at each nonzero index. It is a multiset of `(index, member)`
+//! tuples.
+//!
+//! ## Irreducible encoding
+//!
+//! Construct a single-member indexed multiset of member $m$ at index
+//! $i$ as the polynomial
+//!
+//! $$
+//!   F_{i,m}(X) = (iX + m)^3 - c
+//! $$
+//!
+//! where $c = 2$ is selected because it is the smallest cubic non-residue.
+//!
+//! Since $(iX + m)^3 \neq c$ the encoding is irreducible.
+//!
+//! ## Product composition
+//!
+//! Construct a larger indexed multiset as the product of smaller ones.
+//!
+//! $$
+//!   S(X) = \prod_{(i,m) \in S}{F_{i,m}(X)}
+//! $$
+//!
+//! Combined indexed multisets will maintain input multiplicity. The inputs
+//! may be contiguous, disjoint, or overlapping.
+//!
+//! ## Quotient decomposition
+//!
+//! Since a union is a product of irreducible factors, we may demonstrate
+//! correct division to confirm membership.
+//!
+//! $$
+//!   \begin{aligned}
+//!
+//!   Q \uplus R &= S
+//!       &\quad \iff &\quad
+//!   &R &= S \setminus Q
+//!
+//!   \\ \\
+//!
+//!   Q(X) \cdot R(X) &= S(X)
+//!       &\quad \iff &\quad
+//!   &R(X) &= \frac{S(X)}{Q(X)}
+//!
+//!   \end{aligned}
+//! $$
+//!
+//! Sequences $Q$ and $R$ combine to produce $S$, or, subsequence $R$ is
+//! extracted from $S$ by complement $Q$. Select a challenge and evaluate.
+//!
+//! ## Injectivity
+//!
+//! Single-member encodings collide when the ratio of their linear terms is a
+//! cube root of unity.
+//!
+//! Precisely, if
+//!
+//! $$
+//!   \frac{i_1X + m_1}{i_2X + m_2} \in \{1, \zeta, \zeta^2\}
+//! $$
+//!
+//! then $(i_1, m_1)$ cannot be distinguished from $(i_2, m_2)$ in an
+//! indexed multiset.
+//!
+//! Specifying $i_\mathsf{max}$ below $\lfloor\sqrt{p/3}\rfloor$ is sufficient
+//! to prevent collisions.
+
+#![allow(clippy::min_ident_chars, reason = "just for fun")]
+
+extern crate alloc;
+
+use core::{iter, num::NonZero};
+
+use ff::Field as _;
+use pasta_curves::Fp;
+use ragu::Polynomial;
+use ragu_pasta::fp;
+
+use super::poly_mul;
+
+const NON_RESIDUE: Fp = fp!(0x02);
+
+#[must_use]
+fn encode_single(i: Fp, m: Fp) -> Polynomial {
+    // writing out expanded coefficients for $F(X) = (iX + m)^3 - c$ is
+    // cheaper than constructing a linear $f(X) = iX + m$ and then cubing it.
+    Polynomial::from_coeffs(
+        [
+            m.pow([3]) - NON_RESIDUE,
+            fp!(3) * i * m.square(),
+            fp!(3) * i.square() * m,
+            i.pow([3]),
+        ]
+        .to_vec(),
+    )
+}
+
+#[must_use]
+fn direct_eval_single(i: Fp, m: Fp, x: Fp) -> Fp {
+    ((i * x) + m).pow([3]) - NON_RESIDUE
+}
+
+/// Encode the provided members consecutively.
+pub(crate) fn encode(start_idx: NonZero<u64>, members: impl IntoIterator<Item = Fp>) -> Polynomial {
+    let i_m = iter::successors(Some(start_idx), |idx| idx.checked_add(1))
+        .map(|idx| Fp::from(idx.get()))
+        .zip(members);
+
+    i_m.fold(
+        Polynomial::from_coeffs([Fp::ONE].to_vec()),
+        |acc, (i, m)| poly_mul(&acc, &encode_single(i, m)),
+    )
+}
+
+/// Evaluate the indexed multiset without building the polynomial.
+pub(crate) fn direct_eval(
+    start_idx: NonZero<u64>,
+    members: impl IntoIterator<Item = Fp>,
+    x: Fp,
+) -> Fp {
+    let i_m = iter::successors(Some(start_idx), |idx| idx.checked_add(1))
+        .map(|idx| Fp::from(idx.get()))
+        .zip(members);
+
+    i_m.fold(Fp::ONE, |acc, (i, m)| acc * direct_eval_single(i, m, x))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+    use core::iter;
+
+    use rand::{RngExt as _, SeedableRng as _, rngs::StdRng};
+
+    use super::*;
+
+    #[test]
+    fn member_encoding_matches_manual_evaluation() {
+        let rng = &mut StdRng::seed_from_u64(3);
+        for _ in 0..8 {
+            let idx = NonZero::new(u64::from(rng.random_range(1..u32::MAX))).expect("nonzero");
+            let member = Fp::random(&mut *rng);
+            let x = Fp::random(&mut *rng);
+            assert_eq!(
+                encode_single(Fp::from(idx.get()), member).eval(x),
+                direct_eval(idx, [member], x)
+            );
+        }
+    }
+
+    #[test]
+    fn member_encoding_matches_manual_construction() {
+        let rng = &mut StdRng::seed_from_u64(6);
+        let idx = NonZero::new(u64::from(rng.random_range(1..u32::MAX))).expect("nonzero");
+        let member = Fp::random(&mut *rng);
+        let x = Fp::random(&mut *rng);
+
+        let manual_poly = {
+            let m_ix = Polynomial::from_coeffs([member, Fp::from(idx.get())].to_vec());
+
+            let m_ix_cube = poly_mul(&poly_mul(&m_ix, &m_ix), &m_ix);
+
+            {
+                let mut coeffs = Vec::from_iter(m_ix_cube.iter_coeffs());
+                coeffs[0] -= NON_RESIDUE;
+                Polynomial::from_coeffs(coeffs)
+            }
+        };
+
+        assert_eq!(
+            encode_single(Fp::from(idx.get()), member).eval(x),
+            manual_poly.eval(x)
+        );
+    }
+
+    #[test]
+    fn sequence_evaluation_matches_the_encoding() {
+        let rng = &mut StdRng::seed_from_u64(12);
+        for len in 0..6 {
+            let start_idx =
+                NonZero::new(1 + u64::from(rng.random_range(0..u32::MAX))).expect("nonzero");
+            let members: Vec<Fp> = iter::repeat_with(|| Fp::random(&mut *rng))
+                .take(len)
+                .collect();
+            let x = Fp::random(&mut *rng);
+            assert_eq!(
+                direct_eval(start_idx, members.iter().copied(), x),
+                encode(start_idx, members).eval(x)
+            );
+        }
+    }
+}

--- a/crates/tachyon/src/collections/mod.rs
+++ b/crates/tachyon/src/collections/mod.rs
@@ -1,0 +1,34 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use ff::Field as _;
+use pasta_curves::Fp;
+use ragu::Polynomial;
+
+pub(crate) mod indexed_multiset;
+pub(crate) mod multiset;
+
+fn trim(coeffs: &mut Vec<Fp>) {
+    if let Some(last_nonzero_idx) = coeffs.iter().rposition(|co| co != &Fp::ZERO) {
+        coeffs.truncate(last_nonzero_idx + 1);
+    }
+}
+
+pub(super) fn poly_mul(input_a: &Polynomial, input_b: &Polynomial) -> Polynomial {
+    use ragu_arithmetic as arithmetic;
+
+    let mut a_coeffs = Vec::from_iter(input_a.iter_coeffs());
+    let mut b_coeffs = Vec::from_iter(input_b.iter_coeffs());
+
+    trim(&mut a_coeffs);
+    trim(&mut b_coeffs);
+
+    let mut out_coeffs = Vec::new();
+
+    arithmetic::poly_mul(&a_coeffs, &b_coeffs, &mut out_coeffs);
+
+    trim(&mut out_coeffs);
+
+    Polynomial::from_coeffs(out_coeffs)
+}

--- a/crates/tachyon/src/collections/multiset.rs
+++ b/crates/tachyon/src/collections/multiset.rs
@@ -1,0 +1,12 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use pasta_curves::Fp;
+use ragu::{Polynomial, poly_with_roots};
+
+/// Encode the provided members as roots.
+pub(crate) fn encode(members: impl IntoIterator<Item = Fp>) -> Polynomial {
+    let roots: Vec<Fp> = members.into_iter().collect();
+    Polynomial::from_coeffs(poly_with_roots(&roots))
+}

--- a/crates/tachyon/src/keys/master.rs
+++ b/crates/tachyon/src/keys/master.rs
@@ -1,11 +1,17 @@
 //! Per-note master key for nullifier derivation.
 
+use core::array;
+
 use derive_more::{Debug, Eq as TotalEq, Into, PartialEq};
 use pasta_curves::Fp;
 use ragu_arithmetic::PoseidonPermutation as _;
 use ragu_pasta::PoseidonFp;
 
-use crate::{digest::poseidon, nullifier::Nullifier, primitives::EpochIndex};
+use crate::{
+    digest::poseidon,
+    nullifier::{NF_DERIVATION_WIDTH, Nullifier},
+    primitives::EpochIndex,
+};
 
 /// Per-note master key.
 ///
@@ -13,6 +19,9 @@ use crate::{digest::poseidon, nullifier::Nullifier, primitives::EpochIndex};
 /// the note's $\psi$ trapdoor, and the only key material a nullifier
 /// derivation needs. Epochs are derived `PoseidonFp::RATE` at a time from
 /// one sponge keyed on the group's start epoch.
+///
+/// `mk` grants derivation over the whole epoch space; a delegate receives
+/// proven value windows.
 #[derive(Clone, Copy, Debug, Into, PartialEq, TotalEq)]
 pub struct NoteMasterKey(#[debug(skip)] pub(crate) Fp);
 
@@ -24,30 +33,44 @@ impl NoteMasterKey {
         clippy::cast_possible_truncation,
         clippy::indexing_slicing,
         clippy::integer_division_remainder_used,
-        reason = "the remainder indexes an array of exactly PoseidonFp::RATE \
-                  entries"
+        reason = "the remainder indexes an array of PoseidonFp::RATE"
     )]
     pub fn derive_nullifier(&self, epoch: EpochIndex) -> Nullifier {
-        let offset = epoch.0 as usize % PoseidonFp::RATE;
-        self.derive_group(EpochIndex(epoch.0 - offset as u32))[offset]
+        let inner_index = epoch.0 as usize % PoseidonFp::RATE;
+        let epoch_start = EpochIndex(epoch.0 - (inner_index as u32));
+        Nullifier::from(poseidon::nullifier_group(self.0, epoch_start.into())[inner_index])
     }
 
-    /// Derive one sponge group: the nullifiers for
-    /// `[epoch_start, … + PoseidonFp::RATE)`. `epoch_start` must be
-    /// group-aligned.
+    /// Derive one derivation window: the nullifiers for
+    /// `[epoch_start, … + NF_DERIVATION_WIDTH)`.
+    ///
+    /// `epoch_start` must be group-aligned;
+    /// [`NfDerive`](crate::stamp::proof::delegation::NfDerive) constrains its
+    /// witnessed start epoch accordingly. Group alignment makes the sponge
+    /// count a compile-time constant inside the step:
+    /// `NF_DERIVATION_WIDTH / PoseidonFp::RATE` permutations each way.
     #[must_use]
     #[expect(
         clippy::as_conversions,
         clippy::cast_possible_truncation,
+        clippy::indexing_slicing,
+        clippy::integer_division,
         clippy::integer_division_remainder_used,
-        reason = "the group width is a small constant"
+        reason = "both widths are small powers of two and divide exactly"
     )]
-    pub fn derive_group(&self, epoch_start: EpochIndex) -> [Nullifier; PoseidonFp::RATE] {
+    pub fn derive_window(&self, epoch_start: EpochIndex) -> [Nullifier; NF_DERIVATION_WIDTH] {
         debug_assert_eq!(
-            epoch_start.0 % PoseidonFp::RATE as u32,
+            epoch_start.0 % (PoseidonFp::RATE as u32),
             0,
             "epoch_start must be group-aligned"
         );
-        poseidon::nullifier_group(self.0, Fp::from(epoch_start)).map(Nullifier::from)
+        let groups: [[Fp; PoseidonFp::RATE]; NF_DERIVATION_WIDTH / PoseidonFp::RATE] =
+            array::from_fn(|offset| {
+                let group_start = epoch_start.0 + (offset * PoseidonFp::RATE) as u32;
+                poseidon::nullifier_group(self.0, Fp::from(EpochIndex(group_start)))
+            });
+        array::from_fn(|slot| {
+            Nullifier::from(groups[slot / PoseidonFp::RATE][slot % PoseidonFp::RATE])
+        })
     }
 }

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -71,6 +71,9 @@
 //! $\mathsf{nf}_e$ depends on $(\mathsf{mk}, e)$ alone and overlapping
 //! derivation windows agree on the epochs they share; start epochs are
 //! group-aligned.
+//!
+//! `mk` evaluates the whole epoch space; delegation carries proven value
+//! windows.
 
 pub mod private;
 pub mod public;
@@ -158,12 +161,12 @@ mod tests {
     }
 
     #[test]
-    fn group_matches_per_epoch_derivation() {
+    fn window_matches_per_epoch_derivation() {
         let mk = NoteMasterKey(Fp::random(&mut StdRng::seed_from_u64(0)));
         let epoch_start = EpochIndex(96);
 
         let epochs = (epoch_start.0..).map(EpochIndex);
-        for (epoch, nf) in epochs.zip(mk.derive_group(epoch_start)) {
+        for (epoch, nf) in epochs.zip(mk.derive_window(epoch_start)) {
             assert_eq!(nf, mk.derive_nullifier(epoch), "epoch {}", epoch.0);
         }
     }

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -23,6 +23,9 @@ use crate::{digest::poseidon, nullifier};
 ///
 /// - **Nullifier derivation**: detecting when a note has been spent
 /// - **Oblivious sync delegation**: a delegate receives proven value windows.
+///   The master key $\mathsf{mk} =
+///   \mathsf{Poseidon}(\mathtt{NF\_MASTER\_DOMAIN}, \Psi, \mathsf{nk})$
+///   evaluates every epoch.
 ///
 /// `nk` alone does NOT confer spend authority — combined with `ak` it
 /// forms the proof authorizing key `pak`, enabling proof construction

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -24,6 +24,7 @@ pub mod stamp;
 pub mod value;
 pub mod witness;
 
+mod collections;
 mod primitives;
 mod relations;
 mod serialization;

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -19,9 +19,8 @@
 //!
 //! ## Nullifier Derivation
 //!
-//! $mk = \text{KDF}(\psi, nk)$, then $nf = F_{mk}(\text{epoch})$ via a
-//! Poseidon sponge keyed on $mk$ and the epoch's group start. The epoch is
-//! the point at which the nullifier is revealed.
+//! $mk = \text{KDF}(\psi, nk)$, then $nf_e$ is one squeeze of a Poseidon
+//! sponge keyed on $mk$ and the epoch's group start.
 //!
 //! Evaluated natively by wallets; the sync service handles only opaque
 //! nullifier values. The Ragu circuit constrains that each consumed

--- a/crates/tachyon/src/nullifier/mod.rs
+++ b/crates/tachyon/src/nullifier/mod.rs
@@ -7,10 +7,15 @@ use rand_core::CryptoRng;
 
 use crate::primitives::Tachygram;
 
+/// Epochs covered per nullifier derivation step.
+pub const NF_DERIVATION_WIDTH: usize = 16;
+
 /// A Tachyon nullifier.
 ///
-/// Derived from the note's master key as one squeeze of the sponge keyed on
-/// $\mathsf{mk}$ and the epoch's group start. Published when a note is spent.
+/// Derived from the note's master key $\mathsf{mk} =
+/// \mathsf{Poseidon}(\mathtt{NF\_MASTER\_DOMAIN}, \psi, \mathsf{nk})$ as one
+/// squeeze of the sponge keyed on $\mathsf{mk}$ and the epoch's group start.
+/// Published when a note is spent.
 ///
 /// Unlike Orchard, Tachyon nullifiers:
 /// - Don't need collision resistance (no faerie gold defense)
@@ -23,7 +28,9 @@ pub struct Nullifier(Tachygram);
 
 /// Nullifier trapdoor ($\psi$), per-note randomness for nullifier derivation.
 ///
-/// Used to derive the note's master key.
+/// Used to derive the note's master key $\mathsf{mk} =
+/// \mathsf{Poseidon}(\mathtt{NF\_MASTER\_DOMAIN}, \psi, \mathsf{nk})$, which
+/// evaluates every epoch. Delegation carries proven value windows.
 #[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct Trapdoor(#[debug(skip)] Fp);
 

--- a/crates/tachyon/src/primitives/epoch.rs
+++ b/crates/tachyon/src/primitives/epoch.rs
@@ -42,6 +42,12 @@ impl EpochIndex {
     }
 }
 
+impl From<EpochIndex> for u64 {
+    fn from(epoch: EpochIndex) -> Self {
+        epoch.0.into()
+    }
+}
+
 impl From<EpochIndex> for Fp {
     fn from(epoch: EpochIndex) -> Self {
         Self::from(u64::from(epoch.0))

--- a/crates/tachyon/src/primitives/seq.rs
+++ b/crates/tachyon/src/primitives/seq.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use core::{num::NonZero, ops::Mul};
+use core::ops::Mul;
 
 use derive_more::{AsRef, Debug, Eq as TotalEq, From, Into, PartialEq};
 use ff::Field as _;
@@ -27,10 +27,8 @@ impl NfSeqPoly {
     /// the consecutive epochs starting at `epoch_start`.
     #[must_use]
     pub fn new(epoch_start: EpochIndex, nfs: &[Nullifier]) -> Self {
-        #[expect(clippy::expect_used, reason = "nonzero")]
         Self(indexed_multiset::encode(
-            NonZero::new((u32::from(epoch_start) + 1).into()).expect("nonzero"),
-            nfs.iter().copied().map(Fp::from),
+            (epoch_start.into()..).zip(nfs.iter().copied().map(Fp::from)),
         ))
     }
 

--- a/crates/tachyon/src/primitives/seq.rs
+++ b/crates/tachyon/src/primitives/seq.rs
@@ -1,33 +1,39 @@
 extern crate alloc;
 
-use alloc::vec::Vec;
-use core::iter;
+use core::{num::NonZero, ops::Mul};
 
 use derive_more::{AsRef, Debug, Eq as TotalEq, From, Into, PartialEq};
 use ff::Field as _;
 use pasta_curves::{Eq, Fp};
 use ragu::Polynomial;
 
-use crate::nullifier::Nullifier;
+use crate::{
+    collections::{indexed_multiset, poly_mul},
+    nullifier::Nullifier,
+    primitives::EpochIndex,
+};
 
-/// Pedersen commitment to a nullifier sequence $N$.
+/// Pedersen commitment to a nullifier sequence.
 #[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct NfSeqCommit(Eq);
 
-/// Witness polynomial for a nullifier sequence $N$: members encoded as
-/// coefficients ordered by ascending degree, terminated by a sentinel
-/// coefficient $1$ one degree above the members.
-///
-/// The sentinel makes the polynomial nonzero for every sequence (the empty
-/// sequence is the constant $1$), so the commitment is never the identity
-/// point, which the in-circuit point representation cannot hold. It also pins
-/// the sequence's exact length: commit-equality alone bounds rank only from
-/// above (trailing zeros are invisible), while the sentinel fixes the top
-/// coefficient at the statement's span.
+/// Witness polynomial for a nullifier sequence: the product of its members'
+/// encodings, one per member.
 #[derive(AsRef, Clone, Debug, From, Into)]
 pub struct NfSeqPoly(Polynomial);
 
 impl NfSeqPoly {
+    /// Build the sequence polynomial for one contiguous run: the members of
+    /// the consecutive epochs starting at `epoch_start`.
+    #[must_use]
+    pub fn new(epoch_start: EpochIndex, nfs: &[Nullifier]) -> Self {
+        #[expect(clippy::expect_used, reason = "nonzero")]
+        Self(indexed_multiset::encode(
+            NonZero::new((u32::from(epoch_start) + 1).into()).expect("nonzero"),
+            nfs.iter().copied().map(Fp::from),
+        ))
+    }
+
     /// Deterministic (untrapdoored) commitment to the sequence polynomial.
     #[must_use]
     pub fn commit(&self) -> NfSeqCommit {
@@ -41,29 +47,21 @@ impl NfSeqPoly {
     }
 }
 
-impl FromIterator<Nullifier> for NfSeqPoly {
-    fn from_iter<I: IntoIterator<Item = Nullifier>>(iter: I) -> Self {
-        let coeffs: Vec<Fp> = iter
-            .into_iter()
-            .map(Fp::from)
-            .chain(iter::once(Fp::ONE))
-            .collect();
-        Self(Polynomial::from_coeffs(coeffs))
+impl Default for NfSeqPoly {
+    fn default() -> Self {
+        Self(Polynomial::from_coeffs(alloc::vec![Fp::ONE]))
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use group::Group as _;
+impl Mul for NfSeqPoly {
+    type Output = Self;
 
-    use super::*;
-
-    /// The empty sequence commits to the sentinel constant $1$, never the
-    /// identity point.
-    #[test]
-    fn empty_sequence_commit_is_not_identity() {
-        let empty: NfSeqPoly = iter::empty().collect();
-        assert_eq!(empty.eval(Fp::ZERO), Fp::ONE);
-        assert_ne!(Eq::from(empty.commit()), Eq::identity());
+    /// Multiset union: the product of two sequences' member multisets.
+    ///
+    /// # Panics
+    ///
+    /// If the product exceeds the polynomial coefficient cap.
+    fn mul(self, rhs: Self) -> Self {
+        Self(poly_mul(&self.0, &rhs.0))
     }
 }

--- a/crates/tachyon/src/primitives/sets.rs
+++ b/crates/tachyon/src/primitives/sets.rs
@@ -1,15 +1,13 @@
-extern crate alloc;
-
-use alloc::vec::Vec;
+use core::iter;
 
 use corez::io::{self, Read, Write};
 use derive_more::{AsRef, Debug, Eq as TotalEq, From, Into, PartialEq};
 use group::Curve as _;
 use pasta_curves::{Eq, Fp};
-use ragu::{Polynomial, poly_with_roots};
+use ragu::Polynomial;
 
 use super::{ActionDigest, Tachygram};
-use crate::serialization;
+use crate::{collections::multiset, serialization};
 
 /// Pedersen commitment to a stamp's tachygram set.
 #[derive(AsRef, Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
@@ -32,7 +30,7 @@ impl TachygramSetCommit {
 impl Default for TachygramSetCommit {
     /// A commitment to an empty set.
     fn default() -> Self {
-        Self(Polynomial::from_coeffs(poly_with_roots(&[])).commit())
+        Self(multiset::encode(iter::empty()).commit())
     }
 }
 
@@ -57,7 +55,7 @@ impl ActionSetCommit {
 impl Default for ActionSetCommit {
     /// A commitment to an empty set.
     fn default() -> Self {
-        Self(Polynomial::from_coeffs(poly_with_roots(&[])).commit())
+        Self(multiset::encode(iter::empty()).commit())
     }
 }
 
@@ -100,14 +98,12 @@ impl ActionSetPoly {
 
 impl FromIterator<ActionDigest> for ActionSetPoly {
     fn from_iter<I: IntoIterator<Item = ActionDigest>>(iter: I) -> Self {
-        let roots: Vec<Fp> = iter.into_iter().map(Fp::from).collect();
-        Self(Polynomial::from_coeffs(poly_with_roots(&roots)))
+        Self(multiset::encode(iter.into_iter().map(Fp::from)))
     }
 }
 
 impl FromIterator<Tachygram> for TachygramSetPoly {
     fn from_iter<I: IntoIterator<Item = Tachygram>>(iter: I) -> Self {
-        let roots: Vec<Fp> = iter.into_iter().map(Fp::from).collect();
-        Self(Polynomial::from_coeffs(poly_with_roots(&roots)))
+        Self(multiset::encode(iter.into_iter().map(Fp::from)))
     }
 }

--- a/crates/tachyon/src/relations/enforce.rs
+++ b/crates/tachyon/src/relations/enforce.rs
@@ -37,8 +37,6 @@
 //! operand). A refactor that recomputed or separately witnessed the evals could
 //! let the checked value diverge from the opened one and break soundness.
 
-use ff::Field as _;
-use pasta_curves::Fp;
 use ragu::{Error, Result, ctx::StepCtx, polynomial::Polynomial};
 
 /// Faithful polynomial product: confirm `product = multiplicand · multiplier`
@@ -76,76 +74,6 @@ pub(crate) fn enforce_poly_product(
     ctx.enforce_poly_query(multiplicand_com, z, multiplicand.eval(z))?;
     ctx.enforce_poly_query(multiplier_com, z, multiplier.eval(z))?;
     ctx.enforce_poly_query(product_com, z, product.eval(z))?;
-
-    Ok(())
-}
-
-/// Shifted linear combination of committed polynomials and monomials: confirm
-/// `result(X) = Σ_i X^{k_i}·p_i(X) + Σ_j c_j·X^{m_j}` by opening each `p_i`
-/// and `result` at a Fiat-Shamir challenge.
-///
-/// `result` is prover-supplied (built off-circuit). Each `shifted_polys` entry
-/// pairs a committed operand `p_i` with its shift exponent `k_i`; each
-/// `monomials` entry pairs a raw scalar coefficient `c_j` with its degree
-/// `m_j`. The point-wise identity at a random `z` confirms the combination:
-/// every polynomial operand is committed and absorbed into `z`, so the
-/// difference of the two sides is a fixed polynomial pinned to zero by
-/// Schwartz-Zippel.
-///
-/// # Caller obligations (soundness)
-///
-/// 1. **Binding.** Subject to the module-level binding obligation for every
-///    `shifted_polys` entry and `result`. One nuance: `commit(X^k·p)` lands on
-///    shifted generators, so it is not homomorphically recoverable from
-///    `commit(p)`; a `result` consumed downstream must have its commitment
-///    threaded independently.
-/// 2. **Monomial coefficients fixed before the challenge.** The scalars `c_j`
-///    are not absorbed into `z`, and the identity is *linear* in each: a prover
-///    free to choose one after seeing `z` solves it and passes for any
-///    committed `result`. Pin each coefficient independently of `z` -- a
-///    public/statement input, a prior-step output, or a value absorbed into the
-///    transcript before `z`.
-/// 3. **Exponents.** The integer exponents `k_i` and `m_j` may be left free:
-///    `z` is fixed by the commitments before any exponent is chosen, an
-///    adaptive search over wrong exponents succeeds with probability `<=
-///    tries/|F|`, and recovering an exponent from a `z` power is
-///    discrete-log-hard. Whether a *specific* exponent is the one the
-///    surrounding statement needs (an operand's span, say) is that statement's
-///    obligation, as is any structural well-formedness of the operands (a
-///    shifted sum proves the sum, not that the addends avoid overlapping).
-///
-/// The exponent parameters and the `z^k` point-wise factors stand in for
-/// positional shifts the commitment scheme does not express directly; a
-/// first-class committed `X^k·p` (or a built-in shifted sum) would carry the
-/// shift itself and collapse this to a direct check.
-pub(crate) fn enforce_shifted_combination<const SHIFTED_POLYS: usize, const MONOMIALS: usize>(
-    ctx: &mut StepCtx<'_>,
-    shifted_polys: [(&Polynomial, u64); SHIFTED_POLYS],
-    monomials: [(Fp, u64); MONOMIALS],
-    result: &Polynomial,
-    err: &'static str,
-) -> Result<()> {
-    let poly_coms = shifted_polys.map(|(poly, _)| poly.commit());
-    let result_com = result.commit();
-    let z = ctx.derive_challenge(&[poly_coms.as_slice(), [result_com].as_slice()].concat())?;
-
-    let combination = shifted_polys
-        .iter()
-        .map(|&(poly, shift)| z.pow_vartime([shift]) * poly.eval(z))
-        .chain(
-            monomials
-                .iter()
-                .map(|&(coeff, degree)| coeff * z.pow_vartime([degree])),
-        )
-        .sum::<Fp>();
-    if result.eval(z) != combination {
-        return Err(Error::InvalidWitness(err.into()));
-    }
-
-    for (&(poly, _), com) in shifted_polys.iter().zip(poly_coms) {
-        ctx.enforce_poly_query(com, z, poly.eval(z))?;
-    }
-    ctx.enforce_poly_query(result_com, z, result.eval(z))?;
 
     Ok(())
 }

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -33,12 +33,13 @@ use crate::{
     effect,
     entropy::ActionRandomizer,
     keys::ProofAuthorizingKey,
+    nullifier::Nullifier,
     primitives::{
         ActionDigest, ActionDigestError, Anchor, EpochIndex, Tachygram, TachygramSetCommit,
     },
     serialization,
     stamp::proof::{delegation, pool, spend, spendable},
-    value,
+    value, witness,
 };
 
 /// Marker for a bundle that has not yet been proven.
@@ -360,17 +361,16 @@ impl Plan {
     ///
     /// Stamps are recursively merged via [`MergeStamp`] into a single stamp.
     ///
-    /// `spendbind_inputs` items must correspond to each planned spend, in
+    /// `spend_pcds` items must correspond to each planned spend, in
     /// order.
     ///
-    /// TODO: nf_next parameter may need to come back
     /// TODO: provide a way to lift spend stamps when necessary to merge
     pub fn prove<RNG: CryptoRng>(
         self,
         rng: &mut RNG,
         pak: &ProofAuthorizingKey,
-        spendbind_inputs: Vec<(
-            ragu::Pcd<delegation::NullifierHeader>,
+        spend_pcds: Vec<(
+            ragu::Pcd<delegation::NullifierDerivation>,
             ragu::Pcd<spendable::SpendableHeader>,
         )>,
     ) -> Result<ProofStamp, ProveError> {
@@ -381,27 +381,43 @@ impl Plan {
         // digest is computed once, on the final stamp.
         let mut entries = Vec::with_capacity(self.spends.len() + self.outputs.len());
 
-        if self.spends.len() != spendbind_inputs.len() {
+        if self.spends.len() != spend_pcds.len() {
             return Err(ProveError::MissingPcd(
                 format!(
                     "cannot prove {} spend actions with {} spendbind inputs",
                     self.spends.len(),
-                    spendbind_inputs.len(),
+                    spend_pcds.len(),
                 )
                 .into(),
             ));
         }
 
-        for ((desc, alpha, note, rcv), (nf_pcd, spendable_pcd)) in
-            self.spends.into_iter().zip(spendbind_inputs)
+        for ((desc, alpha, note, rcv), (range_pcd, spendable_pcd)) in
+            self.spends.into_iter().zip(spend_pcds)
         {
-            // SpendBind: confirm the live pair against the derived range.
-            let (_, _, _, (_, nf_next)) = *nf_pcd.data();
+            // SpendBind: confirm the live pair against the covering
+            // derivation. The covering sequence is rebuilt natively from the
+            // note's master key (the succinct header carries only the
+            // commitment); the witness segments its read and complement.
+            let mk = pak.nk.derive_note_private(note.psi);
+            let (_, deriv_start, _, deriv_end) = *range_pcd.data();
+            let window: Vec<Nullifier> = (deriv_start.0..deriv_end.0)
+                .map(|epoch| mk.derive_nullifier(EpochIndex(epoch)))
+                .collect();
+            let bind_witness =
+                witness::spend_bind((*spendable_pcd.data(), *range_pcd.data()), &window);
             let (bind_pcd, ()) = PROOF_SYSTEM
-                .fuse(rng, spend::SpendBind, (nf_next,), spendable_pcd, nf_pcd)
+                .fuse(
+                    rng,
+                    spend::SpendBind,
+                    bind_witness,
+                    spendable_pcd,
+                    range_pcd,
+                )
                 .map_err(ProveError::ProofFailed)?;
 
-            // SpendStamp: prove the action and publish.
+            // SpendStamp: prove the action and publish. The tachygram pair is
+            // read straight off the bind header.
             let (tachygrams, anchor, proof) =
                 ProofStamp::prove_spend(rng, bind_pcd, note, rcv, alpha, *pak)
                     .map_err(ProveError::ProofFailed)?;
@@ -560,11 +576,14 @@ impl ProofStamp {
         Ok((tachygrams, anchor, Box::new(rerand.proof().clone())))
     }
 
-    /// Proves a single spend action from a pre-built [`spend::SpendBind`]
-    /// PCD, returning the stamp components `(tachygrams, anchor, proof)`.
+    /// Creates a stamp for a spend action from a bound
+    /// [`SpendHeader`](spend::SpendHeader) PCD.
     ///
-    /// The spend's `anchor` is taken as the stamp's anchor — chain
-    /// validation lives inside the spendable lineage, not here.
+    /// The nullifier pair `{present_nf, nf_next}` published for data
+    /// availability is read straight off the bind header (already confirmed
+    /// against the derivation at [`SpendBind`](spend::SpendBind)); this step
+    /// only proves the action `(cv, rk)`. The spend's `anchor` is taken as the
+    /// stamp's anchor; chain validation lives inside the spendable lineage.
     pub fn prove_spend<RNG: CryptoRng>(
         rng: &mut RNG,
         bind_pcd: ragu::Pcd<spend::SpendHeader>,

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -10,7 +10,6 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
-use core::num::NonZero;
 
 use pasta_curves::{Ep, Eq, Fp, Fq};
 use ragu::{
@@ -206,12 +205,8 @@ impl Step for NfDerive {
 
         // The window's members at `z`, encoded natively from the
         // sponge-derived nullifiers and their epochs.
-        #[expect(clippy::expect_used, reason = "nonzero")]
-        let window_at_z = indexed_multiset::direct_eval(
-            NonZero::new((u32::from(epoch_start) + 1).into()).expect("nonzero"),
-            nullifiers.map(Fp::from),
-            z,
-        );
+        let window_at_z =
+            indexed_multiset::direct_eval((epoch_start.into()..).zip(nullifiers.map(Fp::from)), z);
 
         enforce_zero(
             seq_at_z - window_at_z,

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -1,11 +1,17 @@
 //! Prove a fusable range of a note's per-epoch nullifiers.
+//!
+//! Three steps. [`NfMasterSeed`] certifies the note's commitment and master
+//! key; [`NfDerive`] consumes that seed and exports one whole window; and
+//! [`NullifierFuse`] concatenates adjacent windows.
+//!
+//! All headers are wallet-only, and no key material rides the exported
+//! [`NullifierDerivation`].
 
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
-use core::array;
+use core::num::NonZero;
 
-use ff::Field as _;
 use pasta_curves::{Ep, Eq, Fp, Fq};
 use ragu::{
     Header, Index, Step, Suffix,
@@ -15,14 +21,19 @@ use ragu_arithmetic::PoseidonPermutation as _;
 use ragu_pasta::PoseidonFp;
 
 use crate::{
+    collections::indexed_multiset,
     keys::{NoteMasterKey, ProofAuthorizingKey},
     note::{self, Note},
-    nullifier::Nullifier,
     primitives::{EpochIndex, NfSeqCommit, NfSeqPoly},
-    relations::enforce::enforce_shifted_combination,
+    relations::enforce::enforce_poly_product,
 };
 
-/// A note commitment and master key.
+/// A note's certified commitment and master key (wallet-only).
+///
+/// `mk` is derived natively from the note's secrets and certified here, so
+/// every consuming [`NfDerive`] threads a genuine master key without
+/// re-witnessing the note. `cm` rides along for the derivation's consumers to
+/// bind against.
 #[derive(Clone, Debug)]
 pub struct NfMasterHeader;
 
@@ -30,7 +41,7 @@ impl Header for NfMasterHeader {
     /// `(cm, mk)`.
     type Data = (note::Commitment, NoteMasterKey);
 
-    const SUFFIX: Suffix = Suffix::new(1);
+    const SUFFIX: Suffix = Suffix::new(13);
 
     fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
         let (cm, mk) = *data;
@@ -38,43 +49,56 @@ impl Header for NfMasterHeader {
     }
 }
 
-/// A proven contiguous range of derived nullifiers.
+/// A proven contiguous range of derived nullifiers (wallet-only).
+///
+/// `(cm, epoch_start, nf_commit, epoch_end)`: covers epochs
+/// `[epoch_start, epoch_end)`; `nf_commit` commits the range's nullifier
+/// sequence as an [`NfSeqPoly`], exactly one member per covered epoch. That
+/// invariant is established at [`NfDerive`], preserved by
+/// [`NullifierFuse`]'s contiguity check, and what the divisibility binds
+/// lean on for per-epoch completeness. `cm` binds the range to the real
+/// note.
+///
+/// No consumer reads the range. It serves [`NullifierFuse`]'s contiguity
+/// check, which keeps the product squarefree, and squarefreeness forces a
+/// tested sequence's members distinct at
+/// [`UnspentBind`](super::pool::UnspentBind).
+///
+/// Masking is the consuming step's responsibility.
 #[derive(Clone, Debug)]
-pub struct NullifierHeader;
+pub struct NullifierDerivation;
 
-impl Header for NullifierHeader {
-    type Data = (
-        note::Commitment,
-        (EpochIndex, Nullifier),
-        NfSeqCommit,
-        (EpochIndex, Nullifier),
-    );
+impl Header for NullifierDerivation {
+    /// `(cm, epoch_start, nf_commit, epoch_end)`. `epoch_end` is exclusive.
+    type Data = (note::Commitment, EpochIndex, NfSeqCommit, EpochIndex);
 
-    const SUFFIX: Suffix = Suffix::new(2);
+    const SUFFIX: Suffix = Suffix::new(3);
 
     fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
-        let (cm, (epoch_start, nf_start), nf_seq_commit, (epoch_end, nf_end)) = *data;
+        let (cm, epoch_start, nf_commit, epoch_end) = *data;
         (
-            vec![
-                Fp::from(cm),
-                Fp::from(u64::from(epoch_start.0)),
-                Fp::from(nf_start),
-                Fp::from(u64::from(epoch_end.0)),
-                Fp::from(nf_end),
-            ],
+            vec![Fp::from(cm), Fp::from(epoch_start), Fp::from(epoch_end)],
             Vec::new(),
             Vec::new(),
-            vec![Eq::from(nf_seq_commit)],
+            vec![Eq::from(nf_commit)],
         )
     }
 }
 
-/// Derive a note commitment and master key.
+/// Certify a note's commitment and master key.
+///
+/// Seed step. Witnesses the note and its proof authorizing key, proves the
+/// key belongs to the note (`note.pk == pak.derive_payment_key()`, which pins
+/// `nk`), derives `mk` from `nk` and the note's trapdoor, and computes `cm`.
+/// `nk` never leaves the step; only `pk`, which preimage-hides it, enters
+/// `cm`.
 ///
 /// # Soundness
 ///
-/// The note commitment binds downstream at [`super::spendable::SpendableInit`]
-/// and [`super::stamp::SpendStamp`].
+/// A seed can invent a note, so `cm` closes downstream, at
+/// [`SpendableInit`](super::spendable::SpendableInit) and
+/// [`SpendStamp`](super::stamp::SpendStamp). What this step establishes is
+/// the pairing: `mk` is *this* `cm`'s master key.
 #[derive(Debug)]
 pub struct NfMasterSeed;
 
@@ -105,151 +129,136 @@ impl Step for NfMasterSeed {
     }
 }
 
-/// Derive one window of nullifiers at sponge rate.
+/// Derive one window of nullifiers and export it as a
+/// [`NullifierDerivation`].
+///
+/// `Left = NfMasterSeed`. Witnesses the window's start epoch (constrained
+/// group-aligned, $w \bmod r = 0$ for $r$ the sponge rate `PoseidonFp::RATE`)
+/// and the window sequence. Runs one sponge per group over
+/// $(\mathtt{NF\_DOMAIN}, \mathsf{mk}, w)$, each absorbing three elements and
+/// squeezing $r$ nullifiers for one permutation, then binds the sequence to
+/// the window's members by a single opening at a free $z$ against their
+/// natively encoded product.
+///
+/// # Soundness
+///
+/// `mk` is threaded from the left header, so it is the note's genuine master
+/// key by PCD soundness. The opening's only free operand is the window
+/// sequence, committed before $z$ exists.
+///
+/// `epoch_start` is a free witness constrained group-aligned, pinned by the
+/// header it produces: it is emitted on the header directly, so every choice
+/// is an honestly labelled window. (The alignment constraint
+/// is a native remainder fed to `enforce_zero` under mock ragu; a real
+/// circuit needs a low-bit decomposition of the witnessed epoch, since
+/// $4q = e$ is always solvable in the field.)
+///
+/// The epoch indices need no absorbing into $z$, each being `epoch_start`
+/// plus a circuit constant. The nullifier scalars are sponge outputs of the
+/// threaded `mk`, pinned in-circuit, so the product identity alone forces
+/// every member.
 #[derive(Debug)]
 pub struct NfDerive;
 
 impl Step for NfDerive {
     type Aux<'source> = ();
     type Left = NfMasterHeader;
-    type Output = NullifierHeader;
+    type Output = NullifierDerivation;
     type Right = ();
-    /// `(window_start, mask, seq)`.
-    type Witness<'source> = (EpochIndex, [bool; PoseidonFp::RATE], NfSeqPoly);
+    /// `(epoch_start, seq)`.
+    type Witness<'source> = (EpochIndex, NfSeqPoly);
 
     const INDEX: Index = Index::new(1);
 
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_truncation,
-        clippy::indexing_slicing,
-        clippy::integer_division_remainder_used,
-        reason = "mask offsets and the alignment remainder are bounded by the \
-                  fixed group width"
-    )]
     fn witness<'source>(
         &self,
         ctx: &mut ragu::StepCtx<'_>,
-        (window_start, mask, seq): Self::Witness<'source>,
+        (epoch_start, seq): Self::Witness<'source>,
         (cm, mk): <Self::Left as Header>::Data,
         _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        #[expect(
+            clippy::as_conversions,
+            clippy::integer_division_remainder_used,
+            reason = "the group width is a small constant"
+        )]
         enforce_zero(
-            Fp::from(u64::from(window_start.0 % PoseidonFp::RATE as u32)),
-            "NfDerive: window start is not group-aligned",
-        )?;
-        let nullifiers = mk.derive_group(window_start).map(Fp::from);
-
-        let bits: [Fp; PoseidonFp::RATE] = mask.map(|selected| Fp::from(u64::from(selected)));
-        for bit in bits {
-            enforce_zero(bit * (bit - Fp::ONE), "NfDerive: mask entry is not boolean")?;
-        }
-        let rise: [Fp; PoseidonFp::RATE] = array::from_fn(|j| {
-            let prev = if j == 0 { Fp::ZERO } else { bits[j - 1] };
-            (Fp::ONE - prev) * bits[j]
-        });
-        let fall: [Fp; PoseidonFp::RATE] = array::from_fn(|j| {
-            let next = if j + 1 == PoseidonFp::RATE {
-                Fp::ZERO
-            } else {
-                bits[j + 1]
-            };
-            bits[j] * (Fp::ONE - next)
-        });
-        enforce_zero(
-            rise.iter().sum::<Fp>() - Fp::ONE,
-            "NfDerive: mask is not one contiguous nonempty run",
+            Fp::from(u64::from(epoch_start.0) % (PoseidonFp::RATE as u64)),
+            "NfDerive: epoch_start is not group-aligned",
         )?;
 
-        let lead = mask.iter().take_while(|selected| !**selected).count() as u32;
-        let count = mask.iter().filter(|selected| **selected).count() as u32;
-        let epoch_start = EpochIndex(window_start.0 + lead);
-        let epoch_end = EpochIndex(epoch_start.0 + count);
+        // NF_DERIVATION_WIDTH nullifiers, PoseidonFp::RATE per sponge.
+        let nullifiers = mk.derive_window(epoch_start);
 
-        // Pin the emitted span to the witnessed window start and mask.
-        let lead_selected: Fp = (0u64..).zip(rise).map(|(j, edge)| Fp::from(j) * edge).sum();
-        let count_selected: Fp = bits.iter().sum();
-        enforce_zero(
-            Fp::from(epoch_start) - (Fp::from(window_start) + lead_selected),
-            "NfDerive: epoch_start does not match the mask shift",
-        )?;
-        enforce_zero(
-            Fp::from(epoch_end) - (Fp::from(window_start) + lead_selected + count_selected),
-            "NfDerive: epoch_end does not match the mask run",
-        )?;
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            reason = "constant length"
+        )]
+        let epoch_end = EpochIndex(epoch_start.0 + nullifiers.len() as u32);
 
-        // The boundary members, edge-selected from the sponge outputs.
-        let nf_start: Fp = rise
-            .iter()
-            .zip(nullifiers)
-            .map(|(edge, nf)| *edge * nf)
-            .sum();
-        let nf_end: Fp = fall
-            .iter()
-            .zip(nullifiers)
-            .map(|(edge, nf)| *edge * nf)
-            .sum();
-
+        // `z`: a fresh transcript challenge over the sequence commitment. The
+        // polynomial is fixed before it exists, so the single opening below
+        // is not vacuous.
         let z = ctx.derive_challenge(&[seq.commit().into()])?;
         let seq_at_z = seq.eval(z);
         ctx.enforce_poly_query(seq.commit().into(), z, seq_at_z)?;
 
-        let mut z_pows = [Fp::ONE; PoseidonFp::RATE + 1];
-        for j in 1..z_pows.len() {
-            z_pows[j] = z_pows[j - 1] * z;
-        }
-        let z_lead: Fp = rise.iter().zip(z_pows).map(|(edge, pow)| *edge * pow).sum();
-        let members_at_z: Fp = (0..PoseidonFp::RATE)
-            .map(|j| bits[j] * nullifiers[j] * z_pows[j])
-            .sum();
-        let sentinel_at_z: Fp = (0..PoseidonFp::RATE).map(|j| fall[j] * z_pows[j + 1]).sum();
+        // The window's members at `z`, encoded natively from the
+        // sponge-derived nullifiers and their epochs.
+        #[expect(clippy::expect_used, reason = "nonzero")]
+        let window_at_z = indexed_multiset::direct_eval(
+            NonZero::new((u32::from(epoch_start) + 1).into()).expect("nonzero"),
+            nullifiers.map(Fp::from),
+            z,
+        );
+
         enforce_zero(
-            seq_at_z * z_lead - members_at_z - sentinel_at_z,
-            "NfDerive: sequence does not match the masked run",
+            seq_at_z - window_at_z,
+            "NfDerive: sequence does not match the derived window",
         )?;
 
-        Ok((
-            (
-                cm,
-                (epoch_start, Nullifier::from(nf_start)),
-                seq.commit(),
-                (epoch_end, Nullifier::from(nf_end)),
-            ),
-            (),
-        ))
+        Ok(((cm, epoch_start, seq.commit(), epoch_end), ()))
     }
 }
 
 /// Merge two adjacent derived ranges into one (`left ++ right`).
+///
+/// Requires the same `cm` and contiguity (`right.epoch_start ==
+/// left.epoch_end`). Witnesses the two range polynomials and their
+/// concatenation, binds each by commit-equality, and proves the concat as the
+/// product
+///
+/// $$\mathsf{merged}(X) = \mathsf{left}(X) \cdot \mathsf{right}(X)$$
+///
+/// since concatenation of disjoint ranges is exactly multiplication.
+///
+/// # Soundness
+///
+/// All three operands are committed and absorbed into the challenge, so the
+/// product identity pins `merged`'s member multiset to the union of the
+/// halves'. The contiguity check preserves the header invariant established
+/// at the leaf: exactly one member per epoch in `[epoch_start, epoch_end)`,
+/// so the announced range labels the member multiset truthfully.
 #[derive(Debug)]
 pub struct NullifierFuse;
 
 impl Step for NullifierFuse {
     type Aux<'source> = ();
-    type Left = NullifierHeader;
-    type Output = NullifierHeader;
-    type Right = NullifierHeader;
+    type Left = NullifierDerivation;
+    type Output = NullifierDerivation;
+    type Right = NullifierDerivation;
     /// `(left_seq, merged_seq, right_seq)`.
     type Witness<'source> = (NfSeqPoly, NfSeqPoly, NfSeqPoly);
 
-    const INDEX: Index = Index::new(2);
+    const INDEX: Index = Index::new(16);
 
     fn witness<'source>(
         &self,
         ctx: &mut ragu::StepCtx<'_>,
         (left_seq, merged_seq, right_seq): Self::Witness<'source>,
-        (
-            left_cm,
-            (left_epoch_start, left_nf_start),
-            left_nf_seq_commit,
-            (left_epoch_end, _left_nf_end),
-        ): <Self::Left as Header>::Data,
-        (
-            right_cm,
-            (right_epoch_start, right_nf_start),
-            right_nf_seq_commit,
-            (right_epoch_end, right_nf_end),
-        ): <Self::Right as Header>::Data,
+        (left_cm, left_epoch_start, left_nf_commit, left_epoch_end): <Self::Left as Header>::Data,
+        (right_cm, right_epoch_start, right_nf_commit, right_epoch_end): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         enforce_zero(
             Fp::from(left_cm) - Fp::from(right_cm),
@@ -261,41 +270,24 @@ impl Step for NullifierFuse {
         )?;
         enforce_equal_point(
             Eq::from(left_seq.commit()),
-            Eq::from(left_nf_seq_commit),
+            Eq::from(left_nf_commit),
             "NullifierFuse: left polynomial does not match header",
         )?;
         enforce_equal_point(
             Eq::from(right_seq.commit()),
-            Eq::from(right_nf_seq_commit),
+            Eq::from(right_nf_commit),
             "NullifierFuse: right polynomial does not match header",
         )?;
-        let merged_nf_seq_commit = merged_seq.commit();
-        let offset = left_epoch_end - left_epoch_start;
-        enforce_shifted_combination(
+        let merged_nf_commit = merged_seq.commit();
+        enforce_poly_product(
             ctx,
-            [(left_seq.as_ref(), 0), (right_seq.as_ref(), offset.into())],
-            [(-Fp::ONE, offset.into())],
+            left_seq.as_ref(),
+            right_seq.as_ref(),
             merged_seq.as_ref(),
             "NullifierFuse: merged is not the concat of the halves",
         )?;
-
-        ctx.enforce_poly_query(
-            merged_nf_seq_commit.into(),
-            Fp::ZERO,
-            Fp::from(left_nf_start),
-        )?;
-        ctx.enforce_poly_query(
-            right_nf_seq_commit.into(),
-            Fp::ZERO,
-            Fp::from(right_nf_start),
-        )?;
         Ok((
-            (
-                left_cm,
-                (left_epoch_start, left_nf_start),
-                merged_nf_seq_commit,
-                (right_epoch_end, right_nf_end),
-            ),
+            (left_cm, left_epoch_start, merged_nf_commit, right_epoch_end),
             (),
         ))
     }

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -20,7 +20,6 @@ fn make_app() -> Result<Application, ragu::Error> {
     ApplicationBuilder::new()
         .register(delegation::NfMasterSeed)?
         .register(delegation::NfDerive)?
-        .register(delegation::NullifierFuse)?
         .register(pool::AnchorSeed)?
         .register(pool::AnchorFuse)?
         .register(pool::UnspentSeed)?
@@ -35,6 +34,7 @@ fn make_app() -> Result<Application, ragu::Error> {
         .register(stamp::SpendStamp)?
         .register(stamp::MergeStamp)?
         .register(stamp::StampLift)?
+        .register(delegation::NullifierFuse)?
         .finalize()
 }
 

--- a/crates/tachyon/src/stamp/proof/output.rs
+++ b/crates/tachyon/src/stamp/proof/output.rs
@@ -49,7 +49,7 @@ impl Step for OutputBind {
     /// `(note,)`.
     type Witness<'source> = (Note,);
 
-    const INDEX: Index = Index::new(11);
+    const INDEX: Index = Index::new(10);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -16,22 +16,24 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
+use core::num::NonZero;
 
 use ff::Field as _;
 use pasta_curves::{Ep, Eq, Fp, Fq};
 use ragu::{
     Cycle as _, FixedGenerators as _, Header, Index, Pasta, Step, Suffix,
-    constraint::{enforce_equal_point, enforce_nonzero, enforce_zero},
+    constraint::{conditional_enforce_equal, enforce_equal_point, enforce_nonzero, enforce_zero},
 };
 
-use super::delegation::NullifierHeader;
+use super::delegation::NullifierDerivation;
 use crate::{
-    note,
+    collections::indexed_multiset,
+    note::{self},
     nullifier::Nullifier,
     primitives::{
         Anchor, EpochIndex, NfSeqCommit, NfSeqPoly, TachygramSetCommit, TachygramSetPoly,
     },
-    relations::enforce::enforce_shifted_combination,
+    relations::enforce::enforce_poly_product,
 };
 
 /// Anchor segment between two endpoints. Composable via [`AnchorFuse`].
@@ -80,33 +82,37 @@ impl Header for AnchorChain {
 /// Multi-stamp / multi-epoch nf-exclusion proof over arbitrary values.
 ///
 /// The tested values are arbitrary field elements until [`UnspentBind`]
-/// attributes them to a note's derivation, which is what makes the segment
-/// safe to delegate: no step producing one touches a note, `cm`, or `mk`.
+/// attributes them to a note's derivation. No step producing one touches a
+/// note, `cm`, or `mk`, so the segment is safe to delegate.
 ///
-/// An `elapsed` polynomial holds one nullifier per crossed epoch boundary over
-/// `[epoch_start, epoch_end)`, sentinel-terminated (see
-/// [`NfSeqPoly`]): the crossings sit at ascending degree with a coefficient
-/// `1` at the crossing count, so the commitment is never the identity point
-/// (the empty sequence is the constant `1`, committing to `g0`) and the
-/// sequence's exact rank is pinned. The seeds establish the sentinel form and
-/// the fuses preserve it.
+/// An `elapsed` [`NfSeqPoly`] holds one tested nullifier per covered epoch
+/// over `[epoch_start, epoch_last]`.
 ///
-/// `nf_start` is the range's first tested nullifier (the leaf at
-/// `epoch_start`); the in-progress `nf_end` corresponds to `epoch_end` and is
-/// represented in `elapsed` only once a segment covering its epoch's closing
-/// boundary joins on, since [`EndEpochUnspentSeed`] is where a member is added.
-/// [`UnspentBind`] binds both endpoints to the note's genuine derivation
-/// nullifiers.
+/// Every producer maintains the provenance [`UnspentBind`]'s completeness
+/// argument leans on. Each member's epoch lies in
+/// `[epoch_start, epoch_last]`, because the seeds encode each member from the
+/// same epoch scalar they fold into the anchor. Each epoch carries exactly
+/// one member: the seeds pin their member counts by their challenge
+/// identities, and [`UnspentFuse`]'s identity determines the combined
+/// polynomial exactly, so the property composes by induction. The boundary
+/// caches name members the sequence holds, pinned at each seed and inherited
+/// through the fuse.
 ///
-/// `epoch_start` is the epoch of the exclusive `anchor_prev`; `epoch_end` the
-/// epoch of `anchor_last`, not yet represented in `elapsed`, so
-/// [`UnspentBind`]'s derived range runs one epoch past it.
+/// Member count tracks span size structurally: [`UnspentSeed`] spans one
+/// epoch, [`EndEpochUnspentSeed`] two, and [`UnspentFuse`] requires
+/// `right.epoch_start == left.epoch_last`, so each composition adds the same
+/// to the count as to the span.
+///
+/// `nf_start` and `nf_last` are scalar caches of the sequence's boundary
+/// members, consumed by [`UnspentFuse`]'s junction check and
+/// [`super::spendable::SpendableLift`]'s seam. [`UnspentBind`] binds every
+/// member, boundaries included, to the note's genuine derivation nullifiers.
 #[derive(Clone, Debug)]
 pub struct ArbitraryUnspent;
 
 impl Header for ArbitraryUnspent {
     /// `(anchor_prev, (epoch_start, nf_start), elapsed,
-    /// (epoch_end, nf_end), anchor_last)`.
+    /// (epoch_last, nf_last), anchor_last)`.
     type Data = (
         Anchor,
         (EpochIndex, Nullifier),
@@ -118,15 +124,15 @@ impl Header for ArbitraryUnspent {
     const SUFFIX: Suffix = Suffix::new(6);
 
     fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
-        let (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_end, nf_end), anchor_last) =
+        let (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_last, nf_last), anchor_last) =
             *data;
         (
             vec![
                 Fp::from(anchor_prev),
                 Fp::from(u64::from(epoch_start.0)),
                 Fp::from(nf_start),
-                Fp::from(u64::from(epoch_end.0)),
-                Fp::from(nf_end),
+                Fp::from(u64::from(epoch_last.0)),
+                Fp::from(nf_last),
                 Fp::from(anchor_last),
             ],
             Vec::new(),
@@ -143,7 +149,7 @@ impl Header for ArbitraryUnspent {
 pub struct Unspent;
 
 impl Header for Unspent {
-    /// `(cm, anchor_prev, (epoch_start, nf_start), (epoch_end, nf_end),
+    /// `(cm, anchor_prev, (epoch_start, nf_start), (epoch_last, nf_last),
     /// anchor_last)`. `cm` leads; the rest mirrors the [`ArbitraryUnspent`]
     /// boundaries collapsed to scalars (no `elapsed` poly).
     type Data = (
@@ -157,15 +163,15 @@ impl Header for Unspent {
     const SUFFIX: Suffix = Suffix::new(8);
 
     fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
-        let (cm, anchor_prev, (epoch_start, nf_start), (epoch_end, nf_end), anchor_last) = *data;
+        let (cm, anchor_prev, (epoch_start, nf_start), (epoch_last, nf_last), anchor_last) = *data;
         (
             vec![
                 Fp::from(cm),
                 Fp::from(anchor_prev),
                 Fp::from(u64::from(epoch_start.0)),
                 Fp::from(nf_start),
-                Fp::from(u64::from(epoch_end.0)),
-                Fp::from(nf_end),
+                Fp::from(u64::from(epoch_last.0)),
+                Fp::from(nf_last),
                 Fp::from(anchor_last),
             ],
             Vec::new(),
@@ -196,7 +202,7 @@ impl Step for AnchorSeed {
     /// `(start, epoch, stamp_commit)`.
     type Witness<'source> = (Anchor, EpochIndex, TachygramSetCommit);
 
-    const INDEX: Index = Index::new(3);
+    const INDEX: Index = Index::new(2);
 
     fn witness<'source>(
         &self,
@@ -225,7 +231,7 @@ impl Step for AnchorFuse {
     type Right = AnchorChain;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(4);
+    const INDEX: Index = Index::new(3);
 
     fn witness<'source>(
         &self,
@@ -244,9 +250,20 @@ impl Step for AnchorFuse {
 
 /// Per-stamp exclusion seed.
 ///
-/// Verify `nf ∉ stamp_tg_set` and use the stamp's commit to produce the
-/// appropriate anchor. The `elapsed` sequence is empty, since we have not
-/// progressed past any nullifiers yet.
+/// Verify $\mathsf{nf} \notin \mathsf{stamp\_tg\_set}$ and use the stamp's
+/// commit to produce the appropriate anchor. The `elapsed` sequence is the
+/// single member $\mathsf{nf}$ at the epoch under test.
+///
+/// # Soundness
+///
+/// `nf` is free, pinned by absorbing $G_0 \cdot \mathsf{nf}$, so the identity
+/// forces the witnessed one-member `elapsed` to the emitted pair.
+///
+/// `epoch` needs no pin of its own, being one variable entering the member
+/// encoding, the emitted header and the anchor fold alike. A solved value
+/// lands in an anchor off the consensus-published chain, and the member it
+/// encodes still names the epoch the header announces, giving
+/// [`UnspentBind`] its epoch support.
 #[derive(Debug)]
 pub struct UnspentSeed;
 
@@ -255,36 +272,54 @@ impl Step for UnspentSeed {
     type Left = ();
     type Output = ArbitraryUnspent;
     type Right = ();
-    /// `(anchor_prev, (epoch, nf), stamp_tg_set)`.
-    type Witness<'source> = (Anchor, (EpochIndex, Nullifier), TachygramSetPoly);
+    /// `(anchor_prev, (epoch, nf), stamp_tg_set, elapsed_seq)`.
+    type Witness<'source> = (Anchor, (EpochIndex, Nullifier), TachygramSetPoly, NfSeqPoly);
 
-    const INDEX: Index = Index::new(5);
+    const INDEX: Index = Index::new(4);
 
     fn witness<'source>(
         &self,
         ctx: &mut ragu::StepCtx<'_>,
-        (anchor_prev, (epoch, nf), stamp_tg_set): Self::Witness<'source>,
+        (anchor_prev, (epoch, nf), stamp_tg_set, elapsed_seq): Self::Witness<'source>,
         _left: <Self::Left as Header>::Data,
         _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
-        #[expect(clippy::expect_used, reason = "constant size")]
-        let &g0 = Pasta::host_generators(Pasta::baked())
-            .g()
-            .first()
-            .expect("at least one generator");
-
         // Exclusion: nf ∉ set ⇔ the set polynomial is nonzero at nf.
-        let nf_point = Fp::from(nf);
-        let eval = stamp_tg_set.eval(nf_point);
-        ctx.enforce_poly_query(stamp_tg_set.commit().into(), nf_point, eval)?;
+        let eval = stamp_tg_set.eval(Fp::from(nf));
+        ctx.enforce_poly_query(stamp_tg_set.commit().into(), Fp::from(nf), eval)?;
         enforce_nonzero(eval, "UnspentSeed: found nullifier in set")?;
         let stamp_commit = stamp_tg_set.commit();
         let tested_anchor = anchor_prev
             .next_stamp(epoch, &stamp_commit)
             .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
-        // Empty elapsed: the sentinel constant `1` commits to `g0`, never the
-        // identity point.
-        let elapsed_commit = NfSeqCommit::from(g0 * Fp::ONE);
+        // Nonzero guard, defensive: zero is reserved.
+        enforce_nonzero(Fp::from(nf), "UnspentSeed: tested nullifier is zero")?;
+
+        // One-member elapsed: bind the witnessed sequence to the emitted
+        // pair's encoding at a challenge absorbing the commitment and the
+        // scalar-binding point.
+        #[expect(clippy::expect_used, reason = "constant size")]
+        let &g0 = Pasta::host_generators(Pasta::baked())
+            .g()
+            .first()
+            .expect("at least one generator");
+        let elapsed_commit = elapsed_seq.commit();
+        let z = ctx.derive_challenge(&[elapsed_commit.into(), g0 * Fp::from(nf)])?;
+        let elapsed_at_z = elapsed_seq.eval(z);
+
+        #[expect(clippy::expect_used, reason = "nonzero")]
+        let member_at_z = indexed_multiset::direct_eval(
+            NonZero::new((u32::from(epoch) + 1).into()).expect("nonzero"),
+            [nf.into()],
+            z,
+        );
+
+        enforce_zero(
+            elapsed_at_z - member_at_z,
+            "UnspentSeed: elapsed does not match the tested pair",
+        )?;
+        ctx.enforce_poly_query(elapsed_commit.into(), z, elapsed_at_z)?;
+
         Ok((
             (
                 anchor_prev,
@@ -302,20 +337,22 @@ impl Step for UnspentSeed {
 /// the next epoch's opening boundary anchor.
 ///
 /// The segment covers exactly the tick `anchor_prev.next_epoch(epoch_prev +
-/// 1)`, so its `elapsed` holds the single nullifier `nf_prev` tested in the
-/// epoch being left, and `nf` opens as the tip in the epoch being entered.
+/// 1)`, so it covers two epochs and its `elapsed` is the two-member sequence
+/// `[nf_prev, nf]`: the nullifier tested in the epoch being left, and the one
+/// that opens the epoch being entered.
 ///
 /// # Soundness
 ///
 /// `nf_prev` and `nf` are unconstrained here, as at every seed;
-/// [`UnspentBind`] forces the endpoints against the note's genuine derivation.
-/// `elapsed` is derived from `nf_prev` rather than witnessed, so the two cannot
-/// disagree.
+/// [`UnspentBind`] forces every `elapsed` member against the note's genuine
+/// derivation. Both are pinned against the header scalars by absorbing
+/// $G_0 \cdot \mathsf{nf\_prev} + G_1 \cdot \mathsf{nf}$, so the identity
+/// forces the sequence to the two crossing members.
 ///
 /// `anchor_prev` is likewise unconstrained, and nothing here requires it to be
-/// its epoch's terminal anchor. Adjacency at the fuses that consume this
-/// segment, and consensus membership of the eventual spend's anchor, are what
-/// reject a tick folded from a short anchor.
+/// its epoch's terminal anchor. A tick folded from a short anchor is rejected
+/// by adjacency at the consuming fuses and by consensus membership of the
+/// eventual spend's anchor.
 #[derive(Debug)]
 pub struct EndEpochUnspentSeed;
 
@@ -324,18 +361,36 @@ impl Step for EndEpochUnspentSeed {
     type Left = ();
     type Output = ArbitraryUnspent;
     type Right = ();
-    /// `(anchor_prev, (epoch_prev, nf_prev), nf)`.
-    type Witness<'source> = (Anchor, (EpochIndex, Nullifier), Nullifier);
+    /// `(anchor_prev, (epoch_prev, nf_prev), nf, elapsed_seq)`.
+    type Witness<'source> = (Anchor, (EpochIndex, Nullifier), Nullifier, NfSeqPoly);
 
-    const INDEX: Index = Index::new(6);
+    const INDEX: Index = Index::new(5);
 
     fn witness<'source>(
         &self,
-        _ctx: &mut ragu::StepCtx<'_>,
-        (anchor_prev, (epoch_prev, nf_prev), nf): Self::Witness<'source>,
+        ctx: &mut ragu::StepCtx<'_>,
+        (anchor_prev, (epoch_prev, nf_prev), nf, elapsed_seq): Self::Witness<'source>,
         _left: <Self::Left as Header>::Data,
         _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        // Nonzero guards, defensive: zero is reserved.
+        enforce_nonzero(
+            Fp::from(nf_prev),
+            "EndEpochUnspentSeed: outgoing nullifier is zero",
+        )?;
+        enforce_nonzero(
+            Fp::from(nf),
+            "EndEpochUnspentSeed: incoming nullifier is zero",
+        )?;
+
+        let epoch = epoch_prev.next();
+        let anchor = anchor_prev
+            .next_epoch(epoch)
+            .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
+
+        // Two-member elapsed: bind the witnessed sequence to the two
+        // crossing members at a challenge absorbing the commitment and the
+        // two-scalar binding point.
         #[expect(clippy::expect_used, reason = "constant size")]
         let (&g0, &g1) = {
             let generators = Pasta::host_generators(Pasta::baked());
@@ -344,14 +399,23 @@ impl Step for EndEpochUnspentSeed {
                 generators.g().get(1).expect("at least two generators"),
             )
         };
+        let elapsed_commit = elapsed_seq.commit();
+        let binding = g0 * Fp::from(nf_prev) + g1 * Fp::from(nf);
+        let z = ctx.derive_challenge(&[elapsed_commit.into(), binding])?;
+        let elapsed_at_z = elapsed_seq.eval(z);
 
-        // One-member elapsed: `[nf_prev]` plus the sentinel `1`.
-        let elapsed_commit = NfSeqCommit::from(g0 * Fp::from(nf_prev) + g1);
+        #[expect(clippy::expect_used, reason = "nonzero")]
+        let crossing_at_z = indexed_multiset::direct_eval(
+            NonZero::new((u32::from(epoch_prev) + 1).into()).expect("nonzero"),
+            [nf_prev.into(), nf.into()],
+            z,
+        );
 
-        let epoch = epoch_prev.next();
-        let anchor = anchor_prev
-            .next_epoch(epoch)
-            .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
+        enforce_zero(
+            elapsed_at_z - crossing_at_z,
+            "EndEpochUnspentSeed: elapsed does not match the crossing pairs",
+        )?;
+        ctx.enforce_poly_query(elapsed_commit.into(), z, elapsed_at_z)?;
 
         Ok((
             (
@@ -368,14 +432,14 @@ impl Step for EndEpochUnspentSeed {
 
 /// Compose two [`ArbitraryUnspent`] lineages sharing a mid-epoch junction.
 ///
-/// The halves meet inside one epoch (`right.epoch_start == left.epoch_end`), at
-/// adjacent anchors (`left.anchor_last == right.anchor_prev`), and agree on the
-/// junction nullifier (`left.nf_end == right.nf_start`); their histories are
-/// concatenated (`combined = left_elapsed ++ right_elapsed`). No epoch boundary
-/// is crossed, so `elapsed` gains no entry (the junction nf is
-/// `right_elapsed`'s head if right later crossed a boundary; otherwise it stays
-/// the in-progress `nf_end`). A crossing is its own segment
-/// ([`EndEpochUnspentSeed`]), so every seam this fuse sees is intra-epoch.
+/// The halves meet inside one epoch (`right.epoch_start == left.epoch_last`),
+/// at adjacent anchors (`left.anchor_last == right.anchor_prev`), and agree on
+/// the junction nullifier (`left.nf_last == right.nf_start`). The junction
+/// epoch's member appears in both sequences, so the concatenation keeps it once
+/// (`combined = left ++ right[1..]`).
+///
+/// A crossing is its own segment ([`EndEpochUnspentSeed`]), so every seam this
+/// fuse sees is a shared junction.
 #[derive(Debug)]
 pub struct UnspentFuse;
 
@@ -387,7 +451,7 @@ impl Step for UnspentFuse {
     /// `(left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq)`.
     type Witness<'source> = (NfSeqPoly, NfSeqPoly, NfSeqPoly);
 
-    const INDEX: Index = Index::new(7);
+    const INDEX: Index = Index::new(6);
 
     fn witness<'source>(
         &self,
@@ -397,14 +461,14 @@ impl Step for UnspentFuse {
             left_anchor_prev,
             (left_epoch_start, left_nf_start),
             left_elapsed,
-            (left_epoch_end, left_nf_end),
+            (left_epoch_last, left_nf_last),
             left_anchor_last,
         ): <Self::Left as Header>::Data,
         (
             right_anchor_prev,
             (right_epoch_start, right_nf_start),
             right_elapsed,
-            (right_epoch_end, right_nf_end),
+            (right_epoch_last, right_nf_last),
             right_anchor_last,
         ): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
@@ -423,40 +487,51 @@ impl Step for UnspentFuse {
             "UnspentFuse: left.anchor_last must equal right.anchor_prev",
         )?;
         enforce_zero(
-            Fp::from(right_epoch_start) - Fp::from(left_epoch_end),
+            Fp::from(right_epoch_start) - Fp::from(left_epoch_last),
             "UnspentFuse: forwards half must sit in left's tip epoch",
         )?;
         // Seam bind: both halves tested the junction epoch at the same nf, so the
         // merged history's view of it is unambiguous.
         enforce_zero(
-            Fp::from(left_nf_end) - Fp::from(right_nf_start),
+            Fp::from(left_nf_last) - Fp::from(right_nf_start),
             "UnspentFuse: halves disagree on the junction nullifier",
         )?;
         let combined_commit = combined_elapsed_seq.commit();
-        let offset = left_epoch_end - left_epoch_start;
-        // Sentinel concat: a sequence of `k` members is `Σ n_i·X^i + X^k`, so
-        // `combined = left ++ right` is the shifted combination
-        // `combined(X) = left(X) + X^offset·right(X) - X^offset`. The
-        // `-X^offset` monomial cancels left's sentinel, right's first crossing
-        // lands in the vacated slot, and right's own sentinel re-terminates
-        // `combined`. The monomial's constant coefficient is trivially
-        // challenge-independent, and `offset` is left's header-fixed span.
-        enforce_shifted_combination(
-            ctx,
-            [
-                (left_elapsed_seq.as_ref(), 0),
-                (right_elapsed_seq.as_ref(), offset.into()),
-            ],
-            [(-Fp::ONE, offset.into())],
-            combined_elapsed_seq.as_ref(),
+        // Junction dedup: both halves carry the junction epoch's member, and
+        // the combined lineage keeps it once, so
+        // `combined · F_junction = left · right`. The junction member is
+        // native from left-header scalars, fixed by the recursive
+        // verification of the left PCD before the challenge. At a one-member
+        // right the identity degenerates to `combined = left`: the merge adds
+        // stamps, not members.
+        let z = ctx.derive_challenge(&[
+            combined_commit.into(),
+            left_elapsed_seq.commit().into(),
+            right_elapsed_seq.commit().into(),
+        ])?;
+        let combined_at_z = combined_elapsed_seq.eval(z);
+        let left_at_z = left_elapsed_seq.eval(z);
+        let right_at_z = right_elapsed_seq.eval(z);
+
+        #[expect(clippy::expect_used, reason = "nonzero")]
+        let junction_at_z = indexed_multiset::direct_eval(
+            NonZero::new((u32::from(left_epoch_last) + 1).into()).expect("nonzero"),
+            [left_nf_last.into()],
+            z,
+        );
+        enforce_zero(
+            combined_at_z * junction_at_z - left_at_z * right_at_z,
             "UnspentFuse: combined is not the concatenation of the halves",
         )?;
+        ctx.enforce_poly_query(combined_commit.into(), z, combined_at_z)?;
+        ctx.enforce_poly_query(left_elapsed_seq.commit().into(), z, left_at_z)?;
+        ctx.enforce_poly_query(right_elapsed_seq.commit().into(), z, right_at_z)?;
         Ok((
             (
                 left_anchor_prev,
                 (left_epoch_start, left_nf_start),
                 combined_commit,
-                (right_epoch_end, right_nf_end),
+                (right_epoch_last, right_nf_last),
                 right_anchor_last,
             ),
             (),
@@ -464,14 +539,35 @@ impl Step for UnspentFuse {
     }
 }
 
-/// Bind an [`ArbitraryUnspent`]'s free-witness nullifiers to a
-/// note's genuine nullifiers.
+/// Bind an [`ArbitraryUnspent`]'s free-witness nullifiers to a note's genuine
+/// nullifiers, by divisibility into the derivation's sequence.
 ///
-/// Proves `range == elapsed ++ [nf_end]` against the derived
-/// [`NullifierHeader`], emitting an [`Unspent`] with the `cm`. The tip
-/// enters as a monomial coefficient of [`enforce_shifted_combination`]:
-/// `unspent_nf_end` is a left-header value, fixed by the recursive
-/// verification of the [`ArbitraryUnspent`] PCD before the challenge.
+/// Consumes any [`NullifierDerivation`], `elapsed` covering
+/// `[epoch_start, epoch_last]` inclusive, one member per epoch:
+///
+/// $$\mathsf{nf\_seq}(X) = \mathsf{elapsed}(X) \cdot \mathsf{complement}(X)$$
+///
+/// The complement holds the derivation's members outside the lineage: epochs
+/// below it, and the epochs it runs ahead of the exclusion evidence, since a
+/// spend publishes two nullifiers while the lineage stops at published
+/// evidence.
+///
+/// # Soundness
+///
+/// `elapsed` is a subsequence of the derivation, so every one of its members
+/// is a genuine derived pair and coverage is a conclusion of the identity.
+///
+/// Completeness rides `elapsed`'s provenance invariants, so every epoch of
+/// the span was tested with its own genuine nullifier, and [`UnspentFuse`]'s
+/// junction check is well-formedness only.
+///
+/// The boundary scalars need no check here. Both seeds pin their boundary
+/// members into `elapsed`, [`UnspentFuse`] inherits boundaries whose members
+/// survive into `combined = left · right / F_junction`, and this identity
+/// makes them genuine, which [`super::spendable::SpendableLift`] relies on.
+///
+/// The lineage is note-blind, so the bind stamps the derivation's `cm` onto
+/// the validated [`Unspent`].
 #[derive(Debug)]
 pub struct UnspentBind;
 
@@ -479,79 +575,61 @@ impl Step for UnspentBind {
     type Aux<'source> = ();
     type Left = ArbitraryUnspent;
     type Output = Unspent;
-    type Right = NullifierHeader;
-    /// `(elapsed_seq, nf_seq)`.
-    type Witness<'source> = (NfSeqPoly, NfSeqPoly);
+    type Right = NullifierDerivation;
+    /// `(elapsed_seq, nf_seq, complement_seq)`.
+    type Witness<'source> = (NfSeqPoly, NfSeqPoly, NfSeqPoly);
 
-    const INDEX: Index = Index::new(8);
+    const INDEX: Index = Index::new(7);
 
     fn witness<'source>(
         &self,
         ctx: &mut ragu::StepCtx<'_>,
-        (elapsed_seq, nf_seq): Self::Witness<'source>,
+        (elapsed_seq, nf_seq, complement_seq): Self::Witness<'source>,
         (
             unspent_anchor_prev,
             (unspent_epoch_start, unspent_nf_start),
             unspent_elapsed,
-            (unspent_epoch_end, unspent_nf_end),
+            (unspent_epoch_last, unspent_nf_last),
             unspent_anchor_last,
         ): <Self::Left as Header>::Data,
-        (nf_cm, (nf_epoch_start, nf_start), nf_seq_commit, (nf_epoch_end, nf_end)): <Self::Right as Header>::Data,
+        (deriv_cm, _, nf_commit, _): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
-        enforce_zero(
-            Fp::from(nf_epoch_start) - Fp::from(unspent_epoch_start),
-            "UnspentBind: derived range does not start at the unspent's start epoch",
-        )?;
-        enforce_zero(
-            Fp::from(nf_epoch_end) - Fp::from(unspent_epoch_end.next()),
-            "UnspentBind: derived range does not span the crossings plus the tip",
-        )?;
         enforce_equal_point(
-            Eq::from(elapsed_seq.commit()),
+            elapsed_seq.commit().into(),
             Eq::from(unspent_elapsed),
             "UnspentBind: elapsed polynomial does not match header",
         )?;
         enforce_equal_point(
             Eq::from(nf_seq.commit()),
-            Eq::from(nf_seq_commit),
-            "UnspentBind: range polynomial does not match header",
+            Eq::from(nf_commit),
+            "UnspentBind: covering sequence does not match header",
         )?;
-        let offset = unspent_epoch_end - unspent_epoch_start;
-        // Sentinel append: a sequence of `k` members is `Σ n_i·X^i + X^k`, so
-        // `nf_seq = elapsed ++ [unspent_nf_end]` is the shifted combination
-        // `nf_seq(X) = elapsed(X) + (unspent_nf_end - 1)·X^offset +
-        // X^{offset+1}`. The first monomial overwrites elapsed's sentinel with
-        // the appended tip; the second re-terminates `nf_seq`. Both
-        // coefficients are challenge-independent: `unspent_nf_end` is a
-        // left-header value, fixed by the recursive verification of the
-        // [`ArbitraryUnspent`] PCD; `offset` is elapsed's header-fixed span.
-        enforce_shifted_combination(
+
+        // The divisibility bind: `nf_seq = elapsed · complement`, so every
+        // elapsed member is a genuine derived pair.
+        enforce_poly_product(
             ctx,
-            [(elapsed_seq.as_ref(), 0)],
-            [
-                (Fp::from(unspent_nf_end) - Fp::ONE, offset.into()),
-                (Fp::ONE, u64::from(offset) + 1),
-            ],
+            elapsed_seq.as_ref(),
+            complement_seq.as_ref(),
             nf_seq.as_ref(),
-            "UnspentBind: range is not elapsed followed by the tip",
+            "UnspentBind: sequence does not match the derivation",
         )?;
-        // Bind the unspent's free-witness boundary nullifiers to the range's
-        // genuine boundary leaves, which the derivation header proved by
-        // construction.
-        enforce_zero(
-            Fp::from(unspent_nf_start) - Fp::from(nf_start),
-            "UnspentBind: start nullifier does not match the derived range",
+
+        // Defensive: a single-epoch segment's boundary caches coincide.
+        let span = Fp::from(unspent_epoch_last) - Fp::from(unspent_epoch_start);
+        conditional_enforce_equal(
+            bool::from(span.is_zero()),
+            Fp::from(unspent_nf_start),
+            Fp::from(unspent_nf_last),
+            "UnspentBind: single-epoch segment boundary nullifiers differ",
         )?;
-        enforce_zero(
-            Fp::from(unspent_nf_end) - Fp::from(nf_end),
-            "UnspentBind: end nullifier does not match the derived range",
-        )?;
+
         Ok((
             (
-                nf_cm,
+                deriv_cm,
                 unspent_anchor_prev,
                 (unspent_epoch_start, unspent_nf_start),
-                (unspent_epoch_end, unspent_nf_end),
+                (unspent_epoch_last, unspent_nf_last),
                 unspent_anchor_last,
             ),
             (),

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -16,7 +16,6 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
-use core::num::NonZero;
 
 use ff::Field as _;
 use pasta_curves::{Ep, Eq, Fp, Fq};
@@ -307,12 +306,7 @@ impl Step for UnspentSeed {
         let z = ctx.derive_challenge(&[elapsed_commit.into(), g0 * Fp::from(nf)])?;
         let elapsed_at_z = elapsed_seq.eval(z);
 
-        #[expect(clippy::expect_used, reason = "nonzero")]
-        let member_at_z = indexed_multiset::direct_eval(
-            NonZero::new((u32::from(epoch) + 1).into()).expect("nonzero"),
-            [nf.into()],
-            z,
-        );
+        let member_at_z = indexed_multiset::direct_eval([(epoch.into(), nf.into())], z);
 
         enforce_zero(
             elapsed_at_z - member_at_z,
@@ -404,10 +398,12 @@ impl Step for EndEpochUnspentSeed {
         let z = ctx.derive_challenge(&[elapsed_commit.into(), binding])?;
         let elapsed_at_z = elapsed_seq.eval(z);
 
-        #[expect(clippy::expect_used, reason = "nonzero")]
+        let epoch_prev_idx = u64::from(u32::from(epoch_prev));
         let crossing_at_z = indexed_multiset::direct_eval(
-            NonZero::new((u32::from(epoch_prev) + 1).into()).expect("nonzero"),
-            [nf_prev.into(), nf.into()],
+            [
+                (epoch_prev_idx, nf_prev.into()),
+                (epoch_prev_idx + 1, nf.into()),
+            ],
             z,
         );
 
@@ -513,12 +509,8 @@ impl Step for UnspentFuse {
         let left_at_z = left_elapsed_seq.eval(z);
         let right_at_z = right_elapsed_seq.eval(z);
 
-        #[expect(clippy::expect_used, reason = "nonzero")]
-        let junction_at_z = indexed_multiset::direct_eval(
-            NonZero::new((u32::from(left_epoch_last) + 1).into()).expect("nonzero"),
-            [left_nf_last.into()],
-            z,
-        );
+        let junction_at_z =
+            indexed_multiset::direct_eval([(left_epoch_last.into(), left_nf_last.into())], z);
         enforce_zero(
             combined_at_z * junction_at_z - left_at_z * right_at_z,
             "UnspentFuse: combined is not the concatenation of the halves",

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -3,15 +3,21 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
+use core::num::NonZero;
 
 use pasta_curves::{Ep, Eq, Fp, Fq};
 use ragu::{
-    Header, Index, Step, Suffix,
-    constraint::{enforce_nonzero, enforce_zero},
+    Cycle as _, FixedGenerators as _, Header, Index, Pasta, Step, Suffix,
+    constraint::{enforce_equal_point, enforce_nonzero, enforce_zero},
 };
 
-use super::{delegation::NullifierHeader, spendable::SpendableHeader};
-use crate::{note, nullifier::Nullifier, primitives::Anchor};
+use super::{delegation::NullifierDerivation, spendable::SpendableHeader};
+use crate::{
+    collections::indexed_multiset,
+    note,
+    nullifier::Nullifier,
+    primitives::{Anchor, NfSeqPoly},
+};
 
 /// Header binding a spend to its lineage note and epoch nullifier pair.
 ///
@@ -46,17 +52,30 @@ impl Header for SpendHeader {
     }
 }
 
-/// Confirms a spend's epoch nullifier pair against a covering two-leaf
-/// [`NullifierHeader`] range and binds it to the spendable lineage.
+/// Confirms a spend's epoch nullifier pair against a covering
+/// [`NullifierDerivation`] and binds it to the spendable lineage.
 ///
 /// The range is tied to the lineage's note by `nf_cm == spendable_cm` (both
 /// are the note commitment, bound where the range was derived and at
 /// [`SpendableInit`](super::spendable::SpendableInit) respectively), so no
-/// note witness is needed here. Witnesses `nf_next` and binds the published
-/// pair to the range's genuine `GGM(mk, ·)` boundary leaves: the range spans
-/// exactly two epochs, `present_nf` is its start leaf, and `nf_next` its end
-/// leaf. Both nullifiers are emitted on the [`SpendHeader`] for the
-/// action-producing step to publish.
+/// note witness is needed here. Any range covering the lineage's epoch and
+/// the next serves: the divisibility
+/// $\mathsf{nf\_seq} = F_{e,\mathsf{present\_nf}} \cdot
+/// F_{e+1,\mathsf{nf\_next}} \cdot \mathsf{complement}$ confirms the pair
+/// at adjacent epochs, with `present_nf` pinned against the spendable. Both
+/// nullifiers are emitted on the [`SpendHeader`] for the action-producing
+/// step to publish.
+///
+/// # Soundness
+///
+/// Neither epoch index is free. The present member's scalars are left-header
+/// fields, fixed by the recursive verification of the spendable PCD before
+/// the challenge, and adjacency is the pair's own epochs `e` and `e + 1`.
+/// The free `nf_next` is the only scalar needing a pin, and gets one from
+/// $G_0 \cdot \mathsf{nf\_next}$.
+///
+/// The step compares no bounds against the derivation's range, the
+/// divisibility concluding coverage.
 #[derive(Debug)]
 pub struct SpendBind;
 
@@ -64,41 +83,59 @@ impl Step for SpendBind {
     type Aux<'source> = ();
     type Left = SpendableHeader;
     type Output = SpendHeader;
-    type Right = NullifierHeader;
-    /// `(nf_next,)`.
-    type Witness<'source> = (Nullifier,);
+    type Right = NullifierDerivation;
+    /// `(nf_seq, complement_seq, nf_next)`.
+    type Witness<'source> = (NfSeqPoly, NfSeqPoly, Nullifier);
 
-    const INDEX: Index = Index::new(13);
+    const INDEX: Index = Index::new(12);
 
     fn witness<'source>(
         &self,
-        _ctx: &mut ragu::StepCtx<'_>,
-        (nf_next,): Self::Witness<'source>,
+        ctx: &mut ragu::StepCtx<'_>,
+        (nf_seq, complement_seq, nf_next): Self::Witness<'source>,
         (spendable_cm, (spendable_epoch, present_nf), anchor): <Self::Left as Header>::Data,
-        (nf_cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, nf_end)): <Self::Right as Header>::Data,
+        (nf_cm, _, nf_commit, _): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
-        enforce_zero(
-            Fp::from(nf_epoch_end) - (Fp::from(nf_epoch_start) + Fp::from(2u64)),
-            "SpendBind: live range must span two epochs",
-        )?;
-        enforce_zero(
-            Fp::from(nf_epoch_start) - Fp::from(spendable_epoch),
-            "SpendBind: live range does not start at the lineage epoch",
-        )?;
         enforce_zero(
             Fp::from(nf_cm) - Fp::from(spendable_cm),
             "SpendBind: derived range does not match note",
         )?;
+        enforce_equal_point(
+            Eq::from(nf_seq.commit()),
+            Eq::from(nf_commit),
+            "SpendBind: covering sequence does not match header",
+        )?;
 
-        // Bind the published nullifiers to the range's genuine boundary leaves.
+        // The 2-wide read at the lineage's epoch: the divisibility
+        // `nf_seq = present · next · complement` at a challenge absorbing the
+        // witnessed commitments and the scalar-binding point of the free
+        // `nf_next`; the present member is native from the spendable header,
+        // pinned by the recursive verification of the left PCD.
+        #[expect(clippy::expect_used, reason = "constant size")]
+        let &g0 = Pasta::host_generators(Pasta::baked())
+            .g()
+            .first()
+            .expect("at least one generator");
+        let z = ctx.derive_challenge(&[
+            nf_seq.commit().into(),
+            complement_seq.commit().into(),
+            g0 * Fp::from(nf_next),
+        ])?;
+        let nf_seq_at_z = nf_seq.eval(z);
+        let complement_at_z = complement_seq.eval(z);
+
+        #[expect(clippy::expect_used, reason = "nonzero")]
+        let pair_at_z = indexed_multiset::direct_eval(
+            NonZero::new((u32::from(spendable_epoch) + 1).into()).expect("nonzero"),
+            [present_nf.into(), nf_next.into()],
+            z,
+        );
         enforce_zero(
-            Fp::from(present_nf) - Fp::from(nf_start),
-            "SpendBind: present nullifier is not the range's start leaf",
+            nf_seq_at_z - pair_at_z * complement_at_z,
+            "SpendBind: nullifier pair does not match the derivation",
         )?;
-        enforce_zero(
-            Fp::from(nf_next) - Fp::from(nf_end),
-            "SpendBind: next nullifier is not the range's end leaf",
-        )?;
+        ctx.enforce_poly_query(nf_seq.commit().into(), z, nf_seq_at_z)?;
+        ctx.enforce_poly_query(complement_seq.commit().into(), z, complement_at_z)?;
 
         // A zero nullifier would collide with the note's own cm tachygram.
         enforce_nonzero(

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -3,7 +3,6 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
-use core::num::NonZero;
 
 use pasta_curves::{Ep, Eq, Fp, Fq};
 use ragu::{
@@ -124,10 +123,11 @@ impl Step for SpendBind {
         let nf_seq_at_z = nf_seq.eval(z);
         let complement_at_z = complement_seq.eval(z);
 
-        #[expect(clippy::expect_used, reason = "nonzero")]
         let pair_at_z = indexed_multiset::direct_eval(
-            NonZero::new((u32::from(spendable_epoch) + 1).into()).expect("nonzero"),
-            [present_nf.into(), nf_next.into()],
+            [
+                (spendable_epoch.into(), present_nf.into()),
+                (spendable_epoch.next().into(), nf_next.into()),
+            ],
             z,
         );
         enforce_zero(

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -1,7 +1,7 @@
 //! Spendable bootstrap and lift.
 //!
 //! The spendable carries `(cm, (epoch, present_nf), anchor)`: the note's
-//! current epoch and its nullifier `GGM(mk, epoch)` there, its pool position,
+//! current epoch and its nullifier `F_mk(epoch)` there, its pool position,
 //! and the minted-note commitment binding the lineage (and its value) across
 //! lifts. [`SpendableInit`]
 //! bootstraps it from a minted note; [`SpendableLift`] advances it over
@@ -10,16 +10,20 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
+use core::num::NonZero;
 
-use ff::Field as _;
 use pasta_curves::{Ep, Eq, Fp, Fq};
-use ragu::{Header, Index, Step, Suffix, constraint::enforce_zero};
+use ragu::{
+    Cycle as _, FixedGenerators as _, Header, Index, Pasta, Step, Suffix,
+    constraint::{enforce_equal_point, enforce_zero},
+};
 
-use super::{delegation::NullifierHeader, pool::Unspent};
+use super::{delegation::NullifierDerivation, pool::Unspent};
 use crate::{
+    collections::indexed_multiset,
     note,
     nullifier::Nullifier,
-    primitives::{Anchor, EpochIndex, TachygramSetPoly},
+    primitives::{Anchor, EpochIndex, NfSeqPoly, TachygramSetPoly},
 };
 
 /// Wallet's spendable position `(cm, (epoch, present_nf), anchor)`
@@ -56,56 +60,104 @@ impl Header for SpendableHeader {
 
 /// Bootstrap a spendable from a minted note, pinned to the creation epoch.
 ///
-/// Wallet-only, one-child over the wallet's single-leaf [`NullifierHeader`]:
-/// binds `present_nf` to the proven leaf, checks `cm in creation_set`, and
-/// computes the post-cm anchor from a free-witnessed predecessor.
+/// Wallet-only, one-child over any [`NullifierDerivation`] covering the
+/// creation epoch, so one derived window feeds init, bind, and spend alike.
+/// The divisibility
+/// $\mathsf{nf\_seq} = F_{\mathsf{creation\_epoch},\mathsf{present\_nf}}
+/// \cdot \mathsf{complement}$ forces `present_nf` to the window's genuine
+/// member at the creation epoch, the complement absorbing the remaining span.
+/// `cm` is proven among the creation stamp's tachygrams, and the post-cm
+/// anchor folds from a free-witnessed predecessor.
 ///
-/// The emitted anchor binds nothing here: `pre_cm_anchor` is a free witness,
-/// so a standalone spendable proves nothing about real chain coverage.
-/// Binding closes downstream. [`SpendableLift`] adjacency threads the anchor
-/// to the eventual spend, whose anchor consensus checks for chain membership;
-/// a genuine chain node is `H(prev || epoch || commit)` under the stamp
-/// domain, so preimage resistance forces the witnessed `pre_cm_anchor`,
-/// `epoch`, and `creation_commit` to be the real predecessor, the real
-/// creation epoch, and the real cm-stamp. The same argument pins the derived
-/// range's starting epoch: a wrong `epoch` folds into an anchor off the
-/// published sequence.
+/// # Soundness
+///
+/// Every free witness closes through consensus or the read. `pre_cm_anchor`,
+/// `creation_epoch` and the creation set close through consensus anchor
+/// membership: the fold absorbs the epoch and the set commit, a genuine
+/// chain node is `H(prev || epoch || commit)` under the stamp domain, and
+/// preimage resistance forces all three once the eventual spend's anchor is
+/// consensus-checked, a wrong epoch landing off the published sequence.
+///
+/// `present_nf` closes through the read, pinned by absorbing
+/// $G_0 \cdot \mathsf{present\_nf}$, so the identity forces the read to the
+/// emitted pair.
+///
+/// `creation_epoch` needs no bound check against the derivation's range. The
+/// divisibility forces $F_{\mathsf{creation\_epoch},\mathsf{present\_nf}}$ to
+/// be one of the derivation's own members, so the epoch is one the derivation
+/// holds a member for.
+///
+/// Nothing ties this window to the one the spend later reads; `cm` equality
+/// binds every window of the same note.
 #[derive(Debug)]
 pub struct SpendableInit;
 
 impl Step for SpendableInit {
     type Aux<'source> = ();
-    type Left = NullifierHeader;
+    type Left = NullifierDerivation;
     type Output = SpendableHeader;
     type Right = ();
-    /// `(pre_cm_anchor, creation_set, present_nf)`.
-    type Witness<'source> = (Anchor, TachygramSetPoly, Nullifier);
+    /// `(pre_cm_anchor, creation_set, creation_epoch, present_nf, nf_seq,
+    /// complement_seq)`.
+    type Witness<'source> = (
+        Anchor,
+        TachygramSetPoly,
+        EpochIndex,
+        Nullifier,
+        NfSeqPoly,
+        NfSeqPoly,
+    );
 
-    const INDEX: Index = Index::new(9);
+    const INDEX: Index = Index::new(8);
 
     fn witness<'source>(
         &self,
         ctx: &mut ragu::StepCtx<'_>,
-        (pre_cm_anchor, creation_set, present_nf): Self::Witness<'source>,
-        (cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, _nf_end)): <Self::Left as Header>::Data,
+        (pre_cm_anchor, creation_set, creation_epoch, present_nf, nf_seq, complement_seq): Self::Witness<
+            'source,
+        >,
+        (cm, _, nf_commit, _): <Self::Left as Header>::Data,
         _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
-        // Bind `present_nf` to the single derived starting leaf `GGM(mk, epoch)`.
-        enforce_zero(
-            Fp::from(nf_epoch_end) - (Fp::from(nf_epoch_start) + Fp::ONE),
-            "SpendableInit: starting range must span one epoch",
+        enforce_equal_point(
+            Eq::from(nf_seq.commit()),
+            Eq::from(nf_commit),
+            "SpendableInit: covering sequence does not match header",
         )?;
+
+        // The 1-wide read at the creation epoch: the divisibility
+        // `nf_seq = read · complement` at a challenge absorbing the witnessed
+        // commitments and the scalar-binding point of the free `present_nf`.
+        #[expect(clippy::expect_used, reason = "constant size")]
+        let &g0 = Pasta::host_generators(Pasta::baked())
+            .g()
+            .first()
+            .expect("at least one generator");
+        let z = ctx.derive_challenge(&[
+            nf_seq.commit().into(),
+            complement_seq.commit().into(),
+            g0 * Fp::from(present_nf),
+        ])?;
+        let nf_seq_at_z = nf_seq.eval(z);
+        let complement_at_z = complement_seq.eval(z);
+
+        #[expect(clippy::expect_used, reason = "nonzero")]
+        let read_at_z = indexed_multiset::direct_eval(
+            NonZero::new((u32::from(creation_epoch) + 1).into()).expect("nonzero"),
+            [present_nf.into()],
+            z,
+        );
         enforce_zero(
-            Fp::from(present_nf) - Fp::from(nf_start),
-            "SpendableInit: present nullifier does not match the derived leaf",
+            nf_seq_at_z - read_at_z * complement_at_z,
+            "SpendableInit: nullifier does not match the derivation",
         )?;
-        let epoch = nf_epoch_start;
+        ctx.enforce_poly_query(nf_seq.commit().into(), z, nf_seq_at_z)?;
+        ctx.enforce_poly_query(complement_seq.commit().into(), z, complement_at_z)?;
 
         // Inclusion: cm ∈ set ⇔ the set polynomial vanishes at cm.
-        let cm_point = Fp::from(cm);
-        let eval = creation_set.eval(cm_point);
-        ctx.enforce_poly_query(creation_set.commit().into(), cm_point, eval)?;
-        enforce_zero(eval, "SpendableInit: commitment not in set")?;
+        let cm_in_set = creation_set.eval(cm.into());
+        ctx.enforce_poly_query(creation_set.commit().into(), cm.into(), cm_in_set)?;
+        enforce_zero(cm_in_set, "SpendableInit: commitment not in set")?;
         let creation_commit = creation_set.commit();
 
         // The anchor immediately after the creation stamp, computed in-circuit
@@ -113,10 +165,10 @@ impl Step for SpendableInit {
         // consensus membership of the eventual spend anchor binds the rest
         // (see the step doc).
         let post_cm_anchor = pre_cm_anchor
-            .next_stamp(epoch, &creation_commit)
+            .next_stamp(creation_epoch, &creation_commit)
             .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
 
-        Ok(((cm, (epoch, present_nf), post_cm_anchor), ()))
+        Ok(((cm, (creation_epoch, present_nf), post_cm_anchor), ()))
     }
 }
 
@@ -124,7 +176,7 @@ impl Step for SpendableInit {
 ///
 /// Wallet-only, witness-free. Checks `cm`, the boundary pair `(epoch_start,
 /// nf_start) == (epoch, present_nf)`, and anchor adjacency, then advances to
-/// the tip `(epoch_end, nf_end, anchor_last)`.
+/// the tip `(epoch_last, nf_last, anchor_last)`.
 ///
 /// The segment may span any number of epochs. A lineage resting on its epoch's
 /// terminal anchor advances the same way, over a segment that opens with the
@@ -139,7 +191,7 @@ impl Step for SpendableLift {
     type Right = Unspent;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(10);
+    const INDEX: Index = Index::new(9);
 
     fn witness<'source>(
         &self,
@@ -150,7 +202,7 @@ impl Step for SpendableLift {
             unspent_cm,
             unspent_anchor_prev,
             (unspent_epoch_start, unspent_nf_start),
-            (unspent_epoch_end, unspent_nf_end),
+            (unspent_epoch_last, unspent_nf_last),
             unspent_anchor_last,
         ): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
@@ -173,7 +225,7 @@ impl Step for SpendableLift {
         Ok((
             (
                 spendable_cm,
-                (unspent_epoch_end, unspent_nf_end),
+                (unspent_epoch_last, unspent_nf_last),
                 unspent_anchor_last,
             ),
             (),

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -10,7 +10,6 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
-use core::num::NonZero;
 
 use pasta_curves::{Ep, Eq, Fp, Fq};
 use ragu::{
@@ -47,7 +46,7 @@ impl Header for SpendableHeader {
         (
             vec![
                 Fp::from(cm),
-                Fp::from(u64::from(epoch.0)),
+                Fp::from(epoch),
                 Fp::from(present_nf),
                 Fp::from(anchor),
             ],
@@ -141,12 +140,8 @@ impl Step for SpendableInit {
         let nf_seq_at_z = nf_seq.eval(z);
         let complement_at_z = complement_seq.eval(z);
 
-        #[expect(clippy::expect_used, reason = "nonzero")]
-        let read_at_z = indexed_multiset::direct_eval(
-            NonZero::new((u32::from(creation_epoch) + 1).into()).expect("nonzero"),
-            [present_nf.into()],
-            z,
-        );
+        let read_at_z =
+            indexed_multiset::direct_eval([(creation_epoch.into(), present_nf.into())], z);
         enforce_zero(
             nf_seq_at_z - read_at_z * complement_at_z,
             "SpendableInit: nullifier does not match the derivation",

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -81,7 +81,7 @@ impl Step for OutputStamp {
         Anchor,
     );
 
-    const INDEX: Index = Index::new(12);
+    const INDEX: Index = Index::new(11);
 
     fn witness<'source>(
         &self,
@@ -138,7 +138,7 @@ impl Step for OutputStamp {
 /// the randomized action key `rk`, and commits the one-action set plus the
 /// two-element tachygram set `{present_nf, nf_next}` (the pair
 /// [`SpendBind`](super::spend::SpendBind) already confirmed against the
-/// covering range).
+/// covering derivation).
 #[derive(Debug)]
 pub struct SpendStamp;
 
@@ -155,7 +155,7 @@ impl Step for SpendStamp {
         ProofAuthorizingKey,
     );
 
-    const INDEX: Index = Index::new(14);
+    const INDEX: Index = Index::new(13);
 
     fn witness<'source>(
         &self,
@@ -209,7 +209,7 @@ impl Step for SpendStamp {
     }
 }
 
-/// Universal merge — transaction assembly and aggregation.
+/// Transaction assembly and aggregation.
 #[derive(Debug)]
 pub struct MergeStamp;
 
@@ -225,7 +225,7 @@ impl Step for MergeStamp {
         (ActionSetPoly, TachygramSetPoly),
     );
 
-    const INDEX: Index = Index::new(15);
+    const INDEX: Index = Index::new(14);
 
     fn witness<'source>(
         &self,
@@ -267,9 +267,7 @@ impl Step for MergeStamp {
             "MergeStamp: right tachygram accumulator must commit to header commit",
         )?;
 
-        // The merged sets are witnessed; confirm each is the `left · right`
-        // union of its halves via the product-opening relation, never built
-        // in-step.
+        // Confirm union via product-opening relation.
         enforce_poly_product(
             ctx,
             left_action_set.as_ref(),
@@ -309,7 +307,7 @@ impl Step for StampLift {
     type Right = AnchorChain;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(16);
+    const INDEX: Index = Index::new(15);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -6,20 +6,19 @@
 //! ready to seed or fuse through `PROOF_SYSTEM`. Functions are named after the
 //! step they serve. Steps with an empty `()` witness need no utility.
 
-use alloc::vec::Vec;
-
 use ragu::{Header, Step};
-use ragu_arithmetic::PoseidonPermutation as _;
-use ragu_pasta::PoseidonFp;
 
 use crate::{
+    keys::ProofAuthorizingKey,
+    note::Note,
     nullifier::Nullifier,
     primitives::{
         ActionDigest, ActionSetPoly, Anchor, EpochIndex, NfSeqPoly, Tachygram, TachygramSetPoly,
     },
     stamp::proof::{
-        delegation::{NfDerive, NullifierFuse},
+        delegation::{NfDerive, NfMasterSeed, NullifierFuse},
         pool::{AnchorSeed, EndEpochUnspentSeed, UnspentBind, UnspentFuse, UnspentSeed},
+        spend::SpendBind,
         spendable::SpendableInit,
         stamp::MergeStamp,
     },
@@ -31,45 +30,53 @@ type StepRight<S> = <<S as Step>::Right as Header>::Data;
 
 type StepWitness<'src, S> = <S as Step>::Witness<'src>;
 
-/// Prepare the witness for [`NfDerive`]: `(window_start, mask, seq)`.
+/// Prepare the witness for [`NfMasterSeed`]: `(note, pak)`.
+#[must_use]
+pub const fn nf_master_seed(
+    (_left, _right): (StepLeft<NfMasterSeed>, StepRight<NfMasterSeed>),
+    note: Note,
+    pak: ProofAuthorizingKey,
+) -> StepWitness<'static, NfMasterSeed> {
+    (note, pak)
+}
+
+/// Prepare the witness for [`NfDerive`]: `(epoch_start, seq)`.
 ///
-/// The sequence covers the mask's contiguous run of the window's epochs,
-/// derived from the master key on the left header. `window_start` must be
-/// group-aligned.
+/// Reads `mk` off the seed header and lays the whole window out as the
+/// sequence. `epoch_start` must be group-aligned. A longer span fuses
+/// windows via [`NullifierFuse`].
 #[must_use]
 pub fn nf_derive(
     (left, _right): (StepLeft<NfDerive>, StepRight<NfDerive>),
-    window_start: EpochIndex,
-    mask: [bool; PoseidonFp::RATE],
+    epoch_start: EpochIndex,
 ) -> StepWitness<'static, NfDerive> {
     let (_cm, mk) = left;
-    let seq = mk
-        .derive_group(window_start)
-        .into_iter()
-        .zip(mask)
-        .filter_map(|(nf, selected)| selected.then_some(nf))
-        .collect::<NfSeqPoly>();
-    (window_start, mask, seq)
+    (
+        epoch_start,
+        NfSeqPoly::new(epoch_start, &mk.derive_window(epoch_start)),
+    )
 }
 
-/// Prepare the witness for [`NullifierFuse`]: `(left, merged, leaf)`.
+/// Prepare the witness for [`NullifierFuse`]:
+/// `(left_seq, merged_seq, right_seq)`.
 #[must_use]
 pub fn nullifier_fuse(
-    (_left, _right): (StepLeft<NullifierFuse>, StepRight<NullifierFuse>),
-    left: &[Nullifier],
-    leaf: Nullifier,
+    (left, right): (StepLeft<NullifierFuse>, StepRight<NullifierFuse>),
+    left_nfs: &[Nullifier],
+    right_nfs: &[Nullifier],
 ) -> StepWitness<'static, NullifierFuse> {
-    let mut merged: Vec<Nullifier> = left.to_vec();
-    merged.push(leaf);
+    let (_, left_epoch_start, ..) = left;
+    let (_, right_epoch_start, ..) = right;
+    let merged = [left_nfs, right_nfs].concat();
     (
-        left.iter().copied().collect::<NfSeqPoly>(),
-        merged.into_iter().collect::<NfSeqPoly>(),
-        NfSeqPoly::from_iter([leaf]),
+        NfSeqPoly::new(left_epoch_start, left_nfs),
+        NfSeqPoly::new(left_epoch_start, &merged),
+        NfSeqPoly::new(right_epoch_start, right_nfs),
     )
 }
 
 /// Prepare the witness for [`UnspentSeed`]: `(anchor_prev, (epoch, nf),
-/// tg_set)`.
+/// tg_set, elapsed_seq)`.
 #[must_use]
 pub fn unspent_seed(
     (_left, _right): (StepLeft<UnspentSeed>, StepRight<UnspentSeed>),
@@ -82,13 +89,14 @@ pub fn unspent_seed(
         anchor_prev,
         (epoch, nf),
         tgs.iter().copied().collect::<TachygramSetPoly>(),
+        NfSeqPoly::new(epoch, &[nf]),
     )
 }
 
 /// Prepare the witness for [`EndEpochUnspentSeed`]:
-/// `(anchor_prev, (epoch_prev, nf_prev), nf)`.
+/// `(anchor_prev, (epoch_prev, nf_prev), nf, elapsed_seq)`.
 #[must_use]
-pub const fn end_epoch_unspent_seed(
+pub fn end_epoch_unspent_seed(
     (_left, _right): (
         StepLeft<EndEpochUnspentSeed>,
         StepRight<EndEpochUnspentSeed>,
@@ -98,57 +106,133 @@ pub const fn end_epoch_unspent_seed(
     nf_prev: Nullifier,
     nf: Nullifier,
 ) -> StepWitness<'static, EndEpochUnspentSeed> {
-    (anchor_prev, (epoch_prev, nf_prev), nf)
+    (
+        anchor_prev,
+        (epoch_prev, nf_prev),
+        nf,
+        NfSeqPoly::new(epoch_prev, &[nf_prev, nf]),
+    )
 }
 
 /// Prepare the witness for [`UnspentFuse`]:
 /// `(left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq)`.
+///
+/// `left_elapsed` and `right_elapsed` are the halves' member lists, one per
+/// covered epoch. Both include the junction epoch's member, which the
+/// combined sequence keeps once.
 #[must_use]
 pub fn unspent_fuse(
-    (_left, _right): (StepLeft<UnspentFuse>, StepRight<UnspentFuse>),
+    (left, right): (StepLeft<UnspentFuse>, StepRight<UnspentFuse>),
     left_elapsed: &[Nullifier],
     right_elapsed: &[Nullifier],
 ) -> StepWitness<'static, UnspentFuse> {
-    let combined = [left_elapsed, right_elapsed].concat();
+    let (_, (left_epoch_start, _), ..) = left;
+    let (_, (right_epoch_start, _), ..) = right;
+    #[expect(clippy::expect_used, reason = "member lists are nonempty")]
+    let (_junction, right_tail) = right_elapsed
+        .split_first()
+        .expect("right members include the junction");
+    let combined = [left_elapsed, right_tail].concat();
     (
-        left_elapsed.iter().copied().collect::<NfSeqPoly>(),
-        combined.into_iter().collect::<NfSeqPoly>(),
-        right_elapsed.iter().copied().collect::<NfSeqPoly>(),
+        NfSeqPoly::new(left_epoch_start, left_elapsed),
+        NfSeqPoly::new(left_epoch_start, &combined),
+        NfSeqPoly::new(right_epoch_start, right_elapsed),
     )
 }
 
-/// Prepare the witness for [`UnspentBind`]: `(elapsed, nf_seq)`.
+/// Prepare the witness for [`UnspentBind`]:
+/// `(elapsed_seq, nf_seq, complement_seq)`.
 ///
-/// The range appends the tip `nf_end` from the left
-/// [`ArbitraryUnspent`](crate::stamp::proof::pool::ArbitraryUnspent) header:
-/// `nf_seq = elapsed ++ [nf_end]`.
+/// `elapsed` is the unspent's member list, one per covered epoch. `window`
+/// is the complete covering sequence, one member per epoch of the
+/// derivation header's range; the complement is the window's runs on both
+/// sides of the unspent's span, multiplied.
 #[must_use]
+#[expect(
+    clippy::indexing_slicing,
+    clippy::as_conversions,
+    reason = "the derivation header's range covers the window"
+)]
 pub fn unspent_bind(
-    (left, _right): (StepLeft<UnspentBind>, StepRight<UnspentBind>),
+    (unspent, deriv): (StepLeft<UnspentBind>, StepRight<UnspentBind>),
+    window: &[Nullifier],
     elapsed: &[Nullifier],
 ) -> StepWitness<'static, UnspentBind> {
-    let (_, _, _, (_, nf_end), _) = left;
-    let mut nf_seq: Vec<Nullifier> = elapsed.to_vec();
-    nf_seq.push(nf_end);
+    let (_, (epoch_start, _), _, (epoch_last, _), _) = unspent;
+    let (_, deriv_start, ..) = deriv;
+    let lo = (epoch_start.0 - deriv_start.0) as usize;
+    let hi = (epoch_last.next().0 - deriv_start.0) as usize;
+    let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
+        * NfSeqPoly::new(epoch_last.next(), &window[hi..]);
     (
-        elapsed.iter().copied().collect::<NfSeqPoly>(),
-        nf_seq.into_iter().collect::<NfSeqPoly>(),
+        NfSeqPoly::new(epoch_start, elapsed),
+        NfSeqPoly::new(deriv_start, window),
+        complement_seq,
     )
 }
 
 /// Prepare the witness for [`SpendableInit`]:
-/// `(pre_cm_anchor, creation_set, present_nf)`.
+/// `(pre_cm_anchor, creation_set, creation_epoch, present_nf, nf_seq,
+/// complement_seq)`.
+///
+/// `window` is the complete covering sequence, one member per epoch of the
+/// derivation header's range; `present_nf` is the member the read forces,
+/// and the complement is the window's runs on both sides of the creation
+/// epoch, multiplied.
 #[must_use]
+#[expect(
+    clippy::indexing_slicing,
+    clippy::as_conversions,
+    reason = "the derivation header's range covers the window"
+)]
 pub fn spendable_init(
-    (_left, _right): (StepLeft<SpendableInit>, StepRight<SpendableInit>),
+    (deriv, _right): (StepLeft<SpendableInit>, StepRight<SpendableInit>),
     pre_cm_anchor: Anchor,
     creation_tgs: &[Tachygram],
-    present_nf: Nullifier,
+    creation_epoch: EpochIndex,
+    window: &[Nullifier],
 ) -> StepWitness<'static, SpendableInit> {
+    let (_, deriv_start, ..) = deriv;
+    let lo = (creation_epoch.0 - deriv_start.0) as usize;
+    let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
+        * NfSeqPoly::new(creation_epoch.next(), &window[lo + 1..]);
     (
         pre_cm_anchor,
         creation_tgs.iter().copied().collect::<TachygramSetPoly>(),
-        present_nf,
+        creation_epoch,
+        window[lo],
+        NfSeqPoly::new(deriv_start, window),
+        complement_seq,
+    )
+}
+
+/// Prepare the witness for [`SpendBind`]:
+/// `(nf_seq, complement_seq, nf_next)`.
+///
+/// `window` is the complete covering sequence, one member per epoch of the
+/// derivation header's range; `nf_next` is the next epoch's member, and the
+/// complement is the window's runs on both sides of the read pair,
+/// multiplied. The pair read requires the derivation range to extend at
+/// least one epoch past the spendable's epoch.
+#[must_use]
+#[expect(
+    clippy::indexing_slicing,
+    clippy::as_conversions,
+    reason = "the derivation header's range covers the window"
+)]
+pub fn spend_bind(
+    (spendable, deriv): (StepLeft<SpendBind>, StepRight<SpendBind>),
+    window: &[Nullifier],
+) -> StepWitness<'static, SpendBind> {
+    let (_, (epoch, _), _) = spendable;
+    let (_, deriv_start, ..) = deriv;
+    let lo = (epoch.0 - deriv_start.0) as usize;
+    let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
+        * NfSeqPoly::new(EpochIndex(epoch.0 + 2), &window[lo + 2..]);
+    (
+        NfSeqPoly::new(deriv_start, window),
+        complement_seq,
+        window[lo + 1],
     )
 }
 

--- a/crates/tachyon/tests/integration/bundle.rs
+++ b/crates/tachyon/tests/integration/bundle.rs
@@ -603,7 +603,7 @@ fn duplicated_spend_cannot_inflate() {
 
     // Build one honest spend with a trapdoor and randomizer we control, so the
     // duplicated bundle's binding and action signatures can be reproduced.
-    let range = wallet.nullifier_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
+    let range = wallet.derivation_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
     let rcv = value::Trapdoor::random(rng);
     let theta = ActionEntropy::random(rng);
     let plan = action::Plan::spend(note, theta, rcv, |alpha| {

--- a/crates/tachyon/tests/integration/fixtures.rs
+++ b/crates/tachyon/tests/integration/fixtures.rs
@@ -1,7 +1,7 @@
 extern crate alloc;
 
 use alloc::{collections::BTreeMap, vec, vec::Vec};
-use core::{array, cell::RefCell, iter, ops::RangeInclusive};
+use core::{cell::RefCell, iter, ops::RangeInclusive};
 
 use ff::{Field as _, PrimeField as _};
 use pasta_curves::Fp;
@@ -20,7 +20,7 @@ use zcash_tachyon::{
     entropy::{ActionEntropy, ActionRandomizer},
     keys::{NoteMasterKey, PaymentKey, ProofAuthorizingKey, private},
     note::{self, Note},
-    nullifier::{self, Nullifier},
+    nullifier::{self, NF_DERIVATION_WIDTH, Nullifier},
     stamp::{
         PointerStamp, ProofStamp, StampState,
         proof::{
@@ -590,10 +590,11 @@ pub(crate) fn build_unspent_pcd_between_anchors<RNG: CryptoRng>(
 
 /// Fuse contiguous [`ArbitraryUnspent`] chains as a binary tree: split at the
 /// midpoint, fuse each half, then concatenate the halves at their shared epoch
-/// ([`UnspentFuse`]). Every seam is intra-epoch, since a boundary is itself a
-/// chain link. Everything a seam needs is read off the halves' headers; a
-/// chain's elapsed slice is `nf[epoch_start - base..epoch_end - base]` (one
-/// nullifier per crossed boundary).
+/// ([`UnspentFuse`]). Every seam is a shared junction, since a boundary is
+/// itself a chain link. Everything a seam needs is read off the halves'
+/// headers; a chain's member slice is
+/// `nf[epoch_start - base..=epoch_last - base]` (one nullifier per covered
+/// epoch).
 fn fuse_unspent_tree<RNG: CryptoRng>(
     rng: &mut RNG,
     nf: &[Nullifier],
@@ -611,14 +612,14 @@ fn fuse_unspent_tree<RNG: CryptoRng>(
     let elapsed_slice = |lo: EpochIndex, hi: EpochIndex| -> &[Nullifier] {
         let from = usize::try_from(u64::from(lo - base)).expect("epoch within span");
         let to = usize::try_from(u64::from(hi - base)).expect("epoch within span");
-        &nf[from..to]
+        &nf[from..=to]
     };
-    let (_, (left_epoch_start, _), _, (left_epoch_end, _), _) = *left.data();
-    let (_, (right_epoch_start, _), _, (right_epoch_end, _), _) = *right.data();
-    let left_el = elapsed_slice(left_epoch_start, left_epoch_end);
-    let right_el = elapsed_slice(right_epoch_start, right_epoch_end);
+    let (_, (left_epoch_start, _), _, (left_epoch_last, _), _) = *left.data();
+    let (_, (right_epoch_start, _), _, (right_epoch_last, _), _) = *right.data();
+    let left_el = elapsed_slice(left_epoch_start, left_epoch_last);
+    let right_el = elapsed_slice(right_epoch_start, right_epoch_last);
     assert_eq!(
-        right_epoch_start.0, left_epoch_end.0,
+        right_epoch_start.0, left_epoch_last.0,
         "fused chains must meet inside one epoch"
     );
     let witness = witness::unspent_fuse((*left.data(), *right.data()), left_el, right_el);
@@ -653,9 +654,21 @@ fn note_stream_seed(pk: PaymentKey, value: u64) -> [u8; 32] {
 pub struct WalletSim {
     pub sk: private::SpendingKey,
     pub pak: ProofAuthorizingKey,
+    /// One note-material stream per requested value, each seeded
+    /// deterministically from `(sk, value)` (independent of any caller
+    /// RNG). `random_note(value)` draws the next note from that value's
+    /// stream, so the k-th note of a given value is identical across every
+    /// wallet built from the same `sk`, and its `cm` collides, reusing
+    /// shared per-note work. Keying by value keeps distinct asks independent:
+    /// different values draw from disjoint field sequences, and interleaved
+    /// draws of other values never shift a stream's position.
     pub notes: RefCell<BTreeMap<u64, StdRng>>,
+    /// Per-note master seed PCDs, keyed by the note's `cm` tachygram.
     pub masters: RefCell<BTreeMap<Tachygram, Pcd<delegation::NfMasterHeader>>>,
-    pub derivations: RefCell<BTreeMap<(Tachygram, u32, u32), Pcd<delegation::NullifierHeader>>>,
+    /// Per-(note, range) derivation PCDs, keyed by `(cm, epoch_start,
+    /// epoch_end)`: repeated derivations of the same exact range share the
+    /// proof.
+    pub derivations: RefCell<BTreeMap<(Tachygram, u32, u32), Pcd<delegation::NullifierDerivation>>>,
 }
 
 impl WalletSim {
@@ -698,10 +711,25 @@ impl WalletSim {
     }
 
     #[must_use]
+    /// The covering sequence's members over a derivation PCD's range, one
+    /// per epoch, for the witness builders to segment.
+    pub fn covering_window(
+        &self,
+        note: &Note,
+        range: &Pcd<delegation::NullifierDerivation>,
+    ) -> Vec<Nullifier> {
+        let (_, start, _, end) = *range.data();
+        (start.0..end.0)
+            .map(|epoch| self.nf_at(note, EpochIndex(epoch)))
+            .collect()
+    }
+
     pub fn nf_at(&self, note: &Note, epoch: EpochIndex) -> Nullifier {
         self.mk(note).derive_nullifier(epoch)
     }
 
+    /// The certified master-key seed PCD for this note, cached by `cm`. The
+    /// note is witnessed once; every window fuses against the same seed.
     pub fn master_pcd<RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
@@ -712,77 +740,81 @@ impl WalletSim {
             return pcd.clone();
         }
         let (pcd, ()) = PROOF_SYSTEM
-            .seed(rng, delegation::NfMasterSeed, (note, self.pak))
-            .expect("note seed");
+            .seed(
+                rng,
+                delegation::NfMasterSeed,
+                witness::nf_master_seed(((), ()), note, self.pak),
+            )
+            .expect("NfMasterSeed");
+
         self.masters.borrow_mut().insert(cm, pcd.clone());
         pcd
     }
 
-    pub fn nullifier_pcd<RNG: CryptoRng>(
+    /// The certified derivation PCD covering `[epoch_start, epoch_end)`,
+    /// built from whole windows and cached by the covering range.
+    ///
+    /// The first window is the one opened by `epoch_start`'s group; further
+    /// windows chain through [`delegation::NullifierFuse`] until the requested
+    /// bound is covered. Consumers read their own epochs out of the covering
+    /// PCD, so every request inside the same covering range shares one proof.
+    pub fn derivation_pcd<RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         note: Note,
         epoch_start: EpochIndex,
         epoch_end: EpochIndex,
-    ) -> Pcd<delegation::NullifierHeader> {
-        assert!(
-            epoch_end.0 > epoch_start.0,
-            "range must cover at least one epoch"
-        );
-        let key = (
-            Tachygram::from(note.commitment()),
-            epoch_start.0,
-            epoch_end.0,
-        );
+    ) -> Pcd<delegation::NullifierDerivation> {
+        let base = epoch_start.0 - epoch_start.0 % PoseidonFp::RATE as u32;
+        let windows = (epoch_end.0 - base).div_ceil(NF_DERIVATION_WIDTH as u32);
+        let cover_end = base + windows * NF_DERIVATION_WIDTH as u32;
+        let key = (Tachygram::from(note.commitment()), base, cover_end);
         if let Some(pcd) = self.derivations.borrow().get(&key) {
             return pcd.clone();
         }
         let master = self.master_pcd(rng, note);
 
-        let width = u32::try_from(PoseidonFp::RATE).expect("group width fits");
-        let mut nfs: Vec<Nullifier> = Vec::new();
-        let mut acc: Option<Pcd<delegation::NullifierHeader>> = None;
-        let mut window = epoch_start.0 - epoch_start.0 % width;
-        while window < epoch_end.0 {
-            let mask: [bool; PoseidonFp::RATE] = array::from_fn(|j| {
-                let epoch = window + u32::try_from(j).expect("window offset fits");
-                (epoch_start.0..epoch_end.0).contains(&epoch)
-            });
-            let derive_witness = witness::nf_derive((*master.data(), ()), EpochIndex(window), mask);
-            let (piece, ()) = PROOF_SYSTEM
+        let mut merged: Option<Pcd<delegation::NullifierDerivation>> = None;
+        for window in 0..windows {
+            let chunk_start = EpochIndex(base + window * NF_DERIVATION_WIDTH as u32);
+            let chunk_end = EpochIndex(chunk_start.0 + NF_DERIVATION_WIDTH as u32);
+            let (leaf, ()) = PROOF_SYSTEM
                 .fuse(
                     rng,
                     delegation::NfDerive,
-                    derive_witness,
+                    witness::nf_derive((*master.data(), ()), chunk_start),
                     master.clone(),
                     Proof::trivial().carry::<()>(()),
                 )
                 .expect("NfDerive");
-            let (_, (piece_start, _), _, (piece_end, _)) = *piece.data();
-            let piece_nfs: Vec<Nullifier> = (piece_start.0..piece_end.0)
-                .map(|epoch| self.nf_at(&note, EpochIndex(epoch)))
-                .collect();
-            acc = Some(match acc {
-                None => piece,
+            merged = Some(match merged {
+                None => leaf,
                 Some(left) => {
-                    let mut merged = nfs.clone();
-                    merged.extend_from_slice(&piece_nfs);
-                    let fuse_witness = (
-                        nfs.iter().copied().collect(),
-                        merged.into_iter().collect(),
-                        piece_nfs.iter().copied().collect(),
-                    );
+                    let left_nfs: Vec<Nullifier> = (base..chunk_start.0)
+                        .map(|epoch| self.nf_at(&note, EpochIndex(epoch)))
+                        .collect();
+                    let right_nfs: Vec<Nullifier> = (chunk_start.0..chunk_end.0)
+                        .map(|epoch| self.nf_at(&note, EpochIndex(epoch)))
+                        .collect();
                     let (fused, ()) = PROOF_SYSTEM
-                        .fuse(rng, delegation::NullifierFuse, fuse_witness, left, piece)
+                        .fuse(
+                            rng,
+                            delegation::NullifierFuse,
+                            witness::nullifier_fuse(
+                                (*left.data(), *leaf.data()),
+                                &left_nfs,
+                                &right_nfs,
+                            ),
+                            left,
+                            leaf,
+                        )
                         .expect("NullifierFuse");
                     fused
                 },
             });
-            nfs.extend_from_slice(&piece_nfs);
-            window += width;
         }
+        let pcd = merged.expect("nonempty range");
 
-        let pcd = acc.expect("nonempty range produced a derivation");
         self.derivations.borrow_mut().insert(key, pcd.clone());
         pcd
     }
@@ -796,7 +828,6 @@ impl WalletSim {
     ) -> Pcd<spendable::SpendableHeader> {
         let cm = note.commitment();
         let epoch = init_height.epoch();
-        let present_nf = self.nf_at(note, epoch);
         let (pre_cm_anchor, creation_tgs) = {
             let stamps = pool.block(init_height).tachygrams();
             let stamp_commits = pool.block(init_height).stamp_commits();
@@ -814,19 +845,20 @@ impl WalletSim {
 
             (pre_cm_anchor, stamps[cm_idx].clone())
         };
-        let nf_header = self.nullifier_pcd(rng, *note, epoch, epoch.next());
+        let deriv = self.derivation_pcd(rng, *note, epoch, epoch.next());
 
         let (spendable, ()) = PROOF_SYSTEM
             .fuse(
                 rng,
                 spendable::SpendableInit,
                 witness::spendable_init(
-                    (*nf_header.data(), ()),
+                    (*deriv.data(), ()),
                     pre_cm_anchor,
                     &creation_tgs,
-                    present_nf,
+                    epoch,
+                    &self.covering_window(note, &deriv),
                 ),
-                nf_header,
+                deriv,
                 Proof::trivial().carry::<()>(()),
             )
             .expect("SpendableInit");
@@ -852,16 +884,19 @@ impl WalletSim {
         note: &Note,
     ) -> Pcd<pool::Unspent> {
         let (_, (epoch_start, _), _, (present_epoch, _), _) = *arbitrary.data();
-        let len = present_epoch.0 - epoch_start.0 + 1;
-        let range = self.nullifier_pcd(rng, *note, epoch_start, EpochIndex(epoch_start.0 + len));
-        let elapsed: Vec<Nullifier> = (epoch_start.0..present_epoch.0)
+        let range = self.derivation_pcd(rng, *note, epoch_start, present_epoch.next());
+        let elapsed: Vec<Nullifier> = (epoch_start.0..=present_epoch.0)
             .map(|epoch| self.nf_at(note, EpochIndex(epoch)))
             .collect();
         let (unspent, ()) = PROOF_SYSTEM
             .fuse(
                 rng,
                 pool::UnspentBind,
-                witness::unspent_bind((*arbitrary.data(), *range.data()), &elapsed),
+                witness::unspent_bind(
+                    (*arbitrary.data(), *range.data()),
+                    &self.covering_window(note, &range),
+                    &elapsed,
+                ),
                 arbitrary,
                 range,
             )
@@ -922,7 +957,7 @@ impl WalletSim {
         let mut spend_pcds = Vec::with_capacity(spends.len());
         for (note, spendable_pcd, spend_epoch) in spends {
             let range_pcd =
-                self.nullifier_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
+                self.derivation_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
             let rcv = value::Trapdoor::random(rng);
             let theta = ActionEntropy::random(rng);
             let plan = action::Plan::spend(note, theta, rcv, |alpha| {

--- a/crates/tachyon/tests/integration/main.rs
+++ b/crates/tachyon/tests/integration/main.rs
@@ -1,5 +1,6 @@
 #![allow(
     clippy::as_conversions,
+    clippy::cast_possible_truncation,
     clippy::expect_used,
     clippy::indexing_slicing,
     clippy::integer_division_remainder_used,

--- a/crates/tachyon/tests/integration/proof.rs
+++ b/crates/tachyon/tests/integration/proof.rs
@@ -1,11 +1,11 @@
-//! Proof-step tests: `StampLift`, `SpendBind` / `SpendStamp`, the nullifier
-//! derivation chain, `ArbitraryUnspent` composition, and the `Spendable*`
-//! lineage.
+//! Proof-step tests: `StampLift`, `SpendBind` / `SpendStamp`, the flat
+//! nullifier-derivation chain, `ArbitraryUnspent` composition, and the
+//! `Spendable*` lineage.
 
 extern crate alloc;
 
 use alloc::{string::ToString as _, vec, vec::Vec};
-use core::array;
+use core::{array, iter};
 
 use ff::Field as _;
 use pasta_curves::Fp;
@@ -19,7 +19,7 @@ use zcash_tachyon::{
     effect,
     entropy::ActionEntropy,
     note,
-    nullifier::{self, Nullifier},
+    nullifier::{self, NF_DERIVATION_WIDTH, Nullifier},
     stamp::proof::{PROOF_SYSTEM, delegation, output, pool, spend, spendable, stamp},
     value, witness,
 };
@@ -57,10 +57,13 @@ fn honest_spend_bind(
     spendable: Pcd<spendable::SpendableHeader>,
     spend_epoch: EpochIndex,
 ) -> Pcd<spend::SpendHeader> {
-    let derived = user.nullifier_pcd(rng, *note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
-    let nf_next = user.nf_at(note, spend_epoch.next());
+    let derived = user.derivation_pcd(rng, *note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
+    let witness = witness::spend_bind(
+        (*spendable.data(), *derived.data()),
+        &user.covering_window(note, &derived),
+    );
     let (bind_pcd, ()) = PROOF_SYSTEM
-        .fuse(rng, spend::SpendBind, (nf_next,), spendable, derived)
+        .fuse(rng, spend::SpendBind, witness, spendable, derived)
         .expect("SpendBind honest");
     bind_pcd
 }
@@ -94,8 +97,8 @@ fn same_epoch_honest_spend_accepted() {
     let epoch = cm_height.epoch();
 
     let spendable = user.spendable_init(rng, &note, &pool, cm_height);
-    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable, epoch);
-    let stamp = honest_spend_stamp(rng, &user, &note, spend_pcd);
+    let bind_pcd = honest_spend_bind(rng, &user, &note, spendable, epoch);
+    let stamp = honest_spend_stamp(rng, &user, &note, bind_pcd);
 
     let expected = TachygramSetPoly::from_iter([
         user.nf_at(&note, epoch).into(),
@@ -145,8 +148,7 @@ fn spendable_init_rejects_tg_absent() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let nf_header = user.nullifier_pcd(rng, note, EpochIndex(0), EpochIndex(1));
-    let present_nf = user.nf_at(&note, EpochIndex(0));
+    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
     let absent_tg = Tachygram::from(Fp::random(&mut *rng));
 
     let err = PROOF_SYSTEM
@@ -157,7 +159,8 @@ fn spendable_init_rejects_tg_absent() {
                 (*nf_header.data(), ()),
                 Anchor::default(),
                 &[absent_tg],
-                present_nf,
+                EpochIndex(0),
+                &user.covering_window(&note, &nf_header),
             ),
             nf_header,
             Proof::trivial().carry::<()>(()),
@@ -175,7 +178,8 @@ fn unspent_seed_rejects_tg_present() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
-    let nf = user.nf_at(&note, EpochIndex(0));
+    let mk = user.pak.nk.derive_note_private(note.psi);
+    let nf = mk.derive_nullifier(EpochIndex(0));
 
     let start = Anchor::default();
 
@@ -212,7 +216,7 @@ fn unspent_fuse_rejects_invalid_compositions() {
         let nf_b = Nullifier::from(Fp::random(&mut *rng));
         let shard_a = build_unspent_seed_pcd(rng, start, EpochIndex(0), &stamps_left.clone(), nf_a);
         let shard_b = build_unspent_seed_pcd(rng, mid, EpochIndex(0), &stamps_right.clone(), nf_b);
-        let w = witness::unspent_fuse((*shard_a.data(), *shard_b.data()), &[], &[]);
+        let w = witness::unspent_fuse((*shard_a.data(), *shard_b.data()), &[nf_a], &[nf_b]);
         let err = PROOF_SYSTEM
             .fuse(rng, pool::UnspentFuse, w, shard_a, shard_b)
             .err()
@@ -232,7 +236,7 @@ fn unspent_fuse_rejects_invalid_compositions() {
         let nf = Nullifier::from(Fp::random(&mut *rng));
         let shard_a = build_unspent_seed_pcd(rng, start, EpochIndex(0), &stamps_left, nf);
         let shard_b = build_unspent_seed_pcd(rng, start, EpochIndex(0), &stamps_right, nf);
-        let w = witness::unspent_fuse((*shard_a.data(), *shard_b.data()), &[], &[]);
+        let w = witness::unspent_fuse((*shard_a.data(), *shard_b.data()), &[nf], &[nf]);
         let err = PROOF_SYSTEM
             .fuse(rng, pool::UnspentFuse, w, shard_a, shard_b)
             .err()
@@ -358,9 +362,10 @@ fn spend_bind_honest() {
     let spend_epoch = height.epoch();
     let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
 
-    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd, spend_epoch);
-    let (_cm, present_nf, _nf_next, _anchor) = *spend_pcd.data();
+    let bind_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd, spend_epoch);
+    let (_cm, present_nf, nf_next, _anchor) = *bind_pcd.data();
     assert_eq!(present_nf, user.nf_at(&note, spend_epoch));
+    assert_eq!(nf_next, user.nf_at(&note, spend_epoch.next()));
 }
 
 #[test]
@@ -381,11 +386,6 @@ fn spend_stamp_rejects_invalid_note() {
     };
     assert_eq!(Fp::from(note.psi), Fp::from(phantom.psi), "shared psi");
     assert_ne!(note.commitment(), phantom.commitment(), "distinct cm");
-    assert_eq!(
-        user.nf_at(&note, spend_epoch),
-        user.nf_at(&phantom, spend_epoch),
-        "shared psi yields shared nullifiers"
-    );
 
     let wrong_value = value::Positive::try_from(999_999u64).expect("test value in range");
     assert_ne!(u64::from(wrong_value), u64::from(note.value));
@@ -436,100 +436,6 @@ fn spend_stamp_rejects_invalid_note() {
         };
         assert_eq!(inner.to_string(), expected, "{label}");
     }
-}
-
-#[test]
-fn spend_bind_rejects_forged_next() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    pool.mine(random_block_with(rng, &[vec![note.commitment()]], 4));
-    let height = pool.height();
-    let spend_epoch = height.epoch();
-    let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
-
-    let derived = user.nullifier_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
-    let forged_next = Nullifier::from(Fp::random(&mut *rng));
-
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            spend::SpendBind,
-            (forged_next,),
-            spendable_pcd,
-            derived,
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "SpendBind: next nullifier is not the range's end leaf"
-    );
-}
-
-#[test]
-fn spend_bind_rejects_range_from_another_epoch() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    pool.mine(random_block_with(rng, &[vec![note.commitment()]], 4));
-    let height = pool.height();
-    let spend_epoch = height.epoch();
-    let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
-
-    // The note's own live pair, but for an epoch the lineage has not reached.
-    let ahead = spend_epoch.next();
-    let derived = user.nullifier_pcd(rng, note, ahead, EpochIndex(ahead.0 + 2));
-
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            spend::SpendBind,
-            (user.nf_at(&note, ahead.next()),),
-            spendable_pcd,
-            derived,
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "SpendBind: live range does not start at the lineage epoch"
-    );
-}
-
-#[test]
-fn spend_bind_rejects_zero_next_nullifier() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    pool.mine(random_block_with(rng, &[vec![note.commitment()]], 4));
-    let height = pool.height();
-    let spend_epoch = height.epoch();
-    let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
-
-    let derived = user.nullifier_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
-    let zero_next = Nullifier::from(Fp::ZERO);
-
-    let err = PROOF_SYSTEM
-        .fuse(rng, spend::SpendBind, (zero_next,), spendable_pcd, derived)
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "SpendBind: next nullifier is not the range's end leaf"
-    );
 }
 
 /// Zero-value notes are valid, so both stamping steps accept them: an output
@@ -617,8 +523,8 @@ fn spend_after_lift_publishes_anchor_epoch_nullifiers() {
     let unspent = sync.build_next_unspent(rng, 0, &pool, target_height);
     let lifted = user.lift(rng, spendable, unspent, &note);
 
-    let spend_pcd = honest_spend_bind(rng, &user, &note, lifted, EpochIndex(1));
-    let (_cm, present_nf, _nf_next, _anchor) = *spend_pcd.data();
+    let bind_pcd = honest_spend_bind(rng, &user, &note, lifted, EpochIndex(1));
+    let (_cm, present_nf, _nf_next, _anchor) = *bind_pcd.data();
     assert_eq!(
         present_nf,
         user.nf_at(&note, EpochIndex(1)),
@@ -630,7 +536,7 @@ fn spend_after_lift_publishes_anchor_epoch_nullifiers() {
         "nf_0 was consumed by the lift"
     );
 
-    let stamp = honest_spend_stamp(rng, &user, &note, spend_pcd);
+    let stamp = honest_spend_stamp(rng, &user, &note, bind_pcd);
     let expected = TachygramSetPoly::from_iter([
         user.nf_at(&note, EpochIndex(1)).into(),
         user.nf_at(&note, EpochIndex(2)).into(),
@@ -650,8 +556,8 @@ fn spend_stamp_assembles_tachygrams() {
     let spend_epoch = height.epoch();
     let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
 
-    let spend_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd, spend_epoch);
-    let stamp_pcd = honest_spend_stamp(rng, &user, &note, spend_pcd);
+    let bind_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd, spend_epoch);
+    let stamp_pcd = honest_spend_stamp(rng, &user, &note, bind_pcd);
     let (_actions, tg_commit, _anchor) = *stamp_pcd.data();
     let expected = TachygramSetPoly::from_iter([
         Tachygram::from(user.nf_at(&note, spend_epoch)),
@@ -659,32 +565,6 @@ fn spend_stamp_assembles_tachygrams() {
     ])
     .commit();
     assert_eq!(tg_commit, expected);
-}
-
-#[test]
-fn notes_with_shared_psi_share_nullifiers() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let note_a = user.random_note(500);
-    let note_b = Note {
-        value: value::Positive::try_from(700u64).expect("test value in range"),
-        rcm: note::CommitmentTrapdoor::random(rng),
-        ..note_a
-    };
-    assert_eq!(Fp::from(note_a.psi), Fp::from(note_b.psi), "shared psi");
-    assert_ne!(
-        note_a.commitment(),
-        note_b.commitment(),
-        "distinct (rcm, value) yields distinct cm"
-    );
-
-    for epoch in 0..4u32 {
-        assert_eq!(
-            user.nf_at(&note_a, EpochIndex(epoch)),
-            user.nf_at(&note_b, EpochIndex(epoch)),
-            "shared psi yields shared nullifiers at epoch {epoch}"
-        );
-    }
 }
 
 #[test]
@@ -863,26 +743,26 @@ fn unspent_fuse_composes() {
         .fuse(
             rng,
             pool::UnspentFuse,
-            witness::unspent_fuse((*left.data(), *right.data()), &[nf0, nf1], &[nf2]),
+            witness::unspent_fuse((*left.data(), *right.data()), &[nf0, nf1, nf2], &[nf2, nf3]),
             left,
             right,
         )
         .expect("UnspentFuse mid-epoch with multi-epoch halves");
 
-    let (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_end, nf_end), anchor_last) =
+    let (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_last, nf_last), anchor_last) =
         *fused.data();
     assert_eq!(anchor_prev, start);
     assert_eq!(anchor_last, end);
     assert_eq!(
         elapsed,
-        NfSeqPoly::from_iter([nf0, nf1, nf2]).commit(),
-        "left's sentinel cancels at X^2 and right's crossing lands in its slot"
+        NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2, nf3]).commit(),
+        "the junction member appears once in the combined sequence"
     );
     assert_eq!(nf_start, nf0);
-    assert_eq!(nf_end, nf3, "tip advances to the right half's present nf");
+    assert_eq!(nf_last, nf3, "tip advances to the right half's present nf");
     assert_eq!(epoch_start.0, 0);
     assert_eq!(
-        epoch_end.0, 3,
+        epoch_last.0, 3,
         "merged range spans the boundary the right half crossed"
     );
 }
@@ -890,15 +770,15 @@ fn unspent_fuse_composes() {
 #[test]
 fn unspent_fuse_rejects_wrong_left_seq() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (nf0, nf1, nf2, _nf3, left, right) = multi_epoch_fuse_setup(rng);
+    let (nf0, nf1, nf2, nf3, left, right) = multi_epoch_fuse_setup(rng);
     let err = PROOF_SYSTEM
         .fuse(
             rng,
             pool::UnspentFuse,
             (
-                NfSeqPoly::from_iter([nf1, nf0]),
-                NfSeqPoly::from_iter([nf0, nf1, nf2]),
-                NfSeqPoly::from_iter([nf2]),
+                NfSeqPoly::new(EpochIndex(0), &[nf1, nf0, nf2]),
+                NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2, nf3]),
+                NfSeqPoly::new(EpochIndex(2), &[nf2, nf3]),
             ),
             left,
             right,
@@ -923,9 +803,9 @@ fn unspent_fuse_rejects_wrong_right_seq() {
             rng,
             pool::UnspentFuse,
             (
-                NfSeqPoly::from_iter([nf0, nf1]),
-                NfSeqPoly::from_iter([nf0, nf1, nf2]),
-                NfSeqPoly::from_iter([nf3]),
+                NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2]),
+                NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2, nf3]),
+                NfSeqPoly::new(EpochIndex(2), &[nf3, nf2]),
             ),
             left,
             right,
@@ -944,17 +824,18 @@ fn unspent_fuse_rejects_wrong_right_seq() {
 #[test]
 fn unspent_fuse_rejects_wrong_combined() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (nf0, nf1, nf2, _nf3, left, right) = multi_epoch_fuse_setup(rng);
-    // Both halves honest; `combined` forged as the right half alone. At offset
-    // 0 this forgery satisfies the degenerate identity, so it must fail here.
+    let (nf0, nf1, nf2, nf3, left, right) = multi_epoch_fuse_setup(rng);
+    // Both halves honest; `combined` forged as the right half alone. The
+    // right half carries two members, so the dedup identity is
+    // non-degenerate and the forgery must fail here.
     let err = PROOF_SYSTEM
         .fuse(
             rng,
             pool::UnspentFuse,
             (
-                NfSeqPoly::from_iter([nf0, nf1]),
-                NfSeqPoly::from_iter([nf2]),
-                NfSeqPoly::from_iter([nf2]),
+                NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2]),
+                NfSeqPoly::new(EpochIndex(2), &[nf2, nf3]),
+                NfSeqPoly::new(EpochIndex(2), &[nf2, nf3]),
             ),
             left,
             right,
@@ -996,7 +877,7 @@ fn unspent_fuse_rejects_epoch_boundary_crossing() {
         .fuse(
             rng,
             pool::UnspentFuse,
-            witness::unspent_fuse((*left.data(), *forged_right.data()), &[], &[]),
+            witness::unspent_fuse((*left.data(), *forged_right.data()), &[nf0], &[nf1]),
             left,
             forged_right,
         )
@@ -1084,7 +965,7 @@ fn end_epoch_unspent_seed_composes_across_a_boundary() {
         .fuse(
             rng,
             pool::UnspentFuse,
-            witness::unspent_fuse((*left.data(), *seed.data()), &[nf0, nf1], &[nf2]),
+            witness::unspent_fuse((*left.data(), *seed.data()), &[nf0, nf1, nf2], &[nf2, nf3]),
             left,
             seed,
         )
@@ -1094,25 +975,57 @@ fn end_epoch_unspent_seed_composes_across_a_boundary() {
         .fuse(
             rng,
             pool::UnspentFuse,
-            witness::unspent_fuse((*crossed.data(), *right.data()), &[nf0, nf1, nf2], &[nf3]),
+            witness::unspent_fuse(
+                (*crossed.data(), *right.data()),
+                &[nf0, nf1, nf2, nf3],
+                &[nf3, nf4],
+            ),
             crossed,
             right,
         )
         .expect("UnspentFuse onto the right half");
 
-    let (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_end, nf_end), anchor_last) =
+    let (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_last, nf_last), anchor_last) =
         *fused.data();
     assert_eq!(anchor_prev, start);
     assert_eq!(anchor_last, end);
     assert_eq!(epoch_start.0, 0);
     assert_eq!(nf_start, nf0);
-    assert_eq!(epoch_end.0, 4);
-    assert_eq!(nf_end, nf4, "tip is the right half's present nf");
+    assert_eq!(epoch_last.0, 4);
+    assert_eq!(nf_last, nf4, "tip is the right half's present nf");
     assert_eq!(
         elapsed,
-        NfSeqPoly::from_iter([nf0, nf1, nf2, nf3]).commit(),
-        "the crossing seed carries left's tip into the merged history"
+        NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2, nf3, nf4]).commit(),
+        "the crossing seed shares a member with each half it joins"
     );
+}
+
+/// Zero is reserved and never a genuine member; the crossing seed's guards
+/// reject it outright.
+#[test]
+fn end_epoch_unspent_seed_rejects_a_zero_member() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let anchor = Anchor::from(Fp::random(&mut *rng));
+    let nf = Nullifier::from(Fp::random(&mut *rng));
+    let zero = Nullifier::from(Fp::ZERO);
+
+    for (nf_prev, incoming, expected) in [
+        (zero, nf, "EndEpochUnspentSeed: outgoing nullifier is zero"),
+        (nf, zero, "EndEpochUnspentSeed: incoming nullifier is zero"),
+    ] {
+        let err = PROOF_SYSTEM
+            .seed(
+                rng,
+                pool::EndEpochUnspentSeed,
+                witness::end_epoch_unspent_seed(((), ()), anchor, EpochIndex(4), nf_prev, incoming),
+            )
+            .err()
+            .unwrap_or_else(|| panic!("EndEpochUnspentSeed accepted {expected}"));
+        let ragu::Error::InvalidWitness(inner) = err else {
+            panic!("expected InvalidWitness for {expected}, got {err:?}");
+        };
+        assert_eq!(inner.to_string(), expected);
+    }
 }
 
 /// The seed spans exactly one boundary link, recording the epoch it leaves.
@@ -1131,7 +1044,7 @@ fn end_epoch_unspent_seed_spans_one_boundary_link() {
         )
         .expect("EndEpochUnspentSeed");
 
-    let (anchor_prev, (epoch_start, seed_nf_start), elapsed, (epoch_end, nf_end), anchor_last) =
+    let (anchor_prev, (epoch_start, seed_nf_start), elapsed, (epoch_last, nf_last), anchor_last) =
         *seed.data();
     assert_eq!(anchor_prev, epoch_tip);
     assert_eq!(
@@ -1140,13 +1053,13 @@ fn end_epoch_unspent_seed_spans_one_boundary_link() {
         "the segment covers the boundary tick"
     );
     assert_eq!(epoch_start, EpochIndex(4));
-    assert_eq!(epoch_end, EpochIndex(5), "one boundary crossed");
+    assert_eq!(epoch_last, EpochIndex(5), "one boundary crossed");
     assert_eq!(seed_nf_start, nf_prev);
-    assert_eq!(nf_end, nf);
+    assert_eq!(nf_last, nf);
     assert_eq!(
         elapsed,
-        NfSeqPoly::from_iter([nf_prev]).commit(),
-        "the crossing records the epoch it leaves"
+        NfSeqPoly::new(EpochIndex(4), &[nf_prev, nf]).commit(),
+        "the crossing records the epoch it leaves and the one it enters"
     );
 }
 
@@ -1275,12 +1188,19 @@ fn unspent_span_starting_on_a_boundary_anchor() {
         ],
         (start_anchor, pool.block(target_height).anchor()),
     );
-    let (_, (epoch_start, _), elapsed, (epoch_end, _), _) = *arbitrary.data();
+    let (_, (epoch_start, _), elapsed, (epoch_last, _), _) = *arbitrary.data();
     assert_eq!(epoch_start, EpochIndex(1));
-    assert_eq!(epoch_end, EpochIndex(2));
+    assert_eq!(epoch_last, EpochIndex(2));
     assert_eq!(
         elapsed,
-        NfSeqPoly::from_iter([user.nf_at(&note, EpochIndex(1))]).commit(),
+        NfSeqPoly::new(
+            EpochIndex(1),
+            &[
+                user.nf_at(&note, EpochIndex(1)),
+                user.nf_at(&note, EpochIndex(2)),
+            ],
+        )
+        .commit(),
         "only the crossing out of the silent epoch, not the one into it"
     );
 
@@ -1327,13 +1247,20 @@ fn unspent_span_ending_on_a_boundary_anchor() {
         ],
         (spendable.data().2, pool.block(target_height).anchor()),
     );
-    let (_, (epoch_start, _), elapsed, (epoch_end, _), anchor_last) = *arbitrary.data();
+    let (_, (epoch_start, _), elapsed, (epoch_last, _), anchor_last) = *arbitrary.data();
     assert_eq!(epoch_start, EpochIndex(0));
-    assert_eq!(epoch_end, EpochIndex(1), "the span stops on the crossing");
+    assert_eq!(epoch_last, EpochIndex(1), "the span stops on the crossing");
     assert_eq!(anchor_last, pool.block(target_height).anchor());
     assert_eq!(
         elapsed,
-        NfSeqPoly::from_iter([user.nf_at(&note, EpochIndex(0))]).commit()
+        NfSeqPoly::new(
+            EpochIndex(0),
+            &[
+                user.nf_at(&note, EpochIndex(0)),
+                user.nf_at(&note, EpochIndex(1)),
+            ],
+        )
+        .commit()
     );
 
     let lifted = user.lift(rng, spendable, arbitrary, &note);
@@ -1377,17 +1304,21 @@ fn end_epoch_unspent_seed_crosses_a_stampless_epoch() {
         ],
         (spendable.data().2, pool.block(target_height).anchor()),
     );
-    let (_, (epoch_start, _), elapsed, (epoch_end, _), _) = *arbitrary.data();
+    let (_, (epoch_start, _), elapsed, (epoch_last, _), _) = *arbitrary.data();
     assert_eq!(epoch_start, EpochIndex(0));
-    assert_eq!(epoch_end, EpochIndex(2));
+    assert_eq!(epoch_last, EpochIndex(2));
     assert_eq!(
         elapsed,
-        NfSeqPoly::from_iter([
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1)),
-        ])
+        NfSeqPoly::new(
+            EpochIndex(0),
+            &[
+                user.nf_at(&note, EpochIndex(0)),
+                user.nf_at(&note, EpochIndex(1)),
+                user.nf_at(&note, EpochIndex(2)),
+            ],
+        )
         .commit(),
-        "both crossings recorded, including the one over the silent epoch"
+        "every covered epoch's member recorded, including the silent epoch's"
     );
 
     let lifted = user.lift(rng, spendable, arbitrary, &note);
@@ -1412,39 +1343,29 @@ fn unspent_bind_rejects_tip_mismatch() {
     let mut sync = SyncSim::new();
     sync.accept_delegation(
         0,
-        alloc::vec![
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1)),
-            user.nf_at(&note, EpochIndex(2)),
-            wrong_tip
-        ],
+        alloc::vec![user.nf_at(&note, EpochIndex(0)), wrong_tip],
         init_height,
         start_anchor,
     );
-    let target_height = BlockHeight(3 * EPOCH_SIZE);
+    let target_height = BlockHeight(EPOCH_SIZE);
     while pool.height() < target_height {
         pool.advance(1, |_| random_block(rng, 1, 2));
     }
     let unspent = sync.build_next_unspent(rng, 0, &pool, target_height);
 
-    // The witnessed polynomials are the genuine derived values; the unspent
-    // header carries the forged tip, so the appended-tip relation rejects the
-    // lineage against the derived range.
-    let range = user.nullifier_pcd(rng, note, EpochIndex(0), EpochIndex(4));
-    let elapsed = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-    ]);
-    let nf_seq = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-        user.nf_at(&note, EpochIndex(3)),
-    ]);
+    // The witnessed sequence matches the header, with the forged tip as its
+    // final member, so the poly bind passes; the divisibility read then
+    // finds no such member in the genuine sequence and rejects it.
+    let (_, _, _, (unspent_last, _), _) = *unspent.data();
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), unspent_last.next());
+    let witness = witness::unspent_bind(
+        (*unspent.data(), *range.data()),
+        &user.covering_window(&note, &range),
+        &[user.nf_at(&note, EpochIndex(0)), wrong_tip],
+    );
 
     let err = PROOF_SYSTEM
-        .fuse(rng, pool::UnspentBind, (elapsed, nf_seq), unspent, range)
+        .fuse(rng, pool::UnspentBind, witness, unspent, range)
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {
@@ -1452,62 +1373,38 @@ fn unspent_bind_rejects_tip_mismatch() {
     };
     assert_eq!(
         inner.to_string(),
-        "UnspentBind: range is not elapsed followed by the tip"
+        "UnspentBind: sequence does not match the derivation"
     );
-}
-
-/// A three-crossing epoch 0..=3 [`pool::ArbitraryUnspent`] lineage from the
-/// block after the note's cm block to a mid-epoch-3 block, for pairing against
-/// derived ranges. Its honest witness polynomials are `elapsed = nf[0..3]`
-/// and `nf_seq = nf[0..4]`, against
-/// `derivation_pcd(.., EpochIndex(0), EpochIndex(4))`.
-fn unspent_bind_setup(rng: &mut StdRng) -> (WalletSim, Note, Pcd<pool::ArbitraryUnspent>) {
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
-    let end_height = BlockHeight(3 * EPOCH_SIZE + 2);
-    while pool.height() < end_height {
-        pool.advance(1, |_| random_block(rng, 1, 2));
-    }
-
-    let unspent = build_unspent_pcd_between_blocks(
-        rng,
-        &pool,
-        &[
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1)),
-            user.nf_at(&note, EpochIndex(2)),
-            user.nf_at(&note, EpochIndex(3)),
-        ],
-        BlockHeight(init_height.0 + 1)..=end_height,
-    );
-    (user, note, unspent)
 }
 
 #[test]
 fn unspent_bind_rejects_elapsed_mismatch() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = unspent_bind_setup(rng);
-    let range = user.nullifier_pcd(rng, note, EpochIndex(0), EpochIndex(4));
-    // The genuine crossings in swapped order commit differently.
-    let bogus_elapsed = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(2)),
-    ]);
-    let nf_seq = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-        user.nf_at(&note, EpochIndex(3)),
-    ]);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    pool.advance(1, |_| random_block(rng, 1, 2));
+
+    let unspent = build_unspent_pcd_between_blocks(
+        rng,
+        &pool,
+        &[user.nf_at(&note, EpochIndex(0))],
+        BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
+    );
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let (_honest_elapsed_seq, nf_seq, complement_seq) = witness::unspent_bind(
+        (*unspent.data(), *range.data()),
+        &user.covering_window(&note, &range),
+        &[user.nf_at(&note, EpochIndex(0))],
+    );
+    let bogus_elapsed = NfSeqPoly::new(EpochIndex(0), &[Nullifier::from(Fp::random(&mut *rng))]);
 
     let err = PROOF_SYSTEM
         .fuse(
             rng,
             pool::UnspentBind,
-            (bogus_elapsed, nf_seq),
+            (bogus_elapsed, nf_seq, complement_seq),
             unspent,
             range,
         )
@@ -1523,24 +1420,34 @@ fn unspent_bind_rejects_elapsed_mismatch() {
 }
 
 #[test]
-fn unspent_bind_rejects_wrong_start_epoch() {
+fn unspent_bind_rejects_uncovered_start() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = unspent_bind_setup(rng);
-    let range = user.nullifier_pcd(rng, note, EpochIndex(1), EpochIndex(5));
-    let elapsed = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-    ]);
-    let nf_seq = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-        user.nf_at(&note, EpochIndex(3)),
-        user.nf_at(&note, EpochIndex(4)),
-    ]);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    pool.advance(1, |_| random_block(rng, 1, 2));
+
+    let unspent = build_unspent_pcd_between_blocks(
+        rng,
+        &pool,
+        &[user.nf_at(&note, EpochIndex(0))],
+        BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
+    );
+    // A derivation whose coverage begins after the unspent's start epoch (a
+    // later window) cannot cover it.
+    // The builder would segment out of range, so the witness is assembled
+    // by hand: the genuine covering sequence, an empty complement.
+    let range = user.derivation_pcd(rng, note, EpochIndex(64), EpochIndex(65));
+    let window = user.covering_window(&note, &range);
+    let witness = (
+        NfSeqPoly::new(EpochIndex(0), &[user.nf_at(&note, EpochIndex(0))]),
+        NfSeqPoly::new(EpochIndex(64), &window),
+        NfSeqPoly::new(EpochIndex(64), &[]),
+    );
 
     let err = PROOF_SYSTEM
-        .fuse(rng, pool::UnspentBind, (elapsed, nf_seq), unspent, range)
+        .fuse(rng, pool::UnspentBind, witness, unspent, range)
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {
@@ -1548,116 +1455,51 @@ fn unspent_bind_rejects_wrong_start_epoch() {
     };
     assert_eq!(
         inner.to_string(),
-        "UnspentBind: derived range does not start at the unspent's start epoch"
+        "UnspentBind: sequence does not match the derivation"
     );
 }
 
+/// The bind needs the tip as well as the crossings, so a derivation
+/// stopping at the unspent's own end epoch does not cover it.
 #[test]
-fn unspent_bind_rejects_wrong_span() {
+fn unspent_bind_rejects_uncovered_end() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = unspent_bind_setup(rng);
-    // A three-crossing lineage demands a range of exactly its crossings plus
-    // the tip (four epochs); a five-epoch range overshoots.
-    let range = user.nullifier_pcd(rng, note, EpochIndex(0), EpochIndex(5));
-    let elapsed = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-    ]);
-    let nf_seq = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-        user.nf_at(&note, EpochIndex(3)),
-        user.nf_at(&note, EpochIndex(4)),
-    ]);
-
-    let err = PROOF_SYSTEM
-        .fuse(rng, pool::UnspentBind, (elapsed, nf_seq), unspent, range)
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "UnspentBind: derived range does not span the crossings plus the tip"
-    );
-}
-
-#[test]
-fn unspent_bind_rejects_wrong_range_poly() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = unspent_bind_setup(rng);
-    let range = user.nullifier_pcd(rng, note, EpochIndex(0), EpochIndex(4));
-    let elapsed = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-    ]);
-    // The genuine range in swapped order commits differently.
-    let bogus_nf_seq = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(2)),
-        user.nf_at(&note, EpochIndex(3)),
-    ]);
-
-    let err = PROOF_SYSTEM
-        .fuse(
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+    // A crossing out of the window's last epoch: its tip sits at the first
+    // epoch the derivation does not reach.
+    let last = EpochIndex(NF_DERIVATION_WIDTH as u32 - 1);
+    let anchor = Anchor::from(Fp::random(&mut *rng));
+    let (unspent, ()) = PROOF_SYSTEM
+        .seed(
             rng,
-            pool::UnspentBind,
-            (elapsed, bogus_nf_seq),
-            unspent,
-            range,
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(
+                ((), ()),
+                anchor,
+                last,
+                user.nf_at(&note, last),
+                user.nf_at(&note, last.next()),
+            ),
         )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "UnspentBind: range polynomial does not match header"
-    );
-}
+        .expect("EndEpochUnspentSeed");
 
-#[test]
-fn unspent_bind_rejects_start_nf_mismatch() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = unspent_bind_setup(rng);
-    // A range header whose `nf_start` disagrees with its own committed
-    // sequence: the derivation steps never produce this, so it is carried
-    // directly.
-    let range = user.nullifier_pcd(rng, note, EpochIndex(0), EpochIndex(4));
-    let (nf_cm, (epoch_start, _nf_start), seq_commit, (epoch_end, nf_end)) = *range.data();
-    let bogus = Nullifier::from(Fp::random(&mut *rng));
-    let forged_range = Proof::trivial().carry::<delegation::NullifierHeader>((
-        nf_cm,
-        (epoch_start, bogus),
-        seq_commit,
-        (epoch_end, nf_end),
-    ));
-    let elapsed = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-    ]);
-    let nf_seq = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-        user.nf_at(&note, EpochIndex(3)),
-    ]);
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let window = user.covering_window(&note, &range);
+    // The builder would segment out of range, so the witness is assembled
+    // by hand: the genuine elapsed and covering sequence, an empty
+    // complement.
+    let witness = (
+        NfSeqPoly::new(
+            last,
+            &[user.nf_at(&note, last), user.nf_at(&note, last.next())],
+        ),
+        NfSeqPoly::new(EpochIndex(0), &window),
+        NfSeqPoly::new(EpochIndex(0), &[]),
+    );
 
     let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentBind,
-            (elapsed, nf_seq),
-            unspent,
-            forged_range,
-        )
+        .fuse(rng, pool::UnspentBind, witness, unspent, range)
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {
@@ -1665,52 +1507,7 @@ fn unspent_bind_rejects_start_nf_mismatch() {
     };
     assert_eq!(
         inner.to_string(),
-        "UnspentBind: start nullifier does not match the derived range"
-    );
-}
-
-#[test]
-fn unspent_bind_rejects_end_nf_mismatch() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = unspent_bind_setup(rng);
-    // The mirror forgery: `nf_end` disagrees with the committed sequence.
-    let range = user.nullifier_pcd(rng, note, EpochIndex(0), EpochIndex(4));
-    let (nf_cm, (epoch_start, nf_start), seq_commit, (epoch_end, _nf_end)) = *range.data();
-    let bogus = Nullifier::from(Fp::random(&mut *rng));
-    let forged_range = Proof::trivial().carry::<delegation::NullifierHeader>((
-        nf_cm,
-        (epoch_start, nf_start),
-        seq_commit,
-        (epoch_end, bogus),
-    ));
-    let elapsed = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-    ]);
-    let nf_seq = NfSeqPoly::from_iter([
-        user.nf_at(&note, EpochIndex(0)),
-        user.nf_at(&note, EpochIndex(1)),
-        user.nf_at(&note, EpochIndex(2)),
-        user.nf_at(&note, EpochIndex(3)),
-    ]);
-
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentBind,
-            (elapsed, nf_seq),
-            unspent,
-            forged_range,
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "UnspentBind: end nullifier does not match the derived range"
+        "UnspentBind: sequence does not match the derivation"
     );
 }
 
@@ -1760,82 +1557,6 @@ fn spendable_lift_rejects_wrong_cm() {
 }
 
 #[test]
-fn crossing_bind_rejects_bad_range() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    let other = user.random_note(700);
-    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
-
-    let cases = [
-        // The range must derive from the lineage's own note. The bind reaches
-        // its polynomial check before its nullifier checks, so a foreign
-        // range's sequence is what first disagrees; the `cm` identity itself
-        // is `SpendableLift`'s to enforce.
-        (
-            &other,
-            EpochIndex(0),
-            2,
-            "UnspentBind: range polynomial does not match header",
-        ),
-        // The range must open on the epoch the lineage is presently in.
-        (
-            &note,
-            EpochIndex(1),
-            2,
-            "UnspentBind: derived range does not start at the unspent's start epoch",
-        ),
-        // The range spans exactly the two epochs the crossing moves between.
-        (
-            &note,
-            EpochIndex(0),
-            3,
-            "UnspentBind: derived range does not span the crossings plus the tip",
-        ),
-    ];
-
-    for (range_note, epoch_start, len, expected) in cases {
-        let spendable = user.spendable_init(rng, &note, &pool, init_height);
-        let (_, (epoch, present_nf), anchor) = *spendable.data();
-        let (crossing, ()) = PROOF_SYSTEM
-            .seed(
-                rng,
-                pool::EndEpochUnspentSeed,
-                witness::end_epoch_unspent_seed(
-                    ((), ()),
-                    anchor,
-                    epoch,
-                    present_nf,
-                    user.nf_at(&note, epoch.next()),
-                ),
-            )
-            .expect("EndEpochUnspentSeed");
-        let range = user.nullifier_pcd(
-            rng,
-            *range_note,
-            epoch_start,
-            EpochIndex(epoch_start.0 + len),
-        );
-        let elapsed = [present_nf];
-        let err = PROOF_SYSTEM
-            .fuse(
-                rng,
-                pool::UnspentBind,
-                witness::unspent_bind((*crossing.data(), *range.data()), &elapsed),
-                crossing,
-                range,
-            )
-            .err()
-            .unwrap_or_else(|| panic!("UnspentBind accepted {expected}"));
-        let ragu::Error::InvalidWitness(inner) = err else {
-            panic!("expected InvalidWitness for {expected}, got {err:?}");
-        };
-        assert_eq!(inner.to_string(), expected);
-    }
-}
-
-#[test]
 fn spendable_lift_rejects_non_adjacent_unspent() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
@@ -1866,18 +1587,179 @@ fn spendable_lift_rejects_non_adjacent_unspent() {
     );
 }
 
+/// Expect `PROOF_SYSTEM.fuse` to fail with the given `InvalidWitness` text.
+fn expect_invalid<H: ragu::Header, S>(
+    rng: &mut StdRng,
+    step: S,
+    witness: S::Witness<'_>,
+    left: Pcd<S::Left>,
+    right: Pcd<S::Right>,
+    message: &str,
+) where
+    S: ragu::Step<Output = H>,
+{
+    let err = PROOF_SYSTEM
+        .fuse(rng, step, witness, left, right)
+        .err()
+        .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(inner.to_string(), message);
+}
+
+/// An honest master seed for a note.
+fn honest_master(
+    rng: &mut StdRng,
+    user: &WalletSim,
+    note: Note,
+) -> Pcd<delegation::NfMasterHeader> {
+    let (master, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            delegation::NfMasterSeed,
+            witness::nf_master_seed(((), ()), note, user.pak),
+        )
+        .expect("NfMasterSeed");
+    master
+}
+
+/// A note paired with an unrelated proof authorizing key fails the
+/// payment-key pin before any master derivation.
+#[test]
+fn master_seed_rejects_unrelated_pak() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let stranger = WalletSim::random(rng);
+    let note = user.random_note(500);
+
+    expect_invalid(
+        rng,
+        delegation::NfMasterSeed,
+        (note, stranger.pak),
+        Proof::trivial().carry::<()>(()),
+        Proof::trivial().carry::<()>(()),
+        "NfMasterSeed: pak not related to note",
+    );
+}
+
+/// A sequence built from a different note's nullifiers fails the accumulation
+/// opening: `mk` is threaded off the seed header, so the step derives the
+/// real note's nullifiers no matter what polynomial is offered.
+#[test]
+fn nf_derive_rejects_a_foreign_sequence() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note_a = user.random_note(500);
+    let note_b = user.random_note(700);
+
+    let master_a = honest_master(rng, &user, note_a);
+    let (cm_a, _) = *master_a.data();
+    let (epoch_start, foreign_seq) =
+        witness::nf_derive(((cm_a, user.mk(&note_b)), ()), EpochIndex(16));
+    expect_invalid(
+        rng,
+        delegation::NfDerive,
+        (epoch_start, foreign_seq),
+        master_a,
+        Proof::trivial().carry::<()>(()),
+        "NfDerive: sequence does not match the derived window",
+    );
+}
+
+/// A start epoch off the group alignment is rejected before any derivation.
+#[test]
+fn nf_derive_rejects_a_misaligned_epoch_start() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    let master = honest_master(rng, &user, note);
+    let (_, seq) = witness::nf_derive((*master.data(), ()), EpochIndex(12));
+    expect_invalid(
+        rng,
+        delegation::NfDerive,
+        (EpochIndex(14), seq),
+        master,
+        Proof::trivial().carry::<()>(()),
+        "NfDerive: epoch_start is not group-aligned",
+    );
+}
+
+/// A leaf exports its whole window, labelled with the window's bounds, and
+/// every window of the same note carries the same `cm`.
+#[test]
+fn derivation_exports_the_whole_window() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    let epoch_start = EpochIndex(12);
+    let epoch_end = EpochIndex(epoch_start.0 + NF_DERIVATION_WIDTH as u32);
+    let range = user.derivation_pcd(rng, note, epoch_start, epoch_end);
+    let (cm, start, commit, range_end) = *range.data();
+
+    assert_eq!(start, epoch_start, "starts at the witnessed epoch");
+    assert_eq!(range_end, epoch_end, "spans the whole window");
+    let members = user.covering_window(&note, &range);
+    let seq = NfSeqPoly::new(epoch_start, &members);
+    assert_eq!(commit, seq.commit(), "header commits the window sequence");
+
+    let far = user.derivation_pcd(
+        rng,
+        note,
+        EpochIndex(100_000),
+        EpochIndex(100_000 + NF_DERIVATION_WIDTH as u32),
+    );
+    assert_eq!(cm, far.data().0, "same note cm");
+}
+
+/// The fixture's covering derivation spans whole windows around the request
+/// and commits the covering sequence.
+#[test]
+fn derivation_covers_with_whole_windows() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    // Spans two windows: the fixture fuses whole-window leaves internally.
+    let start = EpochIndex(NF_DERIVATION_WIDTH as u32 - 2);
+    let end = EpochIndex(NF_DERIVATION_WIDTH as u32 + 2);
+    let range = user.derivation_pcd(rng, note, start, end);
+    let (cm, cover_start, commit, cover_end) = *range.data();
+
+    assert_eq!(Tachygram::from(cm), note.commitment().into());
+    assert!(
+        cover_start.0 <= start.0 && end.0 <= cover_end.0,
+        "covers the requested range"
+    );
+    assert_eq!(
+        (cover_end.0 - cover_start.0) % NF_DERIVATION_WIDTH as u32,
+        0,
+        "whole windows"
+    );
+    let members: Vec<Nullifier> = (cover_start.0..cover_end.0)
+        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .collect();
+    let seq = NfSeqPoly::new(cover_start, &members);
+    assert_eq!(commit, seq.commit(), "merged commit is the concat sequence");
+}
+
 #[test]
 fn nullifier_fuse_rejects_non_contiguous() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let range_a = user.nullifier_pcd(rng, note, EpochIndex(0), EpochIndex(1));
-    let range_b = user.nullifier_pcd(rng, note, EpochIndex(2), EpochIndex(3));
+    // Windows separated by a gap: the left window covers `[0, 16)`, the right
+    // starts at 32, so the halves are not adjacent.
+    let (left_start, right_start) = (EpochIndex(0), EpochIndex(32));
+    let range_a = user.derivation_pcd(rng, note, left_start, EpochIndex(16));
+    let range_b = user.derivation_pcd(rng, note, right_start, EpochIndex(48));
     let witness = witness::nullifier_fuse(
         (*range_a.data(), *range_b.data()),
-        &[user.nf_at(&note, EpochIndex(0))],
-        user.nf_at(&note, EpochIndex(2)),
+        &user.covering_window(&note, &range_a),
+        &user.covering_window(&note, &range_b),
     );
 
     let err = PROOF_SYSTEM
@@ -1895,14 +1777,15 @@ fn nullifier_fuse_rejects_wrong_cm() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note_a = user.random_note(500);
-    let note_b = user.random_note(500);
+    let note_b = user.random_note(700);
 
-    let range_a = user.nullifier_pcd(rng, note_a, EpochIndex(0), EpochIndex(1));
-    let range_b = user.nullifier_pcd(rng, note_b, EpochIndex(1), EpochIndex(2));
+    let (left_start, right_start) = (EpochIndex(0), EpochIndex(16));
+    let range_a = user.derivation_pcd(rng, note_a, left_start, EpochIndex(16));
+    let range_b = user.derivation_pcd(rng, note_b, right_start, EpochIndex(32));
     let witness = witness::nullifier_fuse(
         (*range_a.data(), *range_b.data()),
-        &[user.nf_at(&note_a, EpochIndex(0))],
-        user.nf_at(&note_b, EpochIndex(1)),
+        &user.covering_window(&note_a, &range_a),
+        &user.covering_window(&note_b, &range_b),
     );
 
     let err = PROOF_SYSTEM
@@ -1915,220 +1798,191 @@ fn nullifier_fuse_rejects_wrong_cm() {
     assert_eq!(inner.to_string(), "NullifierFuse: note commitments differ");
 }
 
-/// A note paired with an unrelated proof authorizing key fails the
-/// payment-key pin before any master derivation.
-#[test]
-fn master_seed_rejects_unrelated_pak() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let stranger = WalletSim::random(rng);
-    let note = user.random_note(500);
-
-    let err = PROOF_SYSTEM
-        .seed(rng, delegation::NfMasterSeed, (note, stranger.pak))
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(inner.to_string(), "NfMasterSeed: pak not related to note");
+/// An honest spendable and covering derivation for `SpendBind` witness
+/// substitution tests, at the cm-block's epoch.
+fn spend_bind_parts(
+    rng: &mut StdRng,
+    user: &WalletSim,
+    note: &Note,
+) -> (
+    Pcd<spendable::SpendableHeader>,
+    Pcd<delegation::NullifierDerivation>,
+    EpochIndex,
+) {
+    let mut pool = PoolSim::genesis(rng);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let epoch = init_height.epoch();
+    let spendable = user.spendable_init(rng, note, &pool, init_height);
+    let derived = user.derivation_pcd(rng, *note, epoch, EpochIndex(epoch.0 + 2));
+    (spendable, derived, epoch)
 }
 
-/// A masked derivation exports exactly the mask's run: the start shifted past
-/// the leading unselected epochs, the run's length, the genuine boundary
-/// nullifiers, and the run's sequence commitment. `cm` is the note's. Covers
-/// every contiguous (lead, count) mask.
+/// A forged next nullifier fails the divisibility read.
 #[test]
-fn nf_derive_exports_the_masked_run() {
+fn spend_bind_rejects_forged_next() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
-    let window_start = EpochIndex(12);
 
-    let runs = (0u32..4).flat_map(|lead| (1u32..=4 - lead).map(move |count| (lead, count)));
-    for (lead, count) in runs {
-        let mask: [bool; 4] =
-            array::from_fn(|j| (lead..lead + count).contains(&u32::try_from(j).unwrap()));
-        let master = user.master_pcd(rng, note);
-        let (range, ()) = PROOF_SYSTEM
-            .fuse(
-                rng,
-                delegation::NfDerive,
-                witness::nf_derive((*master.data(), ()), window_start, mask),
-                master,
-                Proof::trivial().carry::<()>(()),
-            )
-            .expect("NfDerive");
-        let (cm, (epoch_start, nf_start), commit, (epoch_end, nf_end)) = *range.data();
-
-        assert_eq!(cm, note.commitment(), "range carries the note's cm");
-        assert_eq!(epoch_start, EpochIndex(window_start.0 + lead));
-        assert_eq!(epoch_end, EpochIndex(epoch_start.0 + count));
-        assert_eq!(nf_start, user.nf_at(&note, epoch_start));
-        assert_eq!(nf_end, user.nf_at(&note, EpochIndex(epoch_end.0 - 1)));
-        let members: NfSeqPoly = (epoch_start.0..epoch_end.0)
-            .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
-            .collect();
-        assert_eq!(commit, members.commit(), "header commits the run sequence");
-    }
-}
-
-/// A sequence built from a different note's nullifiers fails the sequence
-/// bind: `mk` is threaded off the seed header, so the step derives the real
-/// note's nullifiers no matter what polynomial is offered.
-#[test]
-fn nf_derive_rejects_a_foreign_sequence() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let note_a = user.random_note(500);
-    let note_b = user.random_note(700);
-
-    let master_a = user.master_pcd(rng, note_a);
-    let (cm_a, _) = *master_a.data();
-    let mask = [true, true, true, true];
-    let foreign = witness::nf_derive(((cm_a, user.mk(&note_b)), ()), EpochIndex(16), mask);
-
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            delegation::NfDerive,
-            foreign,
-            master_a,
-            Proof::trivial().carry::<()>(()),
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "NfDerive: sequence does not match the masked run"
+    let (spendable, derived, _epoch) = spend_bind_parts(rng, &user, &note);
+    let (nf_seq, complement_seq, _nf_next) = witness::spend_bind(
+        (*spendable.data(), *derived.data()),
+        &user.covering_window(&note, &derived),
+    );
+    let forged = Nullifier::from(Fp::random(&mut *rng));
+    expect_invalid(
+        rng,
+        spend::SpendBind,
+        (nf_seq, complement_seq, forged),
+        spendable,
+        derived,
+        "SpendBind: nullifier pair does not match the derivation",
     );
 }
 
-/// A sequence whose members are genuine but whose run sits at a different
-/// offset than the mask's fails the sequence bind.
+/// A range that does not cover the lineage epoch is rejected, however
+/// internally consistent it is.
 #[test]
-fn nf_derive_rejects_a_misaligned_sequence() {
+fn spend_bind_rejects_uncovering_range() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
-    let master = user.master_pcd(rng, note);
-    let (group, _, seq) = witness::nf_derive(
-        (*master.data(), ()),
-        EpochIndex(16),
-        [true, true, false, false],
-    );
 
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            delegation::NfDerive,
-            (group, [false, true, true, false], seq),
-            master,
-            Proof::trivial().carry::<()>(()),
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "NfDerive: sequence does not match the masked run"
+    let (spendable, _derived, epoch) = spend_bind_parts(rng, &user, &note);
+    let ahead = EpochIndex(epoch.0 + NF_DERIVATION_WIDTH as u32);
+    let derived_ahead = user.derivation_pcd(rng, note, ahead, EpochIndex(ahead.0 + 2));
+    // The builder would segment out of range, so the witness is assembled
+    // by hand: the genuine covering sequence, an empty complement.
+    let window = user.covering_window(&note, &derived_ahead);
+    let witness = (
+        NfSeqPoly::new(ahead, &window),
+        NfSeqPoly::new(ahead, &[]),
+        user.nf_at(&note, epoch.next()),
+    );
+    expect_invalid(
+        rng,
+        spend::SpendBind,
+        witness,
+        spendable,
+        derived_ahead,
+        "SpendBind: nullifier pair does not match the derivation",
     );
 }
 
-/// A mask with a gap in its selected run is rejected before any binding.
+/// A different note's range does not match the lineage's `cm`.
 #[test]
-fn nf_derive_rejects_a_gapped_mask() {
+fn spend_bind_rejects_a_foreign_range() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+    let other = user.random_note(700);
+
+    let (spendable, _derived, epoch) = spend_bind_parts(rng, &user, &note);
+    let foreign = user.derivation_pcd(rng, other, epoch, EpochIndex(epoch.0 + 2));
+    let witness = witness::spend_bind(
+        (*spendable.data(), *foreign.data()),
+        &user.covering_window(&other, &foreign),
+    );
+    expect_invalid(
+        rng,
+        spend::SpendBind,
+        witness,
+        spendable,
+        foreign,
+        "SpendBind: derived range does not match note",
+    );
+}
+
+/// A sequence built from a different note does not match the derivation
+/// header's commitment.
+#[test]
+fn spend_bind_rejects_a_foreign_sequence() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+    let other = user.random_note(700);
+
+    let (spendable, derived, _epoch) = spend_bind_parts(rng, &user, &note);
+    let witness = witness::spend_bind(
+        (*spendable.data(), *derived.data()),
+        &user.covering_window(&other, &derived),
+    );
+    expect_invalid(
+        rng,
+        spend::SpendBind,
+        witness,
+        spendable,
+        derived,
+        "SpendBind: covering sequence does not match header",
+    );
+}
+
+/// A forged present nullifier fails the divisibility read at
+/// `SpendableInit`.
+#[test]
+fn spendable_init_rejects_a_forged_nullifier() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let master = user.master_pcd(rng, note);
-    let gapped = witness::nf_derive(
-        (*master.data(), ()),
+    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let dummy_tg = Tachygram::from(Fp::random(&mut *rng));
+    let (_, _, _, _, nf_seq, complement_seq) = witness::spendable_init(
+        (*nf_header.data(), ()),
+        Anchor::default(),
+        &[dummy_tg],
         EpochIndex(0),
-        [true, false, true, true],
+        &user.covering_window(&note, &nf_header),
     );
-
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            delegation::NfDerive,
-            gapped,
-            master,
-            Proof::trivial().carry::<()>(()),
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "NfDerive: mask is not one contiguous nonempty run"
+    let forged = Nullifier::from(Fp::random(&mut *rng));
+    expect_invalid(
+        rng,
+        spendable::SpendableInit,
+        (
+            Anchor::default(),
+            TachygramSetPoly::from_iter([dummy_tg]),
+            EpochIndex(0),
+            forged,
+            nf_seq,
+            complement_seq,
+        ),
+        nf_header,
+        Proof::trivial().carry::<()>(()),
+        "SpendableInit: nullifier does not match the derivation",
     );
 }
 
-/// An all-false mask selects no epochs and is rejected.
+/// A covering sequence built from a different note does not match the
+/// derivation header's commitment at `UnspentBind`.
 #[test]
-fn nf_derive_rejects_an_empty_mask() {
+fn unspent_bind_rejects_a_foreign_sequence() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(500);
+    let other = user.random_note(700);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    pool.advance(1, |_| random_block(rng, 1, 2));
 
-    let master = user.master_pcd(rng, note);
-    let empty = witness::nf_derive((*master.data(), ()), EpochIndex(0), [false; 4]);
-
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            delegation::NfDerive,
-            empty,
-            master,
-            Proof::trivial().carry::<()>(()),
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "NfDerive: mask is not one contiguous nonempty run"
+    let unspent = build_unspent_pcd_between_blocks(
+        rng,
+        &pool,
+        &[user.nf_at(&note, EpochIndex(0))],
+        BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
     );
-}
-
-/// A window start off the group alignment is rejected before any derivation.
-#[test]
-fn nf_derive_rejects_a_misaligned_window_start() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let note = user.random_note(500);
-
-    let master = user.master_pcd(rng, note);
-    let mask = [true, true, true, true];
-    let (_, _, seq) = witness::nf_derive((*master.data(), ()), EpochIndex(12), mask);
-
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            delegation::NfDerive,
-            (EpochIndex(14), mask, seq),
-            master,
-            Proof::trivial().carry::<()>(()),
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "NfDerive: window start is not group-aligned"
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let witness = witness::unspent_bind(
+        (*unspent.data(), *range.data()),
+        &user.covering_window(&other, &range),
+        &[user.nf_at(&note, EpochIndex(0))],
+    );
+    expect_invalid(
+        rng,
+        pool::UnspentBind,
+        witness,
+        unspent,
+        range,
+        "UnspentBind: covering sequence does not match header",
     );
 }
 
@@ -2198,5 +2052,72 @@ fn output_stamp_rejects_note_not_matching_the_bind() {
     assert_eq!(
         inner.to_string(),
         "OutputStamp: note does not match the bound output"
+    );
+}
+
+/// A merged polynomial that is not the product of the halves fails the
+/// fuse identity.
+#[test]
+fn nullifier_fuse_rejects_a_wrong_merged() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    let left = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(16));
+    let right = user.derivation_pcd(rng, note, EpochIndex(16), EpochIndex(32));
+    let left_nfs: Vec<Nullifier> = (0..16)
+        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .collect();
+    let right_nfs: Vec<Nullifier> = (16..32)
+        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .collect();
+    let (left_seq, _merged, right_seq) =
+        witness::nullifier_fuse((*left.data(), *right.data()), &left_nfs, &right_nfs);
+    let wrong_members: Vec<Nullifier> =
+        iter::repeat_with(|| Nullifier::from(Fp::random(&mut *rng)))
+            .take(32)
+            .collect();
+    let wrong = NfSeqPoly::new(EpochIndex(0), &wrong_members);
+    expect_invalid(
+        rng,
+        delegation::NullifierFuse,
+        (left_seq, wrong, right_seq),
+        left,
+        right,
+        "NullifierFuse: merged is not the concat of the halves",
+    );
+}
+
+/// A segment beginning past the spendable's position does not lift it: its
+/// first member is not the lineage nullifier.
+#[test]
+fn spendable_lift_rejects_a_wrong_start() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let spendable = user.spendable_init(rng, &note, &pool, init_height);
+
+    // A segment covering only epoch 1, one epoch past the spendable.
+    while pool.height().0 < EPOCH_SIZE {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+    let epoch1_height = pool.height();
+    let arbitrary = build_unspent_pcd_between_blocks(
+        rng,
+        &pool,
+        &[user.nf_at(&note, EpochIndex(1))],
+        epoch1_height..=epoch1_height,
+    );
+    let unspent = user.unspent_bind(rng, arbitrary, &note);
+
+    expect_invalid(
+        rng,
+        spendable::SpendableLift,
+        (),
+        spendable,
+        unspent,
+        "SpendableLift: segment does not start at the lineage nullifier",
     );
 }

--- a/crates/tachyon/tests/integration/proof.rs
+++ b/crates/tachyon/tests/integration/proof.rs
@@ -851,6 +851,43 @@ fn unspent_fuse_rejects_wrong_combined() {
     );
 }
 
+/// A same-epoch fuse with a one-member right half adds stamps, not members:
+/// the dedup identity degenerates to `combined = left`, and that combined
+/// sequence is the honest one. Contrast
+/// [`unspent_fuse_rejects_wrong_combined`], where a multi-member right half
+/// makes the same shape a forgery.
+#[test]
+fn unspent_fuse_accepts_left_as_combined_for_one_member_right() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let stamps_left = vec![Tachygram::from(Fp::random(&mut *rng))];
+    let stamps_right = vec![Tachygram::from(Fp::random(&mut *rng))];
+    let start = Anchor::default();
+    let mid = start
+        .next_stamp(
+            EpochIndex(0),
+            &TachygramSetPoly::from_iter(stamps_left.clone()).commit(),
+        )
+        .unwrap();
+    let nf = Nullifier::from(Fp::random(&mut *rng));
+    let left = build_unspent_seed_pcd(rng, start, EpochIndex(0), &stamps_left, nf);
+    let right = build_unspent_seed_pcd(rng, mid, EpochIndex(0), &stamps_right, nf);
+
+    let (fused, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            pool::UnspentFuse,
+            witness::unspent_fuse((*left.data(), *right.data()), &[nf], &[nf]),
+            left,
+            right,
+        )
+        .expect("one-member halves fuse");
+    assert_eq!(
+        fused.data().2,
+        NfSeqPoly::new(EpochIndex(0), &[nf]).commit(),
+        "combined equals the left sequence"
+    );
+}
+
 #[test]
 fn unspent_fuse_rejects_epoch_boundary_crossing() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -1952,6 +1989,39 @@ fn spendable_init_rejects_a_forged_nullifier() {
     );
 }
 
+/// A range that does not cover the creation epoch is rejected at
+/// `SpendableInit`.
+#[test]
+fn spendable_init_rejects_an_uncovering_range() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let past = EpochIndex(NF_DERIVATION_WIDTH as u32);
+    let dummy_tg = Tachygram::from(Fp::random(&mut *rng));
+    // The builder would segment out of range, so the witness is assembled
+    // by hand: the genuine covering sequence, the whole window as the
+    // complement.
+    let window = user.covering_window(&note, &nf_header);
+    let witness = (
+        Anchor::default(),
+        TachygramSetPoly::from_iter([dummy_tg]),
+        past,
+        user.nf_at(&note, past),
+        NfSeqPoly::new(EpochIndex(0), &window),
+        NfSeqPoly::new(EpochIndex(0), &window),
+    );
+    expect_invalid(
+        rng,
+        spendable::SpendableInit,
+        witness,
+        nf_header,
+        Proof::trivial().carry::<()>(()),
+        "SpendableInit: nullifier does not match the derivation",
+    );
+}
+
 /// A covering sequence built from a different note does not match the
 /// derivation header's commitment at `UnspentBind`.
 #[test]
@@ -1984,6 +2054,65 @@ fn unspent_bind_rejects_a_foreign_sequence() {
         range,
         "UnspentBind: covering sequence does not match header",
     );
+}
+
+/// A span exceeding one window chunks through sequential bind+lift rounds,
+/// each bound against its own single window based at its chunk's start.
+#[test]
+fn multi_chunk_lift_uses_per_chunk_windows() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+
+    let spendable = user.spendable_init(rng, &note, &pool, init_height);
+    let start_anchor = spendable.data().2;
+
+    let mut sync = SyncSim::new();
+    sync.accept_delegation(
+        0,
+        alloc::vec![
+            user.nf_at(&note, EpochIndex(0)),
+            user.nf_at(&note, EpochIndex(1)),
+            user.nf_at(&note, EpochIndex(2)),
+        ],
+        init_height,
+        start_anchor,
+    );
+
+    // First chunk: epochs 0 to 1, bound against the window based at epoch 0.
+    let target_one = BlockHeight(EPOCH_SIZE);
+    while pool.height() < target_one {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+    let unspent_one = sync.build_next_unspent(rng, 0, &pool, target_one);
+    let lifted_one = user.lift(rng, spendable, unspent_one, &note);
+    assert_eq!(
+        lifted_one.data().1,
+        (EpochIndex(1), user.nf_at(&note, EpochIndex(1)))
+    );
+
+    // Second chunk: epochs 1 to 2, bound against a fresh window based at
+    // epoch 1 (the chunk boundary needs no alignment between windows).
+    let target_two = BlockHeight(2 * EPOCH_SIZE);
+    while pool.height() < target_two {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+    let unspent_two = sync.build_next_unspent(rng, 0, &pool, target_two);
+    let lifted_two = user.lift(rng, lifted_one, unspent_two, &note);
+
+    assert_eq!(
+        lifted_two.data().1,
+        (EpochIndex(2), user.nf_at(&note, EpochIndex(2))),
+        "tip advanced across two chunks"
+    );
+    assert_eq!(
+        lifted_two.data().2,
+        pool.block(target_two).anchor(),
+        "anchor advanced across two chunks"
+    );
+    assert_eq!(lifted_two.data().0, note.commitment(), "cm threaded");
 }
 
 /// The pad the step publishes is `pad_tachygram` over the note's own fields.
@@ -2055,6 +2184,42 @@ fn output_stamp_rejects_note_not_matching_the_bind() {
     );
 }
 
+/// Adjacent ranges fuse into one: the merged sequence is the product of the
+/// halves, with the range threaded from the halves.
+#[test]
+fn nullifier_fuse_composes() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    let left = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(16));
+    let right = user.derivation_pcd(rng, note, EpochIndex(16), EpochIndex(32));
+    let left_nfs: Vec<Nullifier> = (0..16)
+        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .collect();
+    let right_nfs: Vec<Nullifier> = (16..32)
+        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .collect();
+    let fuse_witness =
+        witness::nullifier_fuse((*left.data(), *right.data()), &left_nfs, &right_nfs);
+    let (merged, ()) = PROOF_SYSTEM
+        .fuse(rng, delegation::NullifierFuse, fuse_witness, left, right)
+        .expect("NullifierFuse");
+
+    let (cm, start, commit, end) = *merged.data();
+    assert_eq!(cm, note.commitment());
+    assert_eq!((start, end), (EpochIndex(0), EpochIndex(32)));
+    let members: Vec<Nullifier> = (0..32)
+        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .collect();
+    let expected = NfSeqPoly::new(EpochIndex(0), &members);
+    assert_eq!(
+        commit,
+        expected.commit(),
+        "merged commits the concatenation"
+    );
+}
+
 /// A merged polynomial that is not the product of the halves fails the
 /// fuse identity.
 #[test]
@@ -2085,6 +2250,61 @@ fn nullifier_fuse_rejects_a_wrong_merged() {
         left,
         right,
         "NullifierFuse: merged is not the concat of the halves",
+    );
+}
+
+/// A forged next-epoch nullifier cannot be compensated by choosing the
+/// complement: the identity pins the whole factorization, so no complement
+/// content absorbs a wrong read.
+///
+/// The derivation starts below the pair's epoch so that the complement
+/// carries runs on *both* sides of the read. `spend_bind_parts` mints at
+/// genesis, which leaves the lower run empty and reduces this to
+/// `spend_bind_rejects_forged_next` with a garbled complement.
+#[test]
+fn spend_bind_rejects_a_forged_next_over_a_garbage_complement() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+
+    // Mint into a later epoch, so the window can start below the pair.
+    while pool.height() < BlockHeight(EPOCH_SIZE) {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+    let note = user.random_note(500);
+    let stranger = user.random_note(900);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let epoch = init_height.epoch();
+    let spendable = user.spendable_init(rng, &note, &pool, init_height);
+    let derived = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(epoch.0 + 2));
+
+    let (nf_seq, _complement_seq, _nf_next) = witness::spend_bind(
+        (*spendable.data(), *derived.data()),
+        &user.covering_window(&note, &derived),
+    );
+
+    // Garbage complement: another note's members in place of this note's.
+    let (_, deriv_start, _, deriv_end) = *derived.data();
+    let stranger_mk = user.mk(&stranger);
+    let older_members: Vec<Nullifier> = (deriv_start.0..epoch.0)
+        .map(|epoch_idx| stranger_mk.derive_nullifier(EpochIndex(epoch_idx)))
+        .collect();
+    let newer_members: Vec<Nullifier> = (epoch.0 + 2..deriv_end.0)
+        .map(|epoch_idx| stranger_mk.derive_nullifier(EpochIndex(epoch_idx)))
+        .collect();
+    assert!(!older_members.is_empty(), "lower run must carry members");
+    assert!(!newer_members.is_empty(), "upper run must carry members");
+    let complement_seq = NfSeqPoly::new(deriv_start, &older_members)
+        * NfSeqPoly::new(EpochIndex(epoch.0 + 2), &newer_members);
+
+    let forged = Nullifier::from(Fp::random(&mut *rng));
+    expect_invalid(
+        rng,
+        spend::SpendBind,
+        (nf_seq, complement_seq, forged),
+        spendable,
+        derived,
+        "SpendBind: nullifier pair does not match the derivation",
     );
 }
 
@@ -2120,4 +2340,316 @@ fn spendable_lift_rejects_a_wrong_start() {
         unspent,
         "SpendableLift: segment does not start at the lineage nullifier",
     );
+}
+
+/// The per-stamp walk from an epoch's terminal anchor opens *on* that anchor:
+/// the boundary is a segment of its own, so the walk seeds the crossing and
+/// the span starts in the outgoing epoch rather than past it. A spendable
+/// resting on the terminal anchor is therefore adjacent to what it lifts over.
+#[test]
+fn unspent_walk_from_an_epoch_tip_opens_on_the_tip() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(300);
+    // A lone cm-stamp, then a silent rest-of-epoch, leaves the spendable's
+    // anchor sitting on epoch 0's terminal anchor.
+    pool.mine(vec![vec![note.commitment().into()]]);
+    let cm_height = pool.height();
+    while pool.height().0 + 1 < EPOCH_SIZE {
+        pool.advance(1, |_| Vec::new());
+    }
+    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
+    let epoch0_tip = spendable.data().2;
+    assert_eq!(
+        epoch0_tip,
+        pool.block(EpochIndex(0).last_block()).anchor(),
+        "the lineage sits on the epoch tip"
+    );
+
+    pool.advance(1, |_| random_block(rng, 1, 2));
+    let target_height = pool.height();
+    assert_eq!(target_height.epoch(), EpochIndex(1));
+
+    let arbitrary = build_unspent_pcd_between_anchors(
+        rng,
+        &pool,
+        &[
+            user.nf_at(&note, EpochIndex(0)),
+            user.nf_at(&note, EpochIndex(1)),
+        ],
+        (epoch0_tip, pool.block(target_height).anchor()),
+    );
+    let unspent = user.unspent_bind(rng, arbitrary, &note);
+
+    assert_eq!(
+        unspent.data().1,
+        epoch0_tip,
+        "the segment opens on the spendable's own anchor, not past it"
+    );
+    assert_eq!(
+        unspent.data().2,
+        (EpochIndex(0), user.nf_at(&note, EpochIndex(0))),
+        "the span begins in the epoch being left"
+    );
+    assert_eq!(
+        unspent.data().3,
+        (EpochIndex(1), user.nf_at(&note, EpochIndex(1)))
+    );
+    assert_eq!(unspent.data().4, pool.block(target_height).anchor());
+}
+
+/// The terminal-anchor composition end to end: a note whose cm-stamp closes
+/// its epoch lifts over a crossing seed, then binds and spends in the next
+/// epoch.
+#[test]
+fn crossing_seed_carries_a_terminal_anchor_to_a_spend() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(300);
+
+    // A lone cm-stamp, then a silent rest-of-epoch, leaves the spendable's
+    // anchor sitting on epoch 0's terminal anchor.
+    pool.mine(vec![vec![note.commitment().into()]]);
+    let cm_height = pool.height();
+    while pool.height().0 + 1 < EPOCH_SIZE {
+        pool.advance(1, |_| Vec::new());
+    }
+    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
+    let epoch0_tip = spendable.data().2;
+    assert_eq!(
+        epoch0_tip,
+        pool.block(EpochIndex(0).last_block()).anchor(),
+        "the lineage sits on the epoch tip"
+    );
+
+    // The tick's bookkeeping: epoch and nullifier advance by one, and the
+    // anchor folds the domain-separated boundary in the crossing segment.
+    let (crossing, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(
+                ((), ()),
+                epoch0_tip,
+                EpochIndex(0),
+                user.nf_at(&note, EpochIndex(0)),
+                user.nf_at(&note, EpochIndex(1)),
+            ),
+        )
+        .expect("EndEpochUnspentSeed");
+    let lifted = user.lift(rng, spendable, crossing, &note);
+    assert_eq!(
+        *lifted.data(),
+        (
+            note.commitment(),
+            (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
+            epoch0_tip.next_epoch(EpochIndex(1)).unwrap(),
+        ),
+        "the lift crosses to the boundary anchor"
+    );
+
+    // Walk through epoch 1 from the boundary anchor the lift landed on.
+    pool.advance(1, |_| random_block(rng, 1, 2));
+    let end_height = pool.height();
+    assert_eq!(end_height.epoch(), EpochIndex(1));
+    let arbitrary = build_unspent_pcd_between_anchors(
+        rng,
+        &pool,
+        &[user.nf_at(&note, EpochIndex(1))],
+        (lifted.data().2, pool.block(end_height).anchor()),
+    );
+    let walked = user.lift(rng, lifted, arbitrary, &note);
+    let bind_pcd = honest_spend_bind(rng, &user, &note, walked, EpochIndex(1));
+    let stamp = honest_spend_stamp(rng, &user, &note, bind_pcd);
+
+    let expected = TachygramSetPoly::from_iter([
+        user.nf_at(&note, EpochIndex(1)).into(),
+        user.nf_at(&note, EpochIndex(2)).into(),
+    ])
+    .commit();
+    assert_eq!(stamp.data().1, expected, "publishes {{N_1, N_2}}");
+}
+
+/// A forged complement cannot compensate the identity: the divisibility
+/// pins the whole factorization, so junk in the complement fails the bind.
+#[test]
+fn unspent_bind_rejects_a_forged_complement() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    pool.advance(1, |_| random_block(rng, 1, 2));
+
+    let unspent = build_unspent_pcd_between_blocks(
+        rng,
+        &pool,
+        &[user.nf_at(&note, EpochIndex(0))],
+        BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
+    );
+    // A two-epoch derivation, so the honest complement is nonempty and the
+    // forgery cannot hide behind the constant 1.
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(2));
+    let (elapsed_seq, nf_seq, _complement_seq) = witness::unspent_bind(
+        (*unspent.data(), *range.data()),
+        &user.covering_window(&note, &range),
+        &[user.nf_at(&note, EpochIndex(0))],
+    );
+    let forged = NfSeqPoly::new(EpochIndex(1), &[Nullifier::from(Fp::random(&mut *rng))]);
+    expect_invalid(
+        rng,
+        pool::UnspentBind,
+        (elapsed_seq, nf_seq, forged),
+        unspent,
+        range,
+        "UnspentBind: sequence does not match the derivation",
+    );
+}
+
+/// The right nullifier value at the wrong epoch is a different member: the
+/// pair binding is positional through the epoch, not just the value.
+#[test]
+fn unspent_bind_rejects_a_wrong_epoch_member() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let _init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    while pool.height().0 < EPOCH_SIZE {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+
+    // A lineage over epoch 1 testing epoch 0's genuine nullifier: the value
+    // is genuine, the epoch is not.
+    let epoch1_height = pool.height();
+    let unspent = build_unspent_pcd_between_blocks(
+        rng,
+        &pool,
+        &[user.nf_at(&note, EpochIndex(0))],
+        epoch1_height..=epoch1_height,
+    );
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(2));
+    let elapsed_seq = NfSeqPoly::new(EpochIndex(1), &[user.nf_at(&note, EpochIndex(0))]);
+    let complement_seq = NfSeqPoly::new(EpochIndex(0), &[user.nf_at(&note, EpochIndex(0))]);
+    let nf_seq = NfSeqPoly::new(EpochIndex(0), &user.covering_window(&note, &range));
+    expect_invalid(
+        rng,
+        pool::UnspentBind,
+        (elapsed_seq, nf_seq, complement_seq),
+        unspent,
+        range,
+        "UnspentBind: sequence does not match the derivation",
+    );
+}
+
+/// A complement duplicating the tested member cannot pass: the derivation
+/// carries each member exactly once, so a duplicated member does not divide
+/// it.
+#[test]
+fn unspent_bind_rejects_a_duplicating_complement() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    pool.advance(1, |_| random_block(rng, 1, 2));
+
+    let unspent = build_unspent_pcd_between_blocks(
+        rng,
+        &pool,
+        &[user.nf_at(&note, EpochIndex(0))],
+        BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
+    );
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let (elapsed_seq, nf_seq, _complement_seq) = witness::unspent_bind(
+        (*unspent.data(), *range.data()),
+        &user.covering_window(&note, &range),
+        &[user.nf_at(&note, EpochIndex(0))],
+    );
+    // The honest complement is empty; duplicating the tested member squares
+    // its encoding, and the squarefree derivation rejects it.
+    let duplicating = NfSeqPoly::new(EpochIndex(0), &[user.nf_at(&note, EpochIndex(0))]);
+    expect_invalid(
+        rng,
+        pool::UnspentBind,
+        (elapsed_seq, nf_seq, duplicating),
+        unspent,
+        range,
+        "UnspentBind: sequence does not match the derivation",
+    );
+}
+
+/// A span exceeding one window binds once, against a fused chain of cached
+/// whole windows; no bind-per-window rounds and no partial leaves.
+#[test]
+fn multi_window_span_binds_once() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let spendable = user.spendable_init(rng, &note, &pool, init_height);
+    let start_anchor = spendable.data().2;
+
+    // Publish one block per epoch (each epoch's first block) through epoch
+    // NF_DERIVATION_WIDTH, so the lineage spans one epoch more than a single
+    // window covers and the span's end anchor is a stamped block's.
+    let last_epoch = NF_DERIVATION_WIDTH as u32;
+    let target_height = BlockHeight(last_epoch * EPOCH_SIZE);
+    while pool.height() < target_height {
+        let publish = pool.height().0 % EPOCH_SIZE == EPOCH_SIZE - 1;
+        if publish {
+            pool.advance(1, |_| random_block(rng, 1, 2));
+        } else {
+            pool.advance(1, |_| Vec::new());
+        }
+    }
+
+    let nfs: Vec<Nullifier> = (0..=last_epoch)
+        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .collect();
+    let arbitrary = build_unspent_pcd_between_anchors(
+        rng,
+        &pool,
+        &nfs,
+        (start_anchor, pool.block(target_height).anchor()),
+    );
+    let unspent = user.unspent_bind(rng, arbitrary, &note);
+
+    assert_eq!(
+        unspent.data().3,
+        (
+            EpochIndex(last_epoch),
+            user.nf_at(&note, EpochIndex(last_epoch))
+        ),
+        "one bind carries the whole multi-window span"
+    );
+}
+
+/// One covering derivation serves init, epoch bookkeeping, and spend: the
+/// fixture's memoized covering window is the same PCD at every consumer, and
+/// the whole spend flow closes against it.
+#[test]
+fn one_window_serves_init_bind_and_spend() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let epoch = init_height.epoch();
+
+    let window = user.derivation_pcd(rng, note, epoch, EpochIndex(epoch.0 + 2));
+    let spendable = user.spendable_init(rng, &note, &pool, init_height);
+    let again = user.derivation_pcd(rng, note, epoch, epoch.next());
+    assert_eq!(
+        again.data(),
+        window.data(),
+        "the memoized covering window is one PCD for every request inside it"
+    );
+
+    let bind_pcd = honest_spend_bind(rng, &user, &note, spendable, epoch);
+    assert_eq!(bind_pcd.data().1, user.nf_at(&note, epoch));
+    assert_eq!(bind_pcd.data().2, user.nf_at(&note, epoch.next()));
 }

--- a/crates/tachyon/tests/integration/stamp.rs
+++ b/crates/tachyon/tests/integration/stamp.rs
@@ -77,8 +77,9 @@ fn plan_prove_rejects_invalid_inputs() {
 
     let sp_a = user.fresh_spend(rng, &pool, height, &note_a);
     let sp_b = user.fresh_spend(rng, &pool, height, &note_b);
-    let range_a = user.nullifier_pcd(rng, note_a, spend_epoch, EpochIndex(spend_epoch.0 + 2));
-    let range_b = user.nullifier_pcd(rng, note_b, spend_epoch, EpochIndex(spend_epoch.0 + 2));
+    let spend_end = EpochIndex(spend_epoch.0 + 2);
+    let range_a = user.derivation_pcd(rng, note_a, spend_epoch, spend_end);
+    let range_b = user.derivation_pcd(rng, note_b, spend_epoch, spend_end);
 
     let (rcv_a, theta_a, alpha_a) = spend_witness(rng, &note_a);
     let plan_a = action::Plan::spend(note_a, theta_a, rcv_a, |alpha| {
@@ -141,10 +142,9 @@ fn plan_prove_rejects_invalid_inputs() {
         );
     }
 
-    // Correspondence swap: lengths match, pairing is wrong. Each pair is
-    // internally consistent, so SpendBind binds it; the plan's note is the
-    // odd one out, and SpendStamp's `note.commitment() == cm` check catches
-    // it when the action is proven.
+    // Correspondence swap: lengths match, pairing is wrong. The spend's note
+    // key rebuilds a covering sequence that cannot match the mispaired
+    // derivation's commitment, so SpendBind rejects.
     {
         let plan = Plan::new(two_spends(), alloc::vec![], anchor);
         let pcds = alloc::vec![bundle_b(), bundle_a()];
@@ -154,7 +154,7 @@ fn plan_prove_rejects_invalid_inputs() {
         };
         assert_eq!(
             reason.to_string(),
-            "SpendStamp: note does not match the spend"
+            "SpendBind: covering sequence does not match header"
         );
     }
 }


### PR DESCRIPTION
nullifier sequences are a multiset of `(nf, epoch)` encodings.

- `NfDerive` emits a window of 16 consecutive nullifiers
- `UnspentBind` confirms a subsequence by quotient
