### PR TITLE
refactor: anchor commits to epoch

### DIFF
--- a/book/src/anchor.md
+++ b/book/src/anchor.md
@@ -2,11 +2,13 @@
 
 An anchor is an $\mathbb{F}_p$ element produced by a Poseidon hash chain, representing a running commitment to the Tachyon pool state.
 
-Each stamp, empty block, and epoch transition produces a new pool state, but consensus may <!-- should? must? --> only acknowledge pool states that represent the end of a block.
+Each stamp and each epoch transition produces a new pool state, but consensus may <!-- should? must? --> only acknowledge pool states that represent the end of a block.
 
 These end-of-block states are anchors.
 
-Every link absorbs an epoch index. The stamp and empty-block links absorb the epoch of the block that contains them, which a validator reads off the block height; the epoch link absorbs the epoch being entered. The three use distinct Poseidon domains, so opening a chain reveals each link's role.
+Both links absorb an epoch index. The stamp link absorbs the epoch of the block that contains it, which a validator reads off the block height; the epoch link absorbs the epoch being entered. The two use distinct Poseidon domains, so opening a chain reveals each link's role.
+
+A block that publishes no stamp produces no link, so the anchor is constant across a stampless span. An anchor names a position in the sequence of published stamps rather than a block height.
 
 ## Stamp absorption
 
@@ -20,16 +22,6 @@ where $e$ is the containing block's epoch and $(\mathsf{tg}_\mathsf{lo}, \mathsf
 
 [^tachygrams]: The [tachygrams](./tachygrams.md) chapter gives the set commitment this absorbs, and the rule that full validation recomputes it from the published tachygrams.
 
-## Empty block
-
-A block with zero stamps still advances the anchor:
-
-$$
-\mathsf{anchor}' = \mathsf{Poseidon}_\mathtt{Tachyon\text{-}EmptyBlk}(\mathsf{anchor},\ e)
-$$
-
-This is what makes anchors unique per block height. Without it, a run of empty blocks would leave the pool state unchanged and an anchor would no longer identify a single point in the chain.
-
 ## Epoch boundary
 
 When the chain crosses from epoch $e$ into epoch $e+1$:
@@ -38,7 +30,7 @@ $$
 \mathsf{anchor}' = \mathsf{Poseidon}_\mathtt{Tachyon\text{-}EpochStp}(\mathsf{anchor},\ e+1)
 $$
 
-All three link types absorb an epoch, so the epoch index alone does not distinguish them. What distinguishes this one is that it absorbs the epoch being *entered* rather than the epoch it sits inside, under its own domain. Reaching a boundary anchor by any other link would therefore be a cross-domain collision, which is what lets a proof pin a lineage to a real epoch boundary.
+Both link types absorb an epoch, so the epoch index alone does not distinguish them. What distinguishes this one is that it absorbs the epoch being *entered* rather than the epoch it sits inside, under its own domain. Reaching a boundary anchor by a stamp link would therefore be a cross-domain collision, which is what lets a proof pin a lineage to a real epoch boundary.
 
 ## Intra-block state vs end-of-block anchor
 

--- a/book/src/domain-separators.md
+++ b/book/src/domain-separators.md
@@ -67,7 +67,6 @@ These are all Tachyon-specific digests, performed in-circuit.
 | Action digest | `Tachyon-ActionDg` |
 | Payment key derivation | `Tachyon-PkDerive` |
 | Anchor stamp step | `Tachyon-StampFld` |
-| Anchor empty step | `Tachyon-EmptyBlk` |
 | Anchor epoch step | `Tachyon-EpochStp` |
 
 ## Hash-to-curve

--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -22,28 +22,33 @@ The result is a `NullifierHeader` proving the range `[epoch_start, epoch_end)` c
 
 ### Bootstrapping a spendable
 
-A spendable starts when `SpendableInit` fuses a boundary-rooted `AnchorChain` with the wallet's single-leaf `NullifierHeader` for the starting epoch.
-It witnesses `((pre_epoch_anchor, pre_cm_anchor), creation_set, present_nf)`: it binds `present_nf` to the proven leaf by equality (`present_nf == nf_start`, the range spanning the single epoch `[epoch_start, epoch_start + 1)`), takes `cm` from the range header, checks `cm` is among the creation stamp's tachygrams[^tachygrams], requires the chain to root at `pre_epoch_anchor.next_epoch(epoch)`, requires the cm-stamp to be the chain's final link, and emits a `SpendableHeader` carrying `(cm, present_nf, anchor)`.
-Rooting the chain at `next_epoch(epoch)` pins the starting GGM leaf index to the consensus epoch: consensus anchor membership of the eventual spend anchor forces the boundary, and hence `epoch`, to be the real creation epoch. Without it a note spent in its creation epoch crosses no boundary, leaving the index a free witness.
-The anchor is set initially to the position immediately after the creation stamp and advanced by each lift.
+A spendable starts when `SpendableInit` consumes the wallet's single-leaf `NullifierHeader` for the starting epoch.
+It witnesses `(pre_cm_anchor, creation_set, present_nf)`: it binds `present_nf` to the proven leaf by equality (`present_nf == nf_start`, the range spanning the single epoch `[epoch_start, epoch_start + 1)`), takes `cm` from the range header, checks `cm` is among the creation stamp's tachygrams[^tachygrams], and emits a `SpendableHeader` carrying `(cm, (epoch, present_nf), anchor)` with `anchor = pre_cm_anchor.next_stamp(epoch, creation_commit)`, the position immediately after the creation stamp, advanced by each lift.
+`pre_cm_anchor` is a free witness, so the anchor binds only downstream: lift adjacency threads it to the eventual spend anchor, which consensus checks for chain membership, and a chain node's preimage fixes the real predecessor, the real creation epoch (pinning the starting GGM leaf index), and the real cm-stamp.
 
 ### Maintaining a spendable
 
-Maintaining the spendable means advancing its anchor forward over `Unspent` segments while proving the crossed nullifiers absent.
-The sync service produces `Unspent` segments without ever holding the note, its `cm`, or `psi`.
-`UnspentSeed` absorbs one stamp at a given absolute epoch and proves a wallet-supplied nullifier was absent from that stamp's tachygram set; the resulting `Unspent` has crossed no epoch boundary, so its `elapsed` is empty and `epoch_start == epoch_end` with `nf_start == nf_end` the tested nullifier.
-`EmptyBlockUnspentSeed` covers empty blocks.
+Maintaining the spendable means advancing its anchor forward over `ArbitraryUnspent` segments while proving the crossed nullifiers absent.
+The sync service produces `ArbitraryUnspent` segments without ever holding the note, its `cm`, or `psi`.
+The values a segment tests are arbitrary field elements as far as its own proof is concerned, which is why the segment can be built by a party that knows nothing about the note; only `UnspentBind` attributes them to a derivation.
+`UnspentSeed` absorbs one stamp at a given absolute epoch and proves a wallet-supplied nullifier was absent from that stamp's tachygram set; the resulting `ArbitraryUnspent` has crossed no epoch boundary, so its `elapsed` is empty and `epoch_start == epoch_end` with `nf_start == nf_end` the tested nullifier.
+A block that publishes no stamp advances no anchor, so a stampless span needs no segment and no proof work.
 `UnspentFuse` composes two contiguous ranges that share a junction epoch (`right.epoch_start == left.epoch_end`): it concatenates their `elapsed` histories and seam-binds the junction nullifier (`left.nf_end == right.nf_start`) at adjacent anchors.
 `UnspentEpochFuse` crosses an epoch boundary: it advances the anchor across the boundary and splices the left range's completing tip `nf_end` into `elapsed`, so the crossing count grows by exactly one; either half may itself be a multi-epoch range.
-An `Unspent` records its span as two absolute epoch endpoints, `epoch_start` and `epoch_end`; the crossing count is their difference.
+`EmptyEpochUnspentSeed` supplies the segment for an epoch that published nothing, which the fuse would otherwise have no operand for on that side. An empty epoch has a single anchor, the epoch tick's output, so the seed folds that tick from the previous epoch's terminal anchor and sits at it on both sides: it crosses nothing itself, and there is no exclusion to prove.
+An `ArbitraryUnspent` records its span as two absolute epoch endpoints, `epoch_start` and `epoch_end`; the crossing count is their difference.
 
-`VerifyUnspent` binds a sync-built `Unspent` to genuine derivation. It is wallet-side: it consumes the `Unspent` and a wallet `NullifierHeader` range, and proves the range commits to exactly the `elapsed` crossings followed by the tip `nf_end`, with the range's epochs equal to the `Unspent`'s span. So every crossed nullifier and the tip are proven `GGM(mk, ·)` leaves.
-It emits a `VerifiedUnspent` carrying the span's boundary nullifiers and anchors, the end epoch, and the note's `cm`.
+`UnspentBind` binds a sync-built `ArbitraryUnspent` to genuine derivation. It is wallet-side: it consumes the `ArbitraryUnspent` and a wallet `NullifierHeader` range, and proves the range commits to exactly the `elapsed` crossings followed by the tip `nf_end`, with the range's epochs equal to the `ArbitraryUnspent`'s span. So every crossed nullifier and the tip are proven `GGM(mk, ·)` leaves.
+It emits an `Unspent` carrying the span's boundary nullifiers and anchors, the end epoch, and the note's `cm`.
 
-`SpendableLift` is wallet-side and witness-free: it consumes a `SpendableHeader` and a `VerifiedUnspent`.
+`SpendableLift` is wallet-side and witness-free: it consumes a `SpendableHeader` and an `Unspent`.
 It checks the verified segment's `cm` equals the spendable's (so the absence-proven nullifiers are this note's, and the value cannot drift), the segment's `nf_start` equals the spendable's `present_nf` (continuity), and the segment's `anchor_prev` equals the spendable's anchor (adjacency).
 It advances to the segment's `nf_end` and `anchor_last`, threading `cm` unchanged.
-A single lift can consume an arbitrarily long composed `Unspent`, including one that crosses many epoch boundaries.
+A single lift can consume an arbitrarily long composed `ArbitraryUnspent`, including one that crosses many epoch boundaries.
+
+`SpendableEpochLift` advances the lineage across a single epoch boundary instead of over a segment.
+A lineage resting on its epoch's terminal anchor cannot lift at all: a segment's `anchor_prev` is the anchor before its first link, and the epoch has no link left for one to open on.
+The step reads both nullifiers off a two-epoch `NullifierHeader` tied to the lineage by `cm`, the same shape `SpendBind` uses, and emits the lineage one epoch on at `anchor.next_epoch(epoch + 1)`.
 
 ### Spending
 
@@ -78,30 +83,30 @@ The aggregated stamp has the same shape as any other, so it is itself eligible f
 ## Roles
 
 The wallet runs every step that touches the note's commitment or master key.
-It seeds and walks the private GGM tree (`NfMasterSeed`, `NfPrefixStep`, `NullifierStep`, `NullifierFuse`), derives spendable status from its own leaf (`SpendableInit`), binds and lifts over sync-built segments (`VerifyUnspent`, `SpendableLift`), and produces spend and output stamps (`SpendBind`, `SpendStamp`, `OutputBind`, `OutputStamp`).
+It seeds and walks the private GGM tree (`NfMasterSeed`, `NfPrefixStep`, `NullifierStep`, `NullifierFuse`), derives spendable status from its own leaf (`SpendableInit`), binds and lifts over sync-built segments (`UnspentBind`, `SpendableLift`) or across a boundary it rests on (`SpendableEpochLift`), and produces spend and output stamps (`SpendBind`, `SpendStamp`, `OutputBind`, `OutputStamp`).
 
 The sync service holds the per-epoch nullifier values the wallet shared and pool history.
-It produces the `Unspent` segments that carry the spendable forward (`UnspentSeed`, `EmptyBlockUnspentSeed`, `UnspentFuse`, `UnspentEpochFuse`) and hands the composed segment to the wallet to bind and lift over; it never sees a note, `cm`, `psi`, or `mk`.
+It produces the `ArbitraryUnspent` segments that carry the spendable forward (`UnspentSeed`, `EmptyEpochUnspentSeed`, `UnspentFuse`, `UnspentEpochFuse`) and hands the composed segment to the wallet to bind and lift over; it never sees a note, `cm`, `psi`, or `mk`.
 
 The aggregator works only with published `StampHeader`s.
-It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `EmptyBlockSeed`, `AnchorFuse`) and fuses with `MergeStamp`.
+It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `AnchorFuse`) and fuses with `MergeStamp`.
 
 | step | wallet | sync service | aggregator |
 | ---- | ------ | ------------ | ---------- |
 | AnchorSeed | possible | yes | yes |
-| EmptyBlockSeed | possible | yes | yes |
 | AnchorFuse | possible | yes | yes |
 | UnspentSeed | possible | yes | no |
-| EmptyBlockUnspentSeed | possible | yes | no |
+| EmptyEpochUnspentSeed | possible | yes | no |
 | UnspentFuse | possible | yes | no |
 | UnspentEpochFuse | possible | yes | no |
 | NfMasterSeed | yes | no | no |
 | NfPrefixStep | yes | no | no |
 | NullifierStep | yes | no | no |
 | NullifierFuse | yes | no | no |
-| VerifyUnspent | yes | no | no |
+| UnspentBind | yes | no | no |
 | SpendableInit | yes | no | no |
 | SpendableLift | yes | no | no |
+| SpendableEpochLift | yes | no | no |
 | SpendBind | yes | no | no |
 | OutputBind | yes | no | no |
 | OutputStamp | yes | no | no |
@@ -111,19 +116,20 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `E
 
 ## Soundness
 
-The subsections below walk each subtree bottom-up: the chain segments that act as primitives, then the `Unspent` segments and the derivation chain that consume them, then the binding at `VerifyUnspent`, the spendable lineage, then spend binding and stamps.
+The subsections below walk each subtree bottom-up: the chain segments that act as primitives, then the `ArbitraryUnspent` segments and the derivation chain that consume them, then the binding at `UnspentBind`, the spendable lineage, then spend binding and stamps.
 
 ### Anchor segments
 
-`AnchorSeed`, `EmptyBlockSeed`, `UnspentSeed`, and `EmptyBlockUnspentSeed` each witness an `anchor_prev` and prove one anchor step.
+`AnchorSeed`, `UnspentSeed`, and `EmptyEpochUnspentSeed` each witness a predecessor anchor and prove one anchor step from it.
 `AnchorFuse` composes adjacent segments by checking endpoint equality; `UnspentFuse` additionally concatenates the two halves' `elapsed` histories.
-A segment ties to real chain history only through a consensus-published stamp whose anchor matches an end-of-block value: `StampLift` emits that stamp directly, while a segment consumed by `SpendableInit` produces a private spendable whose anchor reaches consensus only once it is spent into a stamp.
+A segment ties to real chain history only through a consensus-published stamp whose anchor matches an end-of-block value, emitted at `StampLift`. `SpendableInit`'s anchor closes the same way without a segment: the private spendable's anchor reaches consensus once it is spent into a stamp.
 
-### Unspent composition
+### ArbitraryUnspent composition
 
-An `Unspent` is a contiguous range bracketed by `anchor_prev` and `anchor_last`, with boundary pairs `(epoch_start, nf_start)` and `(epoch_end, nf_end)`, plus `elapsed` (one nullifier coefficient per epoch-boundary crossing in its span, forward-chronological, terminated by a sentinel coefficient $1$ at the crossing count)[^nullifiers]. `nf_start`/`nf_end` are the nullifiers at `epoch_start`/`epoch_end`; the crossing count is `epoch_end - epoch_start`.
+An `ArbitraryUnspent` is a contiguous range bracketed by `anchor_prev` and `anchor_last`, with boundary pairs `(epoch_start, nf_start)` and `(epoch_end, nf_end)`, plus `elapsed` (one nullifier coefficient per epoch-boundary crossing in its span, forward-chronological, terminated by a sentinel coefficient $1$ at the crossing count)[^nullifiers]. `nf_start`/`nf_end` are the nullifiers at `epoch_start`/`epoch_end`; the crossing count is `epoch_end - epoch_start`.
 The sentinel keeps the committed polynomial nonzero for every sequence, so the commitment never falls on the identity point, which the in-circuit point representation cannot hold; it also pins the sequence's exact length, which commit-equality alone bounds only from above.
-`UnspentSeed` and `EmptyBlockUnspentSeed` produce within-epoch `Unspent`s for one stamp's worth of anchor advance: `elapsed` is empty (the sentinel constant $1$, committing to $\mathcal{G}_0$), `epoch_start == epoch_end`, and the nullifier they just non-membership-checked is both `nf_start` and `nf_end`.
+`UnspentSeed` produces a within-epoch `ArbitraryUnspent` for one stamp's worth of anchor advance: `elapsed` is empty (the sentinel constant $1$, committing to $\mathcal{G}_0$), `epoch_start == epoch_end`, and the nullifier it just non-membership-checked is both `nf_start` and `nf_end`.
+`EmptyEpochUnspentSeed` produces the other base case, a whole epoch in which nothing was published. Such an epoch has exactly one anchor, since the tick that opens it is also its terminal anchor, so the seed folds `prev_epoch_tip` through the cross-epoch domain and emits that value as both `anchor_prev` and `anchor_last`, with `epoch_start == epoch_end` and `elapsed` empty. There is no exclusion to prove; the claim that nothing was published rests entirely on `prev_epoch_tip` being the previous epoch's real terminal anchor, which consensus anchor membership of the eventual spend forces.
 `UnspentFuse` composes two contiguous ranges sharing a junction epoch (`right.epoch_start == left.epoch_end`) at adjacent anchors (`left.anchor_last == right.anchor_prev`): it concatenates their histories and seam-binds the junction nullifier (`left.nf_end == right.nf_start`). Writing $s$ for the left crossing count, the concat confirms
 
 $$C(X) = L(X) + X^{s}\,(R(X) - 1)$$
@@ -146,35 +152,45 @@ The crossing epoch is the right half's `epoch_start`, which must be exactly one 
 `NullifierFuse` witnesses the two nullifier sequences and their concatenation, binds each by commit-equality, and confirms the concat at the constant offset `left.epoch_end - left.epoch_start`, requiring the same `cm` and contiguity.
 So a `NullifierHeader` is a sound proof that a contiguous epoch range commits to the genuine leaves of the note identified by `cm`.
 
-### Verifying unspent against derivation
+### Binding unspent to derivation
 
-`VerifyUnspent` consumes the sync's `Unspent` and the wallet's `NullifierHeader`.
-It witnesses the `elapsed` sequence and the range sequence, binds each by commit-equality (`elapsed` to the `Unspent` header, the range to the `NullifierHeader`), and appends the header's tip scalar `nf_end`, confirming
+`UnspentBind` consumes the sync's `ArbitraryUnspent` and the wallet's `NullifierHeader`.
+It witnesses the `elapsed` sequence and the range sequence, binds each by commit-equality (`elapsed` to the `ArbitraryUnspent` header, the range to the `NullifierHeader`), and appends the header's tip scalar `nf_end`, confirming
 
 $$R(X) = E(X) + X^{s}\,(\texttt{nf\_end} - 1) + X^{s+1}$$
 
-for the range $R$, elapsed $E$, and crossing count $s$, at a Fiat-Shamir challenge: the appended tip overwrites `elapsed`'s sentinel and the trailing term re-terminates the range. The tip scalar is a left-header value, fixed by the recursive verification of the `Unspent` PCD before the challenge.
-With the range epochs pinned to the `Unspent`'s span (`range.epoch_start == epoch_start`, `range.epoch_end == epoch_end + 1`), this proves the crossings and the tip are exactly the derived `GGM(mk, ·)` leaves: the tip nullifier is a genuine leaf, not a free value.
+for the range $R$, elapsed $E$, and crossing count $s$, at a Fiat-Shamir challenge: the appended tip overwrites `elapsed`'s sentinel and the trailing term re-terminates the range. The tip scalar is a left-header value, fixed by the recursive verification of the `ArbitraryUnspent` PCD before the challenge.
+With the range epochs pinned to the `ArbitraryUnspent`'s span (`range.epoch_start == epoch_start`, `range.epoch_end == epoch_end + 1`), this proves the crossings and the tip are exactly the derived `GGM(mk, ·)` leaves: the tip nullifier is a genuine leaf, not a free value.
 It binds the span's boundary nullifiers to the range's genuine boundary leaves by equality (`nf_start` and `nf_end`), and threads the range's `cm`.
 
 ### Spendable lineage
 
 `SpendableInit` is the lineage's only seed and is wallet-only.
-It witnesses the note's fields, the creation stamp's tachygrams, the anchor running into the creation stamp, and the starting-epoch nullifier `present_nf`.
-It derives `cm` and binds the note to the pool (`cm` in `creation_set`), which pins the whole note to the real minted note.
-It emits `SpendableHeader(cm, present_nf, anchor)`.
-`present_nf` is unconstrained here; the first lift requires it to equal a `VerifiedUnspent`'s `nf_start`, a genuine leaf, pinning it to the note's starting nullifier at the consensus-tied starting epoch.
+It witnesses the creation stamp's tachygrams, the anchor running into the creation stamp, and the starting-epoch nullifier `present_nf`.
+It takes `cm` from the range header and binds the note to the pool (`cm` in `creation_set`), which pins the whole note to the real minted note.
+It emits `SpendableHeader(cm, (epoch, present_nf), anchor)`, where `epoch` is the range header's starting epoch and `anchor` folds that epoch onto the free-witnessed `pre_cm_anchor`; a wrong epoch or predecessor lands the anchor off the published sequence, so consensus anchor membership of the eventual spend forces both.
+`present_nf` is bound to the range's single derived leaf here; each lift then requires an `Unspent`'s `nf_start` to equal it, a genuine leaf, keeping the lineage on the note's derived nullifiers.
 
-`SpendableLift` advances the lineage over a `VerifiedUnspent` and is witness-free.
-It threads `cm` by equality (`verified.cm == spendable.cm`), so every consumed segment belongs to the lineage's one note and the spent value cannot drift to a different same-`mk` note.
-Continuity holds through nullifier values: `verified.nf_start == spendable.present_nf`.
-Both are `GGM(mk, ·)` PRF outputs, so value-equality forces the same note and the same epoch; combined with the tip binding at `VerifyUnspent` (which makes each new `present_nf` itself a genuine leaf), a lineage cannot skip an epoch or splice in another note.
-The anchor adjacency check (`verified.anchor_prev == spendable.anchor`) welds the segment to the lineage's current position.
+`SpendableLift` advances the lineage over an `Unspent`.
+It threads `cm` by equality (`unspent.cm == spendable.cm`), so every consumed segment belongs to the lineage's one note and the spent value cannot drift to a different same-`mk` note.
+Combined with the tip binding at `UnspentBind` (which makes each new `present_nf` itself a genuine leaf), a lineage cannot skip an epoch or splice in another note.
+
+Continuity holds through the boundary pair: `unspent.nf_start == spendable.present_nf` and `unspent.epoch_start == spendable.epoch`.
+The nullifiers are both `GGM(mk, ·)` PRF outputs, so value-equality alone already forces the same note and the same epoch; carrying the epoch makes that a checked equality per lift rather than one inferred from the PRF, and it is what lets the lineage state its position without a derivation in hand.
+The anchor adjacency check (`unspent.anchor_prev == spendable.anchor`) welds the segment to the lineage's current position.
+
+`SpendableEpochLift` covers the position no segment can adjoin, a lineage resting on its epoch's terminal anchor, and is likewise witness-free.
+It requires `range.epoch_start == spendable.epoch`, `range.epoch_end == range.epoch_start + 2`, and `range.cm == spendable.cm`, binds `range.nf_start == spendable.present_nf`, and emits the lineage at `(epoch + 1, range.nf_end, anchor.next_epoch(epoch + 1))`.
+Only the anchor advances by construction; the nullifier it lands on is a genuine `GGM(mk, ·)` leaf of the same note, so a lineage cannot tick onto a value it did not derive.
+
+That `spendable.anchor` really is the epoch's terminal anchor is not checked and cannot be, being a negative claim about what was published.
+Ticking a mid-epoch anchor lands off the published sequence, which no later link rejoins, so consensus anchor membership of the eventual spend rejects it.
+No coverage is skipped: the tick leaves the epoch at its terminal anchor, and `present_nf`'s absence up to that anchor was proven by whatever placed the lineage there.
 
 ### Spend binding
 
 Spending a note publishes two nullifiers, one for the current epoch and one for the next, both pinned to the note's genuine leaves.
-`SpendBind` consumes the `SpendableHeader` and a length-2 `NullifierHeader` range, witnesses `nf_next`, and requires the range to span exactly two epochs with `range.cm == spendable.cm`.
+`SpendBind` consumes the `SpendableHeader` and a length-2 `NullifierHeader` range, witnesses `nf_next`, and requires the range to span exactly two epochs starting at the lineage's epoch, with `range.cm == spendable.cm`.
 It binds the published pair to the range's boundary leaves by equality (`present_nf == range.nf_start`, `nf_next == range.nf_end`): `present_nf` is threaded from the lineage, so the `nf_start` equality forces the range to start at the lineage's current epoch, and `nf_next` is pinned to the genuine `nf_end` leaf.
 Each published nullifier must be nonzero, or it would collide with the note's own `cm` in the tachygram scan.
 No note witness is needed here: the range and the lineage are already tied to the same note by their two `cm` fields, bound where the range was derived and at `SpendableInit` respectively.
@@ -210,11 +226,11 @@ A PCD proof is a commitment to its own witness data. Two proofs built from overl
 
 A stamp crosses a trust boundary at exactly these points. A wallet hands an autonome to the p2p network; an aggregator hands a merged stamp onward while retaining the inputs it merged. Rerandomizing at each handoff replaces the proof with an unrelated one that verifies against the same header, so the released artifact carries no correlation back to the private lineage that produced it, and none forward to a later release of the same lineage.
 
-The rule is that a proof leaving the process that built it is rerandomized first. Intermediate PCDs that stay inside a wallet, such as a derivation window or an `Unspent` segment, do not need it: nothing outside the wallet ever observes them.
+The rule is that a proof leaving the process that built it is rerandomized first. Intermediate PCDs that stay inside a wallet, such as a derivation window or an `ArbitraryUnspent` segment, do not need it: nothing outside the wallet ever observes them.
 
 ## Simple transaction
 
-A transaction with one spend and one output, where the spendable was bootstrapped in a previous epoch and lifted over an `Unspent` crossing an epoch boundary before the spend.
+A transaction with one spend and one output, where the spendable was bootstrapped in a previous epoch and lifted over an `ArbitraryUnspent` crossing an epoch boundary before the spend.
 
 ```mermaid
 flowchart TB
@@ -228,12 +244,12 @@ flowchart TB
   end
 
   subgraph spendable [spendable advance]
-    w_init[/pre_epoch_anchor, pre_cm_anchor, creation_set, present_nf/]
-    anchor_init((AnchorChain))
+    w_init[/pre_cm_anchor, creation_set, present_nf/]
     s_init[SpendableInit]
-    unspent_in((Unspent))
-    s_verify[VerifyUnspent]
+    unspent_in((ArbitraryUnspent))
+    s_bind[UnspentBind]
     s_lift[SpendableLift]
+    s_epochlift[SpendableEpochLift]
   end
 
   subgraph spend_action [spend action]
@@ -259,13 +275,15 @@ flowchart TB
   s_leaf -->|NullifierHeader| s_dfuse
   s_dfuse --> nf_range
 
-  anchor_init --> s_init
   nf_range -->|NullifierHeader| s_init
   w_init --> s_init
-  nf_range --> s_verify
-  unspent_in --> s_verify
+  nf_range --> s_bind
+  unspent_in --> s_bind
   s_init -->|SpendableHeader| s_lift
-  s_verify -->|VerifiedUnspent| s_lift
+  s_bind -->|Unspent| s_lift
+  s_init -->|SpendableHeader| s_epochlift
+  nf_range -->|NullifierHeader| s_epochlift
+  s_epochlift -->|SpendableHeader| s_lift
   s_lift -->|SpendableHeader| s_bind
 
   w_bind --> s_bind
@@ -281,7 +299,8 @@ flowchart TB
   s_merge --> stamp_out
 ```
 
-The single `SpendableLift` consumes one composed `VerifiedUnspent` (potentially crossing many epoch boundaries); threading `cm` chains the lineage's binding to the note through every advance.
+The single `SpendableLift` consumes one composed `Unspent` (potentially crossing many epoch boundaries); threading `cm` chains the lineage's binding to the note through every advance.
+A lineage resting on an epoch's terminal anchor takes `SpendableEpochLift` first, since no segment can open there.
 
 ## Focused subgraphs
 
@@ -292,39 +311,43 @@ flowchart LR
   sh_in((StampHeader))
   w_seed[/start, stamp_commit/]
   s_seed[AnchorSeed]
-  w_fuse[/empty start/]
-  s_empty[EmptyBlockSeed]
+  w_next[/start, stamp_commit/]
+  s_next[AnchorSeed]
   s_fuse[AnchorFuse]
   s_lift[StampLift]
   sh_out((StampHeader))
 
   w_seed --> s_seed
-  w_fuse --> s_empty
+  w_next --> s_next
   s_seed -->|AnchorChain| s_fuse
-  s_empty -->|AnchorChain| s_fuse
+  s_next -->|AnchorChain| s_fuse
   sh_in --> s_lift
   s_fuse -->|AnchorChain| s_lift
   s_lift --> sh_out
 ```
 
-### Unspent composition across epochs
+### ArbitraryUnspent composition across epochs
 
 ```mermaid
 flowchart LR
   w_seed[/start, epoch, stamp_tg_set, nf/]
   s_useed[UnspentSeed]
-  w_empty[/start, epoch, nf/]
-  s_uempty[EmptyBlockUnspentSeed]
+  w_next[/start, epoch, stamp_tg_set, nf/]
+  s_unext[UnspentSeed]
   s_ufuse[UnspentFuse]
+  w_eseed[/prev_epoch_tip, epoch, nf/]
+  s_eseed[EmptyEpochUnspentSeed]
   w_efuse[/left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq/]
   s_efuse[UnspentEpochFuse]
-  unspent_out((Unspent))
+  unspent_out((ArbitraryUnspent))
 
   w_seed --> s_useed
-  w_empty --> s_uempty
-  s_useed -->|Unspent| s_ufuse
-  s_uempty -->|Unspent| s_ufuse
-  s_ufuse -->|Unspent| s_efuse
+  w_next --> s_unext
+  w_eseed --> s_eseed
+  s_useed -->|ArbitraryUnspent| s_ufuse
+  s_unext -->|ArbitraryUnspent| s_ufuse
+  s_ufuse -->|ArbitraryUnspent| s_efuse
+  s_eseed -->|ArbitraryUnspent| s_efuse
   w_efuse --> s_efuse
   s_efuse --> unspent_out
 ```
@@ -334,11 +357,11 @@ flowchart LR
 | Header | Fields |
 | ------ | ------ |
 | AnchorChain | (start, end) |
-| Unspent | (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_end, nf_end), anchor_last) |
-| VerifiedUnspent | (cm, anchor_prev, (epoch_start, nf_start), (epoch_end, nf_end), anchor_last) |
+| ArbitraryUnspent | (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_end, nf_end), anchor_last) |
+| Unspent | (cm, anchor_prev, (epoch_start, nf_start), (epoch_end, nf_end), anchor_last) |
 | NfPrefixHeader | (cm, node, depth, index) |
 | NullifierHeader | (cm, (epoch_start, nf_start), nf_seq_commit, (epoch_end, nf_end)) |
-| SpendableHeader | (cm, present_nf, anchor) |
+| SpendableHeader | (cm, (epoch, present_nf), anchor) |
 | OutputHeader | (cm, pad) |
 | SpendHeader | (cm, present_nf, nf_next, anchor) |
 | StampHeader | (action_commit, tachygram_commit, anchor) |
@@ -348,19 +371,19 @@ flowchart LR
 | Step | Left | Right | Witness | Output |
 | ---- | ---- | ----- | ------- | ------ |
 | AnchorSeed | — | — | start, epoch, stamp_commit | AnchorChain |
-| EmptyBlockSeed | — | — | start, epoch | AnchorChain |
 | AnchorFuse | AnchorChain | AnchorChain | — | AnchorChain |
