### PR TITLE
feat: expose lift API, enabling stamps to be merged across anchors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+# Inject KaTeX + mermaid into rustdoc output so `cargo doc --open` renders
+# math and diagrams from doc comments. Path is relative to the workspace
+# root (the cwd of rustdoc when cargo invokes it).
+rustdocflags = ["--html-in-header", "doc/rustdoc-header.html"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ProofStamp::lift`, which advances a stamp's anchor along a chain of
+  `AnchorLink`s. `MergeStamp` constrains both sides of a merge to one anchor,
+  but wallets stamp against whatever anchor was current when they built, so an
+  aggregator collecting stamps from different heights had no way to align them.
+  Lifting is the "match/update anchors" step of the aggregation process.
+- `AnchorLink`, one block's contribution to the anchor chain: a `Stamp` link per
+  stamp absorbed, or an `Empty` link for a block absorbing none.
+  `AnchorLink::advance` folds a link over an anchor without proving, so a caller
+  can pick the links reaching a target anchor before paying for a lift.
+
+  Both are wrappers over the already-registered `StampLift`, `AnchorSeed`,
+  `EmptyBlockSeed`, and `AnchorFuse` steps: no circuit, step registration, or
+  proof-system change. A lift cannot cross an epoch boundary, since
+  `AnchorChain` has no link for one.
+
 ## [0.0.0] - 2026-02-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `ProofStamp::lift`, which advances a stamp's anchor along a chain of
-  `AnchorLink`s. `MergeStamp` constrains both sides of a merge to one anchor,
+- `ProofStamp::lift`, which advances a stamp's anchor along a reusable
+  `AnchorSegment`. `MergeStamp` constrains both sides of a merge to one anchor,
   but wallets stamp against whatever anchor was current when they built, so an
-  aggregator collecting stamps from different heights had no way to align them.
-  Lifting is the "match/update anchors" step of the aggregation process.
-- `AnchorLink`, one block's contribution to the anchor chain: a `Stamp` link per
-  stamp absorbed, or an `Empty` link for a block absorbing none.
-  `AnchorLink::advance` folds a link over an anchor without proving, so a caller
-  can pick the links reaching a target anchor before paying for a lift.
+  aggregator collecting stamps from different heights had no way to align
+  them. Lifting is the "match/update anchors" step of aggregation.
+- `AnchorStep` and `AnchorSegment`, the validated, intra-epoch view of an anchor
+  chain. A node supplies one stamp step per absorbed proof stamp, in transaction
+  order, or one empty-block step for a block absorbing none. Segment
+  construction checks the predicted endpoint against consensus state before
+  proving, and the resulting proof can be reused for stamps at the same anchor.
 
   Both are wrappers over the already-registered `StampLift`, `AnchorSeed`,
   `EmptyBlockSeed`, and `AnchorFuse` steps: no circuit, step registration, or

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -38,7 +38,7 @@ use crate::{
         TachygramSetPoly, effect,
     },
     stamp::{
-        AnchorLink, PointerStamp, ProofStamp, StampState,
+        AnchorStep, PointerStamp, ProofStamp, StampState,
         proof::{
             PROOF_SYSTEM, delegation, pool, spendable,
             stamp::{MergeStamp, StampHeader},
@@ -653,32 +653,35 @@ fn build_anchor_chain_inner(
     chain.expect("AnchorChain range must cover at least one block")
 }
 
-/// The [`AnchorLink`] sequence covering blocks `range` in full: one
-/// [`AnchorLink::Stamp`] per stamp absorbed, in stamp order, or a single
-/// [`AnchorLink::Empty`] for a block that absorbs none.
+/// The [`AnchorStep`] sequence covering blocks `range` in full: one stamp step
+/// per stamp absorbed, in stamp order, or one empty-block step for a block that
+/// absorbs none.
 ///
 /// This is the link view of the same walk [`build_anchor_chain_inner`] proves,
 /// and is what a node assembles from block data to drive
 /// [`ProofStamp::lift`].
-pub(crate) fn anchor_links_between(
+pub(crate) fn anchor_steps_between(
     pool: &PoolSim,
     range: RangeInclusive<BlockHeight>,
-) -> Vec<AnchorLink> {
+) -> Vec<AnchorStep> {
     let (start, end) = (*range.start(), *range.end());
     assert!(start <= end);
+    assert_eq!(
+        start.epoch(),
+        end.epoch(),
+        "anchor segment must be intra-epoch"
+    );
 
     let mut links = Vec::new();
     let mut height = start;
     loop {
         let commits = pool.stamp_commits_at(height);
         if commits.is_empty() {
-            links.push(AnchorLink::Empty {
-                epoch: height.epoch(),
-            });
+            links.push(AnchorStep::empty_block());
         } else {
-            links.extend(commits.into_iter().map(|tachygram_set| AnchorLink::Stamp {
-                epoch: height.epoch(),
-                tachygram_set,
+            links.extend(commits.into_iter().map(|tachygram_set| {
+                AnchorStep::stamp(tachygram_set)
+                    .expect("PoolSim stamps have non-identity set commitments")
             }));
         }
 

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -38,7 +38,7 @@ use crate::{
         TachygramSetPoly, effect,
     },
     stamp::{
-        PointerStamp, ProofStamp, StampState,
+        AnchorLink, PointerStamp, ProofStamp, StampState,
         proof::{
             PROOF_SYSTEM, delegation, pool, spendable,
             stamp::{MergeStamp, StampHeader},
@@ -651,6 +651,44 @@ fn build_anchor_chain_inner(
     }
 
     chain.expect("AnchorChain range must cover at least one block")
+}
+
+/// The [`AnchorLink`] sequence covering blocks `range` in full: one
+/// [`AnchorLink::Stamp`] per stamp absorbed, in stamp order, or a single
+/// [`AnchorLink::Empty`] for a block that absorbs none.
+///
+/// This is the link view of the same walk [`build_anchor_chain_inner`] proves,
+/// and is what a node assembles from block data to drive
+/// [`ProofStamp::lift`].
+pub(crate) fn anchor_links_between(
+    pool: &PoolSim,
+    range: RangeInclusive<BlockHeight>,
+) -> Vec<AnchorLink> {
+    let (start, end) = (*range.start(), *range.end());
+    assert!(start <= end);
+
+    let mut links = Vec::new();
+    let mut height = start;
+    loop {
+        let commits = pool.stamp_commits_at(height);
+        if commits.is_empty() {
+            links.push(AnchorLink::Empty {
+                epoch: height.epoch(),
+            });
+        } else {
+            links.extend(commits.into_iter().map(|tachygram_set| AnchorLink::Stamp {
+                epoch: height.epoch(),
+                tachygram_set,
+            }));
+        }
+
+        if height >= end {
+            break;
+        }
+        height = height.next().expect("height < max");
+    }
+
+    links
 }
 
 /// Build an [`AnchorChain`] covering blocks `range` in full, rooted at the

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -40,5 +40,6 @@ pub use note::Note;
 pub use primitives::*;
 pub use serialization::compactsize::{CompactSize, CompactSizeError};
 pub use stamp::{
-    AggregateIdError, AnchorLink, Plan as StampPlan, PointerStamp, ProofStamp, Unproven,
+    AggregateIdError, AnchorSegment, AnchorSegmentError, AnchorStep, AnchorStepError,
+    Plan as StampPlan, PointerStamp, ProofStamp, Unproven,
 };

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -39,4 +39,6 @@ pub use bundle::{
 pub use note::Note;
 pub use primitives::*;
 pub use serialization::compactsize::{CompactSize, CompactSizeError};
-pub use stamp::{AggregateIdError, Plan as StampPlan, PointerStamp, ProofStamp, Unproven};
+pub use stamp::{
+    AggregateIdError, AnchorLink, Plan as StampPlan, PointerStamp, ProofStamp, Unproven,
+};

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -14,7 +14,8 @@ use ff::PrimeField as _;
 use pasta_curves::Fp;
 use proof::{
     PROOF_SYSTEM, output,
-    stamp::{MergeStamp, OutputStamp, SpendStamp, StampHeader},
+    pool::{AnchorChain, AnchorFuse, AnchorSeed, EmptyBlockSeed},
+    stamp::{MergeStamp, OutputStamp, SpendStamp, StampHeader, StampLift},
 };
 use ragu::{self, proof::PROOF_SIZE_COMPRESSED};
 use rand_core::{CryptoRng, RngCore};
@@ -26,7 +27,9 @@ use crate::{
     effect,
     entropy::ActionRandomizer,
     keys::ProofAuthorizingKey,
-    primitives::{ActionDigest, ActionDigestError, Anchor, Tachygram, TachygramSetCommit},
+    primitives::{
+        ActionDigest, ActionDigestError, Anchor, EpochIndex, Tachygram, TachygramSetCommit,
+    },
     serialization,
     stamp::proof::{delegation, spend, spendable},
     value,
@@ -456,6 +459,18 @@ pub enum ProveError {
     /// Stamp merge failed; carries the underlying step-level error.
     #[display("stamp merge failed: {_0}")]
     MergeFailed(ragu::Error),
+    /// A lift was asked for over an empty anchor chain, which would leave the
+    /// stamp where it is.
+    #[display("anchor chain has no links")]
+    LiftEmptyChain,
+    /// A lift was asked for over links from more than one epoch.
+    /// [`AnchorChain`] has no epoch-boundary link, so a segment cannot cross
+    /// one.
+    #[display("anchor chain spans more than one epoch")]
+    LiftAcrossEpochs,
+    /// Stamp lift failed; carries the underlying step-level error.
+    #[display("stamp lift failed: {_0}")]
+    LiftFailed(ragu::Error),
     /// Number of spendable PCDs doesn't match number of spends.
     #[display("spendable PCD count mismatch")]
     SpendableMismatch,
@@ -500,6 +515,112 @@ type StampComponents = (
     Anchor,
     Box<ragu::Proof>,
 );
+
+/// One block's contribution to the anchor chain, as replayed by
+/// [`ProofStamp::lift`].
+///
+/// A node reads these straight off the chain: a block contributes one
+/// [`AnchorLink::Stamp`] per stamp it absorbs, in stamp order, or a single
+/// [`AnchorLink::Empty`] when it absorbs none. That is the same fold
+/// [`Anchor::next_stamp`] and [`Anchor::next_empty`] perform, so a link
+/// sequence and the anchors it produces are two views of one chain.
+///
+/// An epoch boundary has no link: [`AnchorChain`] cannot express one, so a lift
+/// cannot cross one.
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
+#[expect(
+    variant_size_differences,
+    reason = "a stamp link carries a curve point and an empty link carries \
+              nothing; boxing it would cost an allocation per link and drop Copy"
+)]
+pub enum AnchorLink {
+    /// One stamp absorbed by a block in `epoch`.
+    Stamp {
+        /// The epoch of the block containing the stamp.
+        epoch: EpochIndex,
+        /// The absorbed stamp's tachygram-set commitment.
+        tachygram_set: TachygramSetCommit,
+    },
+    /// One block in `epoch` that absorbs no stamps.
+    Empty {
+        /// The epoch of the empty block.
+        epoch: EpochIndex,
+    },
+}
+
+impl AnchorLink {
+    /// The epoch of the block this link came from.
+    #[must_use]
+    pub const fn epoch(self) -> EpochIndex {
+        match self {
+            Self::Stamp { epoch, .. } | Self::Empty { epoch } => epoch,
+        }
+    }
+
+    /// Advance `anchor` across this link, matching what the circuit computes.
+    ///
+    /// Folding [`AnchorLink::advance`] over a link sequence gives the anchor a
+    /// [`ProofStamp::lift`] over that sequence lands on, without proving
+    /// anything — which is how a caller picks the links that reach a target.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a [`AnchorLink::Stamp`] link's `tachygram_set` is the identity
+    /// point. No real stamp produces one: the set polynomial is monic, so its
+    /// commitment is never the identity.
+    #[must_use]
+    pub fn advance(self, anchor: Anchor) -> Anchor {
+        match self {
+            Self::Stamp {
+                epoch,
+                tachygram_set,
+            } => anchor.next_stamp(epoch, &tachygram_set),
+            Self::Empty { epoch } => anchor.next_empty(epoch),
+        }
+    }
+}
+
+/// Seeds the one-link [`AnchorChain`] segment that `link` spans, rooted at
+/// `start`.
+fn seed_anchor_link<RNG: RngCore + CryptoRng>(
+    rng: &mut RNG,
+    start: Anchor,
+    link: AnchorLink,
+) -> Result<ragu::Pcd<AnchorChain>, ragu::Error> {
+    let (seed, ()) = match link {
+        AnchorLink::Stamp {
+            epoch,
+            tachygram_set,
+        } => PROOF_SYSTEM.seed(rng, AnchorSeed, (start, epoch, tachygram_set))?,
+        AnchorLink::Empty { epoch } => PROOF_SYSTEM.seed(rng, EmptyBlockSeed, (start, epoch))?,
+    };
+
+    Ok(seed)
+}
+
+/// Builds the [`AnchorChain`] segment rooted at `start` that spans `first`
+/// followed by `rest`, by seeding each link and composing adjacent segments.
+///
+/// Taking the first link separately keeps the segment non-empty by
+/// construction: [`AnchorChain`] has no identity element to start a fold from.
+fn build_anchor_chain<RNG: RngCore + CryptoRng>(
+    rng: &mut RNG,
+    start: Anchor,
+    (first, rest): (AnchorLink, &[AnchorLink]),
+) -> Result<ragu::Pcd<AnchorChain>, ragu::Error> {
+    let mut chain = seed_anchor_link(rng, start, first)?;
+    let mut state = first.advance(start);
+
+    for &link in rest {
+        let seed = seed_anchor_link(rng, state, link)?;
+        state = link.advance(state);
+
+        let (fused, ()) = PROOF_SYSTEM.fuse(rng, AnchorFuse, (), chain, seed)?;
+        chain = fused;
+    }
+
+    Ok(chain)
+}
 
 impl ProofStamp {
     /// Proves a single output action, returning the stamp components
@@ -693,6 +814,100 @@ impl ProofStamp {
             tachygram_set,
             tachygrams,
             proof,
+        })
+    }
+
+    /// Advances this stamp's anchor along `links`, so it can [`merge`] with
+    /// stamps that already sit at the later anchor.
+    ///
+    /// [`MergeStamp`] constrains both sides to one anchor, but wallets stamp
+    /// against whatever anchor was current when they built, and every block
+    /// mints a new one. Lifting is what lets an aggregator collect stamps from
+    /// different heights into a single merge.
+    ///
+    /// `links` is the anchor chain strictly after the stamp's current anchor,
+    /// in block order, up to and including the target — see [`AnchorLink`]. The
+    /// stamp pairs with the descriptors of its covered actions, as it does for
+    /// [`merge`], because the PCD header is reconstructed rather than stored.
+    ///
+    /// Only `anchor` and `proof` change. [`StampLift`] passes the action and
+    /// tachygram commitments through untouched, so `coverage`, `tachygrams`,
+    /// and `tachygram_set` all survive the lift, and a lifted stamp still
+    /// covers exactly the actions it covered before.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProveError::LiftEmptyChain`] if `links` is empty, and
+    /// [`ProveError::LiftAcrossEpochs`] if the links do not all share one
+    /// epoch, since [`AnchorChain`] has no epoch-boundary link.
+    ///
+    /// The caller must also keep the stamp's own anchor inside that epoch,
+    /// which this function cannot check: an anchor is a field element and
+    /// carries no height. Lifting from the last anchor of one epoch skips the
+    /// [`Anchor::next_epoch`] fold the real chain performs, and lands off the
+    /// published sequence — accepted here, rejected later by consensus anchor
+    /// membership.
+    ///
+    /// [`merge`]: ProofStamp::merge
+    pub fn lift<RNG: RngCore + CryptoRng>(
+        rng: &mut RNG,
+        (stamp, descriptors): (Self, BTreeSet<action::Descriptor>),
+        links: &[AnchorLink],
+    ) -> Result<Self, ProveError> {
+        let Some((&first, rest)) = links.split_first() else {
+            return Err(ProveError::LiftEmptyChain);
+        };
+
+        let epoch = first.epoch();
+        if rest.iter().any(|link| link.epoch() != epoch) {
+            return Err(ProveError::LiftAcrossEpochs);
+        }
+
+        let Self {
+            coverage,
+            anchor,
+            tachygrams,
+            proof,
+            ..
+        } = stamp;
+
+        let action_commit = descriptors
+            .iter()
+            .map(action::Descriptor::digest)
+            .collect::<Result<BTreeSet<ActionDigest>, ActionDigestError>>()
+            .map_err(ProveError::ActionDigest)?
+            .into_iter()
+            .collect::<ActionSetPoly>()
+            .commit();
+
+        // Recomputed rather than read off the stamp, as `prove_merge` does: the
+        // proof binds the accumulator the circuit witnessed, so a carried
+        // `tachygram_set` disagreeing with `tachygrams` fails the fuse instead
+        // of riding along.
+        let tachygram_commit = tachygrams
+            .iter()
+            .copied()
+            .collect::<TachygramSetPoly>()
+            .commit();
+
+        let stamp_pcd = proof.carry::<StampHeader>((action_commit, tachygram_commit, anchor));
+        let chain =
+            build_anchor_chain(rng, anchor, (first, rest)).map_err(ProveError::LiftFailed)?;
+
+        let (pcd, ()) = PROOF_SYSTEM
+            .fuse(rng, StampLift, (), stamp_pcd, chain)
+            .map_err(ProveError::LiftFailed)?;
+        let lifted_anchor = pcd.data().2;
+        let rerand = PROOF_SYSTEM
+            .rerandomize(pcd, rng)
+            .map_err(ProveError::LiftFailed)?;
+
+        Ok(Self {
+            coverage,
+            anchor: lifted_anchor,
+            tachygram_set: tachygram_commit,
+            tachygrams,
+            proof: Box::new(rerand.proof().clone()),
         })
     }
 

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -7,10 +7,12 @@ extern crate alloc;
 pub mod proof;
 
 use alloc::{boxed::Box, collections::BTreeSet, vec, vec::Vec};
