### PR TITLE
ci: zizmor audit fix

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install mdbook and plugins
         uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # v2.79.7


### PR DESCRIPTION
ran with `zizmor ./ --fix=all` for [CI security ](https://docs.zizmor.sh/) best practice.