-| UnspentSeed | — | — | anchor_prev, (epoch, nf), stamp_tg_set | Unspent |
-| EmptyBlockUnspentSeed | — | — | anchor_prev, (epoch, nf) | Unspent |
-| UnspentFuse | Unspent | Unspent | left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq | Unspent |
-| UnspentEpochFuse | Unspent | Unspent | left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq | Unspent |
-| VerifyUnspent | Unspent | NullifierHeader | elapsed_seq, nf_seq | VerifiedUnspent |
+| UnspentSeed | — | — | anchor_prev, (epoch, nf), stamp_tg_set | ArbitraryUnspent |
+| EmptyEpochUnspentSeed | — | — | prev_epoch_tip, (epoch, nf) | ArbitraryUnspent |
+| UnspentFuse | ArbitraryUnspent | ArbitraryUnspent | left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq | ArbitraryUnspent |
+| UnspentEpochFuse | ArbitraryUnspent | ArbitraryUnspent | left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq | ArbitraryUnspent |
+| UnspentBind | ArbitraryUnspent | NullifierHeader | elapsed_seq, nf_seq | Unspent |
 | NfMasterSeed | — | — | note, pak | NfPrefixHeader |
 | NfPrefixStep | NfPrefixHeader | — | chunk | NfPrefixHeader |
 | NullifierStep | NfPrefixHeader | — | — | NullifierHeader |
 | NullifierFuse | NullifierHeader | NullifierHeader | left_seq, merged_seq, right_seq | NullifierHeader |
-| SpendableInit | AnchorChain | NullifierHeader | (pre_epoch_anchor, pre_cm_anchor), creation_set, present_nf | SpendableHeader |
-| SpendableLift | SpendableHeader | VerifiedUnspent | — | SpendableHeader |
+| SpendableInit | NullifierHeader | — | pre_cm_anchor, creation_set, present_nf | SpendableHeader |
+| SpendableLift | SpendableHeader | Unspent | — | SpendableHeader |
+| SpendableEpochLift | SpendableHeader | NullifierHeader | — | SpendableHeader |
 | SpendBind | SpendableHeader | NullifierHeader | nf_next | SpendHeader |
 | OutputBind | — | — | note | OutputHeader |
 | OutputStamp | OutputHeader | — | rcv, alpha, note, anchor | StampHeader |

--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -39,7 +39,7 @@ A block that publishes no stamp advances no anchor, so a stampless span needs no
 An `ArbitraryUnspent` records its span as two absolute epoch endpoints, `epoch_start` and `epoch_end`; the crossing count is their difference.
 
 `UnspentBind` binds a sync-built `ArbitraryUnspent` to genuine derivation. It is wallet-side: it consumes the `ArbitraryUnspent` and a wallet `NullifierHeader` range, and proves the range commits to exactly the `elapsed` crossings followed by the tip `nf_end`, with the range's epochs equal to the `ArbitraryUnspent`'s span. So every crossed nullifier and the tip are proven `GGM(mk, ·)` leaves.
-It emits an `Unspent` carrying the span's boundary nullifiers and anchors, the end epoch, and the note's `cm`.
+It emits an `Unspent` carrying the span's boundary nullifiers, anchors and epochs, and the note's `cm`.
 
 `SpendableLift` is wallet-side and witness-free: it consumes a `SpendableHeader` and an `Unspent`.
 It checks the verified segment's `cm` equals the spendable's (so the absence-proven nullifiers are this note's, and the value cannot drift), the segment's `nf_start` equals the spendable's `present_nf` (continuity), and the segment's `anchor_prev` equals the spendable's anchor (adjacency).
@@ -247,7 +247,7 @@ flowchart TB
     w_init[/pre_cm_anchor, creation_set, present_nf/]
     s_init[SpendableInit]
     unspent_in((ArbitraryUnspent))
-    s_bind[UnspentBind]
+    s_unspentbind[UnspentBind]
     s_lift[SpendableLift]
     s_epochlift[SpendableEpochLift]
   end
@@ -277,10 +277,10 @@ flowchart TB
 
   nf_range -->|NullifierHeader| s_init
   w_init --> s_init
-  nf_range --> s_bind
-  unspent_in --> s_bind
+  nf_range --> s_unspentbind
+  unspent_in --> s_unspentbind
   s_init -->|SpendableHeader| s_lift
-  s_bind -->|Unspent| s_lift
+  s_unspentbind -->|Unspent| s_lift
   s_init -->|SpendableHeader| s_epochlift
   nf_range -->|NullifierHeader| s_epochlift
   s_epochlift -->|SpendableHeader| s_lift
@@ -309,9 +309,9 @@ A lineage resting on an epoch's terminal anchor takes `SpendableEpochLift` first
 ```mermaid
 flowchart LR
   sh_in((StampHeader))
-  w_seed[/start, stamp_commit/]
+  w_seed[/start, epoch, stamp_commit/]
   s_seed[AnchorSeed]
-  w_next[/start, stamp_commit/]
+  w_next[/start, epoch, stamp_commit/]
   s_next[AnchorSeed]
   s_fuse[AnchorFuse]
   s_lift[StampLift]
@@ -330,9 +330,9 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-  w_seed[/start, epoch, stamp_tg_set, nf/]
+  w_seed[/anchor_prev, epoch, stamp_tg_set, nf/]
   s_useed[UnspentSeed]
-  w_next[/start, epoch, stamp_tg_set, nf/]
+  w_next[/anchor_prev, epoch, stamp_tg_set, nf/]
   s_unext[UnspentSeed]
   s_ufuse[UnspentFuse]
   w_eseed[/prev_epoch_tip, epoch, nf/]
@@ -364,7 +364,7 @@ flowchart LR
 | SpendableHeader | (cm, (epoch, present_nf), anchor) |
 | OutputHeader | (cm, pad) |
 | SpendHeader | (cm, present_nf, nf_next, anchor) |
-| StampHeader | (action_commit, tachygram_commit, anchor) |
+| StampHeader | (action_commit, stamp_tg_commit, anchor) |
 
 ## Steps
 

--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -34,8 +34,8 @@ The values a segment tests are arbitrary field elements as far as its own proof 
 `UnspentSeed` absorbs one stamp at a given absolute epoch and proves a wallet-supplied nullifier was absent from that stamp's tachygram set; the resulting `ArbitraryUnspent` has crossed no epoch boundary, so its `elapsed` is empty and `epoch_start == epoch_end` with `nf_start == nf_end` the tested nullifier.
 A block that publishes no stamp advances no anchor, so a stampless span needs no segment and no proof work.
 `UnspentFuse` composes two contiguous ranges that share a junction epoch (`right.epoch_start == left.epoch_end`): it concatenates their `elapsed` histories and seam-binds the junction nullifier (`left.nf_end == right.nf_start`) at adjacent anchors.
-`UnspentEpochFuse` crosses an epoch boundary: it advances the anchor across the boundary and splices the left range's completing tip `nf_end` into `elapsed`, so the crossing count grows by exactly one; either half may itself be a multi-epoch range.
-`EmptyEpochUnspentSeed` supplies the segment for an epoch that published nothing, which the fuse would otherwise have no operand for on that side. An empty epoch has a single anchor, the epoch tick's output, so the seed folds that tick from the previous epoch's terminal anchor and sits at it on both sides: it crosses nothing itself, and there is no exclusion to prove.
+`EndEpochUnspentSeed` is the segment for the boundary itself: it folds the epoch tick from a witnessed epoch-terminal anchor and records the epoch it leaves as the one member of its `elapsed`, so `epoch_end == epoch_start + 1`.
+A boundary is therefore a link like any other, and `UnspentFuse` composes it with its neighbours on both sides; an epoch that published nothing is simply two crossings with no stamp segment between them.
 An `ArbitraryUnspent` records its span as two absolute epoch endpoints, `epoch_start` and `epoch_end`; the crossing count is their difference.
 
 `UnspentBind` binds a sync-built `ArbitraryUnspent` to genuine derivation. It is wallet-side: it consumes the `ArbitraryUnspent` and a wallet `NullifierHeader` range, and proves the range commits to exactly the `elapsed` crossings followed by the tip `nf_end`, with the range's epochs equal to the `ArbitraryUnspent`'s span. So every crossed nullifier and the tip are proven `GGM(mk, ·)` leaves.
@@ -45,10 +45,7 @@ It emits an `Unspent` carrying the span's boundary nullifiers, anchors and epoch
 It checks the verified segment's `cm` equals the spendable's (so the absence-proven nullifiers are this note's, and the value cannot drift), the segment's `nf_start` equals the spendable's `present_nf` (continuity), and the segment's `anchor_prev` equals the spendable's anchor (adjacency).
 It advances to the segment's `nf_end` and `anchor_last`, threading `cm` unchanged.
 A single lift can consume an arbitrarily long composed `ArbitraryUnspent`, including one that crosses many epoch boundaries.
-
-`SpendableEpochLift` advances the lineage across a single epoch boundary instead of over a segment.
-A lineage resting on its epoch's terminal anchor cannot lift at all: a segment's `anchor_prev` is the anchor before its first link, and the epoch has no link left for one to open on.
-The step reads both nullifiers off a two-epoch `NullifierHeader` tied to the lineage by `cm`, the same shape `SpendBind` uses, and emits the lineage one epoch on at `anchor.next_epoch(epoch + 1)`.
+A lineage resting on its epoch's terminal anchor lifts the same way: the boundary tick is a link, so a segment can open on it.
 
 ### Spending
 
@@ -83,10 +80,10 @@ The aggregated stamp has the same shape as any other, so it is itself eligible f
 ## Roles
 
 The wallet runs every step that touches the note's commitment or master key.
-It seeds and walks the private GGM tree (`NfMasterSeed`, `NfPrefixStep`, `NullifierStep`, `NullifierFuse`), derives spendable status from its own leaf (`SpendableInit`), binds and lifts over sync-built segments (`UnspentBind`, `SpendableLift`) or across a boundary it rests on (`SpendableEpochLift`), and produces spend and output stamps (`SpendBind`, `SpendStamp`, `OutputBind`, `OutputStamp`).
+It seeds and walks the private GGM tree (`NfMasterSeed`, `NfPrefixStep`, `NullifierStep`, `NullifierFuse`), derives spendable status from its own leaf (`SpendableInit`), binds and lifts over sync-built segments (`UnspentBind`, `SpendableLift`), and produces spend and output stamps (`SpendBind`, `SpendStamp`, `OutputBind`, `OutputStamp`).
 
 The sync service holds the per-epoch nullifier values the wallet shared and pool history.
-It produces the `ArbitraryUnspent` segments that carry the spendable forward (`UnspentSeed`, `EmptyEpochUnspentSeed`, `UnspentFuse`, `UnspentEpochFuse`) and hands the composed segment to the wallet to bind and lift over; it never sees a note, `cm`, `psi`, or `mk`.
+It produces the `ArbitraryUnspent` segments that carry the spendable forward (`UnspentSeed`, `EndEpochUnspentSeed`, `UnspentFuse`) and hands the composed segment to the wallet to bind and lift over; it never sees a note, `cm`, `psi`, or `mk`.
 
 The aggregator works only with published `StampHeader`s.
 It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `AnchorFuse`) and fuses with `MergeStamp`.
@@ -96,9 +93,8 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `A
 | AnchorSeed | possible | yes | yes |
 | AnchorFuse | possible | yes | yes |
 | UnspentSeed | possible | yes | no |
-| EmptyEpochUnspentSeed | possible | yes | no |
+| EndEpochUnspentSeed | possible | yes | no |
 | UnspentFuse | possible | yes | no |
-| UnspentEpochFuse | possible | yes | no |
 | NfMasterSeed | yes | no | no |
 | NfPrefixStep | yes | no | no |
 | NullifierStep | yes | no | no |
@@ -106,7 +102,6 @@ It aligns anchors with `StampLift` over `AnchorChain` segments (`AnchorSeed`, `A
 | UnspentBind | yes | no | no |
 | SpendableInit | yes | no | no |
 | SpendableLift | yes | no | no |
-| SpendableEpochLift | yes | no | no |
 | SpendBind | yes | no | no |
 | OutputBind | yes | no | no |
 | OutputStamp | yes | no | no |
@@ -120,7 +115,7 @@ The subsections below walk each subtree bottom-up: the chain segments that act a
 
 ### Anchor segments
 
-`AnchorSeed`, `UnspentSeed`, and `EmptyEpochUnspentSeed` each witness a predecessor anchor and prove one anchor step from it.
+`AnchorSeed`, `UnspentSeed`, and `EndEpochUnspentSeed` each witness a predecessor anchor and prove one anchor step from it.
 `AnchorFuse` composes adjacent segments by checking endpoint equality; `UnspentFuse` additionally concatenates the two halves' `elapsed` histories.
 A segment ties to real chain history only through a consensus-published stamp whose anchor matches an end-of-block value, emitted at `StampLift`. `SpendableInit`'s anchor closes the same way without a segment: the private spendable's anchor reaches consensus once it is spent into a stamp.
 
@@ -129,20 +124,15 @@ A segment ties to real chain history only through a consensus-published stamp wh
 An `ArbitraryUnspent` is a contiguous range bracketed by `anchor_prev` and `anchor_last`, with boundary pairs `(epoch_start, nf_start)` and `(epoch_end, nf_end)`, plus `elapsed` (one nullifier coefficient per epoch-boundary crossing in its span, forward-chronological, terminated by a sentinel coefficient $1$ at the crossing count)[^nullifiers]. `nf_start`/`nf_end` are the nullifiers at `epoch_start`/`epoch_end`; the crossing count is `epoch_end - epoch_start`.
 The sentinel keeps the committed polynomial nonzero for every sequence, so the commitment never falls on the identity point, which the in-circuit point representation cannot hold; it also pins the sequence's exact length, which commit-equality alone bounds only from above.
 `UnspentSeed` produces a within-epoch `ArbitraryUnspent` for one stamp's worth of anchor advance: `elapsed` is empty (the sentinel constant $1$, committing to $\mathcal{G}_0$), `epoch_start == epoch_end`, and the nullifier it just non-membership-checked is both `nf_start` and `nf_end`.
-`EmptyEpochUnspentSeed` produces the other base case, a whole epoch in which nothing was published. Such an epoch has exactly one anchor, since the tick that opens it is also its terminal anchor, so the seed folds `prev_epoch_tip` through the cross-epoch domain and emits that value as both `anchor_prev` and `anchor_last`, with `epoch_start == epoch_end` and `elapsed` empty. There is no exclusion to prove; the claim that nothing was published rests entirely on `prev_epoch_tip` being the previous epoch's real terminal anchor, which consensus anchor membership of the eventual spend forces.
+`EndEpochUnspentSeed` produces the other base case, the epoch boundary itself. It folds a witnessed epoch-terminal anchor through the cross-epoch domain and emits the tick's output as `anchor_last`, with `epoch_end == epoch_start + 1` and a one-member `elapsed` holding the nullifier tested in the epoch being left. It is the only step that adds a member, so the invariant that `elapsed` holds exactly `epoch_end - epoch_start` of them holds by induction: the other seed establishes it at zero and the fuse preserves it additively. There is no exclusion to prove; that the witnessed predecessor really is its epoch's terminal anchor rests on consensus anchor membership of the eventual spend, since the tick of a short anchor is not a value consensus recomputes.
 `UnspentFuse` composes two contiguous ranges sharing a junction epoch (`right.epoch_start == left.epoch_end`) at adjacent anchors (`left.anchor_last == right.anchor_prev`): it concatenates their histories and seam-binds the junction nullifier (`left.nf_end == right.nf_start`). Writing $s$ for the left crossing count, the concat confirms
 
 $$C(X) = L(X) + X^{s}\,(R(X) - 1)$$
 
 for the witnessed `combined` $C$, left $L$, and right $R$, at a Fiat-Shamir challenge: the $-1$ cancels the left half's sentinel at degree $s$, the right half's first crossing takes its slot, and the right half's sentinel re-terminates the combined sequence; the seam-bind makes the shared junction epoch's nullifier unambiguous across the merge.
-`UnspentEpochFuse` crosses an epoch boundary: it witnesses the two halves' nullifier polynomials and the combined result, advances the anchor via the cross-epoch domain, and splices the left range's completing tip between them.
-Writing $p$ for the left tip `nf_end`, the splice confirms
-
-$$C(X) = L(X) + X^{s}\,(p - 1) + X^{s+1}\,R(X)$$
-
-at a Fiat-Shamir challenge: the spliced tip overwrites the left half's sentinel and the right half's sentinel re-terminates the combined sequence.
-$L$ and $R$ are bound by the recursive verification of the two input PCDs, and the scalar $p$ is a left-header value bound likewise, all before the challenge; because the identity is linear in $L$, $R$, and $p$, that prior binding is what makes the splice sound.
-The crossing epoch is the right half's `epoch_start`, which must be exactly one past the left tip, and folding it into the boundary anchor via the cross-epoch domain consensus-ties the absolute epoch.
+Every seam is intra-epoch, because a crossing arrives as a segment of its own rather than as a property of the merge, so this concatenation is the only sequence relation the composition needs and its shift $s$ is the only header-fixed quantity in it.
+$L$ and $R$ are bound by the recursive verification of the two input PCDs before the challenge, and $s$ is a left-header value bound likewise; because the identity is linear in $L$ and $R$ with a constant coefficient, that prior binding is what makes the concatenation sound.
+A crossing's absolute epoch is consensus-tied where the crossing is built rather than where it merges: `EndEpochUnspentSeed` folds its witnessed epoch through the cross-epoch domain, and a wrong epoch yields an anchor the published sequence does not contain.
 
 ### Derivation chain
 
@@ -179,13 +169,11 @@ Continuity holds through the boundary pair: `unspent.nf_start == spendable.prese
 The nullifiers are both `GGM(mk, ·)` PRF outputs, so value-equality alone already forces the same note and the same epoch; carrying the epoch makes that a checked equality per lift rather than one inferred from the PRF, and it is what lets the lineage state its position without a derivation in hand.
 The anchor adjacency check (`unspent.anchor_prev == spendable.anchor`) welds the segment to the lineage's current position.
 
-`SpendableEpochLift` covers the position no segment can adjoin, a lineage resting on its epoch's terminal anchor, and is likewise witness-free.
-It requires `range.epoch_start == spendable.epoch`, `range.epoch_end == range.epoch_start + 2`, and `range.cm == spendable.cm`, binds `range.nf_start == spendable.present_nf`, and emits the lineage at `(epoch + 1, range.nf_end, anchor.next_epoch(epoch + 1))`.
-Only the anchor advances by construction; the nullifier it lands on is a genuine `GGM(mk, ·)` leaf of the same note, so a lineage cannot tick onto a value it did not derive.
+A lineage resting on its epoch's terminal anchor is not a special position: the segment it lifts over opens with the boundary tick, so adjacency holds against the anchor it already sits on.
 
-That `spendable.anchor` really is the epoch's terminal anchor is not checked and cannot be, being a negative claim about what was published.
+That the anchor a crossing folds from really is its epoch's terminal anchor is not checked and cannot be, being a negative claim about what was published.
 Ticking a mid-epoch anchor lands off the published sequence, which no later link rejoins, so consensus anchor membership of the eventual spend rejects it.
-No coverage is skipped: the tick leaves the epoch at its terminal anchor, and `present_nf`'s absence up to that anchor was proven by whatever placed the lineage there.
+No coverage is skipped: the crossing leaves the epoch at its terminal anchor, and `present_nf`'s absence up to that anchor was proven by whatever placed the lineage there.
 
 ### Spend binding
 
@@ -249,7 +237,6 @@ flowchart TB
     unspent_in((ArbitraryUnspent))
     s_unspentbind[UnspentBind]
     s_lift[SpendableLift]
-    s_epochlift[SpendableEpochLift]
   end
 
   subgraph spend_action [spend action]
@@ -281,9 +268,6 @@ flowchart TB
   unspent_in --> s_unspentbind
   s_init -->|SpendableHeader| s_lift
   s_unspentbind -->|Unspent| s_lift
-  s_init -->|SpendableHeader| s_epochlift
-  nf_range -->|NullifierHeader| s_epochlift
-  s_epochlift -->|SpendableHeader| s_lift
   s_lift -->|SpendableHeader| s_bind
 
   w_bind --> s_bind
@@ -300,7 +284,6 @@ flowchart TB
 ```
 
 The single `SpendableLift` consumes one composed `Unspent` (potentially crossing many epoch boundaries); threading `cm` chains the lineage's binding to the note through every advance.
-A lineage resting on an epoch's terminal anchor takes `SpendableEpochLift` first, since no segment can open there.
 
 ## Focused subgraphs
 
@@ -332,24 +315,26 @@ flowchart LR
 flowchart LR
   w_seed[/anchor_prev, epoch, stamp_tg_set, nf/]
   s_useed[UnspentSeed]
+  w_cross[/anchor_prev, epoch_prev, nf_prev, nf/]
+  s_cross[EndEpochUnspentSeed]
+  w_ufuse[/left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq/]
+  s_ufuse[UnspentFuse]
   w_next[/anchor_prev, epoch, stamp_tg_set, nf/]
   s_unext[UnspentSeed]
-  s_ufuse[UnspentFuse]
-  w_eseed[/prev_epoch_tip, epoch, nf/]
-  s_eseed[EmptyEpochUnspentSeed]
-  w_efuse[/left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq/]
-  s_efuse[UnspentEpochFuse]
+  w_ufuse2[/left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq/]
+  s_ufuse2[UnspentFuse]
   unspent_out((ArbitraryUnspent))
 
   w_seed --> s_useed
+  w_cross --> s_cross
   w_next --> s_unext
-  w_eseed --> s_eseed
   s_useed -->|ArbitraryUnspent| s_ufuse
-  s_unext -->|ArbitraryUnspent| s_ufuse
-  s_ufuse -->|ArbitraryUnspent| s_efuse
-  s_eseed -->|ArbitraryUnspent| s_efuse
-  w_efuse --> s_efuse
-  s_efuse --> unspent_out
+  s_cross -->|ArbitraryUnspent| s_ufuse
+  w_ufuse --> s_ufuse
+  s_ufuse -->|ArbitraryUnspent| s_ufuse2
+  s_unext -->|ArbitraryUnspent| s_ufuse2
+  w_ufuse2 --> s_ufuse2
+  s_ufuse2 --> unspent_out
 ```
 
 ## Headers
@@ -373,9 +358,8 @@ flowchart LR
 | AnchorSeed | — | — | start, epoch, stamp_commit | AnchorChain |
 | AnchorFuse | AnchorChain | AnchorChain | — | AnchorChain |
 | UnspentSeed | — | — | anchor_prev, (epoch, nf), stamp_tg_set | ArbitraryUnspent |
-| EmptyEpochUnspentSeed | — | — | prev_epoch_tip, (epoch, nf) | ArbitraryUnspent |
+| EndEpochUnspentSeed | — | — | anchor_prev, (epoch_prev, nf_prev), nf | ArbitraryUnspent |
 | UnspentFuse | ArbitraryUnspent | ArbitraryUnspent | left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq | ArbitraryUnspent |
-| UnspentEpochFuse | ArbitraryUnspent | ArbitraryUnspent | left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq | ArbitraryUnspent |
 | UnspentBind | ArbitraryUnspent | NullifierHeader | elapsed_seq, nf_seq | Unspent |
 | NfMasterSeed | — | — | note, pak | NfPrefixHeader |
 | NfPrefixStep | NfPrefixHeader | — | chunk | NfPrefixHeader |
@@ -383,7 +367,6 @@ flowchart LR
 | NullifierFuse | NullifierHeader | NullifierHeader | left_seq, merged_seq, right_seq | NullifierHeader |
 | SpendableInit | NullifierHeader | — | pre_cm_anchor, creation_set, present_nf | SpendableHeader |
 | SpendableLift | SpendableHeader | Unspent | — | SpendableHeader |
-| SpendableEpochLift | SpendableHeader | NullifierHeader | — | SpendableHeader |
 | SpendBind | SpendableHeader | NullifierHeader | nf_next | SpendHeader |
 | OutputBind | — | — | note | OutputHeader |
 | OutputStamp | OutputHeader | — | rcv, alpha, note, anchor | StampHeader |

--- a/crates/tachyon/src/digest/poseidon.rs
+++ b/crates/tachyon/src/digest/poseidon.rs
@@ -154,18 +154,6 @@ pub(crate) fn anchor_stamp_step(anchor_prev: Fp, epoch: EpochIndex, tgs: EqAffin
     ])
 }
 
-const ANCHOR_EMPTY_DOMAIN: &[u8; 16] = b"Tachyon-EmptyBlk";
-
-/// Advances the anchor through one block that contains zero stamps.
-#[must_use]
-pub(crate) fn anchor_empty_step(anchor_prev: Fp, epoch: EpochIndex) -> Fp {
-    hash::<3>([
-        Fp::from_u128(u128::from_le_bytes(*ANCHOR_EMPTY_DOMAIN)),
-        anchor_prev,
-        Fp::from(epoch),
-    ])
-}
-
 const ANCHOR_EPOCH_DOMAIN: &[u8; 16] = b"Tachyon-EpochStp";
 
 /// Advances the terminal anchor of an epoch into a new epoch's initial state.

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -1001,30 +1001,6 @@ impl WalletSim {
         lifted
     }
 
-    /// Advance a lineage across the boundary out of its current epoch.
-    pub fn epoch_lift(
-        &self,
-        rng: &mut (impl RngCore + CryptoRng),
-        spendable: Pcd<spendable::SpendableHeader>,
-        note: &Note,
-    ) -> Pcd<spendable::SpendableHeader> {
-        let (_, (epoch, present_nf), anchor) = *spendable.data();
-        let (crossing, ()) = PROOF_SYSTEM
-            .seed(
-                rng,
-                pool::EndEpochUnspentSeed,
-                witness::end_epoch_unspent_seed(
-                    ((), ()),
-                    anchor,
-                    epoch,
-                    present_nf,
-                    self.nf_at(note, epoch.next()),
-                ),
-            )
-            .expect("EndEpochUnspentSeed");
-        self.lift(rng, spendable, crossing, note, epoch, epoch.next())
-    }
-
     pub fn lift_over_creation_epoch(
         &self,
         rng: &mut (impl RngCore + CryptoRng),

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -477,9 +477,13 @@ impl PoolSim {
             },
         };
 
-        // One past the last included stamp of the end block (whose post is `end`).
-        let (end_height, end_position) = self.locate_anchor(end).expect("end anchor must exist");
-        let to = (end_position + 1).min(stamp_len(end_height));
+        // One past the last included stamp of the end block (whose post is
+        // `end`). A boundary end covers nothing in the epoch it enters, so the
+        // walk stops at that epoch's first block having taken no stamp from it.
+        let (end_height, to) = match self.locate_anchor(end) {
+            Ok((height, position)) => (height, (position + 1).min(stamp_len(height))),
+            Err((_pre_boundary, epoch)) => (epoch_first_of(epoch), 0),
+        };
 
         // Forward walk. The first block is trimmed at its head (`from`), the last
         // at its tail (`to`). A boundary marker precedes every epoch-first block