+use core::fmt;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, Into, PartialEq};
 use ff::PrimeField as _;
+use group::Group as _;
 use pasta_curves::Fp;
 use proof::{
     PROOF_SYSTEM, output,
@@ -459,15 +461,14 @@ pub enum ProveError {
     /// Stamp merge failed; carries the underlying step-level error.
     #[display("stamp merge failed: {_0}")]
     MergeFailed(ragu::Error),
-    /// A lift was asked for over an empty anchor chain, which would leave the
-    /// stamp where it is.
-    #[display("anchor chain has no links")]
-    LiftEmptyChain,
-    /// A lift was asked for over links from more than one epoch.
-    /// [`AnchorChain`] has no epoch-boundary link, so a segment cannot cross
-    /// one.
-    #[display("anchor chain spans more than one epoch")]
-    LiftAcrossEpochs,
+    /// A lift's segment does not start at the stamp's anchor.
+    #[display("anchor segment starts at {segment_start:?}, stamp is at {stamp_anchor:?}")]
+    LiftStartMismatch {
+        /// The stamp's current anchor.
+        stamp_anchor: Anchor,
+        /// The supplied segment's starting anchor.
+        segment_start: Anchor,
+    },
     /// Stamp lift failed; carries the underlying step-level error.
     #[display("stamp lift failed: {_0}")]
     LiftFailed(ragu::Error),
@@ -516,104 +517,204 @@ type StampComponents = (
     Box<ragu::Proof>,
 );
 
-/// One block's contribution to the anchor chain, as replayed by
-/// [`ProofStamp::lift`].
+/// An invalid [`AnchorStep`].
+#[derive(Clone, Copy, Debug, Display, Error, PartialEq, TotalEq)]
+#[non_exhaustive]
+pub enum AnchorStepError {
+    /// A stamp step carried the identity point instead of a real set
+    /// commitment.
+    #[display("stamp tachygram-set commitment is the identity point")]
+    IdentityTachygramSet,
+}
+
+/// One transition in an intra-epoch anchor segment.
 ///
-/// A node reads these straight off the chain: a block contributes one
-/// [`AnchorLink::Stamp`] per stamp it absorbs, in stamp order, or a single
-/// [`AnchorLink::Empty`] when it absorbs none. That is the same fold
-/// [`Anchor::next_stamp`] and [`Anchor::next_empty`] perform, so a link
-/// sequence and the anchors it produces are two views of one chain.
-///
-/// An epoch boundary has no link: [`AnchorChain`] cannot express one, so a lift
-/// cannot cross one.
+/// A node derives these from validated blocks: one stamp step per proof stamp,
+/// in transaction order, or one empty-block step when a block contains no
+/// proof stamps. The epoch is carried once by [`AnchorSegment`], rather than in
+/// every step, so a segment cannot accidentally mix epochs.
 #[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
-#[expect(
-    variant_size_differences,
-    reason = "a stamp link carries a curve point and an empty link carries \
-              nothing; boxing it would cost an allocation per link and drop Copy"
-)]
-pub enum AnchorLink {
-    /// One stamp absorbed by a block in `epoch`.
-    Stamp {
-        /// The epoch of the block containing the stamp.
-        epoch: EpochIndex,
-        /// The absorbed stamp's tachygram-set commitment.
-        tachygram_set: TachygramSetCommit,
-    },
-    /// One block in `epoch` that absorbs no stamps.
-    Empty {
-        /// The epoch of the empty block.
-        epoch: EpochIndex,
-    },
+pub struct AnchorStep(AnchorStepKind);
+
+#[derive(Clone, Copy, Debug, PartialEq, TotalEq)]
+enum AnchorStepKind {
+    Stamp { tachygram_set: TachygramSetCommit },
+    EmptyBlock,
 }
 
-impl AnchorLink {
-    /// The epoch of the block this link came from.
-    #[must_use]
-    pub const fn epoch(self) -> EpochIndex {
-        match self {
-            Self::Stamp { epoch, .. } | Self::Empty { epoch } => epoch,
+impl AnchorStep {
+    /// Construct a step that absorbs one proof stamp.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnchorStepError::IdentityTachygramSet`] if `tachygram_set` is
+    /// the identity point, which no real set-polynomial commitment can be.
+    pub fn stamp(tachygram_set: TachygramSetCommit) -> Result<Self, AnchorStepError> {
+        let point: pasta_curves::Eq = tachygram_set.into();
+        if bool::from(point.is_identity()) {
+            return Err(AnchorStepError::IdentityTachygramSet);
         }
+
+        Ok(Self(AnchorStepKind::Stamp { tachygram_set }))
     }
 
-    /// Advance `anchor` across this link, matching what the circuit computes.
-    ///
-    /// Folding [`AnchorLink::advance`] over a link sequence gives the anchor a
-    /// [`ProofStamp::lift`] over that sequence lands on, without proving
-    /// anything — which is how a caller picks the links that reach a target.
-    ///
-    /// # Panics
-    ///
-    /// Panics if a [`AnchorLink::Stamp`] link's `tachygram_set` is the identity
-    /// point. No real stamp produces one: the set polynomial is monic, so its
-    /// commitment is never the identity.
+    /// Construct the single step contributed by a block with no proof stamps.
     #[must_use]
-    pub fn advance(self, anchor: Anchor) -> Anchor {
-        match self {
-            Self::Stamp {
-                epoch,
-                tachygram_set,
-            } => anchor.next_stamp(epoch, &tachygram_set),
-            Self::Empty { epoch } => anchor.next_empty(epoch),
+    pub const fn empty_block() -> Self {
+        Self(AnchorStepKind::EmptyBlock)
+    }
+
+    /// Whether this is an empty-block step.
+    #[must_use]
+    pub const fn is_empty_block(self) -> bool {
+        matches!(self.0, AnchorStepKind::EmptyBlock)
+    }
+
+    /// Advance `anchor` across this step in `epoch`, matching what the circuit
+    /// computes.
+    ///
+    /// Folding this method over a step sequence predicts its endpoint without
+    /// proving. Construction rejects the only input on which
+    /// [`Anchor::next_stamp`] can panic.
+    #[must_use]
+    pub fn advance(self, anchor: Anchor, epoch: EpochIndex) -> Anchor {
+        match self.0 {
+            AnchorStepKind::Stamp { tachygram_set } => anchor.next_stamp(epoch, &tachygram_set),
+            AnchorStepKind::EmptyBlock => anchor.next_empty(epoch),
         }
     }
 }
 
-/// Seeds the one-link [`AnchorChain`] segment that `link` spans, rooted at
+/// Errors constructing a reusable [`AnchorSegment`].
+#[derive(Debug, Display, Error)]
+#[non_exhaustive]
+pub enum AnchorSegmentError {
+    /// A segment had no steps.
+    #[display("anchor segment has no steps")]
+    Empty,
+    /// The supplied steps do not reach the expected endpoint.
+    #[display("anchor segment ends at {actual:?}, expected {expected:?}")]
+    EndMismatch {
+        /// The endpoint supplied by the caller from consensus state.
+        expected: Anchor,
+        /// The endpoint obtained by folding the supplied steps.
+        actual: Anchor,
+    },
+    /// Proving the anchor segment failed.
+    #[display("anchor segment proof failed: {_0}")]
+    Proof(ragu::Error),
+}
+
+/// A reusable proof of an intra-epoch anchor segment.
+///
+/// Constructing the segment separately lets an aggregator reuse its proof for
+/// multiple stamps at the same anchor. Its endpoint is checked against the
+/// caller's consensus-state anchor before any proof work begins.
+#[derive(Clone)]
+pub struct AnchorSegment {
+    epoch: EpochIndex,
+    chain: ragu::Pcd<AnchorChain>,
+}
+
+impl fmt::Debug for AnchorSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AnchorSegment")
+            .field("epoch", &self.epoch)
+            .field("start", &self.start())
+            .field("end", &self.end())
+            .finish_non_exhaustive()
+    }
+}
+
+impl AnchorSegment {
+    /// Prove that `steps` advance `start` to `expected_end` within `epoch`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnchorSegmentError::Empty`] for an empty segment,
+    /// [`AnchorSegmentError::EndMismatch`] when the host-side fold does not
+    /// reach `expected_end`, or [`AnchorSegmentError::Proof`] if recursive
+    /// proof construction fails.
+    pub fn prove<RNG: RngCore + CryptoRng>(
+        rng: &mut RNG,
+        start: Anchor,
+        epoch: EpochIndex,
+        expected_end: Anchor,
+        steps: &[AnchorStep],
+    ) -> Result<Self, AnchorSegmentError> {
+        let Some((&first, rest)) = steps.split_first() else {
+            return Err(AnchorSegmentError::Empty);
+        };
+
+        let actual = steps
+            .iter()
+            .fold(start, |anchor, step| step.advance(anchor, epoch));
+        if actual != expected_end {
+            return Err(AnchorSegmentError::EndMismatch {
+                expected: expected_end,
+                actual,
+            });
+        }
+
+        let chain = build_anchor_chain(rng, start, epoch, (first, rest))
+            .map_err(AnchorSegmentError::Proof)?;
+
+        Ok(Self { epoch, chain })
+    }
+
+    /// The epoch containing every step in this segment.
+    #[must_use]
+    pub const fn epoch(&self) -> EpochIndex {
+        self.epoch
+    }
+
+    /// The segment's starting anchor.
+    #[must_use]
+    pub fn start(&self) -> Anchor {
+        self.chain.data().0
+    }
+
+    /// The segment's ending anchor.
+    #[must_use]
+    pub fn end(&self) -> Anchor {
+        self.chain.data().1
+    }
+}
+
+/// Seeds the one-step [`AnchorChain`] segment that `step` spans, rooted at
 /// `start`.
-fn seed_anchor_link<RNG: RngCore + CryptoRng>(
+fn seed_anchor_step<RNG: RngCore + CryptoRng>(
     rng: &mut RNG,
     start: Anchor,
-    link: AnchorLink,
+    epoch: EpochIndex,
+    step: AnchorStep,
 ) -> Result<ragu::Pcd<AnchorChain>, ragu::Error> {
-    let (seed, ()) = match link {
-        AnchorLink::Stamp {
-            epoch,
-            tachygram_set,
-        } => PROOF_SYSTEM.seed(rng, AnchorSeed, (start, epoch, tachygram_set))?,
-        AnchorLink::Empty { epoch } => PROOF_SYSTEM.seed(rng, EmptyBlockSeed, (start, epoch))?,
+    let (seed, ()) = match step.0 {
+        AnchorStepKind::Stamp { tachygram_set } => {
+            PROOF_SYSTEM.seed(rng, AnchorSeed, (start, epoch, tachygram_set))?
+        },
+        AnchorStepKind::EmptyBlock => PROOF_SYSTEM.seed(rng, EmptyBlockSeed, (start, epoch))?,
     };
 
     Ok(seed)
 }
 
 /// Builds the [`AnchorChain`] segment rooted at `start` that spans `first`
-/// followed by `rest`, by seeding each link and composing adjacent segments.
+/// followed by `rest`, by seeding each step and composing adjacent segments.
 ///
-/// Taking the first link separately keeps the segment non-empty by
+/// Taking the first step separately keeps the segment non-empty by
 /// construction: [`AnchorChain`] has no identity element to start a fold from.
 fn build_anchor_chain<RNG: RngCore + CryptoRng>(
     rng: &mut RNG,
     start: Anchor,
-    (first, rest): (AnchorLink, &[AnchorLink]),
+    epoch: EpochIndex,
+    (first, rest): (AnchorStep, &[AnchorStep]),
 ) -> Result<ragu::Pcd<AnchorChain>, ragu::Error> {
-    let mut chain = seed_anchor_link(rng, start, first)?;
-    let mut state = first.advance(start);
+    let mut chain = seed_anchor_step(rng, start, epoch, first)?;
 
-    for &link in rest {
-        let seed = seed_anchor_link(rng, state, link)?;
-        state = link.advance(state);
+    for &step in rest {
+        let next_start = chain.data().1;
+        let seed = seed_anchor_step(rng, next_start, epoch, step)?;
 
         let (fused, ()) = PROOF_SYSTEM.fuse(rng, AnchorFuse, (), chain, seed)?;
         chain = fused;
@@ -817,18 +918,18 @@ impl ProofStamp {
         })
     }
 
-    /// Advances this stamp's anchor along `links`, so it can [`merge`] with
-    /// stamps that already sit at the later anchor.
+    /// Advances this stamp's anchor along `segment`, so it can [`merge`] with
+    /// stamps that already sit at the segment's later anchor.
     ///
     /// [`MergeStamp`] constrains both sides to one anchor, but wallets stamp
     /// against whatever anchor was current when they built, and every block
     /// mints a new one. Lifting is what lets an aggregator collect stamps from
     /// different heights into a single merge.
     ///
-    /// `links` is the anchor chain strictly after the stamp's current anchor,
-    /// in block order, up to and including the target — see [`AnchorLink`]. The
-    /// stamp pairs with the descriptors of its covered actions, as it does for
-    /// [`merge`], because the PCD header is reconstructed rather than stored.
+    /// The stamp pairs with the descriptors of its covered actions, as it does
+    /// for [`merge`], because the PCD header is reconstructed rather than
+    /// stored. A segment can be cloned and reused to lift multiple stamps from
+    /// the same anchor.
     ///
     /// Only `anchor` and `proof` change. [`StampLift`] passes the action and
     /// tachygram commitments through untouched, so `coverage`, `tachygrams`,
@@ -837,32 +938,17 @@ impl ProofStamp {
     ///
     /// # Errors
     ///
-    /// Returns [`ProveError::LiftEmptyChain`] if `links` is empty, and
-    /// [`ProveError::LiftAcrossEpochs`] if the links do not all share one
-    /// epoch, since [`AnchorChain`] has no epoch-boundary link.
-    ///
-    /// The caller must also keep the stamp's own anchor inside that epoch,
-    /// which this function cannot check: an anchor is a field element and
-    /// carries no height. Lifting from the last anchor of one epoch skips the
-    /// [`Anchor::next_epoch`] fold the real chain performs, and lands off the
-    /// published sequence — accepted here, rejected later by consensus anchor
-    /// membership.
+    /// Returns [`ProveError::LiftStartMismatch`] if the segment does not start
+    /// at this stamp's anchor. The proof system also verifies the stamp against
+    /// the commitments reconstructed from `descriptors` and the stamp's
+    /// tachygrams.
     ///
     /// [`merge`]: ProofStamp::merge
     pub fn lift<RNG: RngCore + CryptoRng>(
         rng: &mut RNG,
         (stamp, descriptors): (Self, BTreeSet<action::Descriptor>),
-        links: &[AnchorLink],
+        segment: &AnchorSegment,
     ) -> Result<Self, ProveError> {
-        let Some((&first, rest)) = links.split_first() else {
-            return Err(ProveError::LiftEmptyChain);
-        };
-
-        let epoch = first.epoch();
-        if rest.iter().any(|link| link.epoch() != epoch) {
-            return Err(ProveError::LiftAcrossEpochs);
-        }
-
         let Self {
             coverage,
             anchor,
@@ -870,6 +956,14 @@ impl ProofStamp {
             proof,
             ..
         } = stamp;
+
+        let segment_start = segment.start();
+        if segment_start != anchor {
+            return Err(ProveError::LiftStartMismatch {
+                stamp_anchor: anchor,
+                segment_start,
+            });
+        }
 
         let action_commit = descriptors
             .iter()
@@ -880,10 +974,9 @@ impl ProofStamp {
             .collect::<ActionSetPoly>()
             .commit();
 
-        // Recomputed rather than read off the stamp, as `prove_merge` does: the
-        // proof binds the accumulator the circuit witnessed, so a carried
-        // `tachygram_set` disagreeing with `tachygrams` fails the fuse instead
-        // of riding along.
+        // Recomputed rather than trusting the carried cache, as `prove_merge`
+        // does. The proof binds the accumulator the circuit witnessed, so
+        // tachygrams that disagree with the proof fail the fuse.
         let tachygram_commit = tachygrams
             .iter()
             .copied()
@@ -891,11 +984,9 @@ impl ProofStamp {
             .commit();
 
         let stamp_pcd = proof.carry::<StampHeader>((action_commit, tachygram_commit, anchor));
-        let chain =
-            build_anchor_chain(rng, anchor, (first, rest)).map_err(ProveError::LiftFailed)?;
 
         let (pcd, ()) = PROOF_SYSTEM
-            .fuse(rng, StampLift, (), stamp_pcd, chain)
+            .fuse(rng, StampLift, (), stamp_pcd, segment.chain.clone())
             .map_err(ProveError::LiftFailed)?;
         let lifted_anchor = pcd.data().2;
         let rerand = PROOF_SYSTEM

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -3,6 +3,7 @@
 use alloc::{boxed::Box, string::ToString as _, vec, vec::Vec};
 
 use ff::Field as _;
+use group::Group as _;
 use rand::{SeedableRng as _, rngs::StdRng};
 
 use super::*;
@@ -10,7 +11,7 @@ use crate::{
     action,
     constants::EPOCH_SIZE,
     fixtures::{
-        PoolSim, WalletSim, anchor_links_between, build_autonome, build_output_stamp,
+        PoolSim, WalletSim, anchor_steps_between, build_autonome, build_output_stamp,
         forge_overlapping_merge, random_action, random_block, random_block_with, shared_sk,
         spend_witness,
     },
@@ -705,6 +706,9 @@ fn lift_lands_on_chain_anchor() {
     let stamp_height = pool.height();
     let note = wallet.random_note(200);
     let (stamp, plan) = build_output_stamp(rng, pool.anchor_at(stamp_height), note);
+    let second_note = wallet.random_note(300);
+    let (second_stamp, second_plan) =
+        build_output_stamp(rng, pool.anchor_at(stamp_height), second_note);
 
     // A mix of stamp-bearing and empty blocks, so both link kinds are exercised.
     pool.advance(2, |_| random_block(rng, 1, 3));
@@ -712,29 +716,37 @@ fn lift_lands_on_chain_anchor() {
     pool.advance(1, |_| random_block(rng, 1, 2));
     let target_height = pool.height();
 
-    let links = anchor_links_between(
+    let steps = anchor_steps_between(
         &pool,
         stamp_height.next().expect("height < max")..=target_height,
     );
     assert!(
-        links
-            .iter()
-            .any(|link| matches!(link, AnchorLink::Empty { .. })),
+        steps.iter().any(|step| step.is_empty_block()),
         "the chain must cover the empty block"
     );
 
     // `advance` predicts the same anchor the proof lands on, so a caller can
     // pick links without proving.
-    let predicted = links
+    let epoch = stamp_height.epoch();
+    let predicted = steps
         .iter()
-        .fold(stamp.anchor, |anchor, link| link.advance(anchor));
+        .fold(stamp.anchor, |anchor, step| step.advance(anchor, epoch));
     assert_eq!(predicted, pool.anchor_at(target_height));
+
+    let segment = AnchorSegment::prove(
+        rng,
+        stamp.anchor,
+        epoch,
+        pool.anchor_at(target_height),
+        &steps,
+    )
+    .expect("segment");
 
     let before = stamp.clone();
     let lifted = ProofStamp::lift(
         rng,
         (stamp, BTreeSet::from_iter([plan.descriptor()])),
-        &links,
+        &segment,
     )
     .expect("lift");
 
@@ -759,6 +771,21 @@ fn lift_lands_on_chain_anchor() {
             .verify_proof(rng, [plan.digest().expect("valid plan")])
             .expect("verify"),
         "a lifted stamp must still prove its own actions"
+    );
+
+    let lifted_second = ProofStamp::lift(
+        rng,
+        (
+            second_stamp,
+            BTreeSet::from_iter([second_plan.descriptor()]),
+        ),
+        &segment,
+    )
+    .expect("reuse segment");
+    assert_eq!(
+        lifted_second.anchor,
+        pool.anchor_at(target_height),
+        "a segment proof can be reused for another stamp at the same anchor"
     );
 }
 
@@ -794,11 +821,19 @@ fn lift_enables_merge_across_anchors() {
         "stamps at different anchors must not merge"
     );
 
-    let links = anchor_links_between(
+    let steps = anchor_steps_between(
         &pool,
         early_height.next().expect("height < max")..=late_height,
     );
-    let lifted_a = ProofStamp::lift(rng, (stamp_a, descriptors_a.clone()), &links).expect("lift");
+    let segment = AnchorSegment::prove(
+        rng,
+        stamp_a.anchor,
+        early_height.epoch(),
+        stamp_b.anchor,
+        &steps,
+    )
+    .expect("segment");
+    let lifted_a = ProofStamp::lift(rng, (stamp_a, descriptors_a.clone()), &segment).expect("lift");
     assert_eq!(
         lifted_a.anchor, stamp_b.anchor,
         "lift must reach b's anchor"
@@ -825,9 +860,9 @@ fn lift_enables_merge_across_anchors() {
     );
 }
 
-/// The two shapes of link list a lift refuses, before any proving happens.
+/// Invalid steps and unusable segment shapes fail before stamp lifting.
 #[test]
-fn lift_rejects_unusable_chains() {
+fn lift_rejects_unusable_segments() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::random(rng);
     let mut pool = PoolSim::genesis(rng);
@@ -838,25 +873,57 @@ fn lift_rejects_unusable_chains() {
     let (stamp, plan) = build_output_stamp(rng, pool.anchor_at(stamp_height), note);
     let descriptors = BTreeSet::from_iter([plan.descriptor()]);
 
-    let err = ProofStamp::lift(rng, (stamp.clone(), descriptors.clone()), &[]).unwrap_err();
+    let identity = TachygramSetCommit::from(pasta_curves::Eq::identity());
+    let step_err = AnchorStep::stamp(identity).unwrap_err();
     assert!(
-        matches!(err, ProveError::LiftEmptyChain),
-        "an empty chain must be refused, got {err}"
+        matches!(step_err, AnchorStepError::IdentityTachygramSet),
+        "identity commitments must be refused, got {step_err}"
     );
 
-    // `AnchorChain` has no epoch-boundary link, so a segment may not span two
-    // epochs.
-    let straddling = vec![
-        AnchorLink::Empty {
-            epoch: EpochIndex(0),
-        },
-        AnchorLink::Empty {
-            epoch: EpochIndex(1),
-        },
-    ];
-    let straddling_err = ProofStamp::lift(rng, (stamp, descriptors), &straddling).unwrap_err();
+    let empty_err =
+        AnchorSegment::prove(rng, stamp.anchor, stamp_height.epoch(), stamp.anchor, &[])
+            .unwrap_err();
     assert!(
-        matches!(straddling_err, ProveError::LiftAcrossEpochs),
-        "a chain spanning two epochs must be refused, got {straddling_err}"
+        matches!(empty_err, AnchorSegmentError::Empty),
+        "an empty segment must be refused, got {empty_err}"
+    );
+
+    // The first block of epoch 1 includes a `next_epoch` transition that an
+    // intra-epoch AnchorSegment cannot express, so its real chain endpoint
+    // cannot be reached by folding only that block's steps.
+    while pool.height() < BlockHeight(EPOCH_SIZE - 1) {
+        pool.advance(1, |_| random_block(rng, 1, 1));
+    }
+    let pre_boundary = pool.anchor();
+    pool.advance(1, |_| random_block(rng, 1, 2));
+    let epoch_first = pool.height();
+    let steps = anchor_steps_between(&pool, epoch_first..=epoch_first);
+    let boundary_err = AnchorSegment::prove(
+        rng,
+        pre_boundary,
+        epoch_first.epoch(),
+        pool.anchor_at(epoch_first),
+        &steps,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(boundary_err, AnchorSegmentError::EndMismatch { .. }),
+        "a segment that skips the epoch transition must be refused, got {boundary_err}"
+    );
+
+    let wrong_start = Anchor::default();
+    let wrong_steps = [AnchorStep::empty_block()];
+    let wrong_segment = AnchorSegment::prove(
+        rng,
+        wrong_start,
+        EpochIndex(0),
+        wrong_steps[0].advance(wrong_start, EpochIndex(0)),
+        &wrong_steps,
+    )
+    .expect("valid segment at the wrong start");
+    let start_err = ProofStamp::lift(rng, (stamp, descriptors), &wrong_segment).unwrap_err();
+    assert!(
+        matches!(start_err, ProveError::LiftStartMismatch { .. }),
+        "a segment rooted away from the stamp must be refused, got {start_err}"
     );
 }

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -10,8 +10,9 @@ use crate::{
     action,
     constants::EPOCH_SIZE,
     fixtures::{
-        PoolSim, WalletSim, build_autonome, build_output_stamp, forge_overlapping_merge,
-        random_action, random_block, random_block_with, shared_sk, spend_witness,
+        PoolSim, WalletSim, anchor_links_between, build_autonome, build_output_stamp,
+        forge_overlapping_merge, random_action, random_block, random_block_with, shared_sk,
+        spend_witness,
     },
     primitives::BlockHeight,
 };
@@ -689,5 +690,173 @@ fn accumulating_rejects_mismatched_commitment() {
             .verify_proof(rng, [plan.digest().expect("valid plan")])
             .expect("verify"),
         "verification must reject an unconfirmed commitment"
+    );
+}
+
+/// A lift lands on the anchor the chain itself produces, and leaves everything
+/// but the anchor and the proof untouched.
+#[test]
+fn lift_lands_on_chain_anchor() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+
+    pool.advance(1, |_| random_block(rng, 1, 4));
+    let stamp_height = pool.height();
+    let note = wallet.random_note(200);
+    let (stamp, plan) = build_output_stamp(rng, pool.anchor_at(stamp_height), note);
+
+    // A mix of stamp-bearing and empty blocks, so both link kinds are exercised.
+    pool.advance(2, |_| random_block(rng, 1, 3));
+    pool.advance(1, |_| random_block(rng, 1, 0));
+    pool.advance(1, |_| random_block(rng, 1, 2));
+    let target_height = pool.height();
+
+    let links = anchor_links_between(
+        &pool,
+        stamp_height.next().expect("height < max")..=target_height,
+    );
+    assert!(
+        links
+            .iter()
+            .any(|link| matches!(link, AnchorLink::Empty { .. })),
+        "the chain must cover the empty block"
+    );
+
+    // `advance` predicts the same anchor the proof lands on, so a caller can
+    // pick links without proving.
+    let predicted = links
+        .iter()
+        .fold(stamp.anchor, |anchor, link| link.advance(anchor));
+    assert_eq!(predicted, pool.anchor_at(target_height));
+
+    let before = stamp.clone();
+    let lifted = ProofStamp::lift(
+        rng,
+        (stamp, BTreeSet::from_iter([plan.descriptor()])),
+        &links,
+    )
+    .expect("lift");
+
+    assert_eq!(
+        lifted.anchor,
+        pool.anchor_at(target_height),
+        "lift must land on the chain's anchor at the target height"
+    );
+    assert_eq!(lifted.coverage, before.coverage, "coverage survives a lift");
+    assert_eq!(
+        lifted.tachygrams, before.tachygrams,
+        "tachygrams survive a lift"
+    );
+    assert_eq!(
+        lifted.tachygram_set, before.tachygram_set,
+        "the tachygram commitment survives a lift"
+    );
+
+    // The lifted proof still verifies against the actions it covered before.
+    assert!(
+        lifted
+            .verify_proof(rng, [plan.digest().expect("valid plan")])
+            .expect("verify"),
+        "a lifted stamp must still prove its own actions"
+    );
+}
+
+/// Lifting is what lets stamps built at different heights merge: the same pair
+/// that `merge` rejects on mismatched anchors succeeds once one side is lifted.
+#[test]
+fn lift_enables_merge_across_anchors() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+
+    pool.advance(1, |_| random_block(rng, 1, 4));
+    let early_height = pool.height();
+    let note_a = wallet.random_note(200);
+    let (stamp_a, plan_a) = build_output_stamp(rng, pool.anchor_at(early_height), note_a);
+
+    pool.advance(3, |_| random_block(rng, 1, 2));
+    let late_height = pool.height();
+    let note_b = wallet.random_note(300);
+    let (stamp_b, plan_b) = build_output_stamp(rng, pool.anchor_at(late_height), note_b);
+
+    let descriptors_a = BTreeSet::from_iter([plan_a.descriptor()]);
+    let descriptors_b = BTreeSet::from_iter([plan_b.descriptor()]);
+
+    // Mismatched anchors: no merge.
+    assert!(
+        ProofStamp::merge(
+            rng,
+            (stamp_a.clone(), descriptors_a.clone()),
+            (stamp_b.clone(), descriptors_b.clone()),
+        )
+        .is_err(),
+        "stamps at different anchors must not merge"
+    );
+
+    let links = anchor_links_between(
+        &pool,
+        early_height.next().expect("height < max")..=late_height,
+    );
+    let lifted_a = ProofStamp::lift(rng, (stamp_a, descriptors_a.clone()), &links).expect("lift");
+    assert_eq!(
+        lifted_a.anchor, stamp_b.anchor,
+        "lift must reach b's anchor"
+    );
+
+    let merged = ProofStamp::merge(
+        rng,
+        (lifted_a, descriptors_a.clone()),
+        (stamp_b, descriptors_b.clone()),
+    )
+    .expect("merge after lift");
+
+    let digests = [
+        plan_a.digest().expect("valid plan"),
+        plan_b.digest().expect("valid plan"),
+    ];
+    assert!(
+        merged.verify_proof(rng, digests).expect("verify"),
+        "the merged stamp must cover both sides' actions"
+    );
+    assert!(
+        merged.is_covering(descriptors_a.union(&descriptors_b).copied()),
+        "the merged coverage digest must span both descriptor sets"
+    );
+}
+
+/// The two shapes of link list a lift refuses, before any proving happens.
+#[test]
+fn lift_rejects_unusable_chains() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+
+    pool.advance(1, |_| random_block(rng, 1, 4));
+    let stamp_height = pool.height();
+    let note = wallet.random_note(200);
+    let (stamp, plan) = build_output_stamp(rng, pool.anchor_at(stamp_height), note);
+    let descriptors = BTreeSet::from_iter([plan.descriptor()]);
+
+    let err = ProofStamp::lift(rng, (stamp.clone(), descriptors.clone()), &[]).unwrap_err();
+    assert!(
+        matches!(err, ProveError::LiftEmptyChain),
+        "an empty chain must be refused, got {err}"
+    );
+
+    // `AnchorChain` has no epoch-boundary link, so a segment may not span two
+    // epochs.
+    let straddling = vec![
+        AnchorLink::Empty {
+            epoch: EpochIndex(0),
+        },
+        AnchorLink::Empty {
+            epoch: EpochIndex(1),
+        },
+    ];
+    let straddling_err = ProofStamp::lift(rng, (stamp, descriptors), &straddling).unwrap_err();
+    assert!(
+        matches!(straddling_err, ProveError::LiftAcrossEpochs),
+        "a chain spanning two epochs must be refused, got {straddling_err}"
     );
 }

--- a/doc/rustdoc-header.html
+++ b/doc/rustdoc-header.html
@@ -1,0 +1,33 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    renderMathInElement(document.body, {
+      delimiters: [
+        { left: "$$",  right: "$$",  display: true },
+        { left: "\\[", right: "\\]", display: true },
+        { left: "\\(", right: "\\)", display: false },
+        { left: "$",   right: "$",   display: false }
+      ],
+      throwOnError: false
+    });
+  });
+</script>
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+  document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll("pre code.language-mermaid").forEach((code) => {
+      const pre = code.closest("pre");
+      const div = document.createElement("div");
+      div.className = "mermaid";
+      // rustdoc HTML-escapes source; textContent reads the decoded text.
+      div.textContent = code.textContent;
+      pre.replaceWith(div);
+    });
+    mermaid.initialize({ startOnLoad: true, securityLevel: "loose" });
+  });
+</script>
+<style>
+  .mermaid { text-align: center; }
+</style>


### PR DESCRIPTION
expose an API to lift anchors, enabling miners and aggregators to merge stamps with different anchor values.