@@ -668,11 +672,9 @@ pub(crate) fn build_unspent_pcd_between_blocks(
 /// spanned, `nf[0]` for the span's starting epoch. Seeds one leaf per anchor
 /// step and fuses them as a binary tree via [`fuse_unspent_tree`].
 ///
-/// An epoch that publishes no stamp in the span gets an
-/// [`EmptyEpochUnspentSeed`](pool::EmptyEpochUnspentSeed) leaf, seeded from the
-/// previous epoch's terminal anchor. An epoch the span enters mid-way through
-/// has no such anchor to seed from, so a stampless remainder there contributes
-/// no leaf and the segment starts in the next epoch.
+/// Every epoch boundary the span crosses gets an
+/// [`EndEpochUnspentSeed`](pool::EndEpochUnspentSeed) leaf spanning the
+/// boundary tick, seeded from the leaving epoch's terminal anchor.
 pub(crate) fn build_unspent_pcd_between_anchors(
     rng: &mut (impl RngCore + CryptoRng),
     pool: &PoolSim,
@@ -680,33 +682,30 @@ pub(crate) fn build_unspent_pcd_between_anchors(
     (start_anchor, end_anchor): (Anchor, Anchor),
 ) -> Pcd<pool::ArbitraryUnspent> {
     // One leaf per stamp, each advancing its block's running anchor, plus one
-    // per epoch the span crosses without a stamp. The tree fold derives seams
-    // from headers, so the interleaved boundary markers seed no leaf of their
-    // own. Anchors are folded here: the first block runs from `start_anchor`
-    // (possibly mid-block), every other from its recorded entry anchor.
+    // per boundary the span crosses. Anchors are folded here: the first block
+    // runs from `start_anchor` (possibly mid-block), every other from its
+    // recorded entry anchor.
     let steps = pool.anchor_steps(start_anchor, end_anchor);
     let leading = steps.first().expect("anchor span covers at least one step");
     // `nf` is indexed from the epoch `start_anchor` sits in, which a boundary
-    // anchor names directly and any other names through its block.
-    let base = match pool.locate_anchor(start_anchor) {
-        Ok((height, _)) => height.epoch(),
-        Err((_, epoch)) => epoch,
+    // anchor names directly and any other names through its block. A boundary
+    // start's own crossing precedes the span, so its leading marker seeds
+    // nothing; a marker after a block-terminal start is a genuine crossing.
+    let (base, skip) = match pool.locate_anchor(start_anchor) {
+        Ok((height, _)) => (height.epoch(), 0),
+        Err((_, epoch)) => (epoch, 1),
     };
     let nf_at = |epoch: EpochIndex| -> Nullifier {
         nf[usize::try_from(u64::from(epoch - base)).expect("epoch within span")]
     };
 
     let mut leaves: Vec<Pcd<pool::ArbitraryUnspent>> = Vec::with_capacity(steps.len());
-    // Every epoch the span crosses opens with a boundary marker, so breaking a
-    // chunk before each marker buffers one epoch's blocks and defers the choice
-    // of leaf to the chunk's end.
-    for chunk in steps.chunk_by(|_, right| right.is_ok()) {
-        let blocks: Vec<_> = chunk.iter().filter_map(|step| step.as_ref().ok()).collect();
-        if let Some(&&(first_height, _)) = blocks.first() {
-            let epoch = first_height.epoch();
-            let leaf_nf = nf_at(epoch);
-            for step in blocks {
-                let (height, block_stamps) = (step.0, &step.1);
+    for step in steps.iter().skip(skip) {
+        match step.as_ref() {
+            Ok(block) => {
+                let (height, block_stamps) = (block.0, &block.1);
+                let epoch = height.epoch();
+                let leaf_nf = nf_at(epoch);
                 let mut entry = if leaves.is_empty() && leading.is_ok() {
                     start_anchor
                 } else {
@@ -724,38 +723,38 @@ pub(crate) fn build_unspent_pcd_between_anchors(
                     leaves.push(seed);
                     entry = entry.next_stamp(epoch, &commit);
                 }
-            }
-        } else {
-            // An epoch crossed without a stamp has a single anchor, the boundary
-            // tick's output, folded from the previous epoch's terminal anchor.
-            let Err(epoch) = chunk[0] else {
-                panic!("a chunk with no block is a lone boundary marker")
-            };
-            let (seed, ()) = PROOF_SYSTEM
-                .seed(
-                    rng,
-                    pool::EmptyEpochUnspentSeed,
-                    witness::empty_epoch_unspent_seed(
-                        ((), ()),
-                        pool.pre_epoch_anchor(epoch),
-                        epoch,
-                        nf_at(epoch),
-                    ),
-                )
-                .expect("EmptyEpochUnspentSeed");
-            leaves.push(seed);
+            },
+            // The marker denotes the crossing *into* `epoch`, so the segment
+            // leaves `epoch - 1` from that epoch's terminal anchor, which is
+            // what `pre_epoch_anchor` names.
+            Err(&epoch) => {
+                let prev_epoch = EpochIndex(epoch.0 - 1);
+                let (seed, ()) = PROOF_SYSTEM
+                    .seed(
+                        rng,
+                        pool::EndEpochUnspentSeed,
+                        witness::end_epoch_unspent_seed(
+                            ((), ()),
+                            pool.pre_epoch_anchor(epoch),
+                            prev_epoch,
+                            nf_at(prev_epoch),
+                            nf_at(epoch),
+                        ),
+                    )
+                    .expect("EndEpochUnspentSeed");
+                leaves.push(seed);
+            },
         }
     }
     fuse_unspent_tree(rng, nf, base, leaves)
 }
 
 /// Fuse contiguous [`ArbitraryUnspent`] chains as a binary tree: split at the
-/// midpoint, fuse each half, then join the halves at whatever seam their
-/// headers meet: a shared epoch concatenates ([`UnspentFuse`]), consecutive
-/// epochs splice at the boundary ([`UnspentEpochFuse`]). Everything a seam
-/// needs is read off the halves' headers; a chain's elapsed slice is
-/// `nf[epoch_start - base..epoch_end - base]` (one nullifier per crossed
-/// boundary).
+/// midpoint, fuse each half, then concatenate the halves at their shared epoch
+/// ([`UnspentFuse`]). Every seam is intra-epoch, since a boundary is itself a
+/// chain link. Everything a seam needs is read off the halves' headers; a
+/// chain's elapsed slice is `nf[epoch_start - base..epoch_end - base]` (one
+/// nullifier per crossed boundary).
 fn fuse_unspent_tree(
     rng: &mut (impl RngCore + CryptoRng),
     nf: &[Nullifier],
@@ -784,24 +783,15 @@ fn fuse_unspent_tree(
     let (_, (right_epoch_start, _), _, (right_epoch_end, _), _) = *right.data();
     let left_el = elapsed_slice(left_epoch_start, left_epoch_end);
     let right_el = elapsed_slice(right_epoch_start, right_epoch_end);
-    if right_epoch_start.0 == left_epoch_end.0 {
-        let witness = witness::unspent_fuse((*left.data(), *right.data()), left_el, right_el);
-        let (fused, ()) = PROOF_SYSTEM
-            .fuse(rng, pool::UnspentFuse, witness, left, right)
-            .expect("UnspentFuse mid-epoch");
-        fused
-    } else {
-        debug_assert_eq!(
-            right_epoch_start.0,
-            left_epoch_end.0 + 1,
-            "fused chains must be contiguous"
-        );
-        let witness = witness::unspent_epoch_fuse((*left.data(), *right.data()), left_el, right_el);
-        let (fused, ()) = PROOF_SYSTEM
-            .fuse(rng, pool::UnspentEpochFuse, witness, left, right)
-            .expect("UnspentEpochFuse boundary");
-        fused
-    }
+    assert_eq!(
+        right_epoch_start.0, left_epoch_end.0,
+        "fused chains must meet inside one epoch"
+    );
+    let witness = witness::unspent_fuse((*left.data(), *right.data()), left_el, right_el);
+    let (fused, ()) = PROOF_SYSTEM
+        .fuse(rng, pool::UnspentFuse, witness, left, right)
+        .expect("UnspentFuse");
+    fused
 }
 
 /// A fixed, deterministic spending key. Tests that don't need a distinct wallet
@@ -1018,11 +1008,21 @@ impl WalletSim {
         spendable: Pcd<spendable::SpendableHeader>,
         note: &Note,
     ) -> Pcd<spendable::SpendableHeader> {
-        let range = self.derived_range(rng, note, spendable.data().1.0, 2);
-        let (lifted, ()) = PROOF_SYSTEM
-            .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
-            .expect("SpendableEpochLift");
-        lifted
+        let (_, (epoch, present_nf), anchor) = *spendable.data();
+        let (crossing, ()) = PROOF_SYSTEM
+            .seed(
+                rng,
+                pool::EndEpochUnspentSeed,
+                witness::end_epoch_unspent_seed(
+                    ((), ()),
+                    anchor,
+                    epoch,
+                    present_nf,
+                    self.nf_at(note, epoch.next()),
+                ),
+            )
+            .expect("EndEpochUnspentSeed");
+        self.lift(rng, spendable, crossing, note, epoch, epoch.next())
     }
 
     pub fn lift_over_creation_epoch(

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -20,7 +20,7 @@ use core::{
 
 use ff::{Field as _, PrimeField as _};
 use pasta_curves::Fp;
-use ragu::Pcd;
+use ragu::{Pcd, Proof};
 use rand::{SeedableRng as _, rngs::StdRng};
 use rand_core::{CryptoRng, RngCore};
 
@@ -319,21 +319,18 @@ impl PoolSimBlock {
     }
 
     /// The block's commitments and post anchors in one pass: one anchor per
-    /// stamp (folding `next_stamp` from `prev`), or a single `next_empty` tick
-    /// for an empty block. Every link binds `epoch`, the epoch of the block at
-    /// `height`. The anchors reuse the commitments, so the MSMs run once.
+    /// stamp, folding `next_stamp` from `prev`. Every link binds `epoch`, the
+    /// epoch of the block at `height`. A stampless block contributes no link,
+    /// so its anchor list is empty. The anchors reuse the commitments, so the
+    /// MSMs run once.
     fn digest(&self, height: BlockHeight) -> BlockDigest {
         let epoch = height.epoch();
         let commits = self.commits();
-        let anchors = if commits.is_empty() {
-            alloc::vec![self.prev.next_empty(epoch)]
-        } else {
-            commits.iter().fold(Vec::new(), |mut acc, commit| {
-                let last = acc.last().unwrap_or(&self.prev);
-                acc.push(last.next_stamp(epoch, commit));
-                acc
-            })
-        };
+        let anchors = commits.iter().fold(Vec::new(), |mut acc, commit| {
+            let last = acc.last().unwrap_or(&self.prev);
+            acc.push(last.next_stamp(epoch, commit));
+            acc
+        });
         BlockDigest { commits, anchors }
     }
 }
@@ -444,21 +441,22 @@ impl PoolSim {
 
     #[must_use]
     pub fn anchor_at(&self, height: BlockHeight) -> Anchor {
-        // The block's terminal anchor is the last of its memoized post anchors
-        // (the single `next_empty` tick for an empty block).
-        *self
-            .digest_at(height)
+        // The block's terminal anchor is the last of its memoized post anchors,
+        // or its entry anchor unchanged when the block published no stamp.
+        self.digest_at(height)
             .anchors
             .last()
-            .expect("block digest has at least one anchor")
+            .copied()
+            .unwrap_or_else(|| self.prev_anchor_at(height))
     }
 
     /// The pool blocks spanning the anchor range `(start, end]`, in forward
-    /// order: each `Ok((height, stamps))` is a block's in-span tachygrams
-    /// (empty for an empty block), each `Err(epoch)` a `next_epoch` lift
-    /// into `epoch`. `start`/`end` may sit mid-block; the first and last
-    /// blocks are trimmed to the span. Anchors are not returned (the caller
-    /// folds them).
+    /// order: each `Ok((height, stamps))` is a block's in-span tachygrams,
+    /// each `Err(epoch)` a `next_epoch` lift into `epoch`. `start`/`end` may
+    /// sit mid-block; the first and last blocks are trimmed to the span.
+    /// Stampless blocks advance no anchor and so contribute no entry, though
+    /// a boundary marker is still emitted for a stampless epoch-first block.
+    /// Anchors are not returned (the caller folds them).
     #[must_use]
     pub fn anchor_steps(
         &self,
@@ -484,9 +482,8 @@ impl PoolSim {
         let to = (end_position + 1).min(stamp_len(end_height));
 
         // Forward walk. The first block is trimmed at its head (`from`), the last
-        // at its tail (`to`); a `start`-terminal first block contributes no `Ok`
-        // entry. A boundary marker precedes every epoch-first block after the
-        // start block.
+        // at its tail (`to`). A boundary marker precedes every epoch-first block
+        // after the start block, whether or not that block publishes a stamp.
         for height_idx in start_height.0..=end_height.0 {
             let height = BlockHeight(height_idx);
             let block = self.block(height);
@@ -504,9 +501,10 @@ impl PoolSim {
                 block.stamps.len()
             };
             let stamps = block.stamps[lo..hi].to_vec();
-            // Skip a head-trimmed first block that the `start` terminal empties,
-            // but keep a genuinely empty block (it still advances the anchor).
-            if height_idx == start_height.0 && stamps.is_empty() && !block.stamps.is_empty() {
+            // A block with no in-span stamp advances no anchor, so it is not a
+            // step: this covers both a stampless block and a first block the
+            // `start` terminal empties.
+            if stamps.is_empty() {
                 continue;
             }
             steps.push(Ok((height, stamps)));
@@ -580,19 +578,16 @@ impl PoolSim {
     }
 }
 
-/// Build an [`AnchorChain`] covering blocks `range`, rooted at the block-start
-/// anchor of `*range.start()`. When `last_block_upto` is `Some(n)` the final
-/// block absorbs only its first `n` stamps (stopping the chain right after the
-/// cm-stamp); `None` absorbs every block in full.
+/// Build an [`AnchorChain`] covering blocks `range` in full, rooted at the
+/// block-start anchor of `*range.start()`.
 ///
-/// Per non-empty block: one [`AnchorSeed`] per absorbed stamp, fused via
-/// [`AnchorFuse`]. Per empty block: one [`EmptyBlockSeed`]. All segments fused
-/// linearly.
-fn build_anchor_chain_inner(
+/// One [`AnchorSeed`] per absorbed stamp, fused linearly via [`AnchorFuse`].
+/// A stampless block advances no anchor and so contributes no segment; the
+/// range must therefore cover at least one stamp.
+pub(crate) fn build_anchor_chain_pcd(
     rng: &mut (impl RngCore + CryptoRng),
     pool: &PoolSim,
     range: RangeInclusive<BlockHeight>,
-    last_block_upto: Option<usize>,
 ) -> Pcd<pool::AnchorChain> {
     let start = *range.start();
     let end = *range.end();
@@ -603,12 +598,12 @@ fn build_anchor_chain_inner(
     let mut chain: Option<Pcd<pool::AnchorChain>> = None;
     let mut height = start;
     loop {
-        let stamps = pool.tachygrams_at(height);
-        if stamps.is_empty() {
-            let next_state = state.next_empty(height.epoch());
+        for tgs in &pool.tachygrams_at(height) {
+            let witness = witness::anchor_seed(((), ()), state, height.epoch(), tgs);
+            let next_state = state.next_stamp(witness.1, &witness.2);
             let (seed, ()) = PROOF_SYSTEM
-                .seed(rng, pool::EmptyBlockSeed, (state, height.epoch()))
-                .expect("EmptyBlockSeed");
+                .seed(rng, pool::AnchorSeed, witness)
+                .expect("AnchorSeed");
             chain = Some(match chain.take() {
                 None => seed,
                 Some(left) => {
@@ -619,30 +614,6 @@ fn build_anchor_chain_inner(
                 },
             });
             state = next_state;
-        } else {
-            // The final block may be truncated (cm-block prefix); others absorb all.
-            let upto = if height == end {
-                last_block_upto.unwrap_or(stamps.len())
-            } else {
-                stamps.len()
-            };
-            for tgs in &stamps[..upto] {
-                let witness = witness::anchor_seed(((), ()), state, height.epoch(), tgs);
-                let next_state = state.next_stamp(witness.1, &witness.2);
-                let (seed, ()) = PROOF_SYSTEM
-                    .seed(rng, pool::AnchorSeed, witness)
-                    .expect("AnchorSeed");
-                chain = Some(match chain.take() {
-                    None => seed,
-                    Some(left) => {
-                        let (fused, ()) = PROOF_SYSTEM
-                            .fuse(rng, pool::AnchorFuse, (), left, seed)
-                            .expect("AnchorFuse");
-                        fused
-                    },
-                });
-                state = next_state;
-            }
         }
         if height >= end {
             break;
@@ -650,68 +621,18 @@ fn build_anchor_chain_inner(
         height = height.next().expect("height < max");
     }
 
-    chain.expect("AnchorChain range must cover at least one block")
+    chain.expect("AnchorChain range must cover at least one stamp")
 }
 
-/// Build an [`AnchorChain`] covering blocks `range` in full, rooted at the
-/// block-start anchor of `*range.start()`.
-pub(crate) fn build_anchor_chain_pcd(
-    rng: &mut (impl RngCore + CryptoRng),
-    pool: &PoolSim,
-    range: RangeInclusive<BlockHeight>,
-) -> Pcd<pool::AnchorChain> {
-    build_anchor_chain_inner(rng, pool, range, None)
-}
-
-/// Build the boundary->cm segment [`spendable::SpendableInit`] consumes to pin
-/// a spendable's starting epoch: an [`AnchorChain`](pool::AnchorChain) rooted
-/// at the epoch boundary `B_E = prev_anchor_at(epoch_first)` and ending at
-/// `post_cm_anchor`, covering blocks `epoch_first..=cm_height` with the final
-/// (cm) block truncated to its stamps `[0..=cm_idx]` so the cm-stamp is the
-/// chain's last absorbed link. A note created first-in-epoch (`epoch_first ==
-/// cm_height`, `cm_idx == 0`) produces a single-link chain.
-pub(crate) fn build_anchor_chain_prefix_pcd(
-    rng: &mut (impl RngCore + CryptoRng),
-    pool: &PoolSim,
-    epoch_first: BlockHeight,
-    cm_height: BlockHeight,
-    cm_idx: usize,
-) -> Pcd<pool::AnchorChain> {
-    assert_eq!(
-        epoch_first.epoch(),
-        cm_height.epoch(),
-        "prefix chain is single-epoch"
-    );
-    assert!(epoch_first <= cm_height);
-    // The cm-block must be non-empty and `cm_idx` in range; otherwise the
-    // truncation is silently dropped and the chain would not end at the
-    // cm-stamp (surfacing only later as SpendableInit's "cm-stamp is not the
-    // chain's final link").
-    let cm_commits = pool.stamp_commits_at(cm_height);
-    assert!(
-        !cm_commits.is_empty(),
-        "cm-block at {cm_height:?} has no stamps; cm_idx is meaningless"
-    );
-    assert!(
-        cm_idx < cm_commits.len(),
-        "cm_idx {cm_idx} out of range for {}-stamp cm-block",
-        cm_commits.len()
-    );
-    build_anchor_chain_inner(rng, pool, epoch_first..=cm_height, Some(cm_idx + 1))
-}
-
-/// The honest [`spendable::SpendableInit`] inputs for `cm` at `height`,
-/// reconstructed from pool state: the witness `(pre_epoch_anchor,
-/// pre_cm_anchor, creation_tgs)` plus the boundary-rooted
-/// [`AnchorChain`](pool::AnchorChain) for the left input. Shared by
-/// [`WalletSim::spendable_init`] (which `.expect`s the fuse) and tests that
-/// drive a raw fuse to capture the `Err`.
+/// The honest [`spendable::SpendableInit`] witness inputs for `cm` at
+/// `height`, reconstructed from pool state: `(pre_cm_anchor, creation_tgs)`.
+/// Shared by [`WalletSim::spendable_init`] (which `.expect`s the fuse) and
+/// tests that drive a raw fuse directly.
 pub(crate) fn spendable_init_inputs(
-    rng: &mut (impl RngCore + CryptoRng),
     pool: &PoolSim,
     cm: note::Commitment,
     height: BlockHeight,
-) -> (Anchor, Anchor, Vec<Tachygram>, Pcd<pool::AnchorChain>) {
+) -> (Anchor, Vec<Tachygram>) {
     let stamps = pool.tachygrams_at(height);
     let stamp_commits = pool.stamp_commits_at(height);
     let cm_idx = stamps
@@ -726,15 +647,7 @@ pub(crate) fn spendable_init_inputs(
             anchor.next_stamp(height.epoch(), commit)
         });
 
-    // Root the lineage at the epoch boundary `B_E = pre_epoch_anchor.next_epoch(E)
-    // == prev_anchor_at(epoch_first)`; the boundary->cm chain ends at
-    // post_cm_anchor.
-    let epoch = height.epoch();
-    let pre_epoch_anchor = pool.pre_epoch_anchor(epoch);
-    let chain = build_anchor_chain_prefix_pcd(rng, pool, epoch_first_of(epoch), height, cm_idx);
-    let creation_tgs = stamps[cm_idx].clone();
-
-    (pre_epoch_anchor, pre_cm_anchor, creation_tgs, chain)
+    (pre_cm_anchor, stamps[cm_idx].clone())
 }
 
 pub(crate) fn build_unspent_seed_pcd(
@@ -743,7 +656,7 @@ pub(crate) fn build_unspent_seed_pcd(
     epoch: EpochIndex,
     tgs: &[Tachygram],
     nf: Nullifier,
-) -> Pcd<pool::Unspent> {
+) -> Pcd<pool::ArbitraryUnspent> {
     let (pcd, ()) = PROOF_SYSTEM
         .seed(
             rng,
@@ -751,6 +664,22 @@ pub(crate) fn build_unspent_seed_pcd(
             witness::unspent_seed(((), ()), start, epoch, tgs, nf),
         )
         .expect("UnspentSeed");
+    pcd
+}
+
+pub(crate) fn build_empty_epoch_seed_pcd(
+    rng: &mut (impl RngCore + CryptoRng),
+    prev_epoch_tip: Anchor,
+    epoch: EpochIndex,
+    nf: Nullifier,
+) -> Pcd<pool::ArbitraryUnspent> {
+    let (pcd, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EmptyEpochUnspentSeed,
+            witness::empty_epoch_unspent_seed(((), ()), prev_epoch_tip, epoch, nf),
+        )
+        .expect("EmptyEpochUnspentSeed");
     pcd
 }
 
@@ -763,7 +692,7 @@ pub(crate) fn build_unspent_pcd_between_blocks(
     pool: &PoolSim,
     nf: &[Nullifier],
     range: RangeInclusive<BlockHeight>,
-) -> Pcd<pool::Unspent> {
+) -> Pcd<pool::ArbitraryUnspent> {
     build_unspent_pcd_between_anchors(
         rng,
         pool,
@@ -775,74 +704,113 @@ pub(crate) fn build_unspent_pcd_between_blocks(
     )
 }
 
-/// Build an [`Unspent`] for the anchor span `(start_anchor, end_anchor)`,
-/// covering every stamp / empty block that advances the anchor between them;
+/// Build an [`ArbitraryUnspent`] for the anchor span `(start_anchor,
+/// end_anchor)`, covering every stamp that advances the anchor between them;
 /// either endpoint may sit mid-block. `nf` holds one nullifier per epoch
-/// spanned, `nf[0]` for `start_anchor`'s epoch. Seeds one leaf per anchor
+/// spanned, `nf[0]` for the span's starting epoch. Seeds one leaf per anchor
 /// step and fuses them as a binary tree via [`fuse_unspent_tree`].
+///
+/// An epoch that publishes no stamp in the span gets an
+/// [`EmptyEpochUnspentSeed`](pool::EmptyEpochUnspentSeed) leaf, seeded from the
+/// previous epoch's terminal anchor. An epoch the span enters mid-way through
+/// has no such anchor to seed from, so a stampless remainder there contributes
+/// no leaf and the segment starts in the next epoch.
 pub(crate) fn build_unspent_pcd_between_anchors(
     rng: &mut (impl RngCore + CryptoRng),
     pool: &PoolSim,
     nf: &[Nullifier],
     (start_anchor, end_anchor): (Anchor, Anchor),
-) -> Pcd<pool::Unspent> {
-    // One leaf per anchor step: each stamp advances its block's running anchor,
-    // each empty block advances the block anchor once. The tree fold derives
-    // seams from headers, so the interleaved boundary markers are dropped; only
-    // `Ok` segments seed leaves. Anchors are folded here: the first block runs
-    // from `start_anchor` (possibly mid-block), every other from its recorded
-    // entry anchor.
-    let steps: Vec<(BlockHeight, Vec<Vec<Tachygram>>)> = pool
-        .anchor_steps(start_anchor, end_anchor)
-        .into_iter()
-        .filter_map(Result::ok)
-        .collect();
-    let base = steps
-        .first()
-        .expect("anchor span covers at least one block")
-        .0
-        .epoch();
+) -> Pcd<pool::ArbitraryUnspent> {
+    // The tree fold derives seams from headers, so anchors are folded here: the
+    // running cursor enters the span at `start_anchor` (possibly mid-block),
+    // takes a `next_stamp` per absorbed stamp and a `next_epoch` per boundary.
+    let steps = pool.anchor_steps(start_anchor, end_anchor);
+    let leading = steps.first().expect("anchor span covers at least one step");
+    // A leading marker is ambiguous on its own: `anchor_steps` emits one both
+    // when the span *starts* at a boundary and when its first crossing precedes
+    // any stamp. The span's epoch tells them apart.
+    let (base, base_tip) = match *leading {
+        Ok((height, _)) => (height.epoch(), None),
+        Err(epoch) if start_anchor == pool.pre_epoch_anchor(epoch).next_epoch(epoch) => {
+            (epoch, Some(pool.pre_epoch_anchor(epoch)))
+        },
+        Err(epoch) => (EpochIndex(epoch.0 - 1), None),
+    };
     let nf_at = |epoch: EpochIndex| -> Nullifier {
         nf[usize::try_from(u64::from(epoch - base)).expect("epoch within span")]
     };
-    let mut leaves: Vec<Pcd<pool::Unspent>> = Vec::with_capacity(steps.len());
-    for (index, (height, block_stamps)) in steps.into_iter().enumerate() {
-        let epoch = height.epoch();
-        let leaf_nf = nf_at(epoch);
-        let mut entry = if index == 0 {
-            start_anchor
-        } else {
-            pool.prev_anchor_at(height)
-        };
-        if block_stamps.is_empty() {
-            let (seed, ()) = PROOF_SYSTEM
-                .seed(rng, pool::EmptyBlockUnspentSeed, (entry, (epoch, leaf_nf)))
-                .expect("EmptyBlockUnspentSeed");
-            leaves.push(seed);
-        } else {
-            for tgs in block_stamps {
-                let commit = TachygramSetPoly::from_iter(tgs.clone()).commit();
-                leaves.push(build_unspent_seed_pcd(rng, entry, epoch, &tgs, leaf_nf));
-                entry = entry.next_stamp(epoch, &commit);
-            }
+
+    let mut leaves: Vec<Pcd<pool::ArbitraryUnspent>> = Vec::with_capacity(steps.len());
+    let mut cursor_epoch = base;
+    let mut cursor_anchor = start_anchor;
+    // The terminal anchor of the epoch before `cursor_epoch`, present only when
+    // the cursor entered `cursor_epoch` at its boundary. An empty-epoch leaf
+    // folds that tick, so a span opening mid-epoch has nothing to seed with.
+    let mut entry_tip = base_tip;
+    let mut epoch_has_leaf = false;
+    for step in steps {
+        match step {
+            Err(new_epoch) => {
+                if new_epoch == cursor_epoch {
+                    // The span begins at this boundary; it is already crossed.
+                    continue;
+                }
+                if !epoch_has_leaf && let Some(tip) = entry_tip {
+                    leaves.push(build_empty_epoch_seed_pcd(
+                        rng,
+                        tip,
+                        cursor_epoch,
+                        nf_at(cursor_epoch),
+                    ));
+                }
+                entry_tip = Some(cursor_anchor);
+                cursor_anchor = cursor_anchor.next_epoch(new_epoch);
+                cursor_epoch = new_epoch;
+                epoch_has_leaf = false;
+            },
+            Ok((height, block_stamps)) => {
+                let epoch = height.epoch();
+                let leaf_nf = nf_at(epoch);
+                for tgs in block_stamps {
+                    let commit = tgs.iter().copied().collect::<TachygramSetPoly>().commit();
+                    leaves.push(build_unspent_seed_pcd(
+                        rng,
+                        cursor_anchor,
+                        epoch,
+                        &tgs,
+                        leaf_nf,
+                    ));
+                    cursor_anchor = cursor_anchor.next_stamp(epoch, &commit);
+                    epoch_has_leaf = true;
+                }
+            },
         }
+    }
+    // The span's final epoch, if it published nothing after the crossing in.
+    if !epoch_has_leaf && let Some(tip) = entry_tip {
+        leaves.push(build_empty_epoch_seed_pcd(
+            rng,
+            tip,
+            cursor_epoch,
+            nf_at(cursor_epoch),
+        ));
     }
     fuse_unspent_tree(rng, nf, base, leaves)
 }
 
-/// Fuse contiguous [`Unspent`] chains as a binary tree: split at the midpoint,
-/// fuse each half, then join the halves at whatever seam their headers meet:
-/// a shared epoch concatenates ([`UnspentFuse`]), consecutive epochs splice at
-/// the boundary ([`UnspentEpochFuse`]). Everything a seam needs is read off
-/// the halves' headers; a chain's elapsed slice is
+/// Fuse contiguous [`ArbitraryUnspent`] chains as a binary tree: split at the
+/// midpoint, fuse each half, then join the halves at whatever seam their
+/// headers meet: a shared epoch concatenates ([`UnspentFuse`]), consecutive
+/// epochs splice at the boundary ([`UnspentEpochFuse`]). Everything a seam
+/// needs is read off the halves' headers; a chain's elapsed slice is
 /// `nf[epoch_start - base..epoch_end - base]` (one nullifier per crossed
 /// boundary).
 fn fuse_unspent_tree(
     rng: &mut (impl RngCore + CryptoRng),
     nf: &[Nullifier],
     base: EpochIndex,
-    mut chains: Vec<Pcd<pool::Unspent>>,
-) -> Pcd<pool::Unspent> {
+    mut chains: Vec<Pcd<pool::ArbitraryUnspent>>,
+) -> Pcd<pool::ArbitraryUnspent> {
     assert!(!chains.is_empty(), "tree fuses at least one chain");
     if chains.len() == 1 {
         return chains.pop().expect("single chain");
@@ -1005,8 +973,7 @@ impl WalletSim {
         let cm = note.commitment();
         let epoch = init_height.epoch();
         let present_nf = self.nf_at(note, epoch);
-        let (pre_epoch_anchor, pre_cm_anchor, creation_tgs, chain) =
-            spendable_init_inputs(rng, pool, cm, init_height);
+        let (pre_cm_anchor, creation_tgs) = spendable_init_inputs(pool, cm, init_height);
         let nf_header = self.nullifier_pcd(rng, *note, epoch);
 
         let (spendable, ()) = PROOF_SYSTEM
@@ -1014,14 +981,13 @@ impl WalletSim {
                 rng,
                 spendable::SpendableInit,
                 witness::spendable_init(
-                    (*chain.data(), *nf_header.data()),
-                    pre_epoch_anchor,
+                    (*nf_header.data(), ()),
                     pre_cm_anchor,
                     &creation_tgs,
                     present_nf,
                 ),
-                chain,
                 nf_header,
+                Proof::trivial().carry::<()>(()),
             )
             .expect("SpendableInit");
         spendable
@@ -1037,44 +1003,58 @@ impl WalletSim {
         self.spendable_init(rng, spend_note, pool, height)
     }
 
-    pub fn verify_unspent(
+    pub fn unspent_bind(
         &self,
         rng: &mut (impl RngCore + CryptoRng),
-        unspent: Pcd<pool::Unspent>,
+        arbitrary: Pcd<pool::ArbitraryUnspent>,
         note: &Note,
         epoch_start: EpochIndex,
         present_epoch: EpochIndex,
-    ) -> Pcd<pool::VerifiedUnspent> {
+    ) -> Pcd<pool::Unspent> {
         let len = present_epoch.0 - epoch_start.0 + 1;
         let range = self.derived_range(rng, note, epoch_start, len);
         let elapsed: Vec<Nullifier> = (epoch_start.0..present_epoch.0)
             .map(|epoch| self.nf_at(note, EpochIndex(epoch)))
             .collect();
-        let (verified, ()) = PROOF_SYSTEM
+        let (unspent, ()) = PROOF_SYSTEM
             .fuse(
                 rng,
-                pool::VerifyUnspent,
-                witness::verify_unspent((*unspent.data(), *range.data()), &elapsed),
-                unspent,
+                pool::UnspentBind,
+                witness::unspent_bind((*arbitrary.data(), *range.data()), &elapsed),
+                arbitrary,
                 range,
             )
-            .expect("VerifyUnspent");
-        verified
+            .expect("UnspentBind");
+        unspent
     }
 
     pub fn lift(
         &self,
         rng: &mut (impl RngCore + CryptoRng),
         spendable: Pcd<spendable::SpendableHeader>,
-        unspent: Pcd<pool::Unspent>,
+        arbitrary: Pcd<pool::ArbitraryUnspent>,
         note: &Note,
         epoch_start: EpochIndex,
         present_epoch: EpochIndex,
     ) -> Pcd<spendable::SpendableHeader> {
-        let verified = self.verify_unspent(rng, unspent, note, epoch_start, present_epoch);
+        let unspent = self.unspent_bind(rng, arbitrary, note, epoch_start, present_epoch);
         let (lifted, ()) = PROOF_SYSTEM
-            .fuse(rng, spendable::SpendableLift, (), spendable, verified)
+            .fuse(rng, spendable::SpendableLift, (), spendable, unspent)
             .expect("SpendableLift");
+        lifted
+    }
+
+    /// Advance a lineage across the boundary out of its current epoch.
+    pub fn epoch_lift(
+        &self,
+        rng: &mut (impl RngCore + CryptoRng),
+        spendable: Pcd<spendable::SpendableHeader>,
+        note: &Note,
+    ) -> Pcd<spendable::SpendableHeader> {
+        let range = self.derived_range(rng, note, spendable.data().1.0, 2);
+        let (lifted, ()) = PROOF_SYSTEM
+            .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
+            .expect("SpendableEpochLift");
         lifted
     }
 
@@ -1209,7 +1189,7 @@ impl SyncSim {
         handle: usize,
         pool: &PoolSim,
         target_height: BlockHeight,
-    ) -> Pcd<pool::Unspent> {
+    ) -> Pcd<pool::ArbitraryUnspent> {
         let idx = self
             .entries
             .iter()

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -624,32 +624,6 @@ pub(crate) fn build_anchor_chain_pcd(
     chain.expect("AnchorChain range must cover at least one stamp")
 }
 
-/// The honest [`spendable::SpendableInit`] witness inputs for `cm` at
-/// `height`, reconstructed from pool state: `(pre_cm_anchor, creation_tgs)`.
-/// Shared by [`WalletSim::spendable_init`] (which `.expect`s the fuse) and
-/// tests that drive a raw fuse directly.
-pub(crate) fn spendable_init_inputs(
-    pool: &PoolSim,
-    cm: note::Commitment,
-    height: BlockHeight,
-) -> (Anchor, Vec<Tachygram>) {
-    let stamps = pool.tachygrams_at(height);
-    let stamp_commits = pool.stamp_commits_at(height);
-    let cm_idx = stamps
-        .iter()
-        .position(|tgs| tgs.contains(&cm.into()))
-        .expect("cm not found in any stamp at the cm-block");
-
-    // Anchor immediately before the cm-stamp (the cm-block prefix fold).
-    let pre_cm_anchor = stamp_commits[..cm_idx]
-        .iter()
-        .fold(pool.prev_anchor_at(height), |anchor, commit| {
-            anchor.next_stamp(height.epoch(), commit)
-        });
-
-    (pre_cm_anchor, stamps[cm_idx].clone())
-}
-
 pub(crate) fn build_unspent_seed_pcd(
     rng: &mut (impl RngCore + CryptoRng),
     start: Anchor,
@@ -664,22 +638,6 @@ pub(crate) fn build_unspent_seed_pcd(
             witness::unspent_seed(((), ()), start, epoch, tgs, nf),
         )
         .expect("UnspentSeed");
-    pcd
-}
-
-pub(crate) fn build_empty_epoch_seed_pcd(
-    rng: &mut (impl RngCore + CryptoRng),
-    prev_epoch_tip: Anchor,
-    epoch: EpochIndex,
-    nf: Nullifier,
-) -> Pcd<pool::ArbitraryUnspent> {
-    let (pcd, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::EmptyEpochUnspentSeed,
-            witness::empty_epoch_unspent_seed(((), ()), prev_epoch_tip, epoch, nf),
-        )
-        .expect("EmptyEpochUnspentSeed");
     pcd
 }
 
@@ -734,7 +692,15 @@ pub(crate) fn build_unspent_pcd_between_anchors(
         Err(epoch) if start_anchor == pool.pre_epoch_anchor(epoch).next_epoch(epoch) => {
             (epoch, Some(pool.pre_epoch_anchor(epoch)))
         },
-        Err(epoch) => (EpochIndex(epoch.0 - 1), None),
+        Err(epoch) => {
+            // Epoch 0's boundary marker is `Anchor::default()`, which equals
+            // `pre_epoch_anchor(0).next_epoch(0)` and so matches the arm above.
+            let prior = epoch
+                .0
+                .checked_sub(1)
+                .expect("a leading marker into epoch 0 starts at the genesis anchor");
+            (EpochIndex(prior), None)
+        },
     };
     let nf_at = |epoch: EpochIndex| -> Nullifier {
         nf[usize::try_from(u64::from(epoch - base)).expect("epoch within span")]
@@ -756,12 +722,21 @@ pub(crate) fn build_unspent_pcd_between_anchors(
                     continue;
                 }
                 if !epoch_has_leaf && let Some(tip) = entry_tip {
-                    leaves.push(build_empty_epoch_seed_pcd(
-                        rng,
-                        tip,
-                        cursor_epoch,
-                        nf_at(cursor_epoch),
-                    ));
+                    leaves.push({
+                        PROOF_SYSTEM
+                            .seed(
+                                rng,
+                                pool::EmptyEpochUnspentSeed,
+                                witness::empty_epoch_unspent_seed(
+                                    ((), ()),
+                                    tip,
+                                    cursor_epoch,
+                                    nf_at(cursor_epoch),
+                                ),
+                            )
+                            .expect("EmptyEpochUnspentSeed")
+                            .0
+                    });
                 }
                 entry_tip = Some(cursor_anchor);
                 cursor_anchor = cursor_anchor.next_epoch(new_epoch);
@@ -773,13 +748,22 @@ pub(crate) fn build_unspent_pcd_between_anchors(
                 let leaf_nf = nf_at(epoch);
                 for tgs in block_stamps {
                     let commit = tgs.iter().copied().collect::<TachygramSetPoly>().commit();
-                    leaves.push(build_unspent_seed_pcd(
-                        rng,
-                        cursor_anchor,
-                        epoch,
-                        &tgs,
-                        leaf_nf,
-                    ));
+                    leaves.push(
+                        PROOF_SYSTEM
+                            .seed(
+                                rng,
+                                pool::UnspentSeed,
+                                witness::unspent_seed(
+                                    ((), ()),
+                                    cursor_anchor,
+                                    epoch,
+                                    &tgs,
+                                    leaf_nf,
+                                ),
+                            )
+                            .expect("UnspentSeed")
+                            .0,
+                    );
                     cursor_anchor = cursor_anchor.next_stamp(epoch, &commit);
                     epoch_has_leaf = true;
                 }
@@ -788,12 +772,21 @@ pub(crate) fn build_unspent_pcd_between_anchors(
     }
     // The span's final epoch, if it published nothing after the crossing in.
     if !epoch_has_leaf && let Some(tip) = entry_tip {
-        leaves.push(build_empty_epoch_seed_pcd(
-            rng,
-            tip,
-            cursor_epoch,
-            nf_at(cursor_epoch),
-        ));
+        leaves.push({
+            PROOF_SYSTEM
+                .seed(
+                    rng,
+                    pool::EmptyEpochUnspentSeed,
+                    witness::empty_epoch_unspent_seed(
+                        ((), ()),
+                        tip,
+                        cursor_epoch,
+                        nf_at(cursor_epoch),
+                    ),
+                )
+                .expect("EmptyEpochUnspentSeed")
+                .0
+        });
     }
     fuse_unspent_tree(rng, nf, base, leaves)
 }
@@ -973,7 +966,23 @@ impl WalletSim {
         let cm = note.commitment();
         let epoch = init_height.epoch();
         let present_nf = self.nf_at(note, epoch);
-        let (pre_cm_anchor, creation_tgs) = spendable_init_inputs(pool, cm, init_height);
+        let (pre_cm_anchor, creation_tgs) = {
+            let stamps = pool.tachygrams_at(init_height);
+            let stamp_commits = pool.stamp_commits_at(init_height);
+            let cm_idx = stamps
+                .iter()
+                .position(|tgs| tgs.contains(&cm.into()))
+                .expect("cm not found in any stamp at the cm-block");
+
+            // Anchor immediately before the cm-stamp (the cm-block prefix fold).
+            let pre_cm_anchor = stamp_commits[..cm_idx]
+                .iter()
+                .fold(pool.prev_anchor_at(init_height), |anchor, commit| {
+                    anchor.next_stamp(init_height.epoch(), commit)
+                });
+
+            (pre_cm_anchor, stamps[cm_idx].clone())
+        };
         let nf_header = self.nullifier_pcd(rng, *note, epoch);
 
         let (spendable, ()) = PROOF_SYSTEM

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -679,114 +679,72 @@ pub(crate) fn build_unspent_pcd_between_anchors(
     nf: &[Nullifier],
     (start_anchor, end_anchor): (Anchor, Anchor),
 ) -> Pcd<pool::ArbitraryUnspent> {
-    // The tree fold derives seams from headers, so anchors are folded here: the
-    // running cursor enters the span at `start_anchor` (possibly mid-block),
-    // takes a `next_stamp` per absorbed stamp and a `next_epoch` per boundary.
+    // One leaf per stamp, each advancing its block's running anchor, plus one
+    // per epoch the span crosses without a stamp. The tree fold derives seams
+    // from headers, so the interleaved boundary markers seed no leaf of their
+    // own. Anchors are folded here: the first block runs from `start_anchor`
+    // (possibly mid-block), every other from its recorded entry anchor.
     let steps = pool.anchor_steps(start_anchor, end_anchor);
     let leading = steps.first().expect("anchor span covers at least one step");
-    // A leading marker is ambiguous on its own: `anchor_steps` emits one both
-    // when the span *starts* at a boundary and when its first crossing precedes
-    // any stamp. The span's epoch tells them apart.
-    let (base, base_tip) = match *leading {
-        Ok((height, _)) => (height.epoch(), None),
-        Err(epoch) if start_anchor == pool.pre_epoch_anchor(epoch).next_epoch(epoch) => {
-            (epoch, Some(pool.pre_epoch_anchor(epoch)))
-        },
-        Err(epoch) => {
-            // Epoch 0's boundary marker is `Anchor::default()`, which equals
-            // `pre_epoch_anchor(0).next_epoch(0)` and so matches the arm above.
-            let prior = epoch
-                .0
-                .checked_sub(1)
-                .expect("a leading marker into epoch 0 starts at the genesis anchor");
-            (EpochIndex(prior), None)
-        },
+    // `nf` is indexed from the epoch `start_anchor` sits in, which a boundary
+    // anchor names directly and any other names through its block.
+    let base = match pool.locate_anchor(start_anchor) {
+        Ok((height, _)) => height.epoch(),
+        Err((_, epoch)) => epoch,
     };
     let nf_at = |epoch: EpochIndex| -> Nullifier {
         nf[usize::try_from(u64::from(epoch - base)).expect("epoch within span")]
     };
 
     let mut leaves: Vec<Pcd<pool::ArbitraryUnspent>> = Vec::with_capacity(steps.len());
-    let mut cursor_epoch = base;
-    let mut cursor_anchor = start_anchor;
-    // The terminal anchor of the epoch before `cursor_epoch`, present only when
-    // the cursor entered `cursor_epoch` at its boundary. An empty-epoch leaf
-    // folds that tick, so a span opening mid-epoch has nothing to seed with.
-    let mut entry_tip = base_tip;
-    let mut epoch_has_leaf = false;
-    for step in steps {
-        match step {
-            Err(new_epoch) => {
-                if new_epoch == cursor_epoch {
-                    // The span begins at this boundary; it is already crossed.
-                    continue;
-                }
-                if !epoch_has_leaf && let Some(tip) = entry_tip {
-                    leaves.push({
-                        PROOF_SYSTEM
-                            .seed(
-                                rng,
-                                pool::EmptyEpochUnspentSeed,
-                                witness::empty_epoch_unspent_seed(
-                                    ((), ()),
-                                    tip,
-                                    cursor_epoch,
-                                    nf_at(cursor_epoch),
-                                ),
-                            )
-                            .expect("EmptyEpochUnspentSeed")
-                            .0
-                    });
-                }
-                entry_tip = Some(cursor_anchor);
-                cursor_anchor = cursor_anchor.next_epoch(new_epoch);
-                cursor_epoch = new_epoch;
-                epoch_has_leaf = false;
-            },
-            Ok((height, block_stamps)) => {
-                let epoch = height.epoch();
-                let leaf_nf = nf_at(epoch);
+    // Every epoch the span crosses opens with a boundary marker, so breaking a
+    // chunk before each marker buffers one epoch's blocks and defers the choice
+    // of leaf to the chunk's end.
+    for chunk in steps.chunk_by(|_, right| right.is_ok()) {
+        let blocks: Vec<_> = chunk.iter().filter_map(|step| step.as_ref().ok()).collect();
+        if let Some(&&(first_height, _)) = blocks.first() {
+            let epoch = first_height.epoch();
+            let leaf_nf = nf_at(epoch);
+            for step in blocks {
+                let (height, block_stamps) = (step.0, &step.1);
+                let mut entry = if leaves.is_empty() && leading.is_ok() {
+                    start_anchor
+                } else {
+                    pool.prev_anchor_at(height)
+                };
                 for tgs in block_stamps {
                     let commit = tgs.iter().copied().collect::<TachygramSetPoly>().commit();
-                    leaves.push(
-                        PROOF_SYSTEM
-                            .seed(
-                                rng,
-                                pool::UnspentSeed,
-                                witness::unspent_seed(
-                                    ((), ()),
-                                    cursor_anchor,
-                                    epoch,
-                                    &tgs,
-                                    leaf_nf,
-                                ),
-                            )
-                            .expect("UnspentSeed")
-                            .0,
-                    );
-                    cursor_anchor = cursor_anchor.next_stamp(epoch, &commit);
-                    epoch_has_leaf = true;
+                    let (seed, ()) = PROOF_SYSTEM
+                        .seed(
+                            rng,
+                            pool::UnspentSeed,
+                            witness::unspent_seed(((), ()), entry, epoch, tgs, leaf_nf),
+                        )
+                        .expect("UnspentSeed");
+                    leaves.push(seed);
+                    entry = entry.next_stamp(epoch, &commit);
                 }
-            },
-        }
-    }
-    // The span's final epoch, if it published nothing after the crossing in.
-    if !epoch_has_leaf && let Some(tip) = entry_tip {
-        leaves.push({
-            PROOF_SYSTEM
+            }
+        } else {
+            // An epoch crossed without a stamp has a single anchor, the boundary
+            // tick's output, folded from the previous epoch's terminal anchor.
+            let Err(epoch) = chunk[0] else {
+                panic!("a chunk with no block is a lone boundary marker")
+            };
+            let (seed, ()) = PROOF_SYSTEM
                 .seed(
                     rng,
                     pool::EmptyEpochUnspentSeed,
                     witness::empty_epoch_unspent_seed(
                         ((), ()),
-                        tip,
-                        cursor_epoch,
-                        nf_at(cursor_epoch),
+                        pool.pre_epoch_anchor(epoch),
+                        epoch,
+                        nf_at(epoch),
                     ),
                 )
-                .expect("EmptyEpochUnspentSeed")
-                .0
-        });
+                .expect("EmptyEpochUnspentSeed");
+            leaves.push(seed);
+        }
     }
     fuse_unspent_tree(rng, nf, base, leaves)
 }

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -14,9 +14,8 @@ use crate::{digest::poseidon, serialization};
 /// - [`Anchor::next_stamp`] (`Tachyon-StampFld`) absorbs one stamp's epoch and
 ///   tachygram-set commitment.
 /// - [`Anchor::next_epoch`] (`Tachyon-EpochStp`) lifts across an epoch
-///   boundary. `UnspentEpochFuse` checks the boundary against the anchors it
-///   joins; `SpendableEpochLift` and `EmptyEpochUnspentSeed` fold it from a
-///   predecessor they do not constrain to be the epoch's terminal anchor.
+///   boundary. `EndEpochUnspentSeed` is the only step that folds it, from a
+///   predecessor it does not constrain to be the epoch's terminal anchor.
 ///
 /// A block that publishes no stamp contributes no link, so the anchor is
 /// constant across a stampless span.

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -14,7 +14,9 @@ use crate::{digest::poseidon, serialization};
 /// - [`Anchor::next_stamp`] (`Tachyon-StampFld`) absorbs one stamp's epoch and
 ///   tachygram-set commitment.
 /// - [`Anchor::next_epoch`] (`Tachyon-EpochStp`) lifts across an epoch
-///   boundary; checked against a boundary chain's root by `SpendableInit`.
+///   boundary. `UnspentEpochFuse` checks the boundary against the anchors it
+///   joins; `SpendableEpochLift` and `EmptyEpochUnspentSeed` fold it from a
+///   predecessor they do not constrain to be the epoch's terminal anchor.
 ///
 /// A block that publishes no stamp contributes no link, so the anchor is
 /// constant across a stampless span.

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -9,14 +9,15 @@ use crate::{digest::poseidon, serialization};
 
 /// Running anchor over the consensus state.
 ///
-/// A Poseidon hash sequence with three domain-separated link types:
+/// A Poseidon hash sequence with two domain-separated link types:
 ///
 /// - [`Anchor::next_stamp`] (`Tachyon-StampFld`) absorbs one stamp's epoch and
 ///   tachygram-set commitment.
-/// - [`Anchor::next_empty`] (`Tachyon-EmptyBlk`) advances through one block
-///   that contains zero stamps, preserving per-height anchor uniqueness.
 /// - [`Anchor::next_epoch`] (`Tachyon-EpochStp`) lifts across an epoch
 ///   boundary; checked against a boundary chain's root by `SpendableInit`.
+///
+/// A block that publishes no stamp contributes no link, so the anchor is
+/// constant across a stampless span.
 ///
 /// Opening reveals each link's role by its domain.
 #[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
@@ -36,12 +37,6 @@ impl Anchor {
             epoch,
             Eq::from(*stamp_commit).to_affine(),
         ))
-    }
-
-    /// Advance the anchor through one empty block (zero stamps) in `epoch`.
-    #[must_use]
-    pub fn next_empty(self, epoch: EpochIndex) -> Self {
-        Self(poseidon::anchor_empty_step(self.0, epoch))
     }
 
     /// Lift the anchor across an epoch boundary into the new epoch's
@@ -135,33 +130,19 @@ mod tests {
             start.next_stamp(EpochIndex(2), &stamp),
         );
         assert_ne!(
-            start.next_empty(EpochIndex(1)),
-            start.next_empty(EpochIndex(2))
+            start.next_epoch(EpochIndex(1)),
+            start.next_epoch(EpochIndex(2))
         );
     }
 
-    /// An empty-block tick changes the anchor.
+    /// The boundary lift is domain-separated from stamp absorption, so a
+    /// boundary anchor is unreachable by any chain link.
     #[test]
-    fn next_empty_advances_anchor() {
-        let start = Anchor::default();
-        assert_ne!(start, start.next_empty(EPOCH));
-    }
-
-    /// Consecutive empty-block ticks produce distinct anchors.
-    #[test]
-    fn consecutive_empty_distinct() {
-        let first = Anchor::default().next_empty(EPOCH);
-        let second = first.next_empty(EPOCH);
-        assert_ne!(first, second);
-    }
-
-    /// Empty-block tick is domain-separated from stamp absorption.
-    #[test]
-    fn next_empty_distinct_from_next_stamp() {
+    fn next_epoch_distinct_from_next_stamp() {
         let rng = &mut StdRng::seed_from_u64(0);
         let stamp = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
-        let via_empty = Anchor::default().next_empty(EPOCH);
+        let via_epoch = Anchor::default().next_epoch(EPOCH);
         let via_stamp = Anchor::default().next_stamp(EPOCH, &stamp);
-        assert_ne!(via_empty, via_stamp);
+        assert_ne!(via_epoch, via_stamp);
     }
 }

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -26,15 +26,15 @@ fn make_app() -> Result<Application, ragu::Error> {
         .register(delegation::NullifierStep)?
         .register(delegation::NullifierFuse)?
         .register(pool::AnchorSeed)?
-        .register(pool::EmptyBlockSeed)?
         .register(pool::AnchorFuse)?
         .register(pool::UnspentSeed)?
-        .register(pool::EmptyBlockUnspentSeed)?
+        .register(pool::EmptyEpochUnspentSeed)?
         .register(pool::UnspentFuse)?
         .register(pool::UnspentEpochFuse)?
-        .register(pool::VerifyUnspent)?
+        .register(pool::UnspentBind)?
         .register(spendable::SpendableInit)?
         .register(spendable::SpendableLift)?
+        .register(spendable::SpendableEpochLift)?
         .register(output::OutputBind)?
         .register(stamp::OutputStamp)?
         .register(spend::SpendBind)?

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -28,20 +28,17 @@ fn make_app() -> Result<Application, ragu::Error> {
         .register(pool::AnchorSeed)?
         .register(pool::AnchorFuse)?
         .register(pool::UnspentSeed)?
-        .register(pool::EmptyEpochUnspentSeed)?
+        .register(pool::EndEpochUnspentSeed)?
         .register(pool::UnspentFuse)?
-        .register(pool::UnspentEpochFuse)?
         .register(pool::UnspentBind)?
         .register(spendable::SpendableInit)?
         .register(spendable::SpendableLift)?
-        .register(spendable::SpendableEpochLift)?
         .register(output::OutputBind)?
         .register(stamp::OutputStamp)?
         .register(spend::SpendBind)?
         .register(stamp::SpendStamp)?
         .register(stamp::MergeStamp)?
         .register(stamp::StampLift)?
-        .register(pool::EndEpochUnspentSeed)?
         .finalize()
 }
 

--- a/crates/tachyon/src/stamp/proof/mod.rs
+++ b/crates/tachyon/src/stamp/proof/mod.rs
@@ -41,6 +41,7 @@ fn make_app() -> Result<Application, ragu::Error> {
         .register(stamp::SpendStamp)?
         .register(stamp::MergeStamp)?
         .register(stamp::StampLift)?
+        .register(pool::EndEpochUnspentSeed)?
         .finalize()
 }
 

--- a/crates/tachyon/src/stamp/proof/output.rs
+++ b/crates/tachyon/src/stamp/proof/output.rs
@@ -49,7 +49,7 @@ impl Step for OutputBind {
     /// `(note,)`.
     type Witness<'source> = (Note,);
 
-    const INDEX: Index = Index::new(14);
+    const INDEX: Index = Index::new(12);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -348,6 +348,72 @@ impl Step for EmptyEpochUnspentSeed {
     }
 }
 
+/// Seed spanning one epoch boundary link, from an epoch's terminal anchor to
+/// the next epoch's opening boundary anchor.
+///
+/// The segment covers exactly the tick `anchor_prev.next_epoch(epoch_prev +
+/// 1)`, so its `elapsed` holds the single nullifier `nf_prev` tested in the
+/// epoch being left, and `nf` opens as the tip in the epoch being entered.
+///
+/// # Soundness
+///
+/// `nf_prev` and `nf` are unconstrained here, as at every seed;
+/// [`UnspentBind`] forces the endpoints against the note's genuine derivation.
+/// `elapsed` is derived from `nf_prev` rather than witnessed, so the two cannot
+/// disagree.
+///
+/// `anchor_prev` is likewise unconstrained, and nothing here requires it to be
+/// its epoch's terminal anchor. Adjacency at the fuses that consume this
+/// segment, and consensus membership of the eventual spend's anchor, are what
+/// reject a tick folded from a short anchor.
+#[derive(Debug)]
+pub struct EndEpochUnspentSeed;
+
+impl Step for EndEpochUnspentSeed {
+    type Aux<'source> = ();
+    type Left = ();
+    type Output = ArbitraryUnspent;
+    type Right = ();
+    /// `(anchor_prev, (epoch_prev, nf_prev), nf)`.
+    type Witness<'source> = (Anchor, (EpochIndex, Nullifier), Nullifier);
+
+    const INDEX: Index = Index::new(20);
+
+    fn witness<'source>(
+        &self,
+        _ctx: &mut ragu::StepCtx<'_>,
+        (anchor_prev, (epoch_prev, nf_prev), nf): Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data,
+        _right: <Self::Right as Header>::Data,
+    ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        #[expect(clippy::expect_used, reason = "constant size")]
+        let (&g0, &g1) = {
+            let generators = Pasta::host_generators(Pasta::baked());
+            (
+                generators.g().first().expect("at least one generator"),
+                generators.g().get(1).expect("at least two generators"),
+            )
+        };
+
+        // One-member elapsed: `[nf_prev]` plus the sentinel `1`.
+        let elapsed_commit = NfSeqCommit::from(g0 * Fp::from(nf_prev) + g1);
+
+        let epoch = epoch_prev.next();
+        let anchor = anchor_prev.next_epoch(epoch);
+
+        Ok((
+            (
+                anchor_prev,
+                (epoch_prev, nf_prev),
+                elapsed_commit,
+                (epoch, nf),
+                anchor,
+            ),
+            (),
+        ))
+    }
+}
+
 /// Compose two [`ArbitraryUnspent`] lineages sharing a mid-epoch junction.
 ///
 /// The halves meet inside one epoch (`right.epoch_start == left.epoch_end`), at

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -44,7 +44,7 @@ use crate::{
 /// Structurally intra-epoch: the sole builder ([`AnchorSeed`]) invokes only
 /// [`Anchor::next_stamp`], which binds an epoch. The [`Anchor::next_epoch`]
 /// boundary domain is distinct and never a chain link; it is folded at a
-/// crossing by [`UnspentEpochFuse`].
+/// crossing by [`EndEpochUnspentSeed`].
 ///
 /// The within-epoch property pairs with a consensus-side two-epoch
 /// tachygram scan that catches any tachygram already published earlier
@@ -93,8 +93,10 @@ impl Header for AnchorChain {
 ///
 /// `nf_start` is the range's first tested nullifier (the leaf at
 /// `epoch_start`); the in-progress `nf_end` corresponds to `epoch_end` and is
-/// folded into `elapsed` when its epoch completes. [`UnspentBind`] binds both
-/// endpoints to the note's genuine derivation nullifiers.
+/// represented in `elapsed` only once a segment covering its epoch's closing
+/// boundary joins on, since [`EndEpochUnspentSeed`] is where a member is added.
+/// [`UnspentBind`] binds both endpoints to the note's genuine derivation
+/// nullifiers.
 ///
 /// `epoch_start` is the epoch of the exclusive `anchor_prev`; `epoch_end` the
 /// epoch of `anchor_last`, not yet represented in `elapsed`, so
@@ -291,63 +293,6 @@ impl Step for UnspentSeed {
     }
 }
 
-/// Whole-epoch seed for an epoch that published nothing.
-///
-/// An empty epoch has exactly one anchor: the epoch tick's output is both its
-/// opening boundary anchor and its terminal anchor. The step folds that tick
-/// from the previous epoch's terminal anchor and bounds the segment by it on
-/// both sides, so `epoch_start == epoch_end` and `elapsed` stays empty.
-///
-/// [`UnspentEpochFuse`] splices a segment in each of the two epochs it crosses
-/// between; this supplies the one for an epoch with no stamp to seed from.
-///
-/// # Soundness
-///
-/// `nf` is unconstrained here, as at every seed; [`UnspentBind`] forces the
-/// endpoints against the note's genuine derivation.
-///
-/// `prev_epoch_tip` is likewise unconstrained, and the "nothing was published"
-/// claim rests on it: skipping a stamp would leave it short of the previous
-/// epoch's real terminal anchor, and the tick of a short anchor is not the
-/// boundary anchor consensus recomputes. The boundary domain is distinct from
-/// the stamp domain, so no chain link reaches a boundary anchor either.
-#[derive(Debug)]
-pub struct EmptyEpochUnspentSeed;
-
-impl Step for EmptyEpochUnspentSeed {
-    type Aux<'source> = ();
-    type Left = ();
-    type Output = ArbitraryUnspent;
-    type Right = ();
-    /// `(prev_epoch_tip, (epoch, nf))`.
-    type Witness<'source> = (Anchor, (EpochIndex, Nullifier));
-
-    const INDEX: Index = Index::new(7);
-
-    fn witness<'source>(
-        &self,
-        _ctx: &mut ragu::StepCtx<'_>,
-        (prev_epoch_tip, (epoch, nf)): Self::Witness<'source>,
-        _left: <Self::Left as Header>::Data,
-        _right: <Self::Right as Header>::Data,
-    ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
-        #[expect(clippy::expect_used, reason = "constant size")]
-        let &g0 = Pasta::host_generators(Pasta::baked())
-            .g()
-            .first()
-            .expect("at least one generator");
-
-        let boundary = prev_epoch_tip.next_epoch(epoch);
-        // Empty elapsed: the sentinel constant `1` commits to `g0`, never the
-        // identity point.
-        let elapsed_commit = NfSeqCommit::from(g0 * Fp::ONE);
-        Ok((
-            (boundary, (epoch, nf), elapsed_commit, (epoch, nf), boundary),
-            (),
-        ))
-    }
-}
-
 /// Seed spanning one epoch boundary link, from an epoch's terminal anchor to
 /// the next epoch's opening boundary anchor.
 ///
@@ -377,7 +322,7 @@ impl Step for EndEpochUnspentSeed {
     /// `(anchor_prev, (epoch_prev, nf_prev), nf)`.
     type Witness<'source> = (Anchor, (EpochIndex, Nullifier), Nullifier);
 
-    const INDEX: Index = Index::new(20);
+    const INDEX: Index = Index::new(7);
 
     fn witness<'source>(
         &self,
@@ -422,7 +367,8 @@ impl Step for EndEpochUnspentSeed {
 /// concatenated (`combined = left_elapsed ++ right_elapsed`). No epoch boundary
 /// is crossed, so `elapsed` gains no entry (the junction nf is
 /// `right_elapsed`'s head if right later crossed a boundary; otherwise it stays
-/// the in-progress `nf_end`). A crossing is [`UnspentEpochFuse`]'s job.
+/// the in-progress `nf_end`). A crossing is its own segment
+/// ([`EndEpochUnspentSeed`]), so every seam this fuse sees is intra-epoch.
 #[derive(Debug)]
 pub struct UnspentFuse;
 
@@ -511,95 +457,6 @@ impl Step for UnspentFuse {
     }
 }
 
-/// Cross-epoch [`ArbitraryUnspent`] composition. The only step that crosses an
-/// epoch boundary, and so the only one that grows `elapsed`.
-///
-/// At the boundary, left's tip epoch completes
-/// (`left.anchor_last.next_epoch(new_epoch) == right.anchor_prev`) and is
-/// folded into `elapsed`.
-#[derive(Debug)]
-pub struct UnspentEpochFuse;
-
-impl Step for UnspentEpochFuse {
-    type Aux<'source> = ();
-    type Left = ArbitraryUnspent;
-    type Output = ArbitraryUnspent;
-    type Right = ArbitraryUnspent;
-    /// `(left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq)`.
-    type Witness<'source> = (NfSeqPoly, NfSeqPoly, NfSeqPoly);
-
-    const INDEX: Index = Index::new(9);
-
-    fn witness<'source>(
-        &self,
-        ctx: &mut ragu::StepCtx<'_>,
-        (left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq): Self::Witness<'source>,
-        (
-            left_anchor_prev,
-            (left_epoch_start, left_nf_start),
-            left_elapsed,
-            (left_epoch_end, left_nf_end),
-            left_anchor_last,
-        ): <Self::Left as Header>::Data,
-        (
-            right_anchor_prev,
-            (right_epoch_start, _right_nf_start),
-            right_elapsed,
-            (right_epoch_end, right_nf_end),
-            right_anchor_last,
-        ): <Self::Right as Header>::Data,
-    ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
-        enforce_equal_point(
-            Eq::from(left_elapsed_seq.commit()),
-            Eq::from(left_elapsed),
-            "UnspentEpochFuse: left polynomial does not match header",
-        )?;
-        enforce_equal_point(
-            Eq::from(right_elapsed_seq.commit()),
-            Eq::from(right_elapsed),
-            "UnspentEpochFuse: right polynomial does not match header",
-        )?;
-        enforce_zero(
-            Fp::from(right_epoch_start) - Fp::from(left_epoch_end.next()),
-            "UnspentEpochFuse: right epoch must be one past left's tip",
-        )?;
-        enforce_zero(
-            Fp::from(left_anchor_last.next_epoch(right_epoch_start)) - Fp::from(right_anchor_prev),
-            "UnspentEpochFuse: boundary anchor does not match right.anchor_prev",
-        )?;
-        let combined_commit = combined_elapsed_seq.commit();
-        let offset = left_epoch_end - left_epoch_start;
-        // Sentinel splice: a sequence of `k` members is `Σ n_i·X^i + X^k`, so
-        // `combined = left ++ [left_nf_end] ++ right` is the shifted
-        // combination `combined(X) = left(X) + (left_nf_end - 1)·X^offset +
-        // X^{offset+1}·right(X)`. The monomial overwrites left's sentinel with
-        // the folded tip nullifier and right's own sentinel re-terminates
-        // `combined`. The monomial's coefficient is challenge-independent:
-        // `left_nf_end` is a left-header value, fixed by the recursive
-        // verification of the left PCD; `offset` is left's header-fixed span.
-        enforce_shifted_combination(
-            ctx,
-            [
-                (left_elapsed_seq.as_ref(), 0),
-                (right_elapsed_seq.as_ref(), u64::from(offset) + 1),
-            ],
-            [(Fp::from(left_nf_end) - Fp::ONE, offset.into())],
-            combined_elapsed_seq.as_ref(),
-            "UnspentEpochFuse: combined is not the splice of the halves",
-        )?;
-        Ok((
-            (
-                left_anchor_prev,
-                (left_epoch_start, left_nf_start),
-                combined_commit,
-                (right_epoch_end, right_nf_end),
-                right_anchor_last,
-            ),
-            (),
-        ))
-    }
-}
-
 /// Bind an [`ArbitraryUnspent`]'s free-witness nullifiers to a
 /// note's genuine nullifiers.
 ///
@@ -619,7 +476,7 @@ impl Step for UnspentBind {
     /// `(elapsed_seq, nf_seq)`.
     type Witness<'source> = (NfSeqPoly, NfSeqPoly);
 
-    const INDEX: Index = Index::new(10);
+    const INDEX: Index = Index::new(9);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -2,7 +2,7 @@
 //!
 //! Hosts the nf-free anchor segment ([`AnchorChain`]) used by
 //! [`super::stamp::StampLift`] to advance a stamp's anchor, and the
-//! multi-stamp / multi-epoch exclusion proof ([`Unspent`]) used by
+//! multi-stamp / multi-epoch exclusion proof ([`ArbitraryUnspent`]) used by
 //! [`super::spendable::SpendableLift`] to advance a spendable.
 //!
 //! Anchor advances are single-level: every link absorbs the containing
@@ -36,38 +36,33 @@ use crate::{
 
 /// Anchor segment between two endpoints. Composable via [`AnchorFuse`].
 ///
-/// Direction-agnostic: `start` and `end` are both anchors. Two consumers:
-/// [`super::stamp::StampLift`] advances a stamp's anchor, and
-/// [`super::spendable::SpendableInit`] consumes a boundary-rooted segment (from
-/// the epoch boundary through the cm-stamp) to pin a spendable's starting
-/// epoch. Extending an *existing* spendable's anchor must instead go through
-/// [`Unspent`] so each step proves nf-exclusion.
+/// Direction-agnostic: `start` and `end` are both anchors. Sole consumer:
+/// [`super::stamp::StampLift`] advances a stamp's anchor. Extending a
+/// spendable's anchor must instead go through [`ArbitraryUnspent`] so each
+/// step proves nf-exclusion.
 ///
-/// Structurally intra-epoch: the builders ([`AnchorSeed`] / [`EmptyBlockSeed`])
-/// invoke only [`Anchor::next_stamp`] / [`Anchor::next_empty`]. Both bind an
-/// epoch, but the [`Anchor::next_epoch`] boundary domain is distinct and never
-/// a chain link; it is folded at a crossing by [`UnspentEpochFuse`] and checked
-/// against a chain's `start` by [`super::spendable::SpendableInit`].
+/// Structurally intra-epoch: the sole builder ([`AnchorSeed`]) invokes only
+/// [`Anchor::next_stamp`], which binds an epoch. The [`Anchor::next_epoch`]
+/// boundary domain is distinct and never a chain link; it is folded at a
+/// crossing by [`UnspentEpochFuse`].
 ///
 /// The within-epoch property pairs with a consensus-side two-epoch
 /// tachygram scan that catches any tachygram already published earlier
 /// in the epoch a stamp is lifted across. See the Tachygrams book chapter.
 ///
-/// `start` at the seed steps ([`AnchorSeed`] / [`EmptyBlockSeed`]) has
+/// `start` at [`AnchorSeed`] has
 /// PCD lineage rooted in an unbound `start: Anchor` witness, so a
 /// standalone segment proves nothing about real coverage. Final binding
-/// closes through a consensus-published stamp's anchor membership:
-/// [`super::stamp::StampLift`] emits that stamp directly, while a segment
-/// consumed by [`super::spendable::SpendableInit`] binds only once the
-/// resulting (private) spendable is spent into a stamp.
+/// closes through a consensus-published stamp's anchor membership at
+/// [`super::stamp::StampLift`]'s emitted stamp.
 #[derive(Clone, Debug)]
 pub struct AnchorChain;
 
 impl Header for AnchorChain {
-    /// `(start, end)`. `start` roots in an unbound witness at [`AnchorSeed`] or
-    /// [`EmptyBlockSeed`] and flows to [`super::stamp::StampLift`] which must
-    /// ultimately be checked by consensus. `end` is always computed in-circuit
-    /// as `start.next_stamp(epoch, ...)` or `start.next_empty(epoch)`.
+    /// `(start, end)`. `start` roots in an unbound witness at [`AnchorSeed`]
+    /// and flows to [`super::stamp::StampLift`] which must ultimately be
+    /// checked by consensus. `end` is always computed in-circuit as
+    /// `start.next_stamp(epoch, ...)`.
     type Data = (Anchor, Anchor);
 
     const SUFFIX: Suffix = Suffix::new(5);
@@ -82,7 +77,11 @@ impl Header for AnchorChain {
     }
 }
 
-/// Multi-stamp / multi-epoch nf-exclusion proof
+/// Multi-stamp / multi-epoch nf-exclusion proof over arbitrary values.
+///
+/// The tested values are arbitrary field elements until [`UnspentBind`]
+/// attributes them to a note's derivation, which is what makes the segment
+/// safe to delegate: no step producing one touches a note, `cm`, or `mk`.
 ///
 /// An `elapsed` polynomial holds one nullifier per crossed epoch boundary over
 /// `[epoch_start, epoch_end)`, sentinel-terminated (see
@@ -90,16 +89,20 @@ impl Header for AnchorChain {
 /// `1` at the crossing count, so the commitment is never the identity point
 /// (the empty sequence is the constant `1`, committing to `g0`) and the
 /// sequence's exact rank is pinned. The seeds establish the sentinel form and
-/// both fuses preserve it.
+/// the fuses preserve it.
 ///
 /// `nf_start` is the range's first tested nullifier (the leaf at
 /// `epoch_start`); the in-progress `nf_end` corresponds to `epoch_end` and is
-/// folded into `elapsed` when its epoch completes. [`VerifyUnspent`] binds both
+/// folded into `elapsed` when its epoch completes. [`UnspentBind`] binds both
 /// endpoints to the note's genuine derivation nullifiers.
+///
+/// `epoch_start` is the epoch of the exclusive `anchor_prev`; `epoch_end` the
+/// epoch of `anchor_last`, not yet represented in `elapsed`, so
+/// [`UnspentBind`]'s derived range runs one epoch past it.
 #[derive(Clone, Debug)]
-pub struct Unspent;
+pub struct ArbitraryUnspent;
 
-impl Header for Unspent {
+impl Header for ArbitraryUnspent {
     /// `(anchor_prev, (epoch_start, nf_start), elapsed,
     /// (epoch_end, nf_end), anchor_last)`.
     type Data = (
@@ -131,15 +134,16 @@ impl Header for Unspent {
     }
 }
 
-/// An [`Unspent`] bound to a note's genuine derivation nullifiers by
-/// [`VerifyUnspent`], collapsed to boundary scalars.
+/// A note proven unspent across a span: an [`ArbitraryUnspent`] whose values
+/// [`UnspentBind`] has attributed to the note's genuine derivation, collapsed
+/// to boundary scalars.
 #[derive(Clone, Debug)]
-pub struct VerifiedUnspent;
+pub struct Unspent;
 
-impl Header for VerifiedUnspent {
+impl Header for Unspent {
     /// `(cm, anchor_prev, (epoch_start, nf_start), (epoch_end, nf_end),
-    /// anchor_last)`. `cm` leads; the rest mirrors the [`Unspent`] boundaries
-    /// collapsed to scalars (no `elapsed` poly).
+    /// anchor_last)`. `cm` leads; the rest mirrors the [`ArbitraryUnspent`]
+    /// boundaries collapsed to scalars (no `elapsed` poly).
     type Data = (
         note::Commitment,
         Anchor,
@@ -204,40 +208,6 @@ impl Step for AnchorSeed {
     }
 }
 
-/// One-empty-block [`AnchorChain`] seed. Witness `(start, epoch)`; emit
-/// `(start, start.next_empty(epoch))`.
-///
-/// Advances the anchor through one block that contains zero stamps.
-/// Used alongside [`AnchorSeed`] when an anchor segment must traverse
-/// a mix of empty and non-empty blocks.
-///
-/// # Soundness
-///
-/// `epoch` is unconstrained here, for the reason given on [`AnchorSeed`].
-#[derive(Debug)]
-pub struct EmptyBlockSeed;
-
-impl Step for EmptyBlockSeed {
-    type Aux<'source> = ();
-    type Left = ();
-    type Output = AnchorChain;
-    type Right = ();
-    /// `(start, epoch)`.
-    type Witness<'source> = (Anchor, EpochIndex);
-
-    const INDEX: Index = Index::new(5);
-
-    fn witness<'source>(
-        &self,
-        _ctx: &mut ragu::StepCtx<'_>,
-        (start, epoch): Self::Witness<'source>,
-        _left: <Self::Left as Header>::Data,
-        _right: <Self::Right as Header>::Data,
-    ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
-        Ok(((start, start.next_empty(epoch)), ()))
-    }
-}
-
 /// Compose two adjacent [`AnchorChain`] segments — `left.end ==
 /// right.start`.
 #[derive(Debug)]
@@ -250,7 +220,7 @@ impl Step for AnchorFuse {
     type Right = AnchorChain;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(6);
+    const INDEX: Index = Index::new(5);
 
     fn witness<'source>(
         &self,
@@ -278,12 +248,12 @@ pub struct UnspentSeed;
 impl Step for UnspentSeed {
     type Aux<'source> = ();
     type Left = ();
-    type Output = Unspent;
+    type Output = ArbitraryUnspent;
     type Right = ();
     /// `(anchor_prev, (epoch, nf), stamp_tg_set)`.
     type Witness<'source> = (Anchor, (EpochIndex, Nullifier), TachygramSetPoly);
 
-    const INDEX: Index = Index::new(7);
+    const INDEX: Index = Index::new(6);
 
     fn witness<'source>(
         &self,
@@ -321,25 +291,43 @@ impl Step for UnspentSeed {
     }
 }
 
-/// One-empty-block [`Unspent`] seed: emit a one-block segment that crosses no
-/// epoch boundary (an empty block trivially excludes any nf, so no set check).
+/// Whole-epoch seed for an epoch that published nothing.
+///
+/// An empty epoch has exactly one anchor: the epoch tick's output is both its
+/// opening boundary anchor and its terminal anchor. The step folds that tick
+/// from the previous epoch's terminal anchor and bounds the segment by it on
+/// both sides, so `epoch_start == epoch_end` and `elapsed` stays empty.
+///
+/// [`UnspentEpochFuse`] splices a segment in each of the two epochs it crosses
+/// between; this supplies the one for an epoch with no stamp to seed from.
+///
+/// # Soundness
+///
+/// `nf` is unconstrained here, as at every seed; [`UnspentBind`] forces the
+/// endpoints against the note's genuine derivation.
+///
+/// `prev_epoch_tip` is likewise unconstrained, and the "nothing was published"
+/// claim rests on it: skipping a stamp would leave it short of the previous
+/// epoch's real terminal anchor, and the tick of a short anchor is not the
+/// boundary anchor consensus recomputes. The boundary domain is distinct from
+/// the stamp domain, so no chain link reaches a boundary anchor either.
 #[derive(Debug)]
-pub struct EmptyBlockUnspentSeed;
+pub struct EmptyEpochUnspentSeed;
 
-impl Step for EmptyBlockUnspentSeed {
+impl Step for EmptyEpochUnspentSeed {
     type Aux<'source> = ();
     type Left = ();
-    type Output = Unspent;
+    type Output = ArbitraryUnspent;
     type Right = ();
-    /// `(anchor_prev, (epoch, nf))`.
+    /// `(prev_epoch_tip, (epoch, nf))`.
     type Witness<'source> = (Anchor, (EpochIndex, Nullifier));
 
-    const INDEX: Index = Index::new(8);
+    const INDEX: Index = Index::new(7);
 
     fn witness<'source>(
         &self,
         _ctx: &mut ragu::StepCtx<'_>,
-        (anchor_prev, (epoch, nf)): Self::Witness<'source>,
+        (prev_epoch_tip, (epoch, nf)): Self::Witness<'source>,
         _left: <Self::Left as Header>::Data,
         _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
@@ -349,24 +337,18 @@ impl Step for EmptyBlockUnspentSeed {
             .first()
             .expect("at least one generator");
 
-        let tested_anchor = anchor_prev.next_empty(epoch);
+        let boundary = prev_epoch_tip.next_epoch(epoch);
         // Empty elapsed: the sentinel constant `1` commits to `g0`, never the
         // identity point.
         let elapsed_commit = NfSeqCommit::from(g0 * Fp::ONE);
         Ok((
-            (
-                anchor_prev,
-                (epoch, nf),
-                elapsed_commit,
-                (epoch, nf),
-                tested_anchor,
-            ),
+            (boundary, (epoch, nf), elapsed_commit, (epoch, nf), boundary),
             (),
         ))
     }
 }
 
-/// Compose two [`Unspent`] lineages sharing a mid-epoch junction.
+/// Compose two [`ArbitraryUnspent`] lineages sharing a mid-epoch junction.
 ///
 /// The halves meet inside one epoch (`right.epoch_start == left.epoch_end`), at
 /// adjacent anchors (`left.anchor_last == right.anchor_prev`), and agree on the
@@ -380,13 +362,13 @@ pub struct UnspentFuse;
 
 impl Step for UnspentFuse {
     type Aux<'source> = ();
-    type Left = Unspent;
-    type Output = Unspent;
-    type Right = Unspent;
+    type Left = ArbitraryUnspent;
+    type Output = ArbitraryUnspent;
+    type Right = ArbitraryUnspent;
     /// `(left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq)`.
     type Witness<'source> = (NfSeqPoly, NfSeqPoly, NfSeqPoly);
 
-    const INDEX: Index = Index::new(9);
+    const INDEX: Index = Index::new(8);
 
     fn witness<'source>(
         &self,
@@ -463,8 +445,8 @@ impl Step for UnspentFuse {
     }
 }
 
-/// Cross-epoch [`Unspent`] composition. This is the only step that grows
-/// `elapsed`.
+/// Cross-epoch [`ArbitraryUnspent`] composition. The only step that crosses an
+/// epoch boundary, and so the only one that grows `elapsed`.
 ///
 /// At the boundary, left's tip epoch completes
 /// (`left.anchor_last.next_epoch(new_epoch) == right.anchor_prev`) and is
@@ -474,13 +456,13 @@ pub struct UnspentEpochFuse;
 
 impl Step for UnspentEpochFuse {
     type Aux<'source> = ();
-    type Left = Unspent;
-    type Output = Unspent;
-    type Right = Unspent;
+    type Left = ArbitraryUnspent;
+    type Output = ArbitraryUnspent;
+    type Right = ArbitraryUnspent;
     /// `(left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq)`.
     type Witness<'source> = (NfSeqPoly, NfSeqPoly, NfSeqPoly);
 
-    const INDEX: Index = Index::new(10);
+    const INDEX: Index = Index::new(9);
 
     fn witness<'source>(
         &self,
@@ -552,26 +534,26 @@ impl Step for UnspentEpochFuse {
     }
 }
 
-/// Bind an [`Unspent`]'s free-witness nullifiers to a
+/// Bind an [`ArbitraryUnspent`]'s free-witness nullifiers to a
 /// note's genuine nullifiers.
 ///
 /// Proves `range == elapsed ++ [nf_end]` against the derived
-/// [`NullifierHeader`], emitting a [`VerifiedUnspent`] with the `cm`. The tip
+/// [`NullifierHeader`], emitting an [`Unspent`] with the `cm`. The tip
 /// enters as a monomial coefficient of [`enforce_shifted_combination`]:
 /// `unspent_nf_end` is a left-header value, fixed by the recursive
-/// verification of the [`Unspent`] PCD before the challenge.
+/// verification of the [`ArbitraryUnspent`] PCD before the challenge.
 #[derive(Debug)]
-pub struct VerifyUnspent;
+pub struct UnspentBind;
 
-impl Step for VerifyUnspent {
+impl Step for UnspentBind {
     type Aux<'source> = ();
-    type Left = Unspent;
-    type Output = VerifiedUnspent;
+    type Left = ArbitraryUnspent;
+    type Output = Unspent;
     type Right = NullifierHeader;
     /// `(elapsed_seq, nf_seq)`.
     type Witness<'source> = (NfSeqPoly, NfSeqPoly);
 
-    const INDEX: Index = Index::new(11);
+    const INDEX: Index = Index::new(10);
 
     fn witness<'source>(
         &self,
@@ -588,21 +570,21 @@ impl Step for VerifyUnspent {
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         enforce_zero(
             Fp::from(nf_epoch_start) - Fp::from(unspent_epoch_start),
-            "VerifyUnspent: derived range does not start at the unspent's start epoch",
+            "UnspentBind: derived range does not start at the unspent's start epoch",
         )?;
         enforce_zero(
             Fp::from(nf_epoch_end) - Fp::from(unspent_epoch_end.next()),
-            "VerifyUnspent: derived range does not span the crossings plus the tip",
+            "UnspentBind: derived range does not span the crossings plus the tip",
         )?;
         enforce_equal_point(
             Eq::from(elapsed_seq.commit()),
             Eq::from(unspent_elapsed),
-            "VerifyUnspent: elapsed polynomial does not match header",
+            "UnspentBind: elapsed polynomial does not match header",
         )?;
         enforce_equal_point(
             Eq::from(nf_seq.commit()),
             Eq::from(nf_seq_commit),
-            "VerifyUnspent: range polynomial does not match header",
+            "UnspentBind: range polynomial does not match header",
         )?;
         let offset = unspent_epoch_end - unspent_epoch_start;
         // Sentinel append: a sequence of `k` members is `Σ n_i·X^i + X^k`, so
@@ -612,7 +594,7 @@ impl Step for VerifyUnspent {
         // the appended tip; the second re-terminates `nf_seq`. Both
         // coefficients are challenge-independent: `unspent_nf_end` is a
         // left-header value, fixed by the recursive verification of the
-        // [`Unspent`] PCD; `offset` is elapsed's header-fixed span.
+        // [`ArbitraryUnspent`] PCD; `offset` is elapsed's header-fixed span.
         enforce_shifted_combination(
             ctx,
             [(elapsed_seq.as_ref(), 0)],
@@ -621,18 +603,18 @@ impl Step for VerifyUnspent {
                 (Fp::ONE, u64::from(offset) + 1),
             ],
             nf_seq.as_ref(),
-            "VerifyUnspent: range is not elapsed followed by the tip",
+            "UnspentBind: range is not elapsed followed by the tip",
         )?;
         // Bind the unspent's free-witness boundary nullifiers to the range's
         // genuine boundary leaves, which the derivation header proved by
         // construction.
         enforce_zero(
             Fp::from(unspent_nf_start) - Fp::from(nf_start),
-            "VerifyUnspent: start nullifier does not match the derived range",
+            "UnspentBind: start nullifier does not match the derived range",
         )?;
         enforce_zero(
             Fp::from(unspent_nf_end) - Fp::from(nf_end),
-            "VerifyUnspent: end nullifier does not match the derived range",
+            "UnspentBind: end nullifier does not match the derived range",
         )?;
         Ok((
             (

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -74,12 +74,16 @@ impl Step for SpendBind {
         &self,
         _ctx: &mut ragu::StepCtx<'_>,
         (nf_next,): Self::Witness<'source>,
-        (spendable_cm, present_nf, anchor): <Self::Left as Header>::Data,
+        (spendable_cm, (spendable_epoch, present_nf), anchor): <Self::Left as Header>::Data,
         (nf_cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, nf_end)): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         enforce_zero(
             Fp::from(nf_epoch_end) - (Fp::from(nf_epoch_start) + Fp::from(2u64)),
             "SpendBind: live range must span two epochs",
+        )?;
+        enforce_zero(
+            Fp::from(nf_epoch_start) - Fp::from(spendable_epoch),
+            "SpendBind: live range does not start at the lineage epoch",
         )?;
         enforce_zero(
             Fp::from(nf_cm) - Fp::from(spendable_cm),

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -68,7 +68,7 @@ impl Step for SpendBind {
     /// `(nf_next,)`.
     type Witness<'source> = (Nullifier,);
 
-    const INDEX: Index = Index::new(16);
+    const INDEX: Index = Index::new(14);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -5,8 +5,7 @@
 //! and the minted-note commitment binding the lineage (and its value) across
 //! lifts. [`SpendableInit`]
 //! bootstraps it from a minted note; [`SpendableLift`] advances it over
-//! [`Unspent`] segments, and [`SpendableEpochLift`] across an epoch boundary it
-//! rests on.
+//! [`Unspent`] segments.
 
 extern crate alloc;
 
@@ -82,7 +81,7 @@ impl Step for SpendableInit {
     /// `(pre_cm_anchor, creation_set, present_nf)`.
     type Witness<'source> = (Anchor, TachygramSetPoly, Nullifier);
 
-    const INDEX: Index = Index::new(11);
+    const INDEX: Index = Index::new(10);
 
     fn witness<'source>(
         &self,
@@ -125,8 +124,9 @@ impl Step for SpendableInit {
 /// nf_start) == (epoch, present_nf)`, and anchor adjacency, then advances to
 /// the tip `(epoch_end, nf_end, anchor_last)`.
 ///
-/// The segment may span any number of epochs. Advancing across a boundary the
-/// lineage rests on is [`SpendableEpochLift`]'s.
+/// The segment may span any number of epochs. A lineage resting on its epoch's
+/// terminal anchor advances the same way, over a segment that opens with the
+/// boundary tick ([`EndEpochUnspentSeed`](super::pool::EndEpochUnspentSeed)).
 #[derive(Debug)]
 pub struct SpendableLift;
 
@@ -137,7 +137,7 @@ impl Step for SpendableLift {
     type Right = Unspent;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(12);
+    const INDEX: Index = Index::new(11);
 
     fn witness<'source>(
         &self,
@@ -173,71 +173,6 @@ impl Step for SpendableLift {
                 spendable_cm,
                 (unspent_epoch_end, unspent_nf_end),
                 unspent_anchor_last,
-            ),
-            (),
-        ))
-    }
-}
-
-/// Advance the spendable across one epoch boundary.
-///
-/// Wallet-only, witness-free. Takes the lineage from `(e, GGM(mk, e), A)` to
-/// `(e+1, GGM(mk, e+1), A.next_epoch(e+1))`, reading both nullifiers off a
-/// two-epoch [`NullifierHeader`] tied to the lineage by `cm`.
-///
-/// A lineage on its epoch's terminal anchor has no segment to lift over: a
-/// segment's `anchor_prev` is the anchor before its first link, and the epoch
-/// has no link left.
-///
-/// # Soundness
-///
-/// That `spendable_anchor` is epoch `e`'s terminal anchor is unconstrained
-/// here, as at [`EmptyEpochUnspentSeed`](super::pool::EmptyEpochUnspentSeed).
-/// Ticking a mid-epoch anchor lands off the published sequence, which no later
-/// link rejoins, so consensus anchor membership of the eventual spend rejects
-/// it.
-#[derive(Debug)]
-pub struct SpendableEpochLift;
-
-impl Step for SpendableEpochLift {
-    type Aux<'source> = ();
-    type Left = SpendableHeader;
-    type Output = SpendableHeader;
-    type Right = NullifierHeader;
-    type Witness<'source> = ();
-
-    const INDEX: Index = Index::new(13);
-
-    fn witness<'source>(
-        &self,
-        _ctx: &mut ragu::StepCtx<'_>,
-        _witness: Self::Witness<'source>,
-        (spendable_cm, (spendable_epoch, present_nf), spendable_anchor): <Self::Left as Header>::Data,
-        (nf_cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, nf_end)): <Self::Right as Header>::Data,
-    ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
-        enforce_zero(
-            Fp::from(nf_cm) - Fp::from(spendable_cm),
-            "SpendableEpochLift: derived range does not match note",
-        )?;
-        enforce_zero(
-            Fp::from(nf_epoch_start) - Fp::from(spendable_epoch),
-            "SpendableEpochLift: derived range does not start at the lineage epoch",
-        )?;
-        enforce_zero(
-            Fp::from(nf_epoch_end) - (Fp::from(nf_epoch_start) + Fp::from(2u64)),
-            "SpendableEpochLift: derived range must span two epochs",
-        )?;
-        enforce_zero(
-            Fp::from(nf_start) - Fp::from(present_nf),
-            "SpendableEpochLift: derived range does not start at the lineage nullifier",
-        )?;
-
-        let new_epoch = spendable_epoch.next();
-        Ok((
-            (
-                spendable_cm,
-                (new_epoch, nf_end),
-                spendable_anchor.next_epoch(new_epoch),
             ),
             (),
         ))

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -1,10 +1,12 @@
 //! Spendable bootstrap and lift.
 //!
-//! The spendable carries `(present_nf, anchor, cm)`: the note's current
-//! nullifier `GGM(mk, e)`, its pool position, and the minted-note commitment
-//! binding the lineage (and its value) across lifts. [`SpendableInit`]
+//! The spendable carries `(cm, (epoch, present_nf), anchor)`: the note's
+//! current epoch and its nullifier `GGM(mk, epoch)` there, its pool position,
+//! and the minted-note commitment binding the lineage (and its value) across
+//! lifts. [`SpendableInit`]
 //! bootstraps it from a minted note; [`SpendableLift`] advances it over
-//! [`VerifiedUnspent`] segments.
+//! [`Unspent`] segments, and [`SpendableEpochLift`] across an epoch boundary it
+//! rests on.
 
 extern crate alloc;
 
@@ -14,34 +16,38 @@ use ff::Field as _;
 use pasta_curves::{Ep, Eq, Fp, Fq};
 use ragu::{Header, Index, Step, Suffix, constraint::enforce_zero};
 
-use super::{
-    delegation::NullifierHeader,
-    pool::{AnchorChain, VerifiedUnspent},
-};
+use super::{delegation::NullifierHeader, pool::Unspent};
 use crate::{
     note,
     nullifier::Nullifier,
-    primitives::{Anchor, TachygramSetPoly},
+    primitives::{Anchor, EpochIndex, TachygramSetPoly},
 };
 
-/// Wallet's spendable position `(present_nf, anchor, cm)`
+/// Wallet's spendable position `(cm, (epoch, present_nf), anchor)`
 ///
-/// The note's current-epoch nullifier and pool position (advanced per lift)
-/// plus the minted-note commitment, threaded unchanged so the spent value
-/// cannot drift to a different same-`mk` note.
+/// The note's current epoch and its nullifier there, plus the pool position
+/// (all advanced per lift) and the minted-note commitment, threaded unchanged
+/// so the spent value cannot drift to a different same-`mk` note.
 #[derive(Clone, Debug)]
 pub struct SpendableHeader;
 
 impl Header for SpendableHeader {
-    /// `(cm, present_nf, anchor)`. `cm` threads unchanged; `present_nf` and
-    /// `anchor` advance per lift.
-    type Data = (note::Commitment, Nullifier, Anchor);
+    /// `(cm, (epoch, present_nf), anchor)`. `cm` threads unchanged; the rest
+    /// advances per lift. The boundary pairing matches
+    /// [`Unspent`]'s, which is what a lift checks continuity against.
+    type Data = (note::Commitment, (EpochIndex, Nullifier), Anchor);
 
     const SUFFIX: Suffix = Suffix::new(7);
 
     fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
+        let (cm, (epoch, present_nf), anchor) = *data;
         (
-            vec![Fp::from(data.0), Fp::from(data.1), Fp::from(data.2)],
+            vec![
+                Fp::from(cm),
+                Fp::from(u64::from(epoch.0)),
+                Fp::from(present_nf),
+                Fp::from(anchor),
+            ],
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -51,29 +57,39 @@ impl Header for SpendableHeader {
 
 /// Bootstrap a spendable from a minted note, pinned to the creation epoch.
 ///
-/// Wallet-only. Fuses a boundary-rooted [`AnchorChain`] with the wallet's
-/// single-leaf [`NullifierHeader`]: binds
-/// `present_nf` to the proven leaf, checks `cm in creation_set`, roots the
-/// chain at the epoch boundary, and requires the cm-stamp to be its final link.
+/// Wallet-only, one-child over the wallet's single-leaf [`NullifierHeader`]:
+/// binds `present_nf` to the proven leaf, checks `cm in creation_set`, and
+/// computes the post-cm anchor from a free-witnessed predecessor.
+///
+/// The emitted anchor binds nothing here: `pre_cm_anchor` is a free witness,
+/// so a standalone spendable proves nothing about real chain coverage.
+/// Binding closes downstream. [`SpendableLift`] adjacency threads the anchor
+/// to the eventual spend, whose anchor consensus checks for chain membership;
+/// a genuine chain node is `H(prev || epoch || commit)` under the stamp
+/// domain, so preimage resistance forces the witnessed `pre_cm_anchor`,
+/// `epoch`, and `creation_commit` to be the real predecessor, the real
+/// creation epoch, and the real cm-stamp. The same argument pins the derived
+/// range's starting epoch: a wrong `epoch` folds into an anchor off the
+/// published sequence.
 #[derive(Debug)]
 pub struct SpendableInit;
 
 impl Step for SpendableInit {
     type Aux<'source> = ();
-    type Left = AnchorChain;
+    type Left = NullifierHeader;
     type Output = SpendableHeader;
-    type Right = NullifierHeader;
-    /// `((pre_epoch_anchor, pre_cm_anchor), creation_set, present_nf)`.
-    type Witness<'source> = ((Anchor, Anchor), TachygramSetPoly, Nullifier);
+    type Right = ();
+    /// `(pre_cm_anchor, creation_set, present_nf)`.
+    type Witness<'source> = (Anchor, TachygramSetPoly, Nullifier);
 
-    const INDEX: Index = Index::new(12);
+    const INDEX: Index = Index::new(11);
 
     fn witness<'source>(
         &self,
         ctx: &mut ragu::StepCtx<'_>,
-        ((pre_epoch_anchor, pre_cm_anchor), creation_set, present_nf): Self::Witness<'source>,
-        (chain_start, chain_end): <Self::Left as Header>::Data,
-        (cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, _nf_end)): <Self::Right as Header>::Data,
+        (pre_cm_anchor, creation_set, present_nf): Self::Witness<'source>,
+        (cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, _nf_end)): <Self::Left as Header>::Data,
+        _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         // Bind `present_nf` to the single derived starting leaf `GGM(mk, epoch)`.
         enforce_zero(
@@ -93,38 +109,24 @@ impl Step for SpendableInit {
         enforce_zero(eval, "SpendableInit: commitment not in set")?;
         let creation_commit = creation_set.commit();
 
-        // Pin the lineage's starting epoch to consensus. Consensus anchor
-        // membership of the eventual spend anchor requires `chain_start` to be
-        // the real epoch boundary. Every link folds an epoch, but `next_epoch`
-        // (`Tachyon-EpochStp`) is domain-separated from the stamp and empty-block
-        // links, so reaching a boundary anchor by any other link would be a
-        // cross-domain collision; matching `pre_epoch_anchor.next_epoch(epoch)`
-        // against that boundary forces `epoch == E`, tying the derived range's
-        // starting epoch to the creation epoch.
-        enforce_zero(
-            Fp::from(chain_start) - Fp::from(pre_epoch_anchor.next_epoch(epoch)),
-            "SpendableInit: chain not rooted at epoch boundary",
-        )?;
-
-        // The cm-stamp is the chain's final link: `chain_end ==
-        // pre_cm_anchor.next_stamp(epoch, cm_commit)`. This ties the
-        // cm-inclusion to a real, consensus-pinned stamp in the creation epoch
-        // and yields `post_cm_anchor` as the chain end; a note created
-        // first-in-epoch produces a single-link chain.
+        // The anchor immediately after the creation stamp, computed in-circuit
+        // so the proof certifies the fold of `epoch` and `creation_commit`;
+        // consensus membership of the eventual spend anchor binds the rest
+        // (see the step doc).
         let post_cm_anchor = pre_cm_anchor.next_stamp(epoch, &creation_commit);
-        enforce_zero(
-            Fp::from(chain_end) - Fp::from(post_cm_anchor),
-            "SpendableInit: cm-stamp is not the chain's final link",
-        )?;
 
-        Ok(((cm, present_nf, post_cm_anchor), ()))
+        Ok(((cm, (epoch, present_nf), post_cm_anchor), ()))
     }
 }
 
-/// Advance the spendable over one [`VerifiedUnspent`] segment.
+/// Advance the spendable over one [`Unspent`] segment.
 ///
-/// Wallet-only, witness-free. Checks `cm`, `nf_start == present_nf`, and anchor
-/// adjacency, then advances to the tip `(nf_end, anchor_last)`.
+/// Wallet-only, witness-free. Checks `cm`, the boundary pair `(epoch_start,
+/// nf_start) == (epoch, present_nf)`, and anchor adjacency, then advances to
+/// the tip `(epoch_end, nf_end, anchor_last)`.
+///
+/// The segment may span any number of epochs. Advancing across a boundary the
+/// lineage rests on is [`SpendableEpochLift`]'s.
 #[derive(Debug)]
 pub struct SpendableLift;
 
@@ -132,7 +134,76 @@ impl Step for SpendableLift {
     type Aux<'source> = ();
     type Left = SpendableHeader;
     type Output = SpendableHeader;
-    type Right = VerifiedUnspent;
+    type Right = Unspent;
+    type Witness<'source> = ();
+
+    const INDEX: Index = Index::new(12);
+
+    fn witness<'source>(
+        &self,
+        _ctx: &mut ragu::StepCtx<'_>,
+        _witness: Self::Witness<'source>,
+        (spendable_cm, (spendable_epoch, present_nf), spendable_anchor): <Self::Left as Header>::Data,
+        (
+            unspent_cm,
+            unspent_anchor_prev,
+            (unspent_epoch_start, unspent_nf_start),
+            (unspent_epoch_end, unspent_nf_end),
+            unspent_anchor_last,
+        ): <Self::Right as Header>::Data,
+    ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        enforce_zero(
+            Fp::from(unspent_cm) - Fp::from(spendable_cm),
+            "SpendableLift: unspent cm does not match spendable",
+        )?;
+        enforce_zero(
+            Fp::from(unspent_nf_start) - Fp::from(present_nf),
+            "SpendableLift: segment does not start at the lineage nullifier",
+        )?;
+        enforce_zero(
+            Fp::from(unspent_epoch_start) - Fp::from(spendable_epoch),
+            "SpendableLift: segment does not start at the lineage epoch",
+        )?;
+        enforce_zero(
+            Fp::from(unspent_anchor_prev) - Fp::from(spendable_anchor),
+            "SpendableLift: unspent not adjacent to spendable",
+        )?;
+        Ok((
+            (
+                spendable_cm,
+                (unspent_epoch_end, unspent_nf_end),
+                unspent_anchor_last,
+            ),
+            (),
+        ))
+    }
+}
+
+/// Advance the spendable across one epoch boundary.
+///
+/// Wallet-only, witness-free. Takes the lineage from `(e, GGM(mk, e), A)` to
+/// `(e+1, GGM(mk, e+1), A.next_epoch(e+1))`, reading both nullifiers off a
+/// two-epoch [`NullifierHeader`] tied to the lineage by `cm`.
+///
+/// A lineage on its epoch's terminal anchor has no segment to lift over: a
+/// segment's `anchor_prev` is the anchor before its first link, and the epoch
+/// has no link left.
+///
+/// # Soundness
+///
+/// That `spendable_anchor` is epoch `e`'s terminal anchor is unconstrained
+/// here, as at [`EmptyEpochUnspentSeed`](super::pool::EmptyEpochUnspentSeed).
+/// Ticking a mid-epoch anchor lands off the published sequence, which no later
+/// link rejoins, so consensus anchor membership of the eventual spend rejects
+/// it.
+#[derive(Debug)]
+pub struct SpendableEpochLift;
+
+impl Step for SpendableEpochLift {
+    type Aux<'source> = ();
+    type Left = SpendableHeader;
+    type Output = SpendableHeader;
+    type Right = NullifierHeader;
     type Witness<'source> = ();
 
     const INDEX: Index = Index::new(13);
@@ -141,21 +212,34 @@ impl Step for SpendableLift {
         &self,
         _ctx: &mut ragu::StepCtx<'_>,
         _witness: Self::Witness<'source>,
-        (cm, present_nf, spendable_anchor): <Self::Left as Header>::Data,
-        (verified_cm, anchor_prev, (_epoch_start, nf_start), (_epoch_end, nf_end), anchor_last): <Self::Right as Header>::Data,
+        (spendable_cm, (spendable_epoch, present_nf), spendable_anchor): <Self::Left as Header>::Data,
+        (nf_cm, (nf_epoch_start, nf_start), _nf_seq_commit, (nf_epoch_end, nf_end)): <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         enforce_zero(
-            Fp::from(verified_cm) - Fp::from(cm),
-            "SpendableLift: verified unspent cm does not match spendable",
+            Fp::from(nf_cm) - Fp::from(spendable_cm),
+            "SpendableEpochLift: derived range does not match note",
+        )?;
+        enforce_zero(
+            Fp::from(nf_epoch_start) - Fp::from(spendable_epoch),
+            "SpendableEpochLift: derived range does not start at the lineage epoch",
+        )?;
+        enforce_zero(
+            Fp::from(nf_epoch_end) - (Fp::from(nf_epoch_start) + Fp::from(2u64)),
+            "SpendableEpochLift: derived range must span two epochs",
         )?;
         enforce_zero(
             Fp::from(nf_start) - Fp::from(present_nf),
-            "SpendableLift: segment does not start at the lineage nullifier",
+            "SpendableEpochLift: derived range does not start at the lineage nullifier",
         )?;
-        enforce_zero(
-            Fp::from(anchor_prev) - Fp::from(spendable_anchor),
-            "SpendableLift: unspent not adjacent to spendable",
-        )?;
-        Ok(((cm, nf_end, anchor_last), ()))
+
+        let new_epoch = spendable_epoch.next();
+        Ok((
+            (
+                spendable_cm,
+                (new_epoch, nf_end),
+                spendable_anchor.next_epoch(new_epoch),
+            ),
+            (),
+        ))
     }
 }

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -81,7 +81,7 @@ impl Step for OutputStamp {
         Anchor,
     );
 
-    const INDEX: Index = Index::new(15);
+    const INDEX: Index = Index::new(13);
 
     fn witness<'source>(
         &self,
@@ -155,7 +155,7 @@ impl Step for SpendStamp {
         ProofAuthorizingKey,
     );
 
-    const INDEX: Index = Index::new(17);
+    const INDEX: Index = Index::new(15);
 
     fn witness<'source>(
         &self,
@@ -225,7 +225,7 @@ impl Step for MergeStamp {
         (ActionSetPoly, TachygramSetPoly),
     );
 
-    const INDEX: Index = Index::new(18);
+    const INDEX: Index = Index::new(16);
 
     fn witness<'source>(
         &self,
@@ -309,7 +309,7 @@ impl Step for StampLift {
     type Right = AnchorChain;
     type Witness<'source> = ();
 
-    const INDEX: Index = Index::new(19);
+    const INDEX: Index = Index::new(17);
 
     fn witness<'source>(
         &self,

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -1033,22 +1033,55 @@ fn epoch_fuse_setup(
     (nf, left, right)
 }
 
+/// Extend `left` over the boundary out of its tip epoch: seed the crossing on
+/// `left`'s terminal anchor and fuse it on, so the result opens where `left`
+/// did and tips at `nf_in` in the next epoch.
+fn cross_out_of(
+    rng: &mut StdRng,
+    left: Pcd<pool::ArbitraryUnspent>,
+    left_elapsed: &[Nullifier],
+    nf_in: Nullifier,
+) -> Pcd<pool::ArbitraryUnspent> {
+    let (_, _, _, (epoch_end, nf_end), anchor_last) = *left.data();
+    let (seed, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(((), ()), anchor_last, epoch_end, nf_end, nf_in),
+        )
+        .expect("EndEpochUnspentSeed");
+    let (crossed, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            pool::UnspentFuse,
+            witness::unspent_fuse((*left.data(), *seed.data()), left_elapsed, &[nf_end]),
+            left,
+            seed,
+        )
+        .expect("UnspentFuse over the crossing");
+    crossed
+}
+
+/// Two halves meeting at a boundary compose through a crossing seed: the seam
+/// nullifier the left half was still holding as its tip lands in the merged
+/// history, and the merged segment spans both halves' outer endpoints.
 #[test]
-fn unspent_epoch_fuse_composes() {
+fn end_epoch_unspent_seed_composes_across_a_boundary() {
     let rng = &mut StdRng::seed_from_u64(0);
     let ([nf0, nf1, nf2, nf3, nf4], left, right) = epoch_fuse_setup(rng);
     let start = left.data().0;
     let end = right.data().4;
 
+    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
     let (fused, ()) = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::UnspentEpochFuse,
-            witness::unspent_epoch_fuse((*left.data(), *right.data()), &[nf0, nf1], &[nf3]),
-            left,
+            pool::UnspentFuse,
+            witness::unspent_fuse((*crossed.data(), *right.data()), &[nf0, nf1, nf2], &[nf3]),
+            crossed,
             right,
         )
-        .expect("UnspentEpochFuse boundary splice");
+        .expect("UnspentFuse onto the right half");
 
     let (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_end, nf_end), anchor_last) =
         *fused.data();
@@ -1061,7 +1094,7 @@ fn unspent_epoch_fuse_composes() {
     assert_eq!(
         elapsed,
         NfSeqPoly::from_iter([nf0, nf1, nf2, nf3]).commit(),
-        "the boundary fold splices left's tip between the halves' histories"
+        "the crossing seed carries left's tip into the merged history"
     );
 }
 
@@ -1176,7 +1209,10 @@ fn end_epoch_unspent_seed_reproduces_the_spendable_epoch_lift() {
     let alt_spendable = user.spendable_init(rng, &note, &pool, cm_height);
     let epoch0_tip = spendable.data().2;
 
-    let at_boundary = user.epoch_lift(rng, spendable, &note);
+    let range = user.derived_range(rng, &note, EpochIndex(0), 2);
+    let (at_boundary, ()) = PROOF_SYSTEM
+        .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
+        .expect("SpendableEpochLift");
 
     let (seed, ()) = PROOF_SYSTEM
         .seed(
@@ -1203,42 +1239,46 @@ fn end_epoch_unspent_seed_reproduces_the_spendable_epoch_lift() {
     assert_eq!(*alt_at_boundary.data(), *at_boundary.data());
 }
 
-/// An empty epoch has one anchor, so the seed is a point segment at it.
+/// The seed spans exactly one boundary link, recording the epoch it leaves.
 #[test]
-fn empty_epoch_unspent_seed_is_a_point_at_the_boundary() {
+fn end_epoch_unspent_seed_spans_one_boundary_link() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let prev_epoch_tip = Anchor::from(Fp::random(&mut *rng));
+    let epoch_tip = Anchor::from(Fp::random(&mut *rng));
+    let nf_prev = Nullifier::from(Fp::random(&mut *rng));
     let nf = Nullifier::from(Fp::random(&mut *rng));
 
     let (seed, ()) = PROOF_SYSTEM
         .seed(
             rng,
-            pool::EmptyEpochUnspentSeed,
-            witness::empty_epoch_unspent_seed(((), ()), prev_epoch_tip, EpochIndex(4), nf),
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(((), ()), epoch_tip, EpochIndex(4), nf_prev, nf),
         )
-        .expect("EmptyEpochUnspentSeed");
+        .expect("EndEpochUnspentSeed");
 
     let (anchor_prev, (epoch_start, seed_nf_start), elapsed, (epoch_end, nf_end), anchor_last) =
         *seed.data();
-    let boundary = prev_epoch_tip.next_epoch(EpochIndex(4));
-    assert_eq!(anchor_prev, boundary);
-    assert_eq!(anchor_last, boundary, "an empty epoch has a single anchor");
+    assert_eq!(anchor_prev, epoch_tip);
+    assert_eq!(
+        anchor_last,
+        epoch_tip.next_epoch(EpochIndex(5)),
+        "the segment covers the boundary tick"
+    );
     assert_eq!(epoch_start, EpochIndex(4));
-    assert_eq!(epoch_end, EpochIndex(4), "the segment crosses no boundary");
-    assert_eq!(seed_nf_start, nf);
+    assert_eq!(epoch_end, EpochIndex(5), "one boundary crossed");
+    assert_eq!(seed_nf_start, nf_prev);
     assert_eq!(nf_end, nf);
     assert_eq!(
         elapsed,
-        NfSeqPoly::from_iter([]).commit(),
-        "no crossing, so elapsed is the empty sentinel"
+        NfSeqPoly::from_iter([nf_prev]).commit(),
+        "the crossing records the epoch it leaves"
     );
 }
 
-/// A lineage on its epoch's terminal anchor has no segment to lift over.
-/// `SpendableEpochLift` takes it across the boundary, and the next segment
-/// opens on the boundary anchor it lands on.
+/// A lineage on its epoch's terminal anchor lifts over the crossing seed like
+/// any other segment, and the next segment opens on the boundary anchor it
+/// lands on.
 #[test]
-fn spendable_epoch_lift_advances_from_an_epoch_tip() {
+fn spendable_lift_advances_from_an_epoch_tip() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
@@ -1262,7 +1302,29 @@ fn spendable_epoch_lift_advances_from_an_epoch_tip() {
     let target_height = pool.height();
     assert_eq!(target_height.epoch(), EpochIndex(1));
 
-    let at_boundary = user.epoch_lift(rng, spendable, &note);
+    // The crossing is an ordinary segment, so an ordinary lift carries the
+    // lineage over it.
+    let (crossing, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(
+                ((), ()),
+                epoch0_tip,
+                EpochIndex(0),
+                user.nf_at(&note, EpochIndex(0)),
+                user.nf_at(&note, EpochIndex(1)),
+            ),
+        )
+        .expect("EndEpochUnspentSeed");
+    let at_boundary = user.lift(
+        rng,
+        spendable,
+        crossing,
+        &note,
+        EpochIndex(0),
+        EpochIndex(1),
+    );
     assert_eq!(
         *at_boundary.data(),
         (
@@ -1296,10 +1358,153 @@ fn spendable_epoch_lift_advances_from_an_epoch_tip() {
     assert_eq!(lifted.data().2, pool.anchor_at(target_height));
 }
 
-/// The empty-epoch seed is the segment `UnspentEpochFuse` splices against on
-/// each side of a stampless epoch.
+/// A span opening on a boundary anchor covers the crossings after it, not the
+/// one that produced it: the lineage already paid for that crossing to arrive.
 #[test]
-fn empty_epoch_unspent_seed_crosses_a_stampless_epoch() {
+fn unspent_span_starting_on_a_boundary_anchor() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(300);
+    // A lone cm-stamp, then silence to the end of epoch 0, so the lineage ends
+    // up on epoch 0's terminal anchor and crosses to `B_1` by a bare lift.
+    pool.mine(vec![vec![note.commitment().into()]]);
+    let cm_height = pool.height();
+    while pool.height().0 + 1 < EPOCH_SIZE {
+        pool.advance(1, |_| Vec::new());
+    }
+    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
+    let epoch0_tip = spendable.data().2;
+    let (crossing, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(
+                ((), ()),
+                epoch0_tip,
+                EpochIndex(0),
+                user.nf_at(&note, EpochIndex(0)),
+                user.nf_at(&note, EpochIndex(1)),
+            ),
+        )
+        .expect("EndEpochUnspentSeed");
+    let at_boundary = user.lift(
+        rng,
+        spendable,
+        crossing,
+        &note,
+        EpochIndex(0),
+        EpochIndex(1),
+    );
+
+    // Epoch 1 publishes nothing, so the span starts on a boundary anchor whose
+    // own epoch is silent; epoch 2 resumes.
+    while pool.height().0 + 1 < 2 * EPOCH_SIZE {
+        pool.advance(1, |_| Vec::new());
+    }
+    pool.advance(1, |_| random_block(rng, 1, 2));
+    let target_height = pool.height();
+    assert_eq!(target_height.epoch(), EpochIndex(2));
+
+    let start_anchor = at_boundary.data().2;
+    assert_eq!(start_anchor, pool.pre_epoch_anchor(EpochIndex(2)));
+    let arbitrary = build_unspent_pcd_between_anchors(
+        rng,
+        &pool,
+        &[
+            user.nf_at(&note, EpochIndex(1)),
+            user.nf_at(&note, EpochIndex(2)),
+        ],
+        (start_anchor, pool.anchor_at(target_height)),
+    );
+    let (_, (epoch_start, _), elapsed, (epoch_end, _), _) = *arbitrary.data();
+    assert_eq!(epoch_start, EpochIndex(1));
+    assert_eq!(epoch_end, EpochIndex(2));
+    assert_eq!(
+        elapsed,
+        NfSeqPoly::from_iter([user.nf_at(&note, EpochIndex(1))]).commit(),
+        "only the crossing out of the silent epoch, not the one into it"
+    );
+
+    let lifted = user.lift(
+        rng,
+        at_boundary,
+        arbitrary,
+        &note,
+        EpochIndex(1),
+        EpochIndex(2),
+    );
+    assert_eq!(
+        lifted.data().1,
+        (EpochIndex(2), user.nf_at(&note, EpochIndex(2)))
+    );
+    assert_eq!(lifted.data().2, pool.anchor_at(target_height));
+}
+
+/// A span may end on a boundary anchor: an epoch that has published nothing
+/// yet has no post anchor for its blocks to resolve against, so the end
+/// resolves to the boundary and the span stops on the crossing.
+#[test]
+fn unspent_span_ending_on_a_boundary_anchor() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(300);
+    let cm_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
+
+    // Epoch 0 publishes after the cm; epoch 1 opens with a stampless block, so
+    // that block's anchor is `B_1` itself.
+    while pool.height().0 + 1 < EPOCH_SIZE {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+    pool.advance(1, |_| Vec::new());
+    let target_height = pool.height();
+    assert_eq!(target_height.epoch(), EpochIndex(1));
+    assert_eq!(
+        pool.anchor_at(target_height),
+        pool.pre_epoch_anchor(EpochIndex(1))
+            .next_epoch(EpochIndex(1)),
+        "a silent epoch-first block rests on the boundary anchor"
+    );
+
+    let arbitrary = build_unspent_pcd_between_anchors(
+        rng,
+        &pool,
+        &[
+            user.nf_at(&note, EpochIndex(0)),
+            user.nf_at(&note, EpochIndex(1)),
+        ],
+        (spendable.data().2, pool.anchor_at(target_height)),
+    );
+    let (_, (epoch_start, _), elapsed, (epoch_end, _), anchor_last) = *arbitrary.data();
+    assert_eq!(epoch_start, EpochIndex(0));
+    assert_eq!(epoch_end, EpochIndex(1), "the span stops on the crossing");
+    assert_eq!(anchor_last, pool.anchor_at(target_height));
+    assert_eq!(
+        elapsed,
+        NfSeqPoly::from_iter([user.nf_at(&note, EpochIndex(0))]).commit()
+    );
+
+    let lifted = user.lift(
+        rng,
+        spendable,
+        arbitrary,
+        &note,
+        EpochIndex(0),
+        EpochIndex(1),
+    );
+    assert_eq!(
+        lifted.data().1,
+        (EpochIndex(1), user.nf_at(&note, EpochIndex(1)))
+    );
+    assert_eq!(lifted.data().2, pool.anchor_at(target_height));
+}
+
+/// A stampless epoch is two crossings with nothing between them, so the span
+/// still records its nullifier.
+#[test]
+fn end_epoch_unspent_seed_crosses_a_stampless_epoch() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
@@ -1358,19 +1563,20 @@ fn empty_epoch_unspent_seed_crosses_a_stampless_epoch() {
 }
 
 #[test]
-fn unspent_epoch_fuse_rejects_wrong_left_seq() {
+fn crossed_fuse_rejects_wrong_left_seq() {
     let rng = &mut StdRng::seed_from_u64(0);
     let ([nf0, nf1, nf2, nf3, _nf4], left, right) = epoch_fuse_setup(rng);
+    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::UnspentEpochFuse,
+            pool::UnspentFuse,
             (
-                NfSeqPoly::from_iter([nf1, nf0]),
+                NfSeqPoly::from_iter([nf1, nf0, nf2]),
                 NfSeqPoly::from_iter([nf0, nf1, nf2, nf3]),
                 NfSeqPoly::from_iter([nf3]),
             ),
-            left,
+            crossed,
             right,
         )
         .err()
@@ -1380,24 +1586,25 @@ fn unspent_epoch_fuse_rejects_wrong_left_seq() {
     };
     assert_eq!(
         inner.to_string(),
-        "UnspentEpochFuse: left polynomial does not match header"
+        "UnspentFuse: left polynomial does not match header"
     );
 }
 
 #[test]
-fn unspent_epoch_fuse_rejects_wrong_right_seq() {
+fn crossed_fuse_rejects_wrong_right_seq() {
     let rng = &mut StdRng::seed_from_u64(0);
     let ([nf0, nf1, nf2, nf3, nf4], left, right) = epoch_fuse_setup(rng);
+    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::UnspentEpochFuse,
+            pool::UnspentFuse,
             (
-                NfSeqPoly::from_iter([nf0, nf1]),
+                NfSeqPoly::from_iter([nf0, nf1, nf2]),
                 NfSeqPoly::from_iter([nf0, nf1, nf2, nf3]),
                 NfSeqPoly::from_iter([nf4]),
             ),
-            left,
+            crossed,
             right,
         )
         .err()
@@ -1407,26 +1614,27 @@ fn unspent_epoch_fuse_rejects_wrong_right_seq() {
     };
     assert_eq!(
         inner.to_string(),
-        "UnspentEpochFuse: right polynomial does not match header"
+        "UnspentFuse: right polynomial does not match header"
     );
 }
 
 #[test]
-fn unspent_epoch_fuse_rejects_wrong_combined() {
+fn crossed_fuse_rejects_wrong_combined() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let ([nf0, nf1, _nf2, nf3, _nf4], left, right) = epoch_fuse_setup(rng);
+    let ([nf0, nf1, nf2, nf3, _nf4], left, right) = epoch_fuse_setup(rng);
+    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
     // Both halves honest; `combined` forged as the right half alone, dropping
-    // the left history and the boundary fold.
+    // the left history and the crossing it carries.
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::UnspentEpochFuse,
+            pool::UnspentFuse,
             (
-                NfSeqPoly::from_iter([nf0, nf1]),
+                NfSeqPoly::from_iter([nf0, nf1, nf2]),
                 NfSeqPoly::from_iter([nf3]),
                 NfSeqPoly::from_iter([nf3]),
             ),
-            left,
+            crossed,
             right,
         )
         .err()
@@ -1436,26 +1644,31 @@ fn unspent_epoch_fuse_rejects_wrong_combined() {
     };
     assert_eq!(
         inner.to_string(),
-        "UnspentEpochFuse: combined is not the splice of the halves"
+        "UnspentFuse: combined is not the concatenation of the halves"
     );
 }
 
 #[test]
-fn unspent_epoch_fuse_rejects_wrong_boundary_anchor() {
+fn crossed_fuse_rejects_wrong_boundary_anchor() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let ([nf0, nf1, _nf2, nf3, _nf4], left, _right) = epoch_fuse_setup(rng);
+    let ([nf0, nf1, nf2, nf3, _nf4], left, _right) = epoch_fuse_setup(rng);
     let left_end = left.data().4;
-    // A forged epoch-3 right half rooted directly at `left.anchor_last`: the
-    // epoch labels are adjacent, but the root skips the `next_epoch` fold the
-    // boundary demands.
+    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
+    // A forged epoch-3 right half rooted directly at the pre-crossing anchor:
+    // the epoch labels line up, but the root skips the `next_epoch` fold the
+    // crossing seed carries.
     let stamp = [Tachygram::random(&mut *rng)];
     let forged_right = build_unspent_seed_pcd(rng, left_end, EpochIndex(3), &stamp, nf3);
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::UnspentEpochFuse,
-            witness::unspent_epoch_fuse((*left.data(), *forged_right.data()), &[nf0, nf1], &[]),
-            left,
+            pool::UnspentFuse,
+            witness::unspent_fuse(
+                (*crossed.data(), *forged_right.data()),
+                &[nf0, nf1, nf2],
+                &[],
+            ),
+            crossed,
             forged_right,
         )
         .err()
@@ -1465,16 +1678,17 @@ fn unspent_epoch_fuse_rejects_wrong_boundary_anchor() {
     };
     assert_eq!(
         inner.to_string(),
-        "UnspentEpochFuse: boundary anchor does not match right.anchor_prev"
+        "UnspentFuse: left.anchor_last must equal right.anchor_prev"
     );
 }
 
 #[test]
-fn unspent_epoch_fuse_rejects_epoch_skip() {
+fn crossed_fuse_rejects_epoch_skip() {
     let rng = &mut StdRng::seed_from_u64(0);
     let mut pool = PoolSim::genesis(rng);
     pool.advance(2 * EPOCH_SIZE, |_| random_block(rng, 1, 2));
     let nf_e0 = Nullifier::from(Fp::random(&mut *rng));
+    let nf_e1 = Nullifier::from(Fp::random(&mut *rng));
     let nf_e2 = Nullifier::from(Fp::random(&mut *rng));
     let left = build_unspent_pcd_between_blocks(
         rng,
@@ -1482,19 +1696,19 @@ fn unspent_epoch_fuse_rejects_epoch_skip() {
         &[nf_e0],
         BlockHeight(0)..=BlockHeight(EPOCH_SIZE - 1),
     );
-    let right = build_unspent_pcd_between_blocks(
-        rng,
-        &pool,
-        &[nf_e2],
-        BlockHeight(2 * EPOCH_SIZE)..=BlockHeight(2 * EPOCH_SIZE),
-    );
+    // One crossing reaches epoch 1, so an epoch-2 half is still a boundary
+    // away: a single crossing cannot skip an epoch. The forged half roots on
+    // the crossing's own tip, so only the epoch labels disagree.
+    let crossed = cross_out_of(rng, left, &[], nf_e1);
+    let stamp = [Tachygram::random(&mut *rng)];
+    let forged_right = build_unspent_seed_pcd(rng, crossed.data().4, EpochIndex(2), &stamp, nf_e2);
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::UnspentEpochFuse,
-            witness::unspent_epoch_fuse((*left.data(), *right.data()), &[], &[]),
-            left,
-            right,
+            pool::UnspentFuse,
+            witness::unspent_fuse((*crossed.data(), *forged_right.data()), &[nf_e0], &[]),
+            crossed,
+            forged_right,
         )
         .err()
         .unwrap();
@@ -1503,7 +1717,7 @@ fn unspent_epoch_fuse_rejects_epoch_skip() {
     };
     assert_eq!(
         inner.to_string(),
-        "UnspentEpochFuse: right epoch must be one past left's tip"
+        "UnspentFuse: forwards half must sit in left's tip epoch"
     );
 }
 
@@ -1868,7 +2082,7 @@ fn spendable_lift_rejects_wrong_cm() {
 }
 
 #[test]
-fn spendable_epoch_lift_rejects_bad_range() {
+fn crossing_bind_rejects_bad_range() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
@@ -1877,36 +2091,60 @@ fn spendable_epoch_lift_rejects_bad_range() {
     let init_height = mine_cm_block(rng, &mut pool, note.commitment());
 
     let cases = [
-        // The range must derive from the lineage's own note.
+        // The range must derive from the lineage's own note. The bind reaches
+        // its polynomial check before its nullifier checks, so a foreign
+        // range's sequence is what first disagrees; the `cm` identity itself
+        // is `SpendableLift`'s to enforce.
         (
             &other,
             EpochIndex(0),
             2,
-            "SpendableEpochLift: derived range does not match note",
+            "UnspentBind: range polynomial does not match header",
         ),
         // The range must open on the epoch the lineage is presently in.
         (
             &note,
             EpochIndex(1),
             2,
-            "SpendableEpochLift: derived range does not start at the lineage epoch",
+            "UnspentBind: derived range does not start at the unspent's start epoch",
         ),
-        // The range spans exactly the two epochs the tick moves between.
+        // The range spans exactly the two epochs the crossing moves between.
         (
             &note,
             EpochIndex(0),
             3,
-            "SpendableEpochLift: derived range must span two epochs",
+            "UnspentBind: derived range does not span the crossings plus the tip",
         ),
     ];
 
     for (range_note, epoch_start, len, expected) in cases {
         let spendable = user.spendable_init(rng, &note, &pool, init_height);
+        let (_, (epoch, present_nf), anchor) = *spendable.data();
+        let (crossing, ()) = PROOF_SYSTEM
+            .seed(
+                rng,
+                pool::EndEpochUnspentSeed,
+                witness::end_epoch_unspent_seed(
+                    ((), ()),
+                    anchor,
+                    epoch,
+                    present_nf,
+                    user.nf_at(&note, epoch.next()),
+                ),
+            )
+            .expect("EndEpochUnspentSeed");
         let range = user.derived_range(rng, range_note, epoch_start, len);
+        let elapsed = [present_nf];
         let err = PROOF_SYSTEM
-            .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
+            .fuse(
+                rng,
+                pool::UnspentBind,
+                witness::unspent_bind((*crossing.data(), *range.data()), &elapsed),
+                crossing,
+                range,
+            )
             .err()
-            .unwrap_or_else(|| panic!("SpendableEpochLift accepted {expected}"));
+            .unwrap_or_else(|| panic!("UnspentBind accepted {expected}"));
         let ragu::Error::InvalidWitness(inner) = err else {
             panic!("expected InvalidWitness for {expected}, got {err:?}");
         };

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -1033,35 +1033,6 @@ fn epoch_fuse_setup(
     (nf, left, right)
 }
 
-/// Extend `left` over the boundary out of its tip epoch: seed the crossing on
-/// `left`'s terminal anchor and fuse it on, so the result opens where `left`
-/// did and tips at `nf_in` in the next epoch.
-fn cross_out_of(
-    rng: &mut StdRng,
-    left: Pcd<pool::ArbitraryUnspent>,
-    left_elapsed: &[Nullifier],
-    nf_in: Nullifier,
-) -> Pcd<pool::ArbitraryUnspent> {
-    let (_, _, _, (epoch_end, nf_end), anchor_last) = *left.data();
-    let (seed, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::EndEpochUnspentSeed,
-            witness::end_epoch_unspent_seed(((), ()), anchor_last, epoch_end, nf_end, nf_in),
-        )
-        .expect("EndEpochUnspentSeed");
-    let (crossed, ()) = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentFuse,
-            witness::unspent_fuse((*left.data(), *seed.data()), left_elapsed, &[nf_end]),
-            left,
-            seed,
-        )
-        .expect("UnspentFuse over the crossing");
-    crossed
-}
-
 /// Two halves meeting at a boundary compose through a crossing seed: the seam
 /// nullifier the left half was still holding as its tip lands in the merged
 /// history, and the merged segment spans both halves' outer endpoints.
@@ -1072,7 +1043,25 @@ fn end_epoch_unspent_seed_composes_across_a_boundary() {
     let start = left.data().0;
     let end = right.data().4;
 
-    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
+    // Seed the crossing on left's terminal anchor and fuse it on, so left's
+    // tip nullifier stops being in progress and joins the history.
+    let (seed, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(((), ()), left.data().4, EpochIndex(2), nf2, nf3),
+        )
+        .expect("EndEpochUnspentSeed");
+    let (crossed, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            pool::UnspentFuse,
+            witness::unspent_fuse((*left.data(), *seed.data()), &[nf0, nf1], &[nf2]),
+            left,
+            seed,
+        )
+        .expect("UnspentFuse over the crossing");
+
     let (fused, ()) = PROOF_SYSTEM
         .fuse(
             rng,
@@ -1560,165 +1549,6 @@ fn end_epoch_unspent_seed_crosses_a_stampless_epoch() {
         (EpochIndex(2), user.nf_at(&note, EpochIndex(2)))
     );
     assert_eq!(lifted.data().2, pool.anchor_at(target_height));
-}
-
-#[test]
-fn crossed_fuse_rejects_wrong_left_seq() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let ([nf0, nf1, nf2, nf3, _nf4], left, right) = epoch_fuse_setup(rng);
-    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentFuse,
-            (
-                NfSeqPoly::from_iter([nf1, nf0, nf2]),
-                NfSeqPoly::from_iter([nf0, nf1, nf2, nf3]),
-                NfSeqPoly::from_iter([nf3]),
-            ),
-            crossed,
-            right,
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "UnspentFuse: left polynomial does not match header"
-    );
-}
-
-#[test]
-fn crossed_fuse_rejects_wrong_right_seq() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let ([nf0, nf1, nf2, nf3, nf4], left, right) = epoch_fuse_setup(rng);
-    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentFuse,
-            (
-                NfSeqPoly::from_iter([nf0, nf1, nf2]),
-                NfSeqPoly::from_iter([nf0, nf1, nf2, nf3]),
-                NfSeqPoly::from_iter([nf4]),
-            ),
-            crossed,
-            right,
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "UnspentFuse: right polynomial does not match header"
-    );
-}
-
-#[test]
-fn crossed_fuse_rejects_wrong_combined() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let ([nf0, nf1, nf2, nf3, _nf4], left, right) = epoch_fuse_setup(rng);
-    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
-    // Both halves honest; `combined` forged as the right half alone, dropping
-    // the left history and the crossing it carries.
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentFuse,
-            (
-                NfSeqPoly::from_iter([nf0, nf1, nf2]),
-                NfSeqPoly::from_iter([nf3]),
-                NfSeqPoly::from_iter([nf3]),
-            ),
-            crossed,
-            right,
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "UnspentFuse: combined is not the concatenation of the halves"
-    );
-}
-
-#[test]
-fn crossed_fuse_rejects_wrong_boundary_anchor() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let ([nf0, nf1, nf2, nf3, _nf4], left, _right) = epoch_fuse_setup(rng);
-    let left_end = left.data().4;
-    let crossed = cross_out_of(rng, left, &[nf0, nf1], nf3);
-    // A forged epoch-3 right half rooted directly at the pre-crossing anchor:
-    // the epoch labels line up, but the root skips the `next_epoch` fold the
-    // crossing seed carries.
-    let stamp = [Tachygram::random(&mut *rng)];
-    let forged_right = build_unspent_seed_pcd(rng, left_end, EpochIndex(3), &stamp, nf3);
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentFuse,
-            witness::unspent_fuse(
-                (*crossed.data(), *forged_right.data()),
-                &[nf0, nf1, nf2],
-                &[],
-            ),
-            crossed,
-            forged_right,
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "UnspentFuse: left.anchor_last must equal right.anchor_prev"
-    );
-}
-
-#[test]
-fn crossed_fuse_rejects_epoch_skip() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let mut pool = PoolSim::genesis(rng);
-    pool.advance(2 * EPOCH_SIZE, |_| random_block(rng, 1, 2));
-    let nf_e0 = Nullifier::from(Fp::random(&mut *rng));
-    let nf_e1 = Nullifier::from(Fp::random(&mut *rng));
-    let nf_e2 = Nullifier::from(Fp::random(&mut *rng));
-    let left = build_unspent_pcd_between_blocks(
-        rng,
-        &pool,
-        &[nf_e0],
-        BlockHeight(0)..=BlockHeight(EPOCH_SIZE - 1),
-    );
-    // One crossing reaches epoch 1, so an epoch-2 half is still a boundary
-    // away: a single crossing cannot skip an epoch. The forged half roots on
-    // the crossing's own tip, so only the epoch labels disagree.
-    let crossed = cross_out_of(rng, left, &[], nf_e1);
-    let stamp = [Tachygram::random(&mut *rng)];
-    let forged_right = build_unspent_seed_pcd(rng, crossed.data().4, EpochIndex(2), &stamp, nf_e2);
-    let err = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentFuse,
-            witness::unspent_fuse((*crossed.data(), *forged_right.data()), &[nf_e0], &[]),
-            crossed,
-            forged_right,
-        )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "UnspentFuse: forwards half must sit in left's tip epoch"
-    );
 }
 
 #[test]

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -1,5 +1,6 @@
 //! Proof-step tests: `StampLift`, `SpendBind` / `SpendStamp`, the GGM
-//! derivation chain, `Unspent` composition, and the `Spendable*` lineage.
+//! derivation chain, `ArbitraryUnspent` composition, and the `Spendable*`
+//! lineage.
 
 #![allow(clippy::panic, reason = "test code")]
 
@@ -111,7 +112,7 @@ fn same_epoch_honest_spend_accepted() {
 }
 
 #[test]
-fn same_epoch_wrong_index_rejected_against_honest_chain() {
+fn same_epoch_wrong_index_accepted_but_off_sequence() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
@@ -119,93 +120,80 @@ fn same_epoch_wrong_index_rejected_against_honest_chain() {
     let cm_height = mine_cm_in_epoch_one(rng, &mut pool, note.commitment());
     let wrong = EpochIndex(cm_height.epoch().0 + 2);
 
-    let (pre_epoch_anchor, pre_cm_anchor, creation_set, chain) =
-        spendable_init_inputs(rng, &pool, note.commitment(), cm_height);
+    // Honest pre-cm anchor, wrong-epoch derivation: every in-circuit check
+    // passes, but the emitted anchor folds `wrong` and so sits off the
+    // published sequence; consensus anchor membership rejects the eventual
+    // spend.
+    let (pre_cm_anchor, creation_set) = spendable_init_inputs(&pool, note.commitment(), cm_height);
     let present_nf = user.nf_at(&note, wrong);
     let nf_wrong = user.derived_range(rng, &note, wrong, 1);
-    let err = PROOF_SYSTEM
+    let (spendable, ()) = PROOF_SYSTEM
         .fuse(
             rng,
             spendable::SpendableInit,
             witness::spendable_init(
-                (*chain.data(), *nf_wrong.data()),
-                pre_epoch_anchor,
+                (*nf_wrong.data(), ()),
                 pre_cm_anchor,
                 &creation_set,
                 present_nf,
             ),
-            chain,
             nf_wrong,
+            Proof::trivial().carry::<()>(()),
         )
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "SpendableInit: chain not rooted at epoch boundary"
+        .expect("SpendableInit accepts the wrong-index derivation");
+
+    let cm_commit = TachygramSetPoly::from_iter(creation_set).commit();
+    let anchor = spendable.data().2;
+    assert_eq!(anchor, pre_cm_anchor.next_stamp(wrong, &cm_commit));
+    let off_sequence =
+        (0..=cm_height.0).all(|height| pool.anchor_at(BlockHeight(height)) != anchor);
+    assert!(
+        off_sequence,
+        "wrong-index anchor must be absent from the published sequence"
     );
 }
 
 #[test]
-fn spendable_init_accepts_forged_chain() {
+fn spendable_init_accepts_forged_anchor() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(500);
     let cm = note.commitment();
     let cm_height = mine_cm_in_epoch_one(rng, &mut pool, cm);
-    let wrong = EpochIndex(cm_height.epoch().0 + 2);
+    let epoch = cm_height.epoch();
 
-    // Forge a boundary at the wrong epoch: `pre_epoch_anchor = x` (arbitrary), a
-    // chain seeded at `forged_start = x.next_epoch(wrong)` absorbing the real
-    // cm-stamp, and `pre_cm_anchor = forged_start` so `chain_end ==
-    // pre_cm_anchor.next_stamp(cm_commit)`. All SpendableInit checks then pass.
+    // Arbitrary `pre_cm_anchor = x` at the correct epoch: the circuit accepts
+    // (the witness is free by design), but the emitted anchor descends from
+    // `x` rather than a chain member, so consensus anchor membership is what
+    // rejects the eventual spend.
     let stamps = pool.tachygrams_at(cm_height);
     let cm_idx = stamps
         .iter()
         .position(|tgs| tgs.contains(&cm.into()))
         .expect("cm present in cm-block");
     let x = Anchor::from(Fp::random(&mut *rng));
-    let forged_start = x.next_epoch(wrong);
-    let cm_set = TachygramSetPoly::from_iter(stamps[cm_idx].clone());
-    let cm_commit = cm_set.commit();
-    let (forged_chain, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::AnchorSeed,
-            witness::anchor_seed(((), ()), forged_start, wrong, &stamps[cm_idx]),
-        )
-        .expect("AnchorSeed");
+    let cm_commit = TachygramSetPoly::from_iter(stamps[cm_idx].clone()).commit();
 
-    let present_nf = user.nf_at(&note, wrong);
-    let nf_wrong = user.derived_range(rng, &note, wrong, 1);
+    let present_nf = user.nf_at(&note, epoch);
+    let nf_header = user.derived_range(rng, &note, epoch, 1);
     let (forged_spendable, ()) = PROOF_SYSTEM
         .fuse(
             rng,
             spendable::SpendableInit,
-            witness::spendable_init(
-                (*forged_chain.data(), *nf_wrong.data()),
-                x,
-                forged_start,
-                &stamps[cm_idx],
-                present_nf,
-            ),
-            forged_chain,
-            nf_wrong,
+            witness::spendable_init((*nf_header.data(), ()), x, &stamps[cm_idx], present_nf),
+            nf_header,
+            Proof::trivial().carry::<()>(()),
         )
-        .expect("SpendableInit accepts the forged wrong-index chain");
+        .expect("SpendableInit accepts the forged anchor");
 
-    // The circuit accepted, but the produced anchor is off the published sequence,
-    // so consensus anchor membership is what rejects the eventual spend.
     let forged_anchor = forged_spendable.data().2;
-    assert_eq!(forged_anchor, forged_start.next_stamp(wrong, &cm_commit));
+    assert_eq!(forged_anchor, x.next_stamp(epoch, &cm_commit));
     let forged_off_sequence =
         (0..=cm_height.0).all(|height| pool.anchor_at(BlockHeight(height)) != forged_anchor);
     assert!(
         forged_off_sequence,
-        "forged wrong-index anchor must be absent from the published sequence"
+        "forged anchor must be absent from the published sequence"
     );
 }
 
@@ -249,29 +237,19 @@ fn spendable_init_rejects_tg_absent() {
     let nf_header = user.derived_range(rng, &note, EpochIndex(0), 1);
     let present_nf = user.nf_at(&note, EpochIndex(0));
     let absent_tg = Tachygram::random(&mut *rng);
-    // cm-inclusion is checked first, so a dummy boundary chain suffices here.
-    let dummy_tg = Tachygram::random(&mut *rng);
-    let (dummy_chain, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::AnchorSeed,
-            witness::anchor_seed(((), ()), Anchor::default(), EpochIndex(0), &[dummy_tg]),
-        )
-        .expect("AnchorSeed");
 
     let err = PROOF_SYSTEM
         .fuse(
             rng,
             spendable::SpendableInit,
             witness::spendable_init(
-                (*dummy_chain.data(), *nf_header.data()),
-                Anchor::default(),
+                (*nf_header.data(), ()),
                 Anchor::default(),
                 &[absent_tg],
                 present_nf,
             ),
-            dummy_chain,
             nf_header,
+            Proof::trivial().carry::<()>(()),
         )
         .err()
         .unwrap();
@@ -414,27 +392,24 @@ fn anchor_chain_fuse_rejects_invalid_compositions() {
 }
 
 #[test]
-fn empty_block_anchor_unique_per_height() {
-    // Two consecutive empty blocks publish distinct anchors.
+fn empty_blocks_do_not_advance_the_anchor() {
+    // A block that publishes no stamp contributes no anchor link, so a run of
+    // empty blocks shares the anchor of the last block that did publish one.
     let rng = &mut StdRng::seed_from_u64(0);
     let mut pool = PoolSim::genesis(rng);
+    pool.mine(random_block(rng, 1, 2));
     pool.mine(vec![]);
     pool.mine(vec![]);
 
-    let h1 = BlockHeight(1);
-    let h2 = BlockHeight(2);
-    assert_ne!(pool.anchor_at(h1), pool.anchor_at(h2));
-    // h2's anchor is h1's anchor advanced via next_empty.
-    assert_eq!(
-        pool.anchor_at(h2),
-        pool.anchor_at(h1).next_empty(h2.epoch())
-    );
+    let stamped = BlockHeight(1);
+    assert_eq!(pool.anchor_at(BlockHeight(2)), pool.anchor_at(stamped));
+    assert_eq!(pool.anchor_at(BlockHeight(3)), pool.anchor_at(stamped));
 }
 
 #[test]
-fn empty_block_unspent_lifts_spendable() {
-    // Build a spendable, then lift it across an empty block via an
-    // Unspent built solely from EmptyBlockUnspentSeed.
+fn spendable_stays_current_across_empty_blocks() {
+    // A note idling over a stampless span needs no proof work at all: the pool
+    // anchor never leaves the spendable's, so there is nothing to lift over.
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(100);
@@ -443,27 +418,14 @@ fn empty_block_unspent_lifts_spendable() {
     let mut pool = PoolSim::genesis(rng);
     pool.mine(vec![vec![cm.into()]]);
     let cm_height = pool.height();
-    let epoch = cm_height.epoch();
 
-    // Bootstrap spendable at the cm-block's published anchor.
     let spendable = user.spendable_init(rng, &note, &pool, cm_height);
-    let spendable_anchor_before = spendable.data().2;
+    let spendable_anchor = spendable.data().2;
 
-    // Mine one empty block.
     pool.mine(vec![]);
-    let empty_height = pool.height();
+    pool.mine(vec![]);
 
-    // Build an Unspent over the empty block via EmptyBlockUnspentSeed,
-    // then lift the spendable.
-    let nf = spendable.data().1;
-    let unspent = build_unspent_pcd_between_blocks(rng, &pool, &[nf], empty_height..=empty_height);
-    let lifted = user.lift(rng, spendable, unspent, &note, epoch, epoch);
-
-    assert_eq!(
-        lifted.data().2,
-        spendable_anchor_before.next_empty(empty_height.epoch())
-    );
-    assert_eq!(lifted.data().2, pool.anchor_at(empty_height));
+    assert_eq!(pool.anchor_at(pool.height()), spendable_anchor);
 }
 
 #[test]
@@ -587,6 +549,40 @@ fn spend_bind_rejects_forged_next() {
     assert_eq!(
         inner.to_string(),
         "SpendBind: next nullifier is not the range's end leaf"
+    );
+}
+
+#[test]
+fn spend_bind_rejects_range_from_another_epoch() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    pool.mine(random_block_with(rng, &[vec![note.commitment()]], 4));
+    let height = pool.height();
+    let spend_epoch = height.epoch();
+    let spendable_pcd = user.fresh_spend(rng, &pool, height, &note);
+
+    // The note's own live pair, but for an epoch the lineage has not reached.
+    let ahead = spend_epoch.next();
+    let derived = user.derived_range(rng, &note, ahead, 2);
+
+    let err = PROOF_SYSTEM
+        .fuse(
+            rng,
+            spend::SpendBind,
+            (user.nf_at(&note, ahead.next()),),
+            spendable_pcd,
+            derived,
+        )
+        .err()
+        .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(
+        inner.to_string(),
+        "SpendBind: live range does not start at the lineage epoch"
     );
 }
 
@@ -806,7 +802,7 @@ fn sync_sim_builds_unspent_for_wallet_lift_across_epochs() {
 
     assert_eq!(
         lifted.data().1,
-        user.nf_at(&note, EpochIndex(1)),
+        (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
         "tip advanced to nf_1"
     );
     assert_eq!(
@@ -846,8 +842,8 @@ fn unspent_lift_spans_partial_and_whole_epochs() {
     // Advance to a mid-epoch-3 block (neither first nor last) so the last epoch is
     // also partial; epochs 1 and 2 are covered whole. The block-granular tree
     // therefore mixes mid-epoch `UnspentFuse` (incl. multi-epoch right at upper
-    // merges) with boundary `UnspentEpochFuse`. One interior empty block seeds
-    // `EmptyBlockUnspentSeed` into the same walk.
+    // merges) with boundary `UnspentEpochFuse`. One interior empty block sits in
+    // the walk, contributing no leaf.
     let empty_height = BlockHeight(EPOCH_SIZE + 4);
     let target_height = BlockHeight(3 * EPOCH_SIZE + 7);
     while pool.height() < target_height {
@@ -868,7 +864,7 @@ fn unspent_lift_spans_partial_and_whole_epochs() {
     let lifted = user.lift(rng, spendable, unspent, &note, EpochIndex(0), EpochIndex(3));
     assert_eq!(
         lifted.data().1,
-        user.nf_at(&note, EpochIndex(3)),
+        (EpochIndex(3), user.nf_at(&note, EpochIndex(3))),
         "tip advanced to nf_3 across partial first/last and whole interior epochs"
     );
     assert_eq!(
@@ -879,10 +875,10 @@ fn unspent_lift_spans_partial_and_whole_epochs() {
     assert_eq!(lifted.data().0, note.commitment(), "cm threaded unchanged");
 }
 
-/// Two [`pool::Unspent`] halves meeting at a sub-block, mid-epoch junction.
-/// Every anchor involved is off-boundary: the range runs from inside a block
-/// of epoch 0, through a junction inside a block of epoch 2, to inside a
-/// block of epoch 3 (every `random_block(rng, 1, 2)` block carries two
+/// Two [`pool::ArbitraryUnspent`] halves meeting at a sub-block, mid-epoch
+/// junction. Every anchor involved is off-boundary: the range runs from inside
+/// a block of epoch 0, through a junction inside a block of epoch 2, to inside
+/// a block of epoch 3 (every `random_block(rng, 1, 2)` block carries two
 /// stamps, so its first stamp's anchor is sub-block). The left half carries
 /// two crossings (the fuse runs at offset 2), the right half one.
 fn multi_epoch_fuse_setup(
@@ -892,8 +888,8 @@ fn multi_epoch_fuse_setup(
     Nullifier,
     Nullifier,
     Nullifier,
-    Pcd<pool::Unspent>,
-    Pcd<pool::Unspent>,
+    Pcd<pool::ArbitraryUnspent>,
+    Pcd<pool::ArbitraryUnspent>,
 ) {
     let mut pool = PoolSim::genesis(rng);
     pool.advance(3 * EPOCH_SIZE + 3, |_| random_block(rng, 1, 2));
@@ -1083,12 +1079,18 @@ fn unspent_fuse_rejects_epoch_boundary_crossing() {
     );
 }
 
-/// Two [`pool::Unspent`] halves meeting at the epoch 2/3 boundary, together
-/// crossing four boundaries. The junction is boundary-pinned by the step's
-/// design, but both outer endpoints are off-boundary, sub-block anchors: the
-/// left half runs from inside a block of epoch 0 to epoch 2's terminal
+/// Two [`pool::ArbitraryUnspent`] halves meeting at the epoch 2/3 boundary,
+/// together crossing four boundaries. The junction is boundary-pinned by the
+/// step's design, but both outer endpoints are off-boundary, sub-block anchors:
+/// the left half runs from inside a block of epoch 0 to epoch 2's terminal
 /// anchor, the right half from the boundary to inside a block of epoch 4.
-fn epoch_fuse_setup(rng: &mut StdRng) -> ([Nullifier; 5], Pcd<pool::Unspent>, Pcd<pool::Unspent>) {
+fn epoch_fuse_setup(
+    rng: &mut StdRng,
+) -> (
+    [Nullifier; 5],
+    Pcd<pool::ArbitraryUnspent>,
+    Pcd<pool::ArbitraryUnspent>,
+) {
     let mut pool = PoolSim::genesis(rng);
     pool.advance(4 * EPOCH_SIZE + 3, |_| random_block(rng, 1, 2));
     let nf: [Nullifier; 5] = array::from_fn(|_| Nullifier::from(Fp::random(&mut *rng)));
@@ -1148,6 +1150,160 @@ fn unspent_epoch_fuse_composes() {
         NfSeqPoly::from_iter([nf0, nf1, nf2, nf3]).commit(),
         "the boundary fold splices left's tip between the halves' histories"
     );
+}
+
+/// An empty epoch has one anchor, so the seed is a point segment at it.
+#[test]
+fn empty_epoch_unspent_seed_is_a_point_at_the_boundary() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let prev_epoch_tip = Anchor::from(Fp::random(&mut *rng));
+    let nf = Nullifier::from(Fp::random(&mut *rng));
+
+    let (seed, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EmptyEpochUnspentSeed,
+            witness::empty_epoch_unspent_seed(((), ()), prev_epoch_tip, EpochIndex(4), nf),
+        )
+        .expect("EmptyEpochUnspentSeed");
+
+    let (anchor_prev, (epoch_start, seed_nf_start), elapsed, (epoch_end, nf_end), anchor_last) =
+        *seed.data();
+    let boundary = prev_epoch_tip.next_epoch(EpochIndex(4));
+    assert_eq!(anchor_prev, boundary);
+    assert_eq!(anchor_last, boundary, "an empty epoch has a single anchor");
+    assert_eq!(epoch_start, EpochIndex(4));
+    assert_eq!(epoch_end, EpochIndex(4), "the segment crosses no boundary");
+    assert_eq!(seed_nf_start, nf);
+    assert_eq!(nf_end, nf);
+    assert_eq!(
+        elapsed,
+        NfSeqPoly::from_iter([]).commit(),
+        "no crossing, so elapsed is the empty sentinel"
+    );
+}
+
+/// A lineage on its epoch's terminal anchor has no segment to lift over.
+/// `SpendableEpochLift` takes it across the boundary, and the next segment
+/// opens on the boundary anchor it lands on.
+#[test]
+fn spendable_epoch_lift_advances_from_an_epoch_tip() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(300);
+    // A lone cm-stamp, then a silent rest-of-epoch, leaves the spendable's
+    // anchor sitting on epoch 0's terminal anchor.
+    pool.mine(vec![vec![note.commitment().into()]]);
+    let cm_height = pool.height();
+    while pool.height().0 + 1 < EPOCH_SIZE {
+        pool.advance(1, |_| Vec::new());
+    }
+    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
+    let epoch0_tip = spendable.data().2;
+    assert_eq!(
+        epoch0_tip,
+        pool.pre_epoch_anchor(EpochIndex(1)),
+        "the lineage sits on the epoch tip"
+    );
+
+    pool.advance(1, |_| random_block(rng, 1, 2));
+    let target_height = pool.height();
+    assert_eq!(target_height.epoch(), EpochIndex(1));
+
+    let at_boundary = user.epoch_lift(rng, spendable, &note);
+    assert_eq!(
+        *at_boundary.data(),
+        (
+            note.commitment(),
+            (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
+            epoch0_tip.next_epoch(EpochIndex(1))
+        ),
+        "the tick advances epoch, nullifier and anchor together"
+    );
+
+    // The lineage now rests on epoch 1's boundary anchor.
+    let arbitrary = build_unspent_pcd_between_anchors(
+        rng,
+        &pool,
+        &[user.nf_at(&note, EpochIndex(1))],
+        (at_boundary.data().2, pool.anchor_at(target_height)),
+    );
+    let lifted = user.lift(
+        rng,
+        at_boundary,
+        arbitrary,
+        &note,
+        EpochIndex(1),
+        EpochIndex(1),
+    );
+
+    assert_eq!(
+        lifted.data().1,
+        (EpochIndex(1), user.nf_at(&note, EpochIndex(1)))
+    );
+    assert_eq!(lifted.data().2, pool.anchor_at(target_height));
+}
+
+/// The empty-epoch seed is the segment `UnspentEpochFuse` splices against on
+/// each side of a stampless epoch.
+#[test]
+fn empty_epoch_unspent_seed_crosses_a_stampless_epoch() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(300);
+    let cm_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
+
+    // Epoch 0 keeps publishing after the cm, so the lineage is not on its tip.
+    // Epoch 1 then publishes nothing at all; epoch 2 resumes.
+    while pool.height().0 + 1 < EPOCH_SIZE {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+    while pool.height().0 + 1 < 2 * EPOCH_SIZE {
+        pool.advance(1, |_| Vec::new());
+    }
+    pool.advance(1, |_| random_block(rng, 1, 2));
+    let target_height = pool.height();
+    assert_eq!(target_height.epoch(), EpochIndex(2));
+
+    let arbitrary = build_unspent_pcd_between_anchors(
+        rng,
+        &pool,
+        &[
+            user.nf_at(&note, EpochIndex(0)),
+            user.nf_at(&note, EpochIndex(1)),
+            user.nf_at(&note, EpochIndex(2)),
+        ],
+        (spendable.data().2, pool.anchor_at(target_height)),
+    );
+    let (_, (epoch_start, _), elapsed, (epoch_end, _), _) = *arbitrary.data();
+    assert_eq!(epoch_start, EpochIndex(0));
+    assert_eq!(epoch_end, EpochIndex(2));
+    assert_eq!(
+        elapsed,
+        NfSeqPoly::from_iter([
+            user.nf_at(&note, EpochIndex(0)),
+            user.nf_at(&note, EpochIndex(1)),
+        ])
+        .commit(),
+        "both crossings recorded, including the one over the silent epoch"
+    );
+
+    let lifted = user.lift(
+        rng,
+        spendable,
+        arbitrary,
+        &note,
+        EpochIndex(0),
+        EpochIndex(2),
+    );
+    assert_eq!(
+        lifted.data().1,
+        (EpochIndex(2), user.nf_at(&note, EpochIndex(2)))
+    );
+    assert_eq!(lifted.data().2, pool.anchor_at(target_height));
 }
 
 #[test]
@@ -1301,7 +1457,7 @@ fn unspent_epoch_fuse_rejects_epoch_skip() {
 }
 
 #[test]
-fn verify_unspent_rejects_tip_mismatch() {
+fn unspent_bind_rejects_tip_mismatch() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
@@ -1346,7 +1502,7 @@ fn verify_unspent_rejects_tip_mismatch() {
     ]);
 
     let err = PROOF_SYSTEM
-        .fuse(rng, pool::VerifyUnspent, (elapsed, nf_seq), unspent, range)
+        .fuse(rng, pool::UnspentBind, (elapsed, nf_seq), unspent, range)
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {
@@ -1354,15 +1510,15 @@ fn verify_unspent_rejects_tip_mismatch() {
     };
     assert_eq!(
         inner.to_string(),
-        "VerifyUnspent: range is not elapsed followed by the tip"
+        "UnspentBind: range is not elapsed followed by the tip"
     );
 }
 
-/// A three-crossing epoch 0..=3 [`pool::Unspent`] lineage from the block
-/// after the note's cm block to a mid-epoch-3 block, for pairing against
+/// A three-crossing epoch 0..=3 [`pool::ArbitraryUnspent`] lineage from the
+/// block after the note's cm block to a mid-epoch-3 block, for pairing against
 /// derived ranges. Its honest witness polynomials are `elapsed = nf[0..3]`
 /// and `nf_seq = nf[0..4]`, against `derived_range(.., EpochIndex(0), 4)`.
-fn verify_unspent_setup(rng: &mut StdRng) -> (WalletSim, Note, Pcd<pool::Unspent>) {
+fn unspent_bind_setup(rng: &mut StdRng) -> (WalletSim, Note, Pcd<pool::ArbitraryUnspent>) {
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(500);
@@ -1387,9 +1543,9 @@ fn verify_unspent_setup(rng: &mut StdRng) -> (WalletSim, Note, Pcd<pool::Unspent
 }
 
 #[test]
-fn verify_unspent_rejects_elapsed_mismatch() {
+fn unspent_bind_rejects_elapsed_mismatch() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = verify_unspent_setup(rng);
+    let (user, note, unspent) = unspent_bind_setup(rng);
     let range = user.derived_range(rng, &note, EpochIndex(0), 4);
     // The genuine crossings in swapped order commit differently.
     let bogus_elapsed = NfSeqPoly::from_iter([
@@ -1407,7 +1563,7 @@ fn verify_unspent_rejects_elapsed_mismatch() {
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::VerifyUnspent,
+            pool::UnspentBind,
             (bogus_elapsed, nf_seq),
             unspent,
             range,
@@ -1419,14 +1575,14 @@ fn verify_unspent_rejects_elapsed_mismatch() {
     };
     assert_eq!(
         inner.to_string(),
-        "VerifyUnspent: elapsed polynomial does not match header"
+        "UnspentBind: elapsed polynomial does not match header"
     );
 }
 
 #[test]
-fn verify_unspent_rejects_wrong_start_epoch() {
+fn unspent_bind_rejects_wrong_start_epoch() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = verify_unspent_setup(rng);
+    let (user, note, unspent) = unspent_bind_setup(rng);
     let range = user.derived_range(rng, &note, EpochIndex(1), 4);
     let elapsed = NfSeqPoly::from_iter([
         user.nf_at(&note, EpochIndex(0)),
@@ -1441,7 +1597,7 @@ fn verify_unspent_rejects_wrong_start_epoch() {
     ]);
 
     let err = PROOF_SYSTEM
-        .fuse(rng, pool::VerifyUnspent, (elapsed, nf_seq), unspent, range)
+        .fuse(rng, pool::UnspentBind, (elapsed, nf_seq), unspent, range)
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {
@@ -1449,14 +1605,14 @@ fn verify_unspent_rejects_wrong_start_epoch() {
     };
     assert_eq!(
         inner.to_string(),
-        "VerifyUnspent: derived range does not start at the unspent's start epoch"
+        "UnspentBind: derived range does not start at the unspent's start epoch"
     );
 }
 
 #[test]
-fn verify_unspent_rejects_wrong_span() {
+fn unspent_bind_rejects_wrong_span() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = verify_unspent_setup(rng);
+    let (user, note, unspent) = unspent_bind_setup(rng);
     // A three-crossing lineage demands a range of exactly its crossings plus
     // the tip (four epochs); a five-epoch range overshoots.
     let range = user.derived_range(rng, &note, EpochIndex(0), 5);
@@ -1474,7 +1630,7 @@ fn verify_unspent_rejects_wrong_span() {
     ]);
 
     let err = PROOF_SYSTEM
-        .fuse(rng, pool::VerifyUnspent, (elapsed, nf_seq), unspent, range)
+        .fuse(rng, pool::UnspentBind, (elapsed, nf_seq), unspent, range)
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {
@@ -1482,14 +1638,14 @@ fn verify_unspent_rejects_wrong_span() {
     };
     assert_eq!(
         inner.to_string(),
-        "VerifyUnspent: derived range does not span the crossings plus the tip"
+        "UnspentBind: derived range does not span the crossings plus the tip"
     );
 }
 
 #[test]
-fn verify_unspent_rejects_wrong_range_poly() {
+fn unspent_bind_rejects_wrong_range_poly() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = verify_unspent_setup(rng);
+    let (user, note, unspent) = unspent_bind_setup(rng);
     let range = user.derived_range(rng, &note, EpochIndex(0), 4);
     let elapsed = NfSeqPoly::from_iter([
         user.nf_at(&note, EpochIndex(0)),
@@ -1507,7 +1663,7 @@ fn verify_unspent_rejects_wrong_range_poly() {
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::VerifyUnspent,
+            pool::UnspentBind,
             (elapsed, bogus_nf_seq),
             unspent,
             range,
@@ -1519,14 +1675,14 @@ fn verify_unspent_rejects_wrong_range_poly() {
     };
     assert_eq!(
         inner.to_string(),
-        "VerifyUnspent: range polynomial does not match header"
+        "UnspentBind: range polynomial does not match header"
     );
 }
 
 #[test]
-fn verify_unspent_rejects_start_nf_mismatch() {
+fn unspent_bind_rejects_start_nf_mismatch() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = verify_unspent_setup(rng);
+    let (user, note, unspent) = unspent_bind_setup(rng);
     // A range header whose `nf_start` disagrees with its own committed
     // sequence: the derivation steps never produce this, so it is carried
     // directly.
@@ -1554,7 +1710,7 @@ fn verify_unspent_rejects_start_nf_mismatch() {
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::VerifyUnspent,
+            pool::UnspentBind,
             (elapsed, nf_seq),
             unspent,
             forged_range,
@@ -1566,14 +1722,14 @@ fn verify_unspent_rejects_start_nf_mismatch() {
     };
     assert_eq!(
         inner.to_string(),
-        "VerifyUnspent: start nullifier does not match the derived range"
+        "UnspentBind: start nullifier does not match the derived range"
     );
 }
 
 #[test]
-fn verify_unspent_rejects_end_nf_mismatch() {
+fn unspent_bind_rejects_end_nf_mismatch() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let (user, note, unspent) = verify_unspent_setup(rng);
+    let (user, note, unspent) = unspent_bind_setup(rng);
     // The mirror forgery: `nf_end` disagrees with the committed sequence.
     let range = user.derived_range(rng, &note, EpochIndex(0), 4);
     let (nf_cm, (epoch_start, nf_start), seq_commit, (epoch_end, _nf_end)) = *range.data();
@@ -1599,7 +1755,7 @@ fn verify_unspent_rejects_end_nf_mismatch() {
     let err = PROOF_SYSTEM
         .fuse(
             rng,
-            pool::VerifyUnspent,
+            pool::UnspentBind,
             (elapsed, nf_seq),
             unspent,
             forged_range,
@@ -1611,7 +1767,7 @@ fn verify_unspent_rejects_end_nf_mismatch() {
     };
     assert_eq!(
         inner.to_string(),
-        "VerifyUnspent: end nullifier does not match the derived range"
+        "UnspentBind: end nullifier does not match the derived range"
     );
 }
 
@@ -1644,11 +1800,11 @@ fn spendable_lift_rejects_wrong_cm() {
     while pool.height() < target_height {
         pool.advance(1, |_| random_block(rng, 1, 2));
     }
-    let unspent = sync.build_next_unspent(rng, 0, &pool, target_height);
-    let verified = user.verify_unspent(rng, unspent, &phantom, EpochIndex(0), EpochIndex(1));
+    let arbitrary = sync.build_next_unspent(rng, 0, &pool, target_height);
+    let unspent = user.unspent_bind(rng, arbitrary, &phantom, EpochIndex(0), EpochIndex(1));
 
     let err = PROOF_SYSTEM
-        .fuse(rng, spendable::SpendableLift, (), spendable, verified)
+        .fuse(rng, spendable::SpendableLift, (), spendable, unspent)
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {
@@ -1656,7 +1812,80 @@ fn spendable_lift_rejects_wrong_cm() {
     };
     assert_eq!(
         inner.to_string(),
-        "SpendableLift: verified unspent cm does not match spendable"
+        "SpendableLift: unspent cm does not match spendable"
+    );
+}
+
+/// The range must derive from the lineage's own note.
+#[test]
+fn spendable_epoch_lift_rejects_wrong_note() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let other = user.random_note(700);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let spendable = user.spendable_init(rng, &note, &pool, init_height);
+    let range = user.derived_range(rng, &other, EpochIndex(0), 2);
+
+    let err = PROOF_SYSTEM
+        .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
+        .err()
+        .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(
+        inner.to_string(),
+        "SpendableEpochLift: derived range does not match note"
+    );
+}
+
+/// The range must open on the epoch the lineage is presently in.
+#[test]
+fn spendable_epoch_lift_rejects_wrong_epoch() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let spendable = user.spendable_init(rng, &note, &pool, init_height);
+    let range = user.derived_range(rng, &note, EpochIndex(1), 2);
+
+    let err = PROOF_SYSTEM
+        .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
+        .err()
+        .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(
+        inner.to_string(),
+        "SpendableEpochLift: derived range does not start at the lineage epoch"
+    );
+}
+
+/// The range spans exactly the two epochs the tick moves between.
+#[test]
+fn spendable_epoch_lift_rejects_multi_epoch_range() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(500);
+    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
+    let spendable = user.spendable_init(rng, &note, &pool, init_height);
+    let range = user.derived_range(rng, &note, EpochIndex(0), 3);
+
+    let err = PROOF_SYSTEM
+        .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
+        .err()
+        .unwrap();
+    let ragu::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(
+        inner.to_string(),
+        "SpendableEpochLift: derived range must span two epochs"
     );
 }
 
@@ -1670,16 +1899,16 @@ fn spendable_lift_rejects_non_adjacent_unspent() {
     pool.advance(1, |_| random_block(rng, 1, 2));
 
     let spendable = user.spendable_init(rng, &note, &pool, init_height);
-    let unspent = build_unspent_pcd_between_blocks(
+    let arbitrary = build_unspent_pcd_between_blocks(
         rng,
         &pool,
         &[user.nf_at(&note, EpochIndex(0))],
         init_height..=init_height,
     );
-    let verified = user.verify_unspent(rng, unspent, &note, EpochIndex(0), EpochIndex(0));
+    let unspent = user.unspent_bind(rng, arbitrary, &note, EpochIndex(0), EpochIndex(0));
 
     let err = PROOF_SYSTEM
-        .fuse(rng, spendable::SpendableLift, (), spendable, verified)
+        .fuse(rng, spendable::SpendableLift, (), spendable, unspent)
         .err()
         .unwrap();
     let ragu::Error::InvalidWitness(inner) = err else {

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -1245,6 +1245,71 @@ fn spendable_epoch_lift_advances_from_an_epoch_tip() {
     assert_eq!(lifted.data().2, pool.anchor_at(target_height));
 }
 
+/// Nothing constrains the lifted lineage to sit on its epoch's terminal
+/// anchor. Ticking a mid-epoch anchor succeeds in-circuit and emits an anchor
+/// no block ever published, so consensus anchor membership of the eventual
+/// spend is what rejects it.
+#[test]
+fn spendable_epoch_lift_accepts_a_mid_epoch_anchor() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(300);
+    let cm_height = mine_cm_in_epoch_one(rng, &mut pool, note.commitment());
+    let epoch = cm_height.epoch();
+
+    // The cm-block carries four stamps, so the lineage sits on the cm-stamp's
+    // post anchor: on the published sequence, but neither the block's terminal
+    // anchor nor the epoch's.
+    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
+    let mid_epoch_anchor = spendable.data().2;
+    assert_ne!(
+        mid_epoch_anchor,
+        pool.anchor_at(cm_height),
+        "the lineage sits mid-block"
+    );
+
+    // Fill out the epoch and enter the next, so the genuine boundary tick is
+    // published and the forged one has something to differ from.
+    while pool.height().epoch().0 == epoch.0 {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+    assert_ne!(
+        mid_epoch_anchor,
+        pool.pre_epoch_anchor(epoch.next()),
+        "the lineage sits mid-epoch"
+    );
+
+    let lifted = user.epoch_lift(rng, spendable, &note);
+    assert_eq!(
+        *lifted.data(),
+        (
+            note.commitment(),
+            (epoch.next(), user.nf_at(&note, epoch.next())),
+            mid_epoch_anchor.next_epoch(epoch.next())
+        ),
+        "the tick advances from the mid-epoch anchor"
+    );
+
+    // The published sequence is each block's entry anchor, which carries the
+    // epoch ticks, followed by one post anchor per stamp it contains.
+    let forged_anchor = lifted.data().2;
+    for height in (0..=pool.height().0).map(BlockHeight) {
+        let mut anchor = pool.prev_anchor_at(height);
+        assert_ne!(
+            forged_anchor, anchor,
+            "forged anchor must be absent from the published sequence"
+        );
+        for commit in pool.stamp_commits_at(height) {
+            anchor = anchor.next_stamp(height.epoch(), &commit);
+            assert_ne!(
+                forged_anchor, anchor,
+                "forged anchor must be absent from the published sequence"
+            );
+        }
+    }
+}
+
 /// The empty-epoch seed is the segment `UnspentEpochFuse` splices against on
 /// each side of a stampless epoch.
 #[test]

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -754,8 +754,8 @@ fn unspent_lift_spans_partial_and_whole_epochs() {
 
     // Advance to a mid-epoch-3 block (neither first nor last) so the last epoch is
     // also partial; epochs 1 and 2 are covered whole. The block-granular tree
-    // therefore mixes mid-epoch `UnspentFuse` (incl. multi-epoch right at upper
-    // merges) with boundary `UnspentEpochFuse`. One interior empty block sits in
+    // therefore mixes stamp leaves (incl. multi-epoch right at upper
+    // merges) with boundary crossing leaves. One interior empty block sits in
     // the walk, contributing no leaf.
     let empty_height = BlockHeight(EPOCH_SIZE + 4);
     let target_height = BlockHeight(3 * EPOCH_SIZE + 7);
@@ -969,7 +969,7 @@ fn unspent_fuse_rejects_epoch_boundary_crossing() {
     let left_end = left.data().4;
     // A forged epoch-1 right half rooted directly at `left.anchor_last` (no
     // `next_epoch` fold). The anchors line up, but the epoch labels reveal a
-    // boundary the fuse refuses to cross: that is `UnspentEpochFuse`'s job.
+    // boundary the fuse refuses to cross: a crossing needs its own segment.
     let stamp = [Tachygram::random(&mut *rng)];
     let forged_right = build_unspent_seed_pcd(rng, left_end, EpochIndex(1), &stamp, nf1);
 
@@ -1085,147 +1085,6 @@ fn end_epoch_unspent_seed_composes_across_a_boundary() {
         NfSeqPoly::from_iter([nf0, nf1, nf2, nf3]).commit(),
         "the crossing seed carries left's tip into the merged history"
     );
-}
-
-/// Phase-1 equivalence: a crossing seed spliced between two halves by two
-/// plain fuses reproduces `UnspentEpochFuse`'s header exactly.
-#[test]
-fn end_epoch_unspent_seed_reproduces_the_epoch_fuse() {
-    let (nf, left, right) = epoch_fuse_setup(&mut StdRng::seed_from_u64(0));
-    let rng = &mut StdRng::seed_from_u64(0);
-    let (_, alt_left, alt_right) = epoch_fuse_setup(&mut StdRng::seed_from_u64(0));
-
-    let (fused, ()) = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentEpochFuse,
-            witness::unspent_epoch_fuse((*left.data(), *right.data()), &nf[..2], &nf[3..4]),
-            left,
-            right,
-        )
-        .expect("UnspentEpochFuse");
-
-    let (_, _, _, (left_epoch_end, left_nf_end), left_anchor_last) = *alt_left.data();
-    let (_, (_, right_nf_start), ..) = *alt_right.data();
-    let (seed, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::EndEpochUnspentSeed,
-            witness::end_epoch_unspent_seed(
-                ((), ()),
-                left_anchor_last,
-                left_epoch_end,
-                left_nf_end,
-                right_nf_start,
-            ),
-        )
-        .expect("EndEpochUnspentSeed");
-    let (crossed, ()) = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentFuse,
-            witness::unspent_fuse((*alt_left.data(), *seed.data()), &nf[..2], &nf[2..3]),
-            alt_left,
-            seed,
-        )
-        .expect("UnspentFuse over the crossing");
-    let (alt_fused, ()) = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentFuse,
-            witness::unspent_fuse((*crossed.data(), *alt_right.data()), &nf[..3], &nf[3..4]),
-            crossed,
-            alt_right,
-        )
-        .expect("UnspentFuse onto the right half");
-
-    assert_eq!(*alt_fused.data(), *fused.data());
-}
-
-/// Phase-1 equivalence: a silent epoch's point segment adds nothing to the
-/// crossing that enters it, so the empty-epoch seed is redundant.
-#[test]
-fn end_epoch_unspent_seed_absorbs_the_empty_epoch_seed() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let epoch_tip = Anchor::from(Fp::random(&mut *rng));
-    let nf_out = Nullifier::from(Fp::random(&mut *rng));
-    let nf_in = Nullifier::from(Fp::random(&mut *rng));
-    let epoch = EpochIndex(4);
-
-    let (seed, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::EndEpochUnspentSeed,
-            witness::end_epoch_unspent_seed(((), ()), epoch_tip, epoch, nf_out, nf_in),
-        )
-        .expect("EndEpochUnspentSeed");
-    let expected = *seed.data();
-
-    let (empty, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::EmptyEpochUnspentSeed,
-            witness::empty_epoch_unspent_seed(((), ()), epoch_tip, epoch.next(), nf_in),
-        )
-        .expect("EmptyEpochUnspentSeed");
-    let (fused, ()) = PROOF_SYSTEM
-        .fuse(
-            rng,
-            pool::UnspentFuse,
-            witness::unspent_fuse((*seed.data(), *empty.data()), &[nf_out], &[]),
-            seed,
-            empty,
-        )
-        .expect("UnspentFuse");
-
-    assert_eq!(*fused.data(), expected);
-}
-
-/// Phase-1 equivalence: `SpendableEpochLift` decomposes into a crossing seed,
-/// an ordinary bind and an ordinary lift.
-#[test]
-fn end_epoch_unspent_seed_reproduces_the_spendable_epoch_lift() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(300);
-    pool.mine(vec![vec![note.commitment().into()]]);
-    let cm_height = pool.height();
-    while pool.height().0 + 1 < EPOCH_SIZE {
-        pool.advance(1, |_| Vec::new());
-    }
-    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
-    let alt_spendable = user.spendable_init(rng, &note, &pool, cm_height);
-    let epoch0_tip = spendable.data().2;
-
-    let range = user.derived_range(rng, &note, EpochIndex(0), 2);
-    let (at_boundary, ()) = PROOF_SYSTEM
-        .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
-        .expect("SpendableEpochLift");
-
-    let (seed, ()) = PROOF_SYSTEM
-        .seed(
-            rng,
-            pool::EndEpochUnspentSeed,
-            witness::end_epoch_unspent_seed(
-                ((), ()),
-                epoch0_tip,
-                EpochIndex(0),
-                user.nf_at(&note, EpochIndex(0)),
-                user.nf_at(&note, EpochIndex(1)),
-            ),
-        )
-        .expect("EndEpochUnspentSeed");
-    let alt_at_boundary = user.lift(
-        rng,
-        alt_spendable,
-        seed,
-        &note,
-        EpochIndex(0),
-        EpochIndex(1),
-    );
-
-    assert_eq!(*alt_at_boundary.data(), *at_boundary.data());
 }
 
 /// The seed spans exactly one boundary link, recording the epoch it leaves.

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -25,7 +25,6 @@ use crate::{
         PoolSim, SyncSim, WalletSim, build_anchor_chain_pcd, build_output_plan, build_output_stamp,
         build_unspent_pcd_between_anchors, build_unspent_pcd_between_blocks,
         build_unspent_seed_pcd, random_block, random_block_with, shared_sk, spend_witness,
-        spendable_init_inputs,
     },
     note,
     nullifier::{self, Nullifier},
@@ -109,92 +108,6 @@ fn same_epoch_honest_spend_accepted() {
     PROOF_SYSTEM
         .rerandomize(stamp, rng)
         .expect("rerandomize honest same-epoch spend");
-}
-
-#[test]
-fn same_epoch_wrong_index_accepted_but_off_sequence() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    let cm_height = mine_cm_in_epoch_one(rng, &mut pool, note.commitment());
-    let wrong = EpochIndex(cm_height.epoch().0 + 2);
-
-    // Honest pre-cm anchor, wrong-epoch derivation: every in-circuit check
-    // passes, but the emitted anchor folds `wrong` and so sits off the
-    // published sequence; consensus anchor membership rejects the eventual
-    // spend.
-    let (pre_cm_anchor, creation_set) = spendable_init_inputs(&pool, note.commitment(), cm_height);
-    let present_nf = user.nf_at(&note, wrong);
-    let nf_wrong = user.derived_range(rng, &note, wrong, 1);
-    let (spendable, ()) = PROOF_SYSTEM
-        .fuse(
-            rng,
-            spendable::SpendableInit,
-            witness::spendable_init(
-                (*nf_wrong.data(), ()),
-                pre_cm_anchor,
-                &creation_set,
-                present_nf,
-            ),
-            nf_wrong,
-            Proof::trivial().carry::<()>(()),
-        )
-        .expect("SpendableInit accepts the wrong-index derivation");
-
-    let cm_commit = TachygramSetPoly::from_iter(creation_set).commit();
-    let anchor = spendable.data().2;
-    assert_eq!(anchor, pre_cm_anchor.next_stamp(wrong, &cm_commit));
-    let off_sequence =
-        (0..=cm_height.0).all(|height| pool.anchor_at(BlockHeight(height)) != anchor);
-    assert!(
-        off_sequence,
-        "wrong-index anchor must be absent from the published sequence"
-    );
-}
-
-#[test]
-fn spendable_init_accepts_forged_anchor() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    let cm = note.commitment();
-    let cm_height = mine_cm_in_epoch_one(rng, &mut pool, cm);
-    let epoch = cm_height.epoch();
-
-    // Arbitrary `pre_cm_anchor = x` at the correct epoch: the circuit accepts
-    // (the witness is free by design), but the emitted anchor descends from
-    // `x` rather than a chain member, so consensus anchor membership is what
-    // rejects the eventual spend.
-    let stamps = pool.tachygrams_at(cm_height);
-    let cm_idx = stamps
-        .iter()
-        .position(|tgs| tgs.contains(&cm.into()))
-        .expect("cm present in cm-block");
-    let x = Anchor::from(Fp::random(&mut *rng));
-    let cm_commit = TachygramSetPoly::from_iter(stamps[cm_idx].clone()).commit();
-
-    let present_nf = user.nf_at(&note, epoch);
-    let nf_header = user.derived_range(rng, &note, epoch, 1);
-    let (forged_spendable, ()) = PROOF_SYSTEM
-        .fuse(
-            rng,
-            spendable::SpendableInit,
-            witness::spendable_init((*nf_header.data(), ()), x, &stamps[cm_idx], present_nf),
-            nf_header,
-            Proof::trivial().carry::<()>(()),
-        )
-        .expect("SpendableInit accepts the forged anchor");
-
-    let forged_anchor = forged_spendable.data().2;
-    assert_eq!(forged_anchor, x.next_stamp(epoch, &cm_commit));
-    let forged_off_sequence =
-        (0..=cm_height.0).all(|height| pool.anchor_at(BlockHeight(height)) != forged_anchor);
-    assert!(
-        forged_off_sequence,
-        "forged anchor must be absent from the published sequence"
-    );
 }
 
 #[test]
@@ -1291,23 +1204,14 @@ fn spendable_epoch_lift_accepts_a_mid_epoch_anchor() {
         "the tick advances from the mid-epoch anchor"
     );
 
-    // The published sequence is each block's entry anchor, which carries the
-    // epoch ticks, followed by one post anchor per stamp it contains.
+    // Consensus acknowledges each block's terminal anchor only.
     let forged_anchor = lifted.data().2;
-    for height in (0..=pool.height().0).map(BlockHeight) {
-        let mut anchor = pool.prev_anchor_at(height);
-        assert_ne!(
-            forged_anchor, anchor,
-            "forged anchor must be absent from the published sequence"
-        );
-        for commit in pool.stamp_commits_at(height) {
-            anchor = anchor.next_stamp(height.epoch(), &commit);
-            assert_ne!(
-                forged_anchor, anchor,
-                "forged anchor must be absent from the published sequence"
-            );
-        }
-    }
+    let off_sequence =
+        (0..=pool.height().0).all(|height| pool.anchor_at(BlockHeight(height)) != forged_anchor);
+    assert!(
+        off_sequence,
+        "forged anchor must be absent from the published sequence"
+    );
 }
 
 /// The empty-epoch seed is the segment `UnspentEpochFuse` splices against on
@@ -1881,77 +1785,51 @@ fn spendable_lift_rejects_wrong_cm() {
     );
 }
 
-/// The range must derive from the lineage's own note.
 #[test]
-fn spendable_epoch_lift_rejects_wrong_note() {
+fn spendable_epoch_lift_rejects_bad_range() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(500);
     let other = user.random_note(700);
     let init_height = mine_cm_block(rng, &mut pool, note.commitment());
-    let spendable = user.spendable_init(rng, &note, &pool, init_height);
-    let range = user.derived_range(rng, &other, EpochIndex(0), 2);
 
-    let err = PROOF_SYSTEM
-        .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "SpendableEpochLift: derived range does not match note"
-    );
-}
+    let cases = [
+        // The range must derive from the lineage's own note.
+        (
+            &other,
+            EpochIndex(0),
+            2,
+            "SpendableEpochLift: derived range does not match note",
+        ),
+        // The range must open on the epoch the lineage is presently in.
+        (
+            &note,
+            EpochIndex(1),
+            2,
+            "SpendableEpochLift: derived range does not start at the lineage epoch",
+        ),
+        // The range spans exactly the two epochs the tick moves between.
+        (
+            &note,
+            EpochIndex(0),
+            3,
+            "SpendableEpochLift: derived range must span two epochs",
+        ),
+    ];
 
-/// The range must open on the epoch the lineage is presently in.
-#[test]
-fn spendable_epoch_lift_rejects_wrong_epoch() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
-    let spendable = user.spendable_init(rng, &note, &pool, init_height);
-    let range = user.derived_range(rng, &note, EpochIndex(1), 2);
-
-    let err = PROOF_SYSTEM
-        .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "SpendableEpochLift: derived range does not start at the lineage epoch"
-    );
-}
-
-/// The range spans exactly the two epochs the tick moves between.
-#[test]
-fn spendable_epoch_lift_rejects_multi_epoch_range() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(500);
-    let init_height = mine_cm_block(rng, &mut pool, note.commitment());
-    let spendable = user.spendable_init(rng, &note, &pool, init_height);
-    let range = user.derived_range(rng, &note, EpochIndex(0), 3);
-
-    let err = PROOF_SYSTEM
-        .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
-        .err()
-        .unwrap();
-    let ragu::Error::InvalidWitness(inner) = err else {
-        panic!("expected InvalidWitness, got {err:?}");
-    };
-    assert_eq!(
-        inner.to_string(),
-        "SpendableEpochLift: derived range must span two epochs"
-    );
+    for (range_note, epoch_start, len, expected) in cases {
+        let spendable = user.spendable_init(rng, &note, &pool, init_height);
+        let range = user.derived_range(rng, range_note, epoch_start, len);
+        let err = PROOF_SYSTEM
+            .fuse(rng, spendable::SpendableEpochLift, (), spendable, range)
+            .err()
+            .unwrap_or_else(|| panic!("SpendableEpochLift accepted {expected}"));
+        let ragu::Error::InvalidWitness(inner) = err else {
+            panic!("expected InvalidWitness for {expected}, got {err:?}");
+        };
+        assert_eq!(inner.to_string(), expected);
+    }
 }
 
 #[test]

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -1158,62 +1158,6 @@ fn spendable_epoch_lift_advances_from_an_epoch_tip() {
     assert_eq!(lifted.data().2, pool.anchor_at(target_height));
 }
 
-/// Nothing constrains the lifted lineage to sit on its epoch's terminal
-/// anchor. Ticking a mid-epoch anchor succeeds in-circuit and emits an anchor
-/// no block ever published, so consensus anchor membership of the eventual
-/// spend is what rejects it.
-#[test]
-fn spendable_epoch_lift_accepts_a_mid_epoch_anchor() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let user = WalletSim::new(shared_sk());
-    let mut pool = PoolSim::genesis(rng);
-    let note = user.random_note(300);
-    let cm_height = mine_cm_in_epoch_one(rng, &mut pool, note.commitment());
-    let epoch = cm_height.epoch();
-
-    // The cm-block carries four stamps, so the lineage sits on the cm-stamp's
-    // post anchor: on the published sequence, but neither the block's terminal
-    // anchor nor the epoch's.
-    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
-    let mid_epoch_anchor = spendable.data().2;
-    assert_ne!(
-        mid_epoch_anchor,
-        pool.anchor_at(cm_height),
-        "the lineage sits mid-block"
-    );
-
-    // Fill out the epoch and enter the next, so the genuine boundary tick is
-    // published and the forged one has something to differ from.
-    while pool.height().epoch().0 == epoch.0 {
-        pool.advance(1, |_| random_block(rng, 1, 2));
-    }
-    assert_ne!(
-        mid_epoch_anchor,
-        pool.pre_epoch_anchor(epoch.next()),
-        "the lineage sits mid-epoch"
-    );
-
-    let lifted = user.epoch_lift(rng, spendable, &note);
-    assert_eq!(
-        *lifted.data(),
-        (
-            note.commitment(),
-            (epoch.next(), user.nf_at(&note, epoch.next())),
-            mid_epoch_anchor.next_epoch(epoch.next())
-        ),
-        "the tick advances from the mid-epoch anchor"
-    );
-
-    // Consensus acknowledges each block's terminal anchor only.
-    let forged_anchor = lifted.data().2;
-    let off_sequence =
-        (0..=pool.height().0).all(|height| pool.anchor_at(BlockHeight(height)) != forged_anchor);
-    assert!(
-        off_sequence,
-        "forged anchor must be absent from the published sequence"
-    );
-}
-
 /// The empty-epoch seed is the segment `UnspentEpochFuse` splices against on
 /// each side of a stampless epoch.
 #[test]

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -1065,6 +1065,144 @@ fn unspent_epoch_fuse_composes() {
     );
 }
 
+/// Phase-1 equivalence: a crossing seed spliced between two halves by two
+/// plain fuses reproduces `UnspentEpochFuse`'s header exactly.
+#[test]
+fn end_epoch_unspent_seed_reproduces_the_epoch_fuse() {
+    let (nf, left, right) = epoch_fuse_setup(&mut StdRng::seed_from_u64(0));
+    let rng = &mut StdRng::seed_from_u64(0);
+    let (_, alt_left, alt_right) = epoch_fuse_setup(&mut StdRng::seed_from_u64(0));
+
+    let (fused, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            pool::UnspentEpochFuse,
+            witness::unspent_epoch_fuse((*left.data(), *right.data()), &nf[..2], &nf[3..4]),
+            left,
+            right,
+        )
+        .expect("UnspentEpochFuse");
+
+    let (_, _, _, (left_epoch_end, left_nf_end), left_anchor_last) = *alt_left.data();
+    let (_, (_, right_nf_start), ..) = *alt_right.data();
+    let (seed, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(
+                ((), ()),
+                left_anchor_last,
+                left_epoch_end,
+                left_nf_end,
+                right_nf_start,
+            ),
+        )
+        .expect("EndEpochUnspentSeed");
+    let (crossed, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            pool::UnspentFuse,
+            witness::unspent_fuse((*alt_left.data(), *seed.data()), &nf[..2], &nf[2..3]),
+            alt_left,
+            seed,
+        )
+        .expect("UnspentFuse over the crossing");
+    let (alt_fused, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            pool::UnspentFuse,
+            witness::unspent_fuse((*crossed.data(), *alt_right.data()), &nf[..3], &nf[3..4]),
+            crossed,
+            alt_right,
+        )
+        .expect("UnspentFuse onto the right half");
+
+    assert_eq!(*alt_fused.data(), *fused.data());
+}
+
+/// Phase-1 equivalence: a silent epoch's point segment adds nothing to the
+/// crossing that enters it, so the empty-epoch seed is redundant.
+#[test]
+fn end_epoch_unspent_seed_absorbs_the_empty_epoch_seed() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let epoch_tip = Anchor::from(Fp::random(&mut *rng));
+    let nf_out = Nullifier::from(Fp::random(&mut *rng));
+    let nf_in = Nullifier::from(Fp::random(&mut *rng));
+    let epoch = EpochIndex(4);
+
+    let (seed, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(((), ()), epoch_tip, epoch, nf_out, nf_in),
+        )
+        .expect("EndEpochUnspentSeed");
+    let expected = *seed.data();
+
+    let (empty, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EmptyEpochUnspentSeed,
+            witness::empty_epoch_unspent_seed(((), ()), epoch_tip, epoch.next(), nf_in),
+        )
+        .expect("EmptyEpochUnspentSeed");
+    let (fused, ()) = PROOF_SYSTEM
+        .fuse(
+            rng,
+            pool::UnspentFuse,
+            witness::unspent_fuse((*seed.data(), *empty.data()), &[nf_out], &[]),
+            seed,
+            empty,
+        )
+        .expect("UnspentFuse");
+
+    assert_eq!(*fused.data(), expected);
+}
+
+/// Phase-1 equivalence: `SpendableEpochLift` decomposes into a crossing seed,
+/// an ordinary bind and an ordinary lift.
+#[test]
+fn end_epoch_unspent_seed_reproduces_the_spendable_epoch_lift() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let mut pool = PoolSim::genesis(rng);
+    let note = user.random_note(300);
+    pool.mine(vec![vec![note.commitment().into()]]);
+    let cm_height = pool.height();
+    while pool.height().0 + 1 < EPOCH_SIZE {
+        pool.advance(1, |_| Vec::new());
+    }
+    let spendable = user.spendable_init(rng, &note, &pool, cm_height);
+    let alt_spendable = user.spendable_init(rng, &note, &pool, cm_height);
+    let epoch0_tip = spendable.data().2;
+
+    let at_boundary = user.epoch_lift(rng, spendable, &note);
+
+    let (seed, ()) = PROOF_SYSTEM
+        .seed(
+            rng,
+            pool::EndEpochUnspentSeed,
+            witness::end_epoch_unspent_seed(
+                ((), ()),
+                epoch0_tip,
+                EpochIndex(0),
+                user.nf_at(&note, EpochIndex(0)),
+                user.nf_at(&note, EpochIndex(1)),
+            ),
+        )
+        .expect("EndEpochUnspentSeed");
+    let alt_at_boundary = user.lift(
+        rng,
+        alt_spendable,
+        seed,
+        &note,
+        EpochIndex(0),
+        EpochIndex(1),
+    );
+
+    assert_eq!(*alt_at_boundary.data(), *at_boundary.data());
+}
+
 /// An empty epoch has one anchor, so the seed is a point segment at it.
 #[test]
 fn empty_epoch_unspent_seed_is_a_point_at_the_boundary() {

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -17,7 +17,10 @@ use crate::{
     },
     stamp::proof::{
         delegation::NullifierFuse,
-        pool::{AnchorSeed, UnspentEpochFuse, UnspentFuse, UnspentSeed, VerifyUnspent},
+        pool::{
+            AnchorSeed, EmptyEpochUnspentSeed, UnspentBind, UnspentEpochFuse, UnspentFuse,
+            UnspentSeed,
+        },
         spendable::SpendableInit,
         stamp::MergeStamp,
     },
@@ -62,6 +65,21 @@ pub fn unspent_seed(
     )
 }
 
+/// Prepare the witness for [`EmptyEpochUnspentSeed`]:
+/// `(prev_epoch_tip, (epoch, nf))`.
+#[must_use]
+pub const fn empty_epoch_unspent_seed(
+    (_left, _right): (
+        StepLeft<EmptyEpochUnspentSeed>,
+        StepRight<EmptyEpochUnspentSeed>,
+    ),
+    prev_epoch_tip: Anchor,
+    epoch: EpochIndex,
+    nf: Nullifier,
+) -> StepWitness<'static, EmptyEpochUnspentSeed> {
+    (prev_epoch_tip, (epoch, nf))
+}
+
 /// Prepare the witness for [`UnspentFuse`]:
 /// `(left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq)`.
 #[must_use]
@@ -95,16 +113,16 @@ pub fn unspent_epoch_fuse(
     )
 }
 
-/// Prepare the witness for [`VerifyUnspent`]: `(elapsed, nf_seq)`.
+/// Prepare the witness for [`UnspentBind`]: `(elapsed, nf_seq)`.
 ///
 /// The range appends the tip `nf_end` from the left
-/// [`Unspent`](crate::stamp::proof::pool::Unspent) header:
+/// [`ArbitraryUnspent`](crate::stamp::proof::pool::ArbitraryUnspent) header:
 /// `nf_seq = elapsed ++ [nf_end]`.
 #[must_use]
-pub fn verify_unspent(
-    (left, _right): (StepLeft<VerifyUnspent>, StepRight<VerifyUnspent>),
+pub fn unspent_bind(
+    (left, _right): (StepLeft<UnspentBind>, StepRight<UnspentBind>),
     elapsed: &[Nullifier],
-) -> StepWitness<'static, VerifyUnspent> {
+) -> StepWitness<'static, UnspentBind> {
     let (_, _, _, (_, nf_end), _) = left;
     let mut nf_seq: Vec<Nullifier> = elapsed.to_vec();
     nf_seq.push(nf_end);
@@ -115,17 +133,16 @@ pub fn verify_unspent(
 }
 
 /// Prepare the witness for [`SpendableInit`]:
-/// `((pre_epoch_anchor, pre_cm_anchor), creation_set, present_nf)`.
+/// `(pre_cm_anchor, creation_set, present_nf)`.
 #[must_use]
 pub fn spendable_init(
     (_left, _right): (StepLeft<SpendableInit>, StepRight<SpendableInit>),
-    pre_epoch_anchor: Anchor,
     pre_cm_anchor: Anchor,
     creation_tgs: &[Tachygram],
     present_nf: Nullifier,
 ) -> StepWitness<'static, SpendableInit> {
     (
-        (pre_epoch_anchor, pre_cm_anchor),
+        pre_cm_anchor,
         creation_tgs.iter().copied().collect::<TachygramSetPoly>(),
         present_nf,
     )

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -17,10 +17,7 @@ use crate::{
     },
     stamp::proof::{
         delegation::NullifierFuse,
-        pool::{
-            AnchorSeed, EmptyEpochUnspentSeed, EndEpochUnspentSeed, UnspentBind, UnspentEpochFuse,
-            UnspentFuse, UnspentSeed,
-        },
+        pool::{AnchorSeed, EndEpochUnspentSeed, UnspentBind, UnspentFuse, UnspentSeed},
         spendable::SpendableInit,
         stamp::MergeStamp,
     },
@@ -65,23 +62,8 @@ pub fn unspent_seed(
     )
 }
 
-/// Prepare the witness for [`EmptyEpochUnspentSeed`]:
-/// `(prev_epoch_tip, (epoch, nf))`.
-#[must_use]
-pub const fn empty_epoch_unspent_seed(
-    (_left, _right): (
-        StepLeft<EmptyEpochUnspentSeed>,
-        StepRight<EmptyEpochUnspentSeed>,
-    ),
-    prev_epoch_tip: Anchor,
-    epoch: EpochIndex,
-    nf: Nullifier,
-) -> StepWitness<'static, EmptyEpochUnspentSeed> {
-    (prev_epoch_tip, (epoch, nf))
-}
-
 /// Prepare the witness for [`EndEpochUnspentSeed`]:
-/// `(epoch_tip, (epoch, nf_out), nf_in)`.
+/// `(anchor_prev, (epoch_prev, nf_prev), nf)`.
 #[must_use]
 pub const fn end_epoch_unspent_seed(
     (_left, _right): (
@@ -105,23 +87,6 @@ pub fn unspent_fuse(
     right_elapsed: &[Nullifier],
 ) -> StepWitness<'static, UnspentFuse> {
     let combined = [left_elapsed, right_elapsed].concat();
-    (
-        left_elapsed.iter().copied().collect::<NfSeqPoly>(),
-        combined.into_iter().collect::<NfSeqPoly>(),
-        right_elapsed.iter().copied().collect::<NfSeqPoly>(),
-    )
-}
-
-/// Prepare the witness for [`UnspentEpochFuse`]:
-/// `(left_elapsed_seq, combined_elapsed_seq, right_elapsed_seq)`.
-#[must_use]
-pub fn unspent_epoch_fuse(
-    (left, _right): (StepLeft<UnspentEpochFuse>, StepRight<UnspentEpochFuse>),
-    left_elapsed: &[Nullifier],
-    right_elapsed: &[Nullifier],
-) -> StepWitness<'static, UnspentEpochFuse> {
-    let (_, _, _, (_, nf_end), _) = left;
-    let combined = [left_elapsed, &[nf_end], right_elapsed].concat();
     (
         left_elapsed.iter().copied().collect::<NfSeqPoly>(),
         combined.into_iter().collect::<NfSeqPoly>(),

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -18,8 +18,8 @@ use crate::{
     stamp::proof::{
         delegation::NullifierFuse,
         pool::{
-            AnchorSeed, EmptyEpochUnspentSeed, UnspentBind, UnspentEpochFuse, UnspentFuse,
-            UnspentSeed,
+            AnchorSeed, EmptyEpochUnspentSeed, EndEpochUnspentSeed, UnspentBind, UnspentEpochFuse,
+            UnspentFuse, UnspentSeed,
         },
         spendable::SpendableInit,
         stamp::MergeStamp,
@@ -78,6 +78,22 @@ pub const fn empty_epoch_unspent_seed(
     nf: Nullifier,
 ) -> StepWitness<'static, EmptyEpochUnspentSeed> {
     (prev_epoch_tip, (epoch, nf))
+}
+
+/// Prepare the witness for [`EndEpochUnspentSeed`]:
+/// `(epoch_tip, (epoch, nf_out), nf_in)`.
+#[must_use]
+pub const fn end_epoch_unspent_seed(
+    (_left, _right): (
+        StepLeft<EndEpochUnspentSeed>,
+        StepRight<EndEpochUnspentSeed>,
+    ),
+    anchor_prev: Anchor,
+    epoch_prev: EpochIndex,
+    nf_prev: Nullifier,
+    nf: Nullifier,
+) -> StepWitness<'static, EndEpochUnspentSeed> {
+    (anchor_prev, (epoch_prev, nf_prev), nf)
 }
 
 /// Prepare the witness for [`UnspentFuse`]:


### PR DESCRIPTION
the anchor now digests the epoch index at every increment, and no longer changes
when passing an empty block.

the anchor's domain-separated epoch tick remains present.

- removed `EmptyBlockSeed`
- removed `EmptyBlockUnspentSeed`
- removed `UnspentEpochFuse`
- `EndEpochUnspentSeed` is added to transit an epoch boundary
- `SpendableHeader` now carries an epoch field
- `SpendableInit` no longer requires an `AnchorChain` input to bind its epoch

some other renames:
- renamed header `Unspent` to `ArbitraryUnspent`
- renamed header `VerifiedUnspent` to `Unspent`
- renamed step `VerifyUnspent` to `UnspentBind`