### PR TITLE
feat: provide bundle and stamp lifting methods

### DIFF
--- a/book/src/domain-separators.md
+++ b/book/src/domain-separators.md
@@ -66,8 +66,8 @@ These are all Tachyon-specific digests, performed in-circuit.
 | Output padding tachygram | `Tachyon-PadDeriv` |
 | Action digest | `Tachyon-ActionDg` |
 | Payment key derivation | `Tachyon-PkDerive` |
-| Anchor stamp step | `Tachyon-StampFld` |
-| Anchor epoch step | `Tachyon-EpochStp` |
+| Anchor stamp step | `Tachyon-AnchorSt` |
+| Anchor epoch step | `Tachyon-AnchorEp` |
 
 ## Hash-to-curve
 

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -291,9 +291,6 @@ pub enum LiftError {
     /// No lift is needed.
     #[display("no lift is needed")]
     NoLift,
-    /// Action digest construction failed (cv or rk was the identity point).
-    #[display("action digest failed: {_0}")]
-    ActionDigest(ActionDigestError),
     /// A provided anchor input could not advance the anchor.
     #[display("anchor step failed: {_0}")]
     AnchorError(AnchorError),
@@ -302,7 +299,7 @@ pub enum LiftError {
     AnchorContinuityFailed(ragu::Error),
     /// The stamp lift itself failed
     #[display("stamp lift failed: {_0}")]
-    LiftFailed(ragu::Error),
+    LiftFailed(stamp::ProveError),
 }
 
 /// Errors during bundle verification.
@@ -567,14 +564,11 @@ impl Bundle<ProofStamp> {
         adjuncts: &[&Bundle<dyn StampState>],
         (epoch, tachygram_sets): (EpochIndex, Vec<TachygramSetCommit>),
     ) -> Result<Self, LiftError> {
-        let own_digests = self.actions.iter().map(|&action| action.digest());
-        let other_digests = adjuncts
-            .iter()
-            .flat_map(|&adj| adj.actions.iter().map(|&action| action.digest()));
-        let action_digests = own_digests
-            .chain(other_digests)
-            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
-            .map_err(LiftError::ActionDigest)?;
+        let descriptors: BTreeSet<action::Descriptor> = self
+            .descriptors()
+            .into_iter()
+            .chain(adjuncts.iter().flat_map(|&adj| adj.descriptors()))
+            .collect();
 
         let anchor_chain = {
             let seed_witnesses: Vec<(Anchor, EpochIndex, TachygramSetCommit)> = tachygram_sets
@@ -613,7 +607,7 @@ impl Bundle<ProofStamp> {
 
         let stamp = self
             .stamp
-            .lift(rng, action_digests, anchor_chain)
+            .lift(rng, &descriptors, anchor_chain)
             .map_err(LiftError::LiftFailed)?;
 
         Ok(Self { stamp, ..self })

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -98,7 +98,7 @@ use crate::{
     keys::{private, public},
     primitives::{Anchor, AnchorError, EpochIndex, effect},
     reddsa, serialization,
-    stamp::{self, AggregateIdError, PointerStamp, ProofStamp, StampState, Unproven},
+    stamp::{self, AggregateIdError, PointerStamp, ProofStamp, ProveError, StampState, Unproven},
     value,
 };
 
@@ -290,7 +290,7 @@ pub enum LiftError {
     AnchorError(AnchorError),
     /// The stamp lift itself failed.
     #[display("stamp lift failed: {_0}")]
-    LiftFailed(stamp::ProveError),
+    LiftFailed(ProveError),
 }
 
 /// Errors during bundle verification.
@@ -544,27 +544,11 @@ impl Bundle<ProofStamp> {
 
     /// Advance the stamp's anchor across the stamps that follow it.
     ///
-    /// `(epoch, next_bundles)` must contain the epoch index of this bundle's
-    /// anchor and the bundles stamped immediately after it, in chain order.
-    /// Only their tachygram set commitments are read; the anchor chain is
-    /// folded from this bundle's own anchor, so a following bundle's anchor
-    /// does not have to be its position in the chain. Following stamps should
-    /// be obtained from consensus data.
+    /// Provide the consensus sequence of proof-stamped bundles immediately
+    /// following this bundle's anchor as `next_bundles`.
     ///
-    /// The actions of `adjuncts` join this bundle's own in the descriptor set
-    /// the lift proof is built against, so a set that does not match the
-    /// stamp's coverage yields a stamp that fails verification.
-    ///
-    /// Verification of coverage is the responsibility of the caller.
-    ///
-    /// # Errors
-    ///
-    /// An empty `next_bundles` builds no anchor chain, so there is nothing to
-    /// lift along.
-    ///
-    /// Every set is folded through [`Anchor::next_stamp`] before any proving
-    /// begins, so a set that cannot advance the anchor fails with
-    /// [`LiftError::AnchorError`] at no proving cost.
+    /// If you fail to use the correct sequence according to consensus, you will
+    /// succesesfully lift to an anchor that consensus does not recognize.
     pub fn lift<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -98,10 +98,7 @@ use crate::{
     keys::{private, public},
     primitives::{Anchor, AnchorError, EpochIndex, effect},
     reddsa, serialization,
-    stamp::{
-        self, AggregateIdError, PointerStamp, ProofStamp, StampState, Unproven,
-        proof::{PROOF_SYSTEM, pool},
-    },
+    stamp::{self, AggregateIdError, PointerStamp, ProofStamp, StampState, Unproven},
     value,
 };
 
@@ -288,16 +285,10 @@ pub enum VerifyPointersError {
 #[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum LiftError {
-    /// No lift is needed.
-    #[display("no lift is needed")]
-    NoLift,
     /// A provided anchor input could not advance the anchor.
     #[display("anchor advance failed: {_0}")]
     AnchorError(AnchorError),
-    /// Anchor continuity could not be proved
-    #[display("anchor continuity failed: {_0}")]
-    AnchorContinuityFailed(ragu::Error),
-    /// The stamp lift itself failed
+    /// The stamp lift itself failed.
     #[display("stamp lift failed: {_0}")]
     LiftFailed(stamp::ProveError),
 }
@@ -553,61 +544,58 @@ impl Bundle<ProofStamp> {
 
     /// Advance the stamp's anchor across the stamps that follow it.
     ///
-    /// `(epoch, tachygram_sets)` must contain the epoch index of this bundle's
-    /// anchor and a sequence of tachygram set commitments for stamps
-    /// immediately after this bundle's anchor.
+    /// `(epoch, next_bundles)` must contain the epoch index of this bundle's
+    /// anchor and the bundles stamped immediately after it, in chain order.
+    /// Only their tachygram set commitments are read; the anchor chain is
+    /// folded from this bundle's own anchor, so a following bundle's anchor
+    /// does not have to be its position in the chain. Following stamps should
+    /// be obtained from consensus data.
+    ///
+    /// The actions of `adjuncts` join this bundle's own in the descriptor set
+    /// the lift proof is built against, so a set that does not match the
+    /// stamp's coverage yields a stamp that fails verification.
     ///
     /// Verification of coverage is the responsibility of the caller.
+    ///
+    /// # Errors
+    ///
+    /// An empty `next_bundles` builds no anchor chain, so there is nothing to
+    /// lift along.
+    ///
+    /// Every set is folded through [`Anchor::next_stamp`] before any proving
+    /// begins, so a set that cannot advance the anchor fails with
+    /// [`LiftError::AnchorError`] at no proving cost.
     pub fn lift<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,
         adjuncts: &[&Bundle<dyn StampState>],
-        (epoch, tachygram_sets): (EpochIndex, Vec<TachygramSetCommit>),
+        (epoch, next_bundles): (EpochIndex, &[&Self]),
     ) -> Result<Self, LiftError> {
+        let seed_witnesses: Vec<(Anchor, EpochIndex, TachygramSetCommit)> = next_bundles
+            .iter()
+            .scan(self.stamp.anchor, |scanning_anchor, &next_bundle| {
+                let prev_anchor = *scanning_anchor;
+                let tachygram_set = next_bundle.stamp.tachygram_set;
+                let next_anchor = prev_anchor
+                    .next_stamp(epoch, &tachygram_set)
+                    .map_err(LiftError::AnchorError);
+
+                Some(next_anchor.map(|anchor| {
+                    *scanning_anchor = anchor;
+                    (prev_anchor, epoch, tachygram_set)
+                }))
+            })
+            .collect::<Result<Vec<_>, LiftError>>()?;
+
         let descriptors: BTreeSet<action::Descriptor> = self
             .descriptors()
             .into_iter()
             .chain(adjuncts.iter().flat_map(|&adj| adj.descriptors()))
             .collect();
 
-        let anchor_chain = {
-            let seed_witnesses: Vec<(Anchor, EpochIndex, TachygramSetCommit)> = tachygram_sets
-                .into_iter()
-                .scan(self.stamp.anchor, |running_anchor, tg_set| {
-                    let prev_anchor = *running_anchor;
-                    let next_anchor = prev_anchor
-                        .next_stamp(epoch, &tg_set)
-                        .map_err(LiftError::AnchorError);
-
-                    Some(next_anchor.map(|anchor| {
-                        *running_anchor = anchor;
-                        (prev_anchor, epoch, tg_set)
-                    }))
-                })
-                .collect::<Result<Vec<_>, LiftError>>()?;
-
-            let anchor_seeds = seed_witnesses
-                .into_iter()
-                .map(|witness| {
-                    PROOF_SYSTEM
-                        .seed(rng, pool::AnchorSeed, witness)
-                        .map_err(LiftError::AnchorContinuityFailed)
-                        .map(|(pcd, _aux)| pcd)
-                })
-                .collect::<Result<Vec<_>, LiftError>>()?;
-
-            let anchor_fused = anchor_seeds.into_iter().map(Ok).reduce(|left, right| {
-                PROOF_SYSTEM
-                    .fuse(rng, pool::AnchorFuse, (), left?, right?)
-                    .map(|(pcd, _aux)| pcd)
-                    .map_err(LiftError::AnchorContinuityFailed)
-            });
-            anchor_fused.unwrap_or(Err(LiftError::NoLift))?
-        };
-
         let stamp = self
             .stamp
-            .lift(rng, &descriptors, anchor_chain)
+            .lift(rng, &descriptors, seed_witnesses)
             .map_err(LiftError::LiftFailed)?;
 
         Ok(Self { stamp, ..self })

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -292,7 +292,7 @@ pub enum LiftError {
     #[display("no lift is needed")]
     NoLift,
     /// A provided anchor input could not advance the anchor.
-    #[display("anchor step failed: {_0}")]
+    #[display("anchor advance failed: {_0}")]
     AnchorError(AnchorError),
     /// Anchor continuity could not be proved
     #[display("anchor continuity failed: {_0}")]

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -92,13 +92,16 @@ use derive_more::{Debug, Display, Eq as TotalEq, Error, From, IsVariant, Partial
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
-    ActionDigest, ActionDigestError,
+    ActionDigest, ActionDigestError, TachygramSetCommit,
     action::{self, Action},
     digest::blake2b,
     keys::{private, public},
-    primitives::{Anchor, effect},
+    primitives::{Anchor, EpochIndex, effect},
     reddsa, serialization,
-    stamp::{self, AggregateIdError, PointerStamp, ProofStamp, StampState, Unproven},
+    stamp::{
+        self, AggregateIdError, PointerStamp, ProofStamp, StampState, Unproven,
+        proof::{PROOF_SYSTEM, pool},
+    },
     value,
 };
 
@@ -279,6 +282,24 @@ pub enum VerifyPointersError {
     /// The adjunct is not in the expected state.
     #[display("stamp on an adjunct does not contain a valid pointer")]
     AdjunctPointerInvalid(AggregateIdError),
+}
+
+/// Errors that can occur while lifting a bundle's stamp onto a later anchor.
+#[derive(Debug, Display, Error)]
+#[non_exhaustive]
+pub enum LiftError {
+    /// No lift is needed.
+    #[display("no lift is needed")]
+    NoLift,
+    /// Action digest construction failed (cv or rk was the identity point).
+    #[display("action digest failed: {_0}")]
+    ActionDigest(ActionDigestError),
+    /// Anchor continuity could not be proved
+    #[display("anchor continuity failed: {_0}")]
+    AnchorContinuityFailed(ragu::Error),
+    /// The stamp lift itself failed
+    #[display("stamp lift failed: {_0}")]
+    LiftFailed(ragu::Error),
 }
 
 /// Errors during bundle verification.
@@ -528,6 +549,57 @@ impl Bundle<ProofStamp> {
             memo: self.memo,
             stamp: wtxid,
         }
+    }
+
+    /// Advance the stamp's anchor across the stamps that follow it.
+    pub fn lift<RNG: RngCore + CryptoRng>(
+        self,
+        rng: &mut RNG,
+        adjuncts: &[&Bundle<dyn StampState>],
+        epoch: EpochIndex,
+        anchor_inputs: Vec<TachygramSetCommit>,
+    ) -> Result<Self, LiftError> {
+        let own_digests = self.actions.iter().map(|&action| action.digest());
+        let other_digests = adjuncts
+            .iter()
+            .flat_map(|&adj| adj.actions.iter().map(|&action| action.digest()));
+        let action_digests = own_digests
+            .chain(other_digests)
+            .collect::<Result<Vec<ActionDigest>, ActionDigestError>>()
+            .map_err(LiftError::ActionDigest)?;
+
+        let anchor_chain = {
+            let anchor_seeds = anchor_inputs
+                .into_iter()
+                .scan(self.stamp.anchor, |running_anchor, tg_set| {
+                    Some(
+                        PROOF_SYSTEM
+                            .seed(rng, pool::AnchorSeed, (*running_anchor, epoch, tg_set))
+                            .map_err(LiftError::AnchorContinuityFailed)
+                            .map(|(pcd, _aux)| {
+                                *running_anchor = pcd.data().1;
+                                pcd
+                            }),
+                    )
+                })
+                .collect::<Result<Vec<_>, LiftError>>()?;
+
+            let anchor_fused = anchor_seeds.into_iter().map(Ok).reduce(|left, right| {
+                PROOF_SYSTEM
+                    .fuse(rng, pool::AnchorFuse, (), left?, right?)
+                    .map(|(pcd, _aux)| pcd)
+                    .map_err(LiftError::AnchorContinuityFailed)
+            });
+
+            anchor_fused.unwrap_or(Err(LiftError::NoLift))?
+        };
+
+        let stamp = self
+            .stamp
+            .lift(rng, action_digests, anchor_chain)
+            .map_err(LiftError::LiftFailed)?;
+
+        Ok(Self { stamp, ..self })
     }
 
     /// Confirm `hStampActionsTachyon` represents the combined actions of this

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -96,7 +96,7 @@ use crate::{
     action::{self, Action},
     digest::blake2b,
     keys::{private, public},
-    primitives::{Anchor, EpochIndex, effect},
+    primitives::{Anchor, AnchorError, EpochIndex, effect},
     reddsa, serialization,
     stamp::{
         self, AggregateIdError, PointerStamp, ProofStamp, StampState, Unproven,
@@ -294,6 +294,9 @@ pub enum LiftError {
     /// Action digest construction failed (cv or rk was the identity point).
     #[display("action digest failed: {_0}")]
     ActionDigest(ActionDigestError),
+    /// A provided anchor input could not advance the anchor.
+    #[display("anchor step failed: {_0}")]
+    AnchorError(AnchorError),
     /// Anchor continuity could not be proved
     #[display("anchor continuity failed: {_0}")]
     AnchorContinuityFailed(ragu::Error),
@@ -552,12 +555,17 @@ impl Bundle<ProofStamp> {
     }
 
     /// Advance the stamp's anchor across the stamps that follow it.
+    ///
+    /// `(epoch, tachygram_sets)` must contain the epoch index of this bundle's
+    /// anchor and a sequence of tachygram set commitments for stamps
+    /// immediately after this bundle's anchor.
+    ///
+    /// Verification of coverage is the responsibility of the caller.
     pub fn lift<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,
         adjuncts: &[&Bundle<dyn StampState>],
-        epoch: EpochIndex,
-        anchor_inputs: Vec<TachygramSetCommit>,
+        (epoch, tachygram_sets): (EpochIndex, Vec<TachygramSetCommit>),
     ) -> Result<Self, LiftError> {
         let own_digests = self.actions.iter().map(|&action| action.digest());
         let other_digests = adjuncts
@@ -569,18 +577,28 @@ impl Bundle<ProofStamp> {
             .map_err(LiftError::ActionDigest)?;
 
         let anchor_chain = {
-            let anchor_seeds = anchor_inputs
+            let seed_witnesses: Vec<(Anchor, EpochIndex, TachygramSetCommit)> = tachygram_sets
                 .into_iter()
                 .scan(self.stamp.anchor, |running_anchor, tg_set| {
-                    Some(
-                        PROOF_SYSTEM
-                            .seed(rng, pool::AnchorSeed, (*running_anchor, epoch, tg_set))
-                            .map_err(LiftError::AnchorContinuityFailed)
-                            .map(|(pcd, _aux)| {
-                                *running_anchor = pcd.data().1;
-                                pcd
-                            }),
-                    )
+                    let prev_anchor = *running_anchor;
+                    let next_anchor = prev_anchor
+                        .next_stamp(epoch, &tg_set)
+                        .map_err(LiftError::AnchorError);
+
+                    Some(next_anchor.map(|anchor| {
+                        *running_anchor = anchor;
+                        (prev_anchor, epoch, tg_set)
+                    }))
+                })
+                .collect::<Result<Vec<_>, LiftError>>()?;
+
+            let anchor_seeds = seed_witnesses
+                .into_iter()
+                .map(|witness| {
+                    PROOF_SYSTEM
+                        .seed(rng, pool::AnchorSeed, witness)
+                        .map_err(LiftError::AnchorContinuityFailed)
+                        .map(|(pcd, _aux)| pcd)
                 })
                 .collect::<Result<Vec<_>, LiftError>>()?;
 
@@ -590,7 +608,6 @@ impl Bundle<ProofStamp> {
                     .map(|(pcd, _aux)| pcd)
                     .map_err(LiftError::AnchorContinuityFailed)
             });
-
             anchor_fused.unwrap_or(Err(LiftError::NoLift))?
         };
 

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -3,7 +3,8 @@
 use alloc::{boxed::Box, string::ToString as _, vec, vec::Vec};
 use core::cmp::Reverse;
 
-use pasta_curves::Fp;
+use group::Group as _;
+use pasta_curves::{Eq, Fp};
 use ragu::proof::PROOF_SIZE_COMPRESSED;
 use rand::{SeedableRng as _, rngs::StdRng};
 
@@ -2017,7 +2018,7 @@ fn bundle_lift_preserves_coverage() {
         .collect();
 
     let lifted = bundle
-        .lift(rng, &[], cm_height.epoch(), commits)
+        .lift(rng, &[], (cm_height.epoch(), commits))
         .expect("lift an autonome bundle");
 
     assert_eq!(lifted.stamp.anchor, pool.anchor());
@@ -2028,6 +2029,37 @@ fn bundle_lift_preserves_coverage() {
             .expect("coverage survives a lift"),
         descriptors
     );
+}
+
+/// An identity anchor input has no Poseidon absorption, so the lift reports it
+/// rather than unwinding inside the anchor fold.
+#[test]
+fn bundle_lift_rejects_an_identity_anchor_input() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+
+    let spend_note = wallet.random_note(1000);
+    let output_note = wallet.random_note(700);
+    let mut pool = PoolSim::genesis(rng);
+    pool.mine(random_block_with(rng, &[vec![spend_note.commitment()]], 1));
+    let cm_height = pool.height();
+    let spendable_pcd = wallet.fresh_spend(rng, &pool, cm_height, &spend_note);
+    let bundle = wallet.autonome(
+        rng,
+        spendable_pcd.data().2,
+        vec![(spend_note, spendable_pcd, cm_height.epoch())],
+        vec![output_note],
+    );
+
+    pool.advance(1, |_| random_block(rng, 1, 4));
+    let mut commits: Vec<TachygramSetCommit> = pool.stamp_commits_at(pool.height());
+    commits.push(TachygramSetCommit::from(Eq::identity()));
+
+    let Err(LiftError::AnchorError(AnchorError::ZeroStamp)) =
+        bundle.lift(rng, &[], (cm_height.epoch(), commits))
+    else {
+        panic!("identity anchor input advanced the anchor");
+    };
 }
 
 /// An aggregate's action commitment spans its adjuncts, so a lift that was
@@ -2107,7 +2139,7 @@ fn bundle_lift_over_an_aggregate() {
         .collect();
 
     let lifted = innocent
-        .lift(rng, &adjuncts, pool.height().epoch(), commits)
+        .lift(rng, &adjuncts, (pool.height().epoch(), commits))
         .expect("lift an aggregate over its adjuncts");
 
     assert_eq!(lifted.stamp.anchor, pool.anchor());
@@ -2128,7 +2160,7 @@ fn bundle_lift_over_no_stamps_is_refused() {
     let bundle = build_autonome(rng, &wallet, 1000, 700);
 
     let err = bundle
-        .lift(rng, &[], EpochIndex(0), vec![])
+        .lift(rng, &[], (EpochIndex(0), vec![]))
         .expect_err("a lift over no stamps must be refused");
     let LiftError::NoLift = err else {
         panic!("expected NoLift, got {err:?}");

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -1982,3 +1982,155 @@ fn read_rejects_truncated_memo() {
     let err = Bundle::<ProofStamp>::read(&*buf).expect_err("declared memo length must be honoured");
     assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
 }
+
+/// A lift moves the bundle's anchor to the pool's later state while leaving
+/// its coverage untouched.
+#[test]
+fn bundle_lift_preserves_coverage() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+
+    // `build_autonome` keeps its pool to itself, and a lift needs the pool's
+    // own tachygrams: the anchor is a hash chain over published stamp
+    // commitments, so invented sets land nowhere the pool recognizes.
+    let spend_note = wallet.random_note(1000);
+    let output_note = wallet.random_note(700);
+    let mut pool = PoolSim::genesis(rng);
+    // One stamp in the block, so the spendable's anchor is that block's
+    // terminal anchor and the lift's segment starts at the next block.
+    pool.mine(random_block_with(rng, &[vec![spend_note.commitment()]], 1));
+    let cm_height = pool.height();
+    let spendable_pcd = wallet.fresh_spend(rng, &pool, cm_height, &spend_note);
+    let bundle = wallet.autonome(
+        rng,
+        spendable_pcd.data().2,
+        vec![(spend_note, spendable_pcd, cm_height.epoch())],
+        vec![output_note],
+    );
+
+    let descriptors = bundle.verify_coverage(&[]).expect("autonome coverage");
+
+    // Two blocks, so the chain fuses rather than standing on one seed.
+    pool.advance(2, |_| random_block(rng, 1, 4));
+    let commits = (cm_height.0 + 1..=pool.height().0)
+        .flat_map(|height| pool.stamp_commits_at(BlockHeight(height)))
+        .collect();
+
+    let lifted = bundle
+        .lift(rng, &[], cm_height.epoch(), commits)
+        .expect("lift an autonome bundle");
+
+    assert_eq!(lifted.stamp.anchor, pool.anchor());
+    assert!(lifted.is_autonome());
+    assert_eq!(
+        lifted
+            .verify_coverage(&[])
+            .expect("coverage survives a lift"),
+        descriptors
+    );
+}
+
+/// An aggregate's action commitment spans its adjuncts, so a lift that was
+/// handed them rebuilds the header the proof was made against.
+#[test]
+fn bundle_lift_over_an_aggregate() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+
+    let spend_a = wallet.random_note(1000);
+    let output_a = wallet.random_note(700);
+    let spend_b = wallet.random_note(500);
+    let output_b = wallet.random_note(200);
+
+    let mut pool = PoolSim::genesis(rng);
+    pool.mine(random_block_with(
+        rng,
+        &[vec![spend_a.commitment()], vec![spend_b.commitment()]],
+        50,
+    ));
+    let cm_height = pool.height();
+    while pool.height() < BlockHeight(EPOCH_SIZE) {
+        pool.advance(1, |_| random_block(rng, 1, 2));
+    }
+
+    let init_a = wallet.spendable_init(rng, &spend_a, &pool, cm_height);
+    let sp_a = wallet.lift_over_creation_epoch(rng, &pool, &spend_a, cm_height, init_a);
+    let init_b = wallet.spendable_init(rng, &spend_b, &pool, cm_height);
+    let sp_b = wallet.lift_over_creation_epoch(rng, &pool, &spend_b, cm_height, init_b);
+    let anchor = sp_a.data().2;
+
+    let spend_epoch = cm_height.epoch().next();
+    let autonome_a = wallet.autonome(
+        rng,
+        anchor,
+        vec![(spend_a, sp_a, spend_epoch)],
+        vec![output_a],
+    );
+    let autonome_b = wallet.autonome(
+        rng,
+        anchor,
+        vec![(spend_b, sp_b, spend_epoch)],
+        vec![output_b],
+    );
+
+    let descriptors_a: BTreeSet<action::Descriptor> =
+        autonome_a.actions.iter().map(Action::descriptor).collect();
+    let descriptors_b: BTreeSet<action::Descriptor> =
+        autonome_b.actions.iter().map(Action::descriptor).collect();
+
+    let innocent_plan = Plan::new(vec![], vec![]);
+    let innocent = Bundle {
+        actions: vec![],
+        value_balance: value::Balance::ZERO,
+        binding_sig: innocent_plan
+            .derive_bsk_private()
+            .sign(rng, &mock_sighash(innocent_plan.commitment().unwrap())),
+        memo: Vec::new(),
+        stamp: ProofStamp::merge(
+            rng,
+            (autonome_a.stamp.clone(), descriptors_a),
+            (autonome_b.stamp.clone(), descriptors_b),
+        )
+        .expect("merge"),
+    };
+
+    let adjunct_a = autonome_a.strip(mock_wtxid(&innocent));
+    let adjunct_b = autonome_b.strip(mock_wtxid(&innocent));
+    let adjuncts = [adjunct_a.as_dyn(), adjunct_b.as_dyn()];
+
+    // The aggregate's anchor is the epoch's terminal one, so the segment it
+    // lifts over must start in the next epoch's first block.
+    let lifted_from = pool.height();
+    pool.advance(2, |_| random_block(rng, 1, 2));
+    let commits = (lifted_from.0 + 1..=pool.height().0)
+        .flat_map(|height| pool.stamp_commits_at(BlockHeight(height)))
+        .collect();
+
+    let lifted = innocent
+        .lift(rng, &adjuncts, pool.height().epoch(), commits)
+        .expect("lift an aggregate over its adjuncts");
+
+    assert_eq!(lifted.stamp.anchor, pool.anchor());
+    assert!(
+        lifted
+            .verify_proof(rng, &adjuncts)
+            .expect("a lifted aggregate verifies against its adjuncts"),
+        "a lifted aggregate must verify against its adjuncts"
+    );
+}
+
+/// An anchor chain has no zero-link form, so a lift with nothing to cross is
+/// refused rather than silently returning the bundle unchanged.
+#[test]
+fn bundle_lift_over_no_stamps_is_refused() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::new(shared_sk());
+    let bundle = build_autonome(rng, &wallet, 1000, 700);
+
+    let err = bundle
+        .lift(rng, &[], EpochIndex(0), vec![])
+        .expect_err("a lift over no stamps must be refused");
+    let LiftError::NoLift = err else {
+        panic!("expected NoLift, got {err:?}");
+    };
+}

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -19,6 +19,7 @@ use crate::{
         shared_sk, spend_witness,
     },
     primitives::{BlockHeight, Tachygram, TachygramSetPoly},
+    stamp::ProveError,
     value,
 };
 
@@ -2011,14 +2012,14 @@ fn bundle_lift_preserves_coverage() {
 
     let descriptors = bundle.verify_coverage(&[]).expect("autonome coverage");
 
-    // Two blocks, so the chain fuses rather than standing on one seed.
-    pool.advance(2, |_| random_block(rng, 1, 4));
-    let commits = (cm_height.0 + 1..=pool.height().0)
-        .flat_map(|height| pool.stamp_commits_at(BlockHeight(height)))
-        .collect();
+    // Two following stamps, so the chain fuses rather than standing on one
+    // seed.
+    let next_a = build_autonome(rng, &wallet, 400, 300);
+    let next_b = build_autonome(rng, &wallet, 500, 200);
+    pool.mine_bundles(&[&next_a, &next_b]);
 
     let lifted = bundle
-        .lift(rng, &[], (cm_height.epoch(), commits))
+        .lift(rng, &[], (cm_height.epoch(), &[&next_a, &next_b]))
         .expect("lift an autonome bundle");
 
     assert_eq!(lifted.stamp.anchor, pool.anchor());
@@ -2051,12 +2052,15 @@ fn bundle_lift_rejects_an_identity_anchor_input() {
         vec![output_note],
     );
 
-    pool.advance(1, |_| random_block(rng, 1, 4));
-    let mut commits: Vec<TachygramSetCommit> = pool.stamp_commits_at(pool.height());
-    commits.push(TachygramSetCommit::from(Eq::identity()));
+    // A proven bundle never carries the identity, so the fold is fed one
+    // directly. The lift must refuse it before any proving, which is why the
+    // rest of this bundle's incoherence never comes into play.
+    let mut next = build_autonome(rng, &wallet, 400, 300);
+    pool.mine_bundles(&[&next]);
+    next.stamp.tachygram_set = TachygramSetCommit::from(Eq::identity());
 
     let Err(LiftError::AnchorError(AnchorError::ZeroStamp)) =
-        bundle.lift(rng, &[], (cm_height.epoch(), commits))
+        bundle.lift(rng, &[], (cm_height.epoch(), &[&next]))
     else {
         panic!("identity anchor input advanced the anchor");
     };
@@ -2132,14 +2136,12 @@ fn bundle_lift_over_an_aggregate() {
 
     // The aggregate's anchor is the epoch's terminal one, so the segment it
     // lifts over must start in the next epoch's first block.
-    let lifted_from = pool.height();
-    pool.advance(2, |_| random_block(rng, 1, 2));
-    let commits = (lifted_from.0 + 1..=pool.height().0)
-        .flat_map(|height| pool.stamp_commits_at(BlockHeight(height)))
-        .collect();
+    pool.advance(1, |_| alloc::vec![]);
+    let next = build_autonome(rng, &wallet, 400, 300);
+    pool.mine_bundles(&[&next]);
 
     let lifted = innocent
-        .lift(rng, &adjuncts, (pool.height().epoch(), commits))
+        .lift(rng, &adjuncts, (pool.height().epoch(), &[&next]))
         .expect("lift an aggregate over its adjuncts");
 
     assert_eq!(lifted.stamp.anchor, pool.anchor());
@@ -2160,9 +2162,9 @@ fn bundle_lift_over_no_stamps_is_refused() {
     let bundle = build_autonome(rng, &wallet, 1000, 700);
 
     let err = bundle
-        .lift(rng, &[], (EpochIndex(0), vec![]))
+        .lift(rng, &[], (EpochIndex(0), &[]))
         .expect_err("a lift over no stamps must be refused");
-    let LiftError::NoLift = err else {
-        panic!("expected NoLift, got {err:?}");
+    let LiftError::LiftFailed(ProveError::MissingPcd(_reason)) = err else {
+        panic!("expected a missing anchor chain, got {err:?}");
     };
 }

--- a/crates/tachyon/src/bundle/tests.rs
+++ b/crates/tachyon/src/bundle/tests.rs
@@ -2032,10 +2032,8 @@ fn bundle_lift_preserves_coverage() {
     );
 }
 
-/// An identity anchor input has no Poseidon absorption, so the lift reports it
-/// rather than unwinding inside the anchor fold.
 #[test]
-fn bundle_lift_rejects_an_identity_anchor_input() {
+fn bundle_lift_rejects_invalid_anchor_inputs() {
     let rng = &mut StdRng::seed_from_u64(0);
     let wallet = WalletSim::new(shared_sk());
 
@@ -2052,18 +2050,51 @@ fn bundle_lift_rejects_an_identity_anchor_input() {
         vec![output_note],
     );
 
-    // A proven bundle never carries the identity, so the fold is fed one
-    // directly. The lift must refuse it before any proving, which is why the
-    // rest of this bundle's incoherence never comes into play.
-    let mut next = build_autonome(rng, &wallet, 400, 300);
+    let next = build_autonome(rng, &wallet, 400, 300);
     pool.mine_bundles(&[&next]);
-    next.stamp.tachygram_set = TachygramSetCommit::from(Eq::identity());
 
-    let Err(LiftError::AnchorError(AnchorError::ZeroStamp)) =
-        bundle.lift(rng, &[], (cm_height.epoch(), &[&next]))
-    else {
-        panic!("identity anchor input advanced the anchor");
+    let forged_with = |tachygram_set| {
+        let mut forged = next.clone();
+        forged.stamp.tachygram_set = tachygram_set;
+        forged
     };
+
+    // The identity point is not a valid set.
+    {
+        let forged = forged_with(TachygramSetCommit::from(Eq::identity()));
+        let err = bundle
+            .clone()
+            .lift(rng, &[], (cm_height.epoch(), &[&forged]))
+            .unwrap_err();
+        let LiftError::AnchorError(AnchorError::NextStampZero) = err else {
+            panic!("expected NextStampZero, got {err:?}");
+        };
+    }
+
+    // An empty set is rejected.
+    {
+        let forged = forged_with(TachygramSetCommit::default());
+        let err = bundle
+            .clone()
+            .lift(rng, &[], (cm_height.epoch(), &[&forged]))
+            .unwrap_err();
+        let LiftError::AnchorError(AnchorError::NextStampEmpty) = err else {
+            panic!("expected NextStampEmpty, got {err:?}");
+        };
+    }
+
+    // Lifting over an empty sequence nonsensical.
+    {
+        let err = bundle.lift(rng, &[], (cm_height.epoch(), &[])).unwrap_err();
+
+        let LiftError::LiftFailed(ProveError::MissingPcd(reason)) = err else {
+            panic!("expected a missing anchor chain, got {err:?}");
+        };
+        assert_eq!(
+            reason.to_string(),
+            "no anchor chain proof for no anchor advance"
+        );
+    }
 }
 
 /// An aggregate's action commitment spans its adjuncts, so a lift that was
@@ -2151,20 +2182,4 @@ fn bundle_lift_over_an_aggregate() {
             .expect("a lifted aggregate verifies against its adjuncts"),
         "a lifted aggregate must verify against its adjuncts"
     );
-}
-
-/// An anchor chain has no zero-link form, so a lift with nothing to cross is
-/// refused rather than silently returning the bundle unchanged.
-#[test]
-fn bundle_lift_over_no_stamps_is_refused() {
-    let rng = &mut StdRng::seed_from_u64(0);
-    let wallet = WalletSim::new(shared_sk());
-    let bundle = build_autonome(rng, &wallet, 1000, 700);
-
-    let err = bundle
-        .lift(rng, &[], (EpochIndex(0), &[]))
-        .expect_err("a lift over no stamps must be refused");
-    let LiftError::LiftFailed(ProveError::MissingPcd(_reason)) = err else {
-        panic!("expected a missing anchor chain, got {err:?}");
-    };
 }

--- a/crates/tachyon/src/digest/poseidon.rs
+++ b/crates/tachyon/src/digest/poseidon.rs
@@ -7,8 +7,6 @@ use group::{GroupEncoding as _, prime::PrimeCurveAffine as _};
 use pasta_curves::{EpAffine, EqAffine, Fp, arithmetic::Coordinates};
 use ragu::Sponge;
 
-use crate::EpochIndex;
-
 #[expect(
     clippy::expect_used,
     reason = "mock sponge absorb/squeeze cannot fail in wireless `Always` mode"
@@ -143,12 +141,12 @@ const ANCHOR_STAMP_DOMAIN: &[u8; 16] = b"Tachyon-StampFld";
 ///
 /// Panics if `tgs` is the identity point.
 #[must_use]
-pub(crate) fn anchor_stamp_step(anchor_prev: Fp, epoch: EpochIndex, tgs: EqAffine) -> Fp {
+pub(crate) fn anchor_stamp_step(anchor_prev: Fp, epoch: Fp, tgs: EqAffine) -> Fp {
     let (tgs_lo, tgs_hi) = point_limbs(tgs);
     hash::<5>([
         Fp::from_u128(u128::from_le_bytes(*ANCHOR_STAMP_DOMAIN)),
         anchor_prev,
-        Fp::from(epoch),
+        epoch,
         tgs_lo,
         tgs_hi,
     ])
@@ -158,10 +156,10 @@ const ANCHOR_EPOCH_DOMAIN: &[u8; 16] = b"Tachyon-EpochStp";
 
 /// Advances the terminal anchor of an epoch into a new epoch's initial state.
 #[must_use]
-pub(crate) fn anchor_epoch_step(anchor_prev: Fp, new_epoch: EpochIndex) -> Fp {
+pub(crate) fn anchor_epoch_step(anchor_prev: Fp, new_epoch: Fp) -> Fp {
     hash::<3>([
         Fp::from_u128(u128::from_le_bytes(*ANCHOR_EPOCH_DOMAIN)),
         anchor_prev,
-        Fp::from(new_epoch),
+        new_epoch,
     ])
 }

--- a/crates/tachyon/src/digest/poseidon.rs
+++ b/crates/tachyon/src/digest/poseidon.rs
@@ -132,7 +132,7 @@ fn point_limbs(point: EqAffine) -> (Fp, Fp) {
     )
 }
 
-const ANCHOR_STAMP_DOMAIN: &[u8; 16] = b"Tachyon-StampFld";
+const ANCHOR_STAMP_DOMAIN: &[u8; 16] = b"Tachyon-AnchorSt";
 
 /// Advances the anchor by absorbing one stamp's epoch and tachygram-set
 /// commitment.
@@ -141,7 +141,7 @@ const ANCHOR_STAMP_DOMAIN: &[u8; 16] = b"Tachyon-StampFld";
 ///
 /// Panics if `tgs` is the identity point.
 #[must_use]
-pub(crate) fn anchor_stamp_step(anchor_prev: Fp, epoch: Fp, tgs: EqAffine) -> Fp {
+pub(crate) fn anchor_next_stamp(anchor_prev: Fp, epoch: Fp, tgs: EqAffine) -> Fp {
     let (tgs_lo, tgs_hi) = point_limbs(tgs);
     hash::<5>([
         Fp::from_u128(u128::from_le_bytes(*ANCHOR_STAMP_DOMAIN)),
@@ -152,11 +152,11 @@ pub(crate) fn anchor_stamp_step(anchor_prev: Fp, epoch: Fp, tgs: EqAffine) -> Fp
     ])
 }
 
-const ANCHOR_EPOCH_DOMAIN: &[u8; 16] = b"Tachyon-EpochStp";
+const ANCHOR_EPOCH_DOMAIN: &[u8; 16] = b"Tachyon-AnchorEp";
 
 /// Advances the terminal anchor of an epoch into a new epoch's initial state.
 #[must_use]
-pub(crate) fn anchor_epoch_step(anchor_prev: Fp, new_epoch: Fp) -> Fp {
+pub(crate) fn anchor_next_epoch(anchor_prev: Fp, new_epoch: Fp) -> Fp {
     hash::<3>([
         Fp::from_u128(u128::from_le_bytes(*ANCHOR_EPOCH_DOMAIN)),
         anchor_prev,

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -568,6 +568,16 @@ impl PoolSim {
         }
     }
 
+    /// Mine a block publishing the stamps of `bundles`, in order.
+    pub fn mine_bundles(&mut self, bundles: &[&Bundle<ProofStamp>]) {
+        self.mine(
+            bundles
+                .iter()
+                .map(|&bundle| bundle.stamp.tachygrams.iter().copied().collect())
+                .collect(),
+        );
+    }
+
     pub fn mine(&mut self, stamps: Vec<Vec<Tachygram>>) {
         let new_height = BlockHeight::from(self.history.len());
         let old_tip = self.anchor();

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -328,7 +328,7 @@ impl PoolSimBlock {
         let commits = self.commits();
         let anchors = commits.iter().fold(Vec::new(), |mut acc, commit| {
             let last = acc.last().unwrap_or(&self.prev);
-            acc.push(last.next_stamp(epoch, commit).expect("valid step"));
+            acc.push(last.next_stamp(epoch, commit).unwrap());
             acc
         });
         BlockDigest { commits, anchors }
@@ -584,7 +584,7 @@ impl PoolSim {
         // Epoch-first blocks are preceded by a boundary anchor lift;
         // intra-epoch blocks advance directly from the previous tip.
         let prev = if new_height.is_epoch_first() {
-            old_tip.next_epoch(new_height.epoch()).expect("valid step")
+            old_tip.next_epoch(new_height.epoch()).unwrap()
         } else {
             old_tip
         };
@@ -614,7 +614,7 @@ pub(crate) fn build_anchor_chain_pcd(
     loop {
         for tgs in &pool.tachygrams_at(height) {
             let witness = witness::anchor_seed(((), ()), state, height.epoch(), tgs);
-            let next_state = state.next_stamp(witness.1, &witness.2).expect("valid step");
+            let next_state = state.next_stamp(witness.1, &witness.2).unwrap();
             let (seed, ()) = PROOF_SYSTEM
                 .seed(rng, pool::AnchorSeed, witness)
                 .expect("AnchorSeed");
@@ -731,7 +731,7 @@ pub(crate) fn build_unspent_pcd_between_anchors(
                         )
                         .expect("UnspentSeed");
                     leaves.push(seed);
-                    entry = entry.next_stamp(epoch, &commit).expect("valid step");
+                    entry = entry.next_stamp(epoch, &commit).unwrap();
                 }
             },
             // The marker denotes the crossing *into* `epoch`, so the segment
@@ -933,14 +933,11 @@ impl WalletSim {
                 .expect("cm not found in any stamp at the cm-block");
 
             // Anchor immediately before the cm-stamp (the cm-block prefix fold).
-            let pre_cm_anchor = stamp_commits[..cm_idx].iter().fold(
-                pool.prev_anchor_at(init_height),
-                |anchor, commit| {
-                    anchor
-                        .next_stamp(init_height.epoch(), commit)
-                        .expect("valid step")
-                },
-            );
+            let pre_cm_anchor = stamp_commits[..cm_idx]
+                .iter()
+                .fold(pool.prev_anchor_at(init_height), |anchor, commit| {
+                    anchor.next_stamp(init_height.epoch(), commit).unwrap()
+                });
 
             (pre_cm_anchor, stamps[cm_idx].clone())
         };

--- a/crates/tachyon/src/fixtures.rs
+++ b/crates/tachyon/src/fixtures.rs
@@ -328,7 +328,7 @@ impl PoolSimBlock {
         let commits = self.commits();
         let anchors = commits.iter().fold(Vec::new(), |mut acc, commit| {
             let last = acc.last().unwrap_or(&self.prev);
-            acc.push(last.next_stamp(epoch, commit));
+            acc.push(last.next_stamp(epoch, commit).expect("valid step"));
             acc
         });
         BlockDigest { commits, anchors }
@@ -574,7 +574,7 @@ impl PoolSim {
         // Epoch-first blocks are preceded by a boundary anchor lift;
         // intra-epoch blocks advance directly from the previous tip.
         let prev = if new_height.is_epoch_first() {
-            old_tip.next_epoch(new_height.epoch())
+            old_tip.next_epoch(new_height.epoch()).expect("valid step")
         } else {
             old_tip
         };
@@ -604,7 +604,7 @@ pub(crate) fn build_anchor_chain_pcd(
     loop {
         for tgs in &pool.tachygrams_at(height) {
             let witness = witness::anchor_seed(((), ()), state, height.epoch(), tgs);
-            let next_state = state.next_stamp(witness.1, &witness.2);
+            let next_state = state.next_stamp(witness.1, &witness.2).expect("valid step");
             let (seed, ()) = PROOF_SYSTEM
                 .seed(rng, pool::AnchorSeed, witness)
                 .expect("AnchorSeed");
@@ -721,7 +721,7 @@ pub(crate) fn build_unspent_pcd_between_anchors(
                         )
                         .expect("UnspentSeed");
                     leaves.push(seed);
-                    entry = entry.next_stamp(epoch, &commit);
+                    entry = entry.next_stamp(epoch, &commit).expect("valid step");
                 }
             },
             // The marker denotes the crossing *into* `epoch`, so the segment
@@ -923,11 +923,14 @@ impl WalletSim {
                 .expect("cm not found in any stamp at the cm-block");
 
             // Anchor immediately before the cm-stamp (the cm-block prefix fold).
-            let pre_cm_anchor = stamp_commits[..cm_idx]
-                .iter()
-                .fold(pool.prev_anchor_at(init_height), |anchor, commit| {
-                    anchor.next_stamp(init_height.epoch(), commit)
-                });
+            let pre_cm_anchor = stamp_commits[..cm_idx].iter().fold(
+                pool.prev_anchor_at(init_height),
+                |anchor, commit| {
+                    anchor
+                        .next_stamp(init_height.epoch(), commit)
+                        .expect("valid step")
+                },
+            );
 
             (pre_cm_anchor, stamps[cm_idx].clone())
         };

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -79,7 +79,7 @@ impl NullifierKey {
 /// note commitment. It is NOT an on-chain address; payment coordination
 /// happens out-of-band via higher-level protocols (ZIP 321 payment
 /// requests, ZIP 324 URI encapsulated payments).
-#[derive(Clone, Copy, Debug, AsRef, From, Into)]
+#[derive(AsRef, Clone, Copy, Debug, From, Into)]
 pub struct PaymentKey(#[debug(skip)] Fp);
 
 impl PaymentKey {

--- a/crates/tachyon/src/lib.rs
+++ b/crates/tachyon/src/lib.rs
@@ -33,7 +33,7 @@ pub(crate) mod fixtures;
 
 pub use action::{Action, Plan as ActionPlan};
 pub use bundle::{
-    Bundle, Plan as BundlePlan, SignatureError, TachyonBundle, VerificationError,
+    Bundle, LiftError, Plan as BundlePlan, SignatureError, TachyonBundle, VerificationError,
     VerifyCoverageError, VerifyPointersError, VerifyProofError,
 };
 pub use note::Note;

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -10,65 +10,54 @@ use crate::{digest::poseidon, serialization};
 /// Errors that can occur when advancing an anchor.
 #[derive(Debug, Display, Error)]
 pub enum AnchorError {
-    /// The stamp commit is the identity point.
-    #[display("stamp commit is the identity point")]
+    /// The provided tachygram set is empty.
+    #[display("next stamp cannot be empty")]
     ZeroStamp,
-    /// The epoch is zero.
-    #[display("epoch is zero")]
+    /// The provided epoch index is zero.
+    #[display("next epoch cannot be zero")]
     ZeroEpoch,
 }
 
 /// Running anchor over the consensus state.
-///
-/// A Poseidon hash sequence with two domain-separated link types:
-///
-/// - [`Anchor::next_stamp`] (`Tachyon-StampFld`) absorbs one stamp's epoch and
-///   tachygram-set commitment.
-/// - [`Anchor::next_epoch`] (`Tachyon-EpochStp`) lifts across an epoch
-///   boundary. `EndEpochUnspentSeed` is the only step that folds it, from a
-///   predecessor it does not constrain to be the epoch's terminal anchor.
-///
-/// A block that publishes no stamp contributes no link, so the anchor is
-/// constant across a stampless span.
-///
-/// Opening reveals each link's role by its domain.
 #[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct Anchor(pub Fp);
 
 impl Anchor {
-    /// Advance the anchor by absorbing one stamp's commit, bound to the epoch
-    /// of the block containing it.
+    /// Advance the anchor to the next stamp in the present epoch.
+    ///
+    /// The present epoch index may be zero, within the genesis epoch.
     ///
     /// # Errors
     ///
-    /// Fails if `stamp_commit` is the identity point.
+    /// Fails with `AnchorError::ZeroStamp` if `stamp_commit` is the identity
+    /// point.
     pub fn next_stamp(
         self,
-        epoch: EpochIndex,
+        present_epoch: EpochIndex,
         stamp_commit: &TachygramSetCommit,
     ) -> Result<Self, AnchorError> {
         if bool::from(stamp_commit.as_ref().is_identity()) {
             Err(AnchorError::ZeroStamp)
         } else {
-            Ok(Self(poseidon::anchor_stamp_step(
+            Ok(Self(poseidon::anchor_next_stamp(
                 self.0,
-                epoch.into(),
+                present_epoch.into(),
                 stamp_commit.as_ref().to_affine(),
             )))
         }
     }
 
-    /// Lift the anchor across an epoch boundary into the new epoch's
-    /// initial state.
+    /// Advance the anchor to the next epoch boundary.
     ///
     /// # Errors
     ///
-    /// Fails if `new_epoch` is zero, which no boundary crosses into.
-    pub fn next_epoch(self, new_epoch: EpochIndex) -> Result<Self, AnchorError> {
-        if new_epoch == EpochIndex(0) {
+    /// Fails with `AnchorError::ZeroEpoch` if `next_epoch` is zero, since there
+    /// is no valid anchor before the genesis epoch boundary [`Anchor::default`].
+    pub fn next_epoch(self, next_epoch: EpochIndex) -> Result<Self, AnchorError> {
+        if next_epoch == EpochIndex(0) {
             Err(AnchorError::ZeroEpoch)
         } else {
-            Ok(Self(poseidon::anchor_epoch_step(self.0, new_epoch.into())))
+            Ok(Self(poseidon::anchor_next_epoch(self.0, next_epoch.into())))
         }
     }
 
@@ -84,9 +73,9 @@ impl Anchor {
 }
 
 impl Default for Anchor {
-    /// The genesis epoch boundary.
+    /// The genesis epoch boundary, for epoch zero.
     fn default() -> Self {
-        Self(poseidon::anchor_epoch_step(Fp::ZERO, Fp::ZERO))
+        Self(poseidon::anchor_next_epoch(Fp::ZERO, Fp::ZERO))
     }
 }
 
@@ -208,7 +197,7 @@ mod tests {
 
         assert_eq!(
             Anchor::default(),
-            Anchor(poseidon::anchor_epoch_step(Fp::ZERO, Fp::ZERO)),
+            Anchor(poseidon::anchor_next_epoch(Fp::ZERO, Fp::ZERO)),
             "genesis remains the epoch-zero link"
         );
     }

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -52,7 +52,8 @@ impl Anchor {
     /// # Errors
     ///
     /// Fails with `AnchorError::ZeroEpoch` if `next_epoch` is zero, since there
-    /// is no valid anchor before the genesis epoch boundary [`Anchor::default`].
+    /// is no valid anchor before the genesis epoch boundary
+    /// [`Anchor::default`].
     pub fn next_epoch(self, next_epoch: EpochIndex) -> Result<Self, AnchorError> {
         if next_epoch == EpochIndex(0) {
             Err(AnchorError::ZeroEpoch)

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -1,11 +1,22 @@
 use corez::io::{self, Read, Write};
-use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
+use derive_more::{Debug, Display, Eq as TotalEq, Error, From, Into, PartialEq};
 use ff::Field as _;
-use group::Curve as _;
-use pasta_curves::{Eq, Fp};
+use group::{Curve as _, Group as _};
+use pasta_curves::Fp;
 
 use super::{EpochIndex, TachygramSetCommit};
 use crate::{digest::poseidon, serialization};
+
+/// Errors that can occur when advancing an anchor.
+#[derive(Debug, Display, Error)]
+pub enum AnchorError {
+    /// The stamp commit is the identity point.
+    #[display("stamp commit is the identity point")]
+    ZeroStamp,
+    /// The epoch is zero.
+    #[display("epoch is zero")]
+    ZeroEpoch,
+}
 
 /// Running anchor over the consensus state.
 ///
@@ -28,23 +39,37 @@ impl Anchor {
     /// Advance the anchor by absorbing one stamp's commit, bound to the epoch
     /// of the block containing it.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `stamp_commit` is the identity point.
-    #[must_use]
-    pub fn next_stamp(self, epoch: EpochIndex, stamp_commit: &TachygramSetCommit) -> Self {
-        Self(poseidon::anchor_stamp_step(
-            self.0,
-            epoch,
-            Eq::from(*stamp_commit).to_affine(),
-        ))
+    /// Fails if `stamp_commit` is the identity point.
+    pub fn next_stamp(
+        self,
+        epoch: EpochIndex,
+        stamp_commit: &TachygramSetCommit,
+    ) -> Result<Self, AnchorError> {
+        if bool::from(stamp_commit.as_ref().is_identity()) {
+            Err(AnchorError::ZeroStamp)
+        } else {
+            Ok(Self(poseidon::anchor_stamp_step(
+                self.0,
+                epoch.into(),
+                stamp_commit.as_ref().to_affine(),
+            )))
+        }
     }
 
     /// Lift the anchor across an epoch boundary into the new epoch's
     /// initial state.
-    #[must_use]
-    pub fn next_epoch(self, new_epoch: EpochIndex) -> Self {
-        Self(poseidon::anchor_epoch_step(self.0, new_epoch))
+    ///
+    /// # Errors
+    ///
+    /// Fails if `new_epoch` is zero, which no boundary crosses into.
+    pub fn next_epoch(self, new_epoch: EpochIndex) -> Result<Self, AnchorError> {
+        if new_epoch == EpochIndex(0) {
+            Err(AnchorError::ZeroEpoch)
+        } else {
+            Ok(Self(poseidon::anchor_epoch_step(self.0, new_epoch.into())))
+        }
     }
 
     /// Read a 32-byte anchor.
@@ -61,12 +86,13 @@ impl Anchor {
 impl Default for Anchor {
     /// The genesis epoch boundary.
     fn default() -> Self {
-        Self(Fp::ZERO).next_epoch(EpochIndex(0))
+        Self(poseidon::anchor_epoch_step(Fp::ZERO, Fp::ZERO))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use pasta_curves::Eq;
     use rand::{SeedableRng as _, rngs::StdRng};
 
     use super::*;
@@ -83,10 +109,14 @@ mod tests {
 
         let run_one = Anchor::default()
             .next_stamp(EPOCH, &first)
-            .next_stamp(EPOCH, &second);
+            .expect("valid step")
+            .next_stamp(EPOCH, &second)
+            .expect("valid step");
         let run_two = Anchor::default()
             .next_stamp(EPOCH, &first)
-            .next_stamp(EPOCH, &second);
+            .expect("valid step")
+            .next_stamp(EPOCH, &second)
+            .expect("valid step");
         assert_eq!(run_one, run_two);
     }
 
@@ -98,8 +128,12 @@ mod tests {
         let second = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
 
         assert_ne!(
-            Anchor::default().next_stamp(EPOCH, &first),
-            Anchor::default().next_stamp(EPOCH, &second),
+            Anchor::default()
+                .next_stamp(EPOCH, &first)
+                .expect("valid step"),
+            Anchor::default()
+                .next_stamp(EPOCH, &second)
+                .expect("valid step"),
         );
     }
 
@@ -112,10 +146,14 @@ mod tests {
 
         let forward = Anchor::default()
             .next_stamp(EPOCH, &first)
-            .next_stamp(EPOCH, &second);
+            .expect("valid step")
+            .next_stamp(EPOCH, &second)
+            .expect("valid step");
         let reverse = Anchor::default()
             .next_stamp(EPOCH, &second)
-            .next_stamp(EPOCH, &first);
+            .expect("valid step")
+            .next_stamp(EPOCH, &first)
+            .expect("valid step");
         assert_ne!(forward, reverse);
     }
 
@@ -127,12 +165,12 @@ mod tests {
         let start = Anchor::default();
 
         assert_ne!(
-            start.next_stamp(EpochIndex(1), &stamp),
-            start.next_stamp(EpochIndex(2), &stamp),
+            start.next_stamp(EpochIndex(1), &stamp).expect("valid step"),
+            start.next_stamp(EpochIndex(2), &stamp).expect("valid step"),
         );
         assert_ne!(
-            start.next_epoch(EpochIndex(1)),
-            start.next_epoch(EpochIndex(2))
+            start.next_epoch(EpochIndex(1)).expect("valid step"),
+            start.next_epoch(EpochIndex(2)).expect("valid step"),
         );
     }
 
@@ -144,6 +182,34 @@ mod tests {
         let stamp = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
         let via_epoch = Anchor::default().next_epoch(EPOCH);
         let via_stamp = Anchor::default().next_stamp(EPOCH, &stamp);
-        assert_ne!(via_epoch, via_stamp);
+        assert_ne!(
+            via_epoch.expect("valid step"),
+            via_stamp.expect("valid step")
+        );
+    }
+
+    /// The identity commitment has no Poseidon absorption, so it cannot
+    /// advance the anchor.
+    #[test]
+    fn next_stamp_rejects_the_identity_commitment() {
+        let identity = TachygramSetCommit::from(Eq::identity());
+
+        let Err(AnchorError::ZeroStamp) = Anchor::default().next_stamp(EPOCH, &identity) else {
+            panic!("identity commitment advanced the anchor");
+        };
+    }
+
+    /// No boundary crosses into epoch zero; genesis rests there already.
+    #[test]
+    fn next_epoch_rejects_epoch_zero() {
+        let Err(AnchorError::ZeroEpoch) = Anchor::default().next_epoch(EpochIndex(0)) else {
+            panic!("epoch zero was crossed into");
+        };
+
+        assert_eq!(
+            Anchor::default(),
+            Anchor(poseidon::anchor_epoch_step(Fp::ZERO, Fp::ZERO)),
+            "genesis remains the epoch-zero link"
+        );
     }
 }

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -2,20 +2,28 @@ use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, From, Into, PartialEq};
 use ff::Field as _;
 use group::{Curve as _, Group as _};
-use pasta_curves::Fp;
+use lazy_static::lazy_static;
+use pasta_curves::{Eq, Fp};
 
 use super::{EpochIndex, TachygramSetCommit};
 use crate::{digest::poseidon, serialization};
 
+lazy_static! {
+    static ref ANCHOR_GENESIS: Fp = poseidon::anchor_next_epoch(Fp::ZERO, Fp::ZERO);
+}
+
 /// Errors that can occur when advancing an anchor.
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, Error, PartialEq, TotalEq)]
 pub enum AnchorError {
+    /// The provided tachygram set is the identity point.
+    #[display("next stamp cannot be the identity point")]
+    NextStampZero,
     /// The provided tachygram set is empty.
     #[display("next stamp cannot be empty")]
-    ZeroStamp,
+    NextStampEmpty,
     /// The provided epoch index is zero.
     #[display("next epoch cannot be zero")]
-    ZeroEpoch,
+    NextEpochZero,
 }
 
 /// Running anchor over the consensus state.
@@ -29,15 +37,17 @@ impl Anchor {
     ///
     /// # Errors
     ///
-    /// Fails with `AnchorError::ZeroStamp` if `stamp_commit` is the identity
-    /// point.
+    /// Fails if `stamp_commit` is the identity point or a commitment to an
+    /// empty set.
     pub fn next_stamp(
         self,
         present_epoch: EpochIndex,
-        stamp_commit: &TachygramSetCommit,
+        &stamp_commit: &TachygramSetCommit,
     ) -> Result<Self, AnchorError> {
-        if bool::from(stamp_commit.as_ref().is_identity()) {
-            Err(AnchorError::ZeroStamp)
+        if *stamp_commit.as_ref() == Eq::identity() {
+            Err(AnchorError::NextStampZero)
+        } else if stamp_commit == TachygramSetCommit::default() {
+            Err(AnchorError::NextStampEmpty)
         } else {
             Ok(Self(poseidon::anchor_next_stamp(
                 self.0,
@@ -51,12 +61,10 @@ impl Anchor {
     ///
     /// # Errors
     ///
-    /// Fails with `AnchorError::ZeroEpoch` if `next_epoch` is zero, since there
-    /// is no valid anchor before the genesis epoch boundary
-    /// [`Anchor::default`].
+    /// Fails if `next_epoch` is zero.
     pub fn next_epoch(self, next_epoch: EpochIndex) -> Result<Self, AnchorError> {
         if next_epoch == EpochIndex(0) {
-            Err(AnchorError::ZeroEpoch)
+            Err(AnchorError::NextEpochZero)
         } else {
             Ok(Self(poseidon::anchor_next_epoch(self.0, next_epoch.into())))
         }
@@ -74,9 +82,9 @@ impl Anchor {
 }
 
 impl Default for Anchor {
-    /// The genesis epoch boundary, for epoch zero.
+    /// The leading epoch boundary for epoch zero.
     fn default() -> Self {
-        Self(poseidon::anchor_next_epoch(Fp::ZERO, Fp::ZERO))
+        Self(*ANCHOR_GENESIS)
     }
 }
 
@@ -88,46 +96,6 @@ mod tests {
     use super::*;
     use crate::{Tachygram, TachygramSetPoly};
 
-    const EPOCH: EpochIndex = EpochIndex(7);
-
-    /// Folding the same stamps in the same order yields the same anchor.
-    #[test]
-    fn next_stamp_is_deterministic() {
-        let rng = &mut StdRng::seed_from_u64(0);
-        let first = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
-        let second = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
-
-        let run_one = Anchor::default()
-            .next_stamp(EPOCH, &first)
-            .expect("valid step")
-            .next_stamp(EPOCH, &second)
-            .expect("valid step");
-        let run_two = Anchor::default()
-            .next_stamp(EPOCH, &first)
-            .expect("valid step")
-            .next_stamp(EPOCH, &second)
-            .expect("valid step");
-        assert_eq!(run_one, run_two);
-    }
-
-    /// Two distinct stamp commits absorb to distinct anchors.
-    #[test]
-    fn distinct_stamps_distinct_anchors() {
-        let rng = &mut StdRng::seed_from_u64(0);
-        let first = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
-        let second = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
-
-        assert_ne!(
-            Anchor::default()
-                .next_stamp(EPOCH, &first)
-                .expect("valid step"),
-            Anchor::default()
-                .next_stamp(EPOCH, &second)
-                .expect("valid step"),
-        );
-    }
-
-    /// Order matters: absorbing the same stamps in different orders diverges.
     #[test]
     fn order_matters() {
         let rng = &mut StdRng::seed_from_u64(0);
@@ -135,71 +103,55 @@ mod tests {
         let second = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
 
         let forward = Anchor::default()
-            .next_stamp(EPOCH, &first)
-            .expect("valid step")
-            .next_stamp(EPOCH, &second)
-            .expect("valid step");
+            .next_stamp(EpochIndex(7), &first)
+            .unwrap()
+            .next_stamp(EpochIndex(7), &second)
+            .unwrap();
+
         let reverse = Anchor::default()
-            .next_stamp(EPOCH, &second)
-            .expect("valid step")
-            .next_stamp(EPOCH, &first)
-            .expect("valid step");
+            .next_stamp(EpochIndex(7), &second)
+            .unwrap()
+            .next_stamp(EpochIndex(7), &first)
+            .unwrap();
+
         assert_ne!(forward, reverse);
     }
 
-    /// Every link binds its epoch: the same tick in two epochs diverges.
     #[test]
-    fn epoch_distinguishes_ticks() {
+    fn next_stamp_rejects_invalid_sets() {
         let rng = &mut StdRng::seed_from_u64(0);
-        let stamp = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
-        let start = Anchor::default();
 
-        assert_ne!(
-            start.next_stamp(EpochIndex(1), &stamp).expect("valid step"),
-            start.next_stamp(EpochIndex(2), &stamp).expect("valid step"),
-        );
-        assert_ne!(
-            start.next_epoch(EpochIndex(1)).expect("valid step"),
-            start.next_epoch(EpochIndex(2)).expect("valid step"),
-        );
+        // The identity commitment is not a valid set
+        {
+            let anchor = Anchor(Fp::random(&mut *rng));
+            let zero_set = TachygramSetCommit::from(Eq::identity());
+
+            let Err(AnchorError::NextStampZero) = anchor.next_stamp(EpochIndex(7), &zero_set)
+            else {
+                panic!("should not be able to advance with an identity stamp");
+            };
+        }
+
+        // An empty set commits to a constant polynomial
+        {
+            let anchor = Anchor(Fp::random(&mut *rng));
+            let one_set = TachygramSetCommit::default();
+
+            let Err(AnchorError::NextStampEmpty) = anchor.next_stamp(EpochIndex(1), &one_set)
+            else {
+                panic!("should not be able to advance with an empty stamp");
+            };
+        }
     }
 
-    /// The boundary lift is domain-separated from stamp absorption, so a
-    /// boundary anchor is unreachable by any chain link.
-    #[test]
-    fn next_epoch_distinct_from_next_stamp() {
-        let rng = &mut StdRng::seed_from_u64(0);
-        let stamp = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
-        let via_epoch = Anchor::default().next_epoch(EPOCH);
-        let via_stamp = Anchor::default().next_stamp(EPOCH, &stamp);
-        assert_ne!(
-            via_epoch.expect("valid step"),
-            via_stamp.expect("valid step")
-        );
-    }
-
-    /// The identity commitment has no Poseidon absorption, so it cannot
-    /// advance the anchor.
-    #[test]
-    fn next_stamp_rejects_the_identity_commitment() {
-        let identity = TachygramSetCommit::from(Eq::identity());
-
-        let Err(AnchorError::ZeroStamp) = Anchor::default().next_stamp(EPOCH, &identity) else {
-            panic!("identity commitment advanced the anchor");
-        };
-    }
-
-    /// No boundary crosses into epoch zero; genesis rests there already.
     #[test]
     fn next_epoch_rejects_epoch_zero() {
-        let Err(AnchorError::ZeroEpoch) = Anchor::default().next_epoch(EpochIndex(0)) else {
-            panic!("epoch zero was crossed into");
-        };
+        let rng = &mut StdRng::seed_from_u64(0);
 
-        assert_eq!(
-            Anchor::default(),
-            Anchor(poseidon::anchor_next_epoch(Fp::ZERO, Fp::ZERO)),
-            "genesis remains the epoch-zero link"
-        );
+        let anchor = Anchor(Fp::random(rng));
+
+        let Err(AnchorError::NextEpochZero) = anchor.next_epoch(EpochIndex(0)) else {
+            panic!("should not be able to advance to epoch zero");
+        };
     }
 }

--- a/crates/tachyon/src/primitives/mod.rs
+++ b/crates/tachyon/src/primitives/mod.rs
@@ -8,7 +8,7 @@ mod sets;
 mod tachygram;
 
 pub use action_digest::{ActionDigest, ActionDigestError};
-pub use anchor::Anchor;
+pub use anchor::{Anchor, AnchorError};
 pub use block_height::BlockHeight;
 pub use effect::Effect;
 pub use epoch::{EpochDiff, EpochIndex};

--- a/crates/tachyon/src/primitives/sets.rs
+++ b/crates/tachyon/src/primitives/sets.rs
@@ -2,40 +2,33 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use corez::io::{self, Read, Write};
 use derive_more::{AsRef, Debug, Eq as TotalEq, From, Into, PartialEq};
-use group::{Curve as _, GroupEncoding as _};
 use pasta_curves::{Eq, Fp};
 use ragu::{Polynomial, poly_with_roots};
 
 use super::{ActionDigest, Tachygram};
-use crate::serialization;
 
 /// Pedersen commitment to a stamp's tachygram set.
 #[derive(AsRef, Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct TachygramSetCommit(Eq);
 
-impl TachygramSetCommit {
-    /// The 32-byte compressed encoding.
-    #[must_use]
-    pub fn to_bytes(&self) -> [u8; 32] {
-        self.0.to_affine().to_bytes()
-    }
-
-    /// Read a 32-byte compressed commitment.
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
-        serialization::read_eq_affine(&mut reader).map(|point| Self(point.into()))
-    }
-
-    /// Write a 32-byte compressed commitment.
-    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        serialization::write_eq_affine(&mut writer, &self.0.to_affine())
+impl Default for TachygramSetCommit {
+    /// A commitment to an empty set.
+    fn default() -> Self {
+        Self(Polynomial::from_coeffs(poly_with_roots(&[])).commit())
     }
 }
 
 /// Pedersen commitment to a stamp's action-digest set.
-#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
+#[derive(AsRef, Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct ActionSetCommit(Eq);
+
+impl Default for ActionSetCommit {
+    /// A commitment to an empty set.
+    fn default() -> Self {
+        Self(Polynomial::from_coeffs(poly_with_roots(&[])).commit())
+    }
+}
 
 /// Witness polynomial for a stamp's tachygram set (members encoded as roots).
 #[derive(AsRef, Clone, Debug, Into)]

--- a/crates/tachyon/src/primitives/sets.rs
+++ b/crates/tachyon/src/primitives/sets.rs
@@ -12,7 +12,7 @@ use super::{ActionDigest, Tachygram};
 use crate::serialization;
 
 /// Pedersen commitment to a stamp's tachygram set.
-#[derive(Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
+#[derive(AsRef, Clone, Copy, Debug, From, Into, PartialEq, TotalEq)]
 pub struct TachygramSetCommit(Eq);
 
 impl TachygramSetCommit {

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -408,7 +408,7 @@ impl Plan {
                         (left_digests, left_tachygrams, left_anchor, left_proof),
                         (right_digests, right_tachygrams, right_anchor, right_proof),
                     )
-                    .map_err(ProveError::MergeFailed)?;
+                    .map_err(ProveError::ProofFailed)?;
 
                 let merged_descs = left_desc.union(&right_desc).copied().collect();
 
@@ -449,16 +449,9 @@ pub enum ProveError {
     /// Action digest construction failed (cv or rk was the identity point).
     #[display("action digest failed: {_0}")]
     ActionDigest(ActionDigestError),
-    /// Proof creation failed for an action; carries the underlying
-    /// step-level error.
-    #[display("action proof failed: {_0}")]
+    /// Proof creation failed; carries the underlying step-level error.
+    #[display("proof failed: {_0}")]
     ProofFailed(ragu::Error),
-    /// Stamp merge failed; carries the underlying step-level error.
-    #[display("stamp merge failed: {_0}")]
-    MergeFailed(ragu::Error),
-    /// Stamp lift failed; carries the underlying step-level error.
-    #[display("stamp lift failed: {_0}")]
-    LiftFailed(ragu::Error),
     /// Number of spendable PCDs doesn't match number of spends.
     #[display("spendable PCD count mismatch")]
     SpendableMismatch,
@@ -678,7 +671,7 @@ impl ProofStamp {
             .map_err(ProveError::ActionDigest)?;
 
         self.prove_lift(rng, action_digests, chain)
-            .map_err(ProveError::LiftFailed)
+            .map_err(ProveError::ProofFailed)
     }
 
     /// Merges two stamps into one covering stamp.
@@ -720,7 +713,7 @@ impl ProofStamp {
                 right_stamp.proof,
             ),
         )
-        .map_err(ProveError::MergeFailed)?;
+        .map_err(ProveError::ProofFailed)?;
 
         let coverage = blake2b::action_descriptor_digest(
             &left_desc

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 pub mod proof;
 
 use alloc::{boxed::Box, collections::BTreeSet, vec, vec::Vec};
+use core::error;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, Into, PartialEq};
@@ -26,9 +27,11 @@ use crate::{
     effect,
     entropy::ActionRandomizer,
     keys::ProofAuthorizingKey,
-    primitives::{ActionDigest, ActionDigestError, Anchor, Tachygram, TachygramSetCommit},
+    primitives::{
+        ActionDigest, ActionDigestError, Anchor, EpochIndex, Tachygram, TachygramSetCommit,
+    },
     serialization,
-    stamp::proof::{delegation, pool::AnchorChain, spend, spendable},
+    stamp::proof::{delegation, pool, pool::AnchorChain, spend, spendable},
     value,
 };
 
@@ -352,7 +355,9 @@ impl Plan {
         let mut entries = Vec::with_capacity(self.spends.len() + self.outputs.len());
 
         if self.spends.len() != spendbind_inputs.len() {
-            return Err(ProveError::SpendableMismatch);
+            return Err(ProveError::MissingPcd(
+                "one spendbind input per spend action".into(),
+            ));
         }
 
         for ((desc, alpha, note, rcv), (nf_pcd, spendable_pcd)) in
@@ -420,7 +425,8 @@ impl Plan {
                     merged_proof,
                 ))
             })
-            .ok_or(ProveError::NoActions)??;
+            .transpose()?
+            .ok_or(ProveError::MissingPcd("no actions to prove".into()))?;
 
         let coverage = blake2b::action_descriptor_digest(&Vec::<[u8; 64]>::from_iter(descriptors));
         let tachygram_set = tachygrams
@@ -443,18 +449,15 @@ impl Plan {
 #[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum ProveError {
-    /// The plan has no actions to prove.
-    #[display("no actions to prove")]
-    NoActions,
+    /// Missing PCD inputs for the operation.
+    #[display("missing pcd inputs: {_0}")]
+    MissingPcd(Box<dyn error::Error + Send + Sync + 'static>),
     /// Action digest construction failed (cv or rk was the identity point).
     #[display("action digest failed: {_0}")]
     ActionDigest(ActionDigestError),
     /// Proof creation failed; carries the underlying step-level error.
     #[display("proof failed: {_0}")]
     ProofFailed(ragu::Error),
-    /// Number of spendable PCDs doesn't match number of spends.
-    #[display("spendable PCD count mismatch")]
-    SpendableMismatch,
 }
 
 /// A stamp carrying tachygrams, anchor, and a proof for specific actions.
@@ -470,17 +473,13 @@ pub struct ProofStamp {
     /// See [`blake2b::action_descriptor_digest`]
     pub coverage: [u8; 32],
 
-    /// Pool state at the anchor block.
+    /// The historic pool state for which this stamp is valid.
     pub anchor: Anchor,
 
-    /// Commitment to the tachygram multiset below, so that anchor advancement
-    /// reads the point rather than rebuilding it.
-    ///
-    /// Carried, not derived, so full validation must confirm it against
-    /// `tachygrams`. See [`ProofStamp::is_accumulating`].
+    /// The commitment to this stamp's tachygram set.
     pub tachygram_set: TachygramSetCommit,
 
-    /// Tachygrams (nullifiers and note commitments) for data availability.
+    /// This stamp's tachygram set.
     pub tachygrams: BTreeSet<Tachygram>,
 
     /// The Ragu proof bytes.
@@ -656,21 +655,53 @@ impl ProofStamp {
         })
     }
 
-    /// Advances the stamp's anchor along an [`AnchorChain`] segment, deriving
+    /// Advances the stamp's anchor across the stamps that follow it, deriving
     /// the action digests for the lift proof from the covered descriptors.
+    ///
+    /// `seed_witnesses` are the [`pool::AnchorSeed`] witnesses of the stamps
+    /// immediately following this one, in chain order. They are expected to
+    /// form a valid chain rooted at [`ProofStamp::anchor`], which the caller
+    /// establishes by folding them through [`Anchor::next_stamp`].
+    ///
+    /// # Errors
+    ///
+    /// A sequence that is empty, or that does not chain, fails as
+    /// [`ProveError::ProofFailed`].
     pub fn lift<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,
         descriptors: &BTreeSet<action::Descriptor>,
-        chain: ragu::Pcd<AnchorChain>,
+        seed_witnesses: Vec<(Anchor, EpochIndex, TachygramSetCommit)>,
     ) -> Result<Self, ProveError> {
+        let anchor_seeds = seed_witnesses
+            .into_iter()
+            .map(|witness| {
+                PROOF_SYSTEM
+                    .seed(rng, pool::AnchorSeed, witness)
+                    .map(|(pcd, _aux)| pcd)
+                    .map_err(ProveError::ProofFailed)
+            })
+            .collect::<Result<Vec<_>, ProveError>>()?;
+
+        let anchor_chain = anchor_seeds
+            .into_iter()
+            .map(Ok)
+            .reduce(|left, right| {
+                PROOF_SYSTEM
+                    .fuse(rng, pool::AnchorFuse, (), left?, right?)
+                    .map(|(pcd, _aux)| pcd)
+                    .map_err(ProveError::ProofFailed)
+            })
+            .transpose()?
+            .ok_or(ProveError::MissingPcd("anchor chain is empty".into()))?;
+
         let action_digests = descriptors
             .iter()
             .map(action::Descriptor::digest)
             .collect::<Result<BTreeSet<ActionDigest>, ActionDigestError>>()
             .map_err(ProveError::ActionDigest)?;
 
-        self.prove_lift(rng, action_digests, chain)
+        self.prove_lift(rng, action_digests, anchor_chain)
             .map_err(ProveError::ProofFailed)
     }
 

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -6,13 +6,14 @@ extern crate alloc;
 
 pub mod proof;
 
-use alloc::{boxed::Box, collections::BTreeSet, vec, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeSet, format, vec, vec::Vec};
 use core::error;
 
 use corez::io::{self, Read, Write};
 use derive_more::{Debug, Display, Eq as TotalEq, Error, Into, PartialEq};
 use ff::PrimeField as _;
-use pasta_curves::Fp;
+use group::{Curve as _, GroupEncoding as _};
+use pasta_curves::{Eq, Fp};
 use proof::{
     PROOF_SYSTEM, output,
     stamp::{MergeStamp, OutputStamp, SpendStamp, StampHeader, StampLift},
@@ -172,7 +173,7 @@ impl StampState for ProofStamp {
             blake2b::stamp_data_digest(
                 blake2b::stamp_proof_digest(proof.as_ref()),
                 anchor,
-                self.tachygram_set.to_bytes(),
+                self.tachygram_set.as_ref().to_affine().to_bytes(),
                 &tachygrams,
             )
         };
@@ -199,7 +200,8 @@ impl StampState for ProofStamp {
         // Parsing does not confirm this against the tachygrams below: an MSM
         // over attacker-supplied bytes is a denial-of-service vector. See
         // `ProofStamp::is_accumulating`.
-        let tachygram_set = TachygramSetCommit::read(&mut reader)?;
+        let tachygram_set =
+            TachygramSetCommit::from(Eq::from(serialization::read_eq_affine(&mut reader)?));
 
         // `n_tachygrams` is attacker-controlled up to MAX_COMPACT_SIZE (2^25), so
         // do not pre-allocate vector capacity. vector reads are ASSUMED to hit
@@ -255,7 +257,7 @@ impl StampState for ProofStamp {
     fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.coverage)?;
         self.anchor.write(&mut writer)?;
-        self.tachygram_set.write(&mut writer)?;
+        serialization::write_eq_affine(&mut writer, &self.tachygram_set.as_ref().to_affine())?;
         serialization::write_compactsize(
             &mut writer,
             u64::try_from(self.tachygrams.len()).map_err(|_err| {
@@ -356,7 +358,12 @@ impl Plan {
 
         if self.spends.len() != spendbind_inputs.len() {
             return Err(ProveError::MissingPcd(
-                "one spendbind input per spend action".into(),
+                format!(
+                    "cannot prove {} spend actions with {} spendbind inputs",
+                    self.spends.len(),
+                    spendbind_inputs.len(),
+                )
+                .into(),
             ));
         }
 
@@ -401,7 +408,7 @@ impl Plan {
 
         let (descriptors, _digests, tachygrams, anchor, proof) = entries
             .into_iter()
-            .map(Ok::<_, ProveError>)
+            .map(Ok)
             .reduce(|acc, next| {
                 let (left_desc, left_digests, left_tachygrams, left_anchor, left_proof) = acc?;
                 let (right_desc, right_digests, right_tachygrams, right_anchor, right_proof) =
@@ -426,7 +433,9 @@ impl Plan {
                 ))
             })
             .transpose()?
-            .ok_or(ProveError::MissingPcd("no actions to prove".into()))?;
+            .ok_or(ProveError::MissingPcd(
+                "no proof for no planned actions".into(),
+            ))?;
 
         let coverage = blake2b::action_descriptor_digest(&Vec::<[u8; 64]>::from_iter(descriptors));
         let tachygram_set = tachygrams
@@ -693,7 +702,9 @@ impl ProofStamp {
                     .map_err(ProveError::ProofFailed)
             })
             .transpose()?
-            .ok_or(ProveError::MissingPcd("anchor chain is empty".into()))?;
+            .ok_or(ProveError::MissingPcd(
+                "no anchor chain proof for no anchor advance".into(),
+            ))?;
 
         let action_digests = descriptors
             .iter()

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -32,7 +32,7 @@ use crate::{
         ActionDigest, ActionDigestError, Anchor, EpochIndex, Tachygram, TachygramSetCommit,
     },
     serialization,
-    stamp::proof::{delegation, pool, pool::AnchorChain, spend, spendable},
+    stamp::proof::{delegation, pool, spend, spendable},
     value,
 };
 
@@ -637,21 +637,19 @@ impl ProofStamp {
         ))
     }
 
-    /// Advances the stamp's anchor along an [`AnchorChain`] segment.
-    ///
-    /// `action_digests` and the chain's root are unchecked here.
+    /// Advances the stamp's anchor with the provided anchor chain proof.
     pub fn prove_lift<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,
         action_digests: impl IntoIterator<Item = ActionDigest>,
-        chain: ragu::Pcd<AnchorChain>,
+        anchor_chain: ragu::Pcd<pool::AnchorChain>,
     ) -> Result<Self, ragu::Error> {
         let action_set = action_digests.into_iter().collect::<ActionSetPoly>();
         let stamp_pcd =
             self.proof
                 .carry::<StampHeader>((action_set.commit(), self.tachygram_set, self.anchor));
 
-        let (pcd, ()) = PROOF_SYSTEM.fuse(rng, StampLift, (), stamp_pcd, chain)?;
+        let (pcd, ()) = PROOF_SYSTEM.fuse(rng, StampLift, (), stamp_pcd, anchor_chain)?;
         let anchor = pcd.data().2;
         let rerand = PROOF_SYSTEM.rerandomize(pcd, rng)?;
 
@@ -664,18 +662,7 @@ impl ProofStamp {
         })
     }
 
-    /// Advances the stamp's anchor across the stamps that follow it, deriving
-    /// the action digests for the lift proof from the covered descriptors.
-    ///
-    /// `seed_witnesses` are the [`pool::AnchorSeed`] witnesses of the stamps
-    /// immediately following this one, in chain order. They are expected to
-    /// form a valid chain rooted at [`ProofStamp::anchor`], which the caller
-    /// establishes by folding them through [`Anchor::next_stamp`].
-    ///
-    /// # Errors
-    ///
-    /// A sequence that is empty, or that does not chain, fails as
-    /// [`ProveError::ProofFailed`].
+    /// Advances the stamp's anchor with a proof of the provided sequence.
     pub fn lift<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -456,6 +456,9 @@ pub enum ProveError {
     /// Stamp merge failed; carries the underlying step-level error.
     #[display("stamp merge failed: {_0}")]
     MergeFailed(ragu::Error),
+    /// Stamp lift failed; carries the underlying step-level error.
+    #[display("stamp lift failed: {_0}")]
+    LiftFailed(ragu::Error),
     /// Number of spendable PCDs doesn't match number of spends.
     #[display("spendable PCD count mismatch")]
     SpendableMismatch,
@@ -634,7 +637,9 @@ impl ProofStamp {
     }
 
     /// Advances the stamp's anchor along an [`AnchorChain`] segment.
-    pub fn lift<RNG: RngCore + CryptoRng>(
+    ///
+    /// `action_digests` and the chain's root are unchecked here.
+    pub fn prove_lift<RNG: RngCore + CryptoRng>(
         self,
         rng: &mut RNG,
         action_digests: impl IntoIterator<Item = ActionDigest>,
@@ -656,6 +661,24 @@ impl ProofStamp {
             tachygrams: self.tachygrams,
             proof: Box::new(rerand.proof().clone()),
         })
+    }
+
+    /// Advances the stamp's anchor along an [`AnchorChain`] segment, deriving
+    /// the action digests for the lift proof from the covered descriptors.
+    pub fn lift<RNG: RngCore + CryptoRng>(
+        self,
+        rng: &mut RNG,
+        descriptors: &BTreeSet<action::Descriptor>,
+        chain: ragu::Pcd<AnchorChain>,
+    ) -> Result<Self, ProveError> {
+        let action_digests = descriptors
+            .iter()
+            .map(action::Descriptor::digest)
+            .collect::<Result<BTreeSet<ActionDigest>, ActionDigestError>>()
+            .map_err(ProveError::ActionDigest)?;
+
+        self.prove_lift(rng, action_digests, chain)
+            .map_err(ProveError::LiftFailed)
     }
 
     /// Merges two stamps into one covering stamp.

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     keys::ProofAuthorizingKey,
     primitives::{ActionDigest, ActionDigestError, Anchor, Tachygram, TachygramSetCommit},
     serialization,
-    stamp::proof::{delegation, spend, spendable},
+    stamp::proof::{delegation, pool::AnchorChain, spend, spendable},
     value,
 };
 
@@ -638,7 +638,7 @@ impl ProofStamp {
         self,
         rng: &mut RNG,
         action_digests: impl IntoIterator<Item = ActionDigest>,
-        chain: ragu::Pcd<proof::pool::AnchorChain>,
+        chain: ragu::Pcd<AnchorChain>,
     ) -> Result<Self, ragu::Error> {
         let action_set = action_digests.into_iter().collect::<ActionSetPoly>();
         let stamp_pcd =

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -14,7 +14,7 @@ use ff::PrimeField as _;
 use pasta_curves::Fp;
 use proof::{
     PROOF_SYSTEM, output,
-    stamp::{MergeStamp, OutputStamp, SpendStamp, StampHeader},
+    stamp::{MergeStamp, OutputStamp, SpendStamp, StampHeader, StampLift},
 };
 use ragu::{self, proof::PROOF_SIZE_COMPRESSED};
 use rand_core::{CryptoRng, RngCore};
@@ -631,6 +631,31 @@ impl ProofStamp {
             anchor,
             Box::new(rerand.proof().clone()),
         ))
+    }
+
+    /// Advances the stamp's anchor along an [`AnchorChain`] segment.
+    pub fn lift<RNG: RngCore + CryptoRng>(
+        self,
+        rng: &mut RNG,
+        action_digests: impl IntoIterator<Item = ActionDigest>,
+        chain: ragu::Pcd<proof::pool::AnchorChain>,
+    ) -> Result<Self, ragu::Error> {
+        let action_set = action_digests.into_iter().collect::<ActionSetPoly>();
+        let stamp_pcd =
+            self.proof
+                .carry::<StampHeader>((action_set.commit(), self.tachygram_set, self.anchor));
+
+        let (pcd, ()) = PROOF_SYSTEM.fuse(rng, StampLift, (), stamp_pcd, chain)?;
+        let anchor = pcd.data().2;
+        let rerand = PROOF_SYSTEM.rerandomize(pcd, rng)?;
+
+        Ok(Self {
+            coverage: self.coverage,
+            anchor,
+            tachygram_set: self.tachygram_set,
+            tachygrams: self.tachygrams,
+            proof: Box::new(rerand.proof().clone()),
+        })
     }
 
     /// Merges two stamps into one covering stamp.

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -205,7 +205,10 @@ impl Step for AnchorSeed {
         _left: <Self::Left as Header>::Data,
         _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
-        let end = start.next_stamp(epoch, &stamp_commit);
+        let end = start
+            .next_stamp(epoch, &stamp_commit)
+            .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
+
         Ok(((start, end), ()))
     }
 }
@@ -276,7 +279,9 @@ impl Step for UnspentSeed {
         ctx.enforce_poly_query(stamp_tg_set.commit().into(), nf_point, eval)?;
         enforce_nonzero(eval, "UnspentSeed: found nullifier in set")?;
         let stamp_commit = stamp_tg_set.commit();
-        let tested_anchor = anchor_prev.next_stamp(epoch, &stamp_commit);
+        let tested_anchor = anchor_prev
+            .next_stamp(epoch, &stamp_commit)
+            .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
         // Empty elapsed: the sentinel constant `1` commits to `g0`, never the
         // identity point.
         let elapsed_commit = NfSeqCommit::from(g0 * Fp::ONE);
@@ -344,7 +349,9 @@ impl Step for EndEpochUnspentSeed {
         let elapsed_commit = NfSeqCommit::from(g0 * Fp::from(nf_prev) + g1);
 
         let epoch = epoch_prev.next();
-        let anchor = anchor_prev.next_epoch(epoch);
+        let anchor = anchor_prev
+            .next_epoch(epoch)
+            .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
 
         Ok((
             (

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -112,7 +112,9 @@ impl Step for SpendableInit {
         // so the proof certifies the fold of `epoch` and `creation_commit`;
         // consensus membership of the eventual spend anchor binds the rest
         // (see the step doc).
-        let post_cm_anchor = pre_cm_anchor.next_stamp(epoch, &creation_commit);
+        let post_cm_anchor = pre_cm_anchor
+            .next_stamp(epoch, &creation_commit)
+            .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
 
         Ok(((cm, (epoch, present_nf), post_cm_anchor), ()))
     }

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -201,10 +201,12 @@ fn unspent_fuse_rejects_invalid_compositions() {
     let stamps_left = vec![Tachygram::random(&mut *rng)];
     let stamps_right = vec![Tachygram::random(&mut *rng)];
     let start = Anchor::default();
-    let mid = start.next_stamp(
-        EpochIndex(0),
-        &TachygramSetPoly::from_iter(stamps_left.clone()).commit(),
-    );
+    let mid = start
+        .next_stamp(
+            EpochIndex(0),
+            &TachygramSetPoly::from_iter(stamps_left.clone()).commit(),
+        )
+        .expect("valid step");
 
     // nf mismatch: contiguous states but different nfs.
     {
@@ -813,17 +815,24 @@ fn multi_epoch_fuse_setup(
     let start_height = BlockHeight(2);
     let junction_height = BlockHeight(2 * EPOCH_SIZE + 2);
     let end_height = BlockHeight(3 * EPOCH_SIZE + 2);
-    let start = pool.prev_anchor_at(start_height).next_stamp(
-        start_height.epoch(),
-        &pool.stamp_commits_at(start_height)[0],
-    );
-    let junction = pool.prev_anchor_at(junction_height).next_stamp(
-        junction_height.epoch(),
-        &pool.stamp_commits_at(junction_height)[0],
-    );
+    let start = pool
+        .prev_anchor_at(start_height)
+        .next_stamp(
+            start_height.epoch(),
+            &pool.stamp_commits_at(start_height)[0],
+        )
+        .expect("valid step");
+    let junction = pool
+        .prev_anchor_at(junction_height)
+        .next_stamp(
+            junction_height.epoch(),
+            &pool.stamp_commits_at(junction_height)[0],
+        )
+        .expect("valid step");
     let end = pool
         .prev_anchor_at(end_height)
-        .next_stamp(end_height.epoch(), &pool.stamp_commits_at(end_height)[0]);
+        .next_stamp(end_height.epoch(), &pool.stamp_commits_at(end_height)[0])
+        .expect("valid step");
     let left = build_unspent_pcd_between_anchors(rng, &pool, &[nf0, nf1, nf2], (start, junction));
     let right = build_unspent_pcd_between_anchors(rng, &pool, &[nf2, nf3], (junction, end));
     assert_eq!(left.data().0, start, "left rooted at the sub-block start");
@@ -1009,13 +1018,17 @@ fn epoch_fuse_setup(
     let nf: [Nullifier; 5] = array::from_fn(|_| Nullifier::from(Fp::random(&mut *rng)));
     let start_height = BlockHeight(2);
     let end_height = BlockHeight(4 * EPOCH_SIZE + 2);
-    let start = pool.prev_anchor_at(start_height).next_stamp(
-        start_height.epoch(),
-        &pool.stamp_commits_at(start_height)[0],
-    );
+    let start = pool
+        .prev_anchor_at(start_height)
+        .next_stamp(
+            start_height.epoch(),
+            &pool.stamp_commits_at(start_height)[0],
+        )
+        .expect("valid step");
     let end = pool
         .prev_anchor_at(end_height)
-        .next_stamp(end_height.epoch(), &pool.stamp_commits_at(end_height)[0]);
+        .next_stamp(end_height.epoch(), &pool.stamp_commits_at(end_height)[0])
+        .expect("valid step");
     let left = build_unspent_pcd_between_anchors(
         rng,
         &pool,
@@ -1108,7 +1121,7 @@ fn end_epoch_unspent_seed_spans_one_boundary_link() {
     assert_eq!(anchor_prev, epoch_tip);
     assert_eq!(
         anchor_last,
-        epoch_tip.next_epoch(EpochIndex(5)),
+        epoch_tip.next_epoch(EpochIndex(5)).expect("valid step"),
         "the segment covers the boundary tick"
     );
     assert_eq!(epoch_start, EpochIndex(4));
@@ -1178,7 +1191,7 @@ fn spendable_lift_advances_from_an_epoch_tip() {
         (
             note.commitment(),
             (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
-            epoch0_tip.next_epoch(EpochIndex(1))
+            epoch0_tip.next_epoch(EpochIndex(1)).expect("valid step")
         ),
         "the tick advances epoch, nullifier and anchor together"
     );
@@ -1312,7 +1325,8 @@ fn unspent_span_ending_on_a_boundary_anchor() {
     assert_eq!(
         pool.anchor_at(target_height),
         pool.pre_epoch_anchor(EpochIndex(1))
-            .next_epoch(EpochIndex(1)),
+            .next_epoch(EpochIndex(1))
+            .expect("valid step"),
         "a silent epoch-first block rests on the boundary anchor"
     );
 

--- a/crates/tachyon/src/stamp/proof/tests.rs
+++ b/crates/tachyon/src/stamp/proof/tests.rs
@@ -206,7 +206,7 @@ fn unspent_fuse_rejects_invalid_compositions() {
             EpochIndex(0),
             &TachygramSetPoly::from_iter(stamps_left.clone()).commit(),
         )
-        .expect("valid step");
+        .unwrap();
 
     // nf mismatch: contiguous states but different nfs.
     {
@@ -821,18 +821,18 @@ fn multi_epoch_fuse_setup(
             start_height.epoch(),
             &pool.stamp_commits_at(start_height)[0],
         )
-        .expect("valid step");
+        .unwrap();
     let junction = pool
         .prev_anchor_at(junction_height)
         .next_stamp(
             junction_height.epoch(),
             &pool.stamp_commits_at(junction_height)[0],
         )
-        .expect("valid step");
+        .unwrap();
     let end = pool
         .prev_anchor_at(end_height)
         .next_stamp(end_height.epoch(), &pool.stamp_commits_at(end_height)[0])
-        .expect("valid step");
+        .unwrap();
     let left = build_unspent_pcd_between_anchors(rng, &pool, &[nf0, nf1, nf2], (start, junction));
     let right = build_unspent_pcd_between_anchors(rng, &pool, &[nf2, nf3], (junction, end));
     assert_eq!(left.data().0, start, "left rooted at the sub-block start");
@@ -1024,11 +1024,11 @@ fn epoch_fuse_setup(
             start_height.epoch(),
             &pool.stamp_commits_at(start_height)[0],
         )
-        .expect("valid step");
+        .unwrap();
     let end = pool
         .prev_anchor_at(end_height)
         .next_stamp(end_height.epoch(), &pool.stamp_commits_at(end_height)[0])
-        .expect("valid step");
+        .unwrap();
     let left = build_unspent_pcd_between_anchors(
         rng,
         &pool,
@@ -1121,7 +1121,7 @@ fn end_epoch_unspent_seed_spans_one_boundary_link() {
     assert_eq!(anchor_prev, epoch_tip);
     assert_eq!(
         anchor_last,
-        epoch_tip.next_epoch(EpochIndex(5)).expect("valid step"),
+        epoch_tip.next_epoch(EpochIndex(5)).unwrap(),
         "the segment covers the boundary tick"
     );
     assert_eq!(epoch_start, EpochIndex(4));
@@ -1191,7 +1191,7 @@ fn spendable_lift_advances_from_an_epoch_tip() {
         (
             note.commitment(),
             (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
-            epoch0_tip.next_epoch(EpochIndex(1)).expect("valid step")
+            epoch0_tip.next_epoch(EpochIndex(1)).unwrap()
         ),
         "the tick advances epoch, nullifier and anchor together"
     );
@@ -1326,7 +1326,7 @@ fn unspent_span_ending_on_a_boundary_anchor() {
         pool.anchor_at(target_height),
         pool.pre_epoch_anchor(EpochIndex(1))
             .next_epoch(EpochIndex(1))
-            .expect("valid step"),
+            .unwrap(),
         "a silent epoch-first block rests on the boundary anchor"
     );
 

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -99,7 +99,10 @@ fn plan_prove_rejects_invalid_inputs() {
     {
         let plan = Plan::new(alloc::vec![], alloc::vec![], anchor);
         let err = plan.prove(rng, &user.pak, alloc::vec![]).unwrap_err();
-        assert!(matches!(err, ProveError::NoActions), "expected NoActions");
+        let ProveError::MissingPcd(reason) = err else {
+            panic!("expected MissingPcd, got {err:?}");
+        };
+        assert_eq!(reason.to_string(), "no actions to prove");
     }
 
     let bundle_a = || (range_a.clone(), sp_a.clone());
@@ -110,10 +113,10 @@ fn plan_prove_rejects_invalid_inputs() {
         let plan = Plan::new(two_spends(), alloc::vec![], anchor);
         let pcds = alloc::vec![bundle_a()];
         let err = plan.prove(rng, &user.pak, pcds).unwrap_err();
-        assert!(
-            matches!(err, ProveError::SpendableMismatch),
-            "expected SpendableMismatch"
-        );
+        let ProveError::MissingPcd(reason) = err else {
+            panic!("expected MissingPcd, got {err:?}");
+        };
+        assert_eq!(reason.to_string(), "one spendbind input per spend action");
     }
 
     // Too many PCDs: 2 spends, 3 PCDs.
@@ -121,10 +124,10 @@ fn plan_prove_rejects_invalid_inputs() {
         let plan = Plan::new(two_spends(), alloc::vec![], anchor);
         let pcds = alloc::vec![bundle_a(), bundle_b(), bundle_a()];
         let err = plan.prove(rng, &user.pak, pcds).unwrap_err();
-        assert!(
-            matches!(err, ProveError::SpendableMismatch),
-            "expected SpendableMismatch"
-        );
+        let ProveError::MissingPcd(reason) = err else {
+            panic!("expected MissingPcd, got {err:?}");
+        };
+        assert_eq!(reason.to_string(), "one spendbind input per spend action");
     }
 
     // Correspondence swap: lengths match, pairing is wrong. Each pair is
@@ -135,11 +138,11 @@ fn plan_prove_rejects_invalid_inputs() {
         let plan = Plan::new(two_spends(), alloc::vec![], anchor);
         let pcds = alloc::vec![bundle_b(), bundle_a()];
         let err = plan.prove(rng, &user.pak, pcds).unwrap_err();
-        let ProveError::ProofFailed(ragu::Error::InvalidWitness(inner)) = err else {
+        let ProveError::ProofFailed(ragu::Error::InvalidWitness(reason)) = err else {
             panic!("expected ProofFailed(InvalidWitness), got {err:?}");
         };
         assert_eq!(
-            inner.to_string(),
+            reason.to_string(),
             "SpendStamp: note does not match the spend"
         );
     }
@@ -747,8 +750,9 @@ fn lift_then_verify() {
     );
 }
 
-/// The descriptor wrapper derives the same action set the digest-taking core
-/// is given, so a lift over descriptors verifies against their digests.
+/// A stamp covers the actions of the plan it was proven for, so lifting it
+/// over their descriptors reaches the same action set the digest-taking core
+/// is given directly, and the result verifies against their digests.
 #[test]
 fn lift_over_descriptors_then_verify() {
     let rng = &mut StdRng::seed_from_u64(0);
@@ -757,20 +761,32 @@ fn lift_over_descriptors_then_verify() {
 
     pool.advance(3, |_| random_block(rng, 1, 4));
     let note = wallet.random_note(200);
-    let (stamp, plan) = build_output_stamp(rng, pool.anchor(), note);
+    let (stamp, covered_plan) = build_output_stamp(rng, pool.anchor(), note);
+    let covered_descriptors = BTreeSet::from_iter([covered_plan.descriptor()]);
     let stamped_at = pool.height();
 
+    // The stamps published after this one, each paired with the anchor it
+    // absorbs into, which is what an `AnchorSeed` witnesses.
     pool.advance(2, |_| random_block(rng, 1, 4));
-    let chain =
-        build_anchor_chain_pcd(rng, &pool, stamped_at.next().expect("next")..=pool.height());
+    let epoch = pool.height().epoch();
+    let following_stamps = (stamped_at.0 + 1..=pool.height().0)
+        .flat_map(|height| pool.stamp_commits_at(BlockHeight(height)))
+        .scan(stamp.anchor, |anchor_before, tachygram_set| {
+            let witness = (*anchor_before, epoch, tachygram_set);
+            *anchor_before = anchor_before
+                .next_stamp(epoch, &tachygram_set)
+                .expect("valid step");
+            Some(witness)
+        })
+        .collect();
 
     let lifted = stamp
-        .lift(rng, &BTreeSet::from_iter([plan.descriptor()]), chain)
+        .lift(rng, &covered_descriptors, following_stamps)
         .expect("lift over the covered descriptors");
 
     assert!(
         lifted
-            .verify_proof(rng, [plan.digest().expect("valid plan")])
+            .verify_proof(rng, [covered_plan.digest().expect("valid plan")])
             .expect("verify"),
         "a lifted stamp must verify against the actions it covers"
     );

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -212,8 +212,8 @@ fn double_output_cannot_aggregate() {
             (stamp_b.clone(), descriptors_b.clone()),
         )
         .expect_err("overlapping tachygrams must not merge");
-        let ProveError::MergeFailed(ragu::Error::InvalidWitness(inner)) = merge_err else {
-            panic!("expected MergeFailed(InvalidWitness), got {merge_err:?}");
+        let ProveError::ProofFailed(ragu::Error::InvalidWitness(inner)) = merge_err else {
+            panic!("expected ProofFailed(InvalidWitness), got {merge_err:?}");
         };
         assert_eq!(
             inner.to_string(),
@@ -339,8 +339,8 @@ fn double_spend_cannot_aggregate() {
             (stamp_b.clone(), descriptors_b.clone()),
         )
         .expect_err("shared nullifiers must not merge");
-        let ProveError::MergeFailed(ragu::Error::InvalidWitness(inner)) = merge_err else {
-            panic!("expected MergeFailed(InvalidWitness), got {merge_err:?}");
+        let ProveError::ProofFailed(ragu::Error::InvalidWitness(inner)) = merge_err else {
+            panic!("expected ProofFailed(InvalidWitness), got {merge_err:?}");
         };
         assert_eq!(
             inner.to_string(),
@@ -423,8 +423,8 @@ fn cannot_forge_stamp_covering_duplicated_action() {
             (output_stamp.clone(), descriptors.clone()),
         )
         .expect_err("a duplicated action must not merge");
-        let ProveError::MergeFailed(ragu::Error::InvalidWitness(inner)) = merge_err else {
-            panic!("expected MergeFailed(InvalidWitness), got {merge_err:?}");
+        let ProveError::ProofFailed(ragu::Error::InvalidWitness(inner)) = merge_err else {
+            panic!("expected ProofFailed(InvalidWitness), got {merge_err:?}");
         };
         assert_eq!(
             inner.to_string(),

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -98,11 +98,12 @@ fn plan_prove_rejects_invalid_inputs() {
     // Empty plan: no actions at all.
     {
         let plan = Plan::new(alloc::vec![], alloc::vec![], anchor);
+
         let err = plan.prove(rng, &user.pak, alloc::vec![]).unwrap_err();
         let ProveError::MissingPcd(reason) = err else {
             panic!("expected MissingPcd, got {err:?}");
         };
-        assert_eq!(reason.to_string(), "no actions to prove");
+        assert_eq!(reason.to_string(), "no proof for no planned actions");
     }
 
     let bundle_a = || (range_a.clone(), sp_a.clone());
@@ -112,22 +113,30 @@ fn plan_prove_rejects_invalid_inputs() {
     {
         let plan = Plan::new(two_spends(), alloc::vec![], anchor);
         let pcds = alloc::vec![bundle_a()];
+
         let err = plan.prove(rng, &user.pak, pcds).unwrap_err();
         let ProveError::MissingPcd(reason) = err else {
             panic!("expected MissingPcd, got {err:?}");
         };
-        assert_eq!(reason.to_string(), "one spendbind input per spend action");
+        assert_eq!(
+            reason.to_string(),
+            "cannot prove 2 spend actions with 1 spendbind inputs"
+        );
     }
 
     // Too many PCDs: 2 spends, 3 PCDs.
     {
         let plan = Plan::new(two_spends(), alloc::vec![], anchor);
         let pcds = alloc::vec![bundle_a(), bundle_b(), bundle_a()];
+
         let err = plan.prove(rng, &user.pak, pcds).unwrap_err();
         let ProveError::MissingPcd(reason) = err else {
             panic!("expected MissingPcd, got {err:?}");
         };
-        assert_eq!(reason.to_string(), "one spendbind input per spend action");
+        assert_eq!(
+            reason.to_string(),
+            "cannot prove 2 spend actions with 3 spendbind inputs"
+        );
     }
 
     // Correspondence swap: lengths match, pairing is wrong. Each pair is
@@ -607,18 +616,34 @@ fn verify_proof_action_multiset_invariants() {
 /// even though the sequence is non-decreasing.
 #[test]
 fn read_rejects_duplicate_tachygrams() {
-    let tg = Tachygram::from(Fp::ONE);
+    let rng = &mut StdRng::seed_from_u64(0);
+
+    let anchor = Anchor(Fp::random(&mut *rng));
+    let tg = Tachygram::random(&mut *rng);
+    let tg_set = [tg, tg];
 
     let mut buf = Vec::new();
-    buf.extend_from_slice(&[0u8; 32]); // covered actions digest
-    Anchor(Fp::ZERO).write(&mut buf).expect("write anchor");
-    TachygramSetPoly::from_iter([tg])
-        .commit()
-        .write(&mut buf)
+    {
+        buf.extend_from_slice(&[0u8; 32]); // dummy actions digest
+        anchor.write(&mut buf).expect("write anchor");
+        serialization::write_eq_affine(
+            &mut buf,
+            &TachygramSetPoly::from_iter(tg_set)
+                .commit()
+                .as_ref()
+                .to_affine(),
+        )
         .expect("write tachygram set commitment");
-    serialization::write_compactsize(&mut buf, 2).expect("write tachygram count");
-    serialization::write_fp(&mut buf, &Fp::from(tg)).expect("write tachygram");
-    serialization::write_fp(&mut buf, &Fp::from(tg)).expect("write tachygram");
+
+        serialization::write_compactsize(
+            &mut buf,
+            tg_set.len().try_into().expect("tachygram count"),
+        )
+        .expect("write tachygram count");
+        for write_tg in tg_set {
+            serialization::write_fp(&mut buf, &write_tg.into()).expect("write tachygram");
+        }
+    }
 
     let err = ProofStamp::read(&*buf).expect_err("duplicate tachygrams must be rejected");
     assert_eq!(err.to_string(), "tachygrams are not unique");
@@ -773,9 +798,7 @@ fn lift_over_descriptors_then_verify() {
         .flat_map(|height| pool.stamp_commits_at(BlockHeight(height)))
         .scan(stamp.anchor, |anchor_before, tachygram_set| {
             let witness = (*anchor_before, epoch, tachygram_set);
-            *anchor_before = anchor_before
-                .next_stamp(epoch, &tachygram_set)
-                .expect("valid step");
+            *anchor_before = anchor_before.next_stamp(epoch, &tachygram_set).unwrap();
             Some(witness)
         })
         .collect();

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -712,7 +712,7 @@ fn lift_advances_a_stamp_anchor() {
 
     let before = stamp.clone();
     let lifted = stamp
-        .lift(rng, [], chain)
+        .prove_lift(rng, [], chain)
         .expect("lift over a within-epoch segment");
 
     assert_eq!(lifted.anchor, pool.anchor_at(lifted_to));
@@ -739,10 +739,39 @@ fn lift_then_verify() {
     let chain =
         build_anchor_chain_pcd(rng, &pool, stamped_at.next().expect("next")..=pool.height());
 
-    let lifted = stamp.lift(rng, [digest], chain).expect("lift");
+    let lifted = stamp.prove_lift(rng, [digest], chain).expect("lift");
 
     assert!(
         lifted.verify_proof(rng, [digest]).expect("verify"),
+        "a lifted stamp must verify against the actions it covers"
+    );
+}
+
+/// The descriptor wrapper derives the same action set the digest-taking core
+/// is given, so a lift over descriptors verifies against their digests.
+#[test]
+fn lift_over_descriptors_then_verify() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+
+    pool.advance(3, |_| random_block(rng, 1, 4));
+    let note = wallet.random_note(200);
+    let (stamp, plan) = build_output_stamp(rng, pool.anchor(), note);
+    let stamped_at = pool.height();
+
+    pool.advance(2, |_| random_block(rng, 1, 4));
+    let chain =
+        build_anchor_chain_pcd(rng, &pool, stamped_at.next().expect("next")..=pool.height());
+
+    let lifted = stamp
+        .lift(rng, &BTreeSet::from_iter([plan.descriptor()]), chain)
+        .expect("lift over the covered descriptors");
+
+    assert!(
+        lifted
+            .verify_proof(rng, [plan.digest().expect("valid plan")])
+            .expect("verify"),
         "a lifted stamp must verify against the actions it covers"
     );
 }
@@ -763,7 +792,7 @@ fn lift_rejects_a_foreign_chain() {
     let chain = build_anchor_chain_pcd(rng, &foreign, BlockHeight(1)..=foreign.height());
 
     stamp
-        .lift(rng, [], chain)
+        .prove_lift(rng, [], chain)
         .expect_err("a segment from another chain must not lift a stamp");
 }
 
@@ -787,7 +816,7 @@ fn lift_rejects_wrong_digests() {
         build_anchor_chain_pcd(rng, &pool, stamped_at.next().expect("next")..=pool.height());
 
     let lifted = stamp
-        .lift(rng, [foreign_digest], chain)
+        .prove_lift(rng, [foreign_digest], chain)
         .expect("the lift itself cannot see the wrong action set");
 
     assert!(
@@ -829,7 +858,7 @@ fn merge_after_lift() {
 
     let chain = build_anchor_chain_pcd(rng, &pool, height_a.next().expect("next")..=height_b);
     let lifted_a = stamp_a
-        .lift(rng, [plan_a.digest().expect("valid plan")], chain)
+        .prove_lift(rng, [plan_a.digest().expect("valid plan")], chain)
         .expect("lift onto the later anchor");
 
     assert_eq!(lifted_a.anchor, stamp_b.anchor);

--- a/crates/tachyon/src/stamp/tests.rs
+++ b/crates/tachyon/src/stamp/tests.rs
@@ -10,8 +10,9 @@ use crate::{
     action,
     constants::EPOCH_SIZE,
     fixtures::{
-        PoolSim, WalletSim, build_autonome, build_output_stamp, forge_overlapping_merge,
-        random_action, random_block, random_block_with, shared_sk, spend_witness,
+        PoolSim, WalletSim, build_anchor_chain_pcd, build_autonome, build_output_stamp,
+        forge_overlapping_merge, random_action, random_block, random_block_with, shared_sk,
+        spend_witness,
     },
     primitives::BlockHeight,
 };
@@ -690,4 +691,148 @@ fn accumulating_rejects_mismatched_commitment() {
             .expect("verify"),
         "verification must reject an unconfirmed commitment"
     );
+}
+
+/// A lift moves the anchor to the segment's end and leaves the stamp's
+/// published data alone.
+#[test]
+fn lift_advances_a_stamp_anchor() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+
+    pool.advance(3, |_| random_block(rng, 1, 4));
+    let note = wallet.random_note(200);
+    let (stamp, _plan) = build_output_stamp(rng, pool.anchor(), note);
+    let stamped_at = pool.height();
+
+    pool.advance(2, |_| random_block(rng, 1, 4));
+    let lifted_to = pool.height();
+    let chain = build_anchor_chain_pcd(rng, &pool, stamped_at.next().expect("next")..=lifted_to);
+
+    let before = stamp.clone();
+    let lifted = stamp
+        .lift(rng, [], chain)
+        .expect("lift over a within-epoch segment");
+
+    assert_eq!(lifted.anchor, pool.anchor_at(lifted_to));
+    assert_eq!(lifted.coverage, before.coverage);
+    assert_eq!(lifted.tachygram_set, before.tachygram_set);
+    assert_eq!(lifted.tachygrams, before.tachygrams);
+}
+
+/// The header the lift rebuilds is the one the original proof was made
+/// against, so the lifted stamp still verifies against its covered actions.
+#[test]
+fn lift_then_verify() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+
+    pool.advance(3, |_| random_block(rng, 1, 4));
+    let note = wallet.random_note(200);
+    let (stamp, plan) = build_output_stamp(rng, pool.anchor(), note);
+    let stamped_at = pool.height();
+    let digest = plan.digest().expect("valid plan");
+
+    pool.advance(2, |_| random_block(rng, 1, 4));
+    let chain =
+        build_anchor_chain_pcd(rng, &pool, stamped_at.next().expect("next")..=pool.height());
+
+    let lifted = stamp.lift(rng, [digest], chain).expect("lift");
+
+    assert!(
+        lifted.verify_proof(rng, [digest]).expect("verify"),
+        "a lifted stamp must verify against the actions it covers"
+    );
+}
+
+/// A segment from an unrelated chain does not root at the stamp's anchor.
+#[test]
+fn lift_rejects_a_foreign_chain() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+    pool.advance(3, |_| random_block(rng, 1, 4));
+
+    let note = wallet.random_note(200);
+    let (stamp, _plan) = build_output_stamp(rng, pool.anchor(), note);
+
+    let mut foreign = PoolSim::genesis(rng);
+    foreign.advance(3, |_| random_block(rng, 1, 4));
+    let chain = build_anchor_chain_pcd(rng, &foreign, BlockHeight(1)..=foreign.height());
+
+    stamp
+        .lift(rng, [], chain)
+        .expect_err("a segment from another chain must not lift a stamp");
+}
+
+/// A lift takes the caller's word for the covered action set, so a wrong
+/// digest list is caught at verification rather than at prove time.
+#[test]
+fn lift_rejects_wrong_digests() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let wallet = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+
+    pool.advance(3, |_| random_block(rng, 1, 4));
+    let note = wallet.random_note(200);
+    let (stamp, plan) = build_output_stamp(rng, pool.anchor(), note);
+    let stamped_at = pool.height();
+    let digest = plan.digest().expect("valid plan");
+    let foreign_digest = random_action(rng).digest().expect("valid action");
+
+    pool.advance(2, |_| random_block(rng, 1, 4));
+    let chain =
+        build_anchor_chain_pcd(rng, &pool, stamped_at.next().expect("next")..=pool.height());
+
+    let lifted = stamp
+        .lift(rng, [foreign_digest], chain)
+        .expect("the lift itself cannot see the wrong action set");
+
+    assert!(
+        !lifted.verify_proof(rng, [digest]).expect("verify"),
+        "a stamp lifted under a forged action set must not verify"
+    );
+}
+
+/// Stamps taken at different anchors cannot merge until one is lifted onto
+/// the other's anchor.
+#[test]
+fn merge_after_lift() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user_a = WalletSim::random(rng);
+    let user_b = WalletSim::random(rng);
+    let mut pool = PoolSim::genesis(rng);
+
+    pool.advance(3, |_| random_block(rng, 1, 4));
+    let note_a = user_a.random_note(200);
+    let (stamp_a, plan_a) = build_output_stamp(rng, pool.anchor(), note_a);
+    let height_a = pool.height();
+
+    pool.advance(3, |_| random_block(rng, 1, 4));
+    let note_b = user_b.random_note(300);
+    let (stamp_b, plan_b) = build_output_stamp(rng, pool.anchor(), note_b);
+    let height_b = pool.height();
+
+    let (desc_a, desc_b) = (
+        BTreeSet::from_iter([plan_a.descriptor()]),
+        BTreeSet::from_iter([plan_b.descriptor()]),
+    );
+
+    ProofStamp::merge(
+        rng,
+        (stamp_a.clone(), desc_a.clone()),
+        (stamp_b.clone(), desc_b.clone()),
+    )
+    .expect_err("mismatched anchors must not merge");
+
+    let chain = build_anchor_chain_pcd(rng, &pool, height_a.next().expect("next")..=height_b);
+    let lifted_a = stamp_a
+        .lift(rng, [plan_a.digest().expect("valid plan")], chain)
+        .expect("lift onto the later anchor");
+
+    assert_eq!(lifted_a.anchor, stamp_b.anchor);
+    ProofStamp::merge(rng, (lifted_a, desc_a), (stamp_b, desc_b))
+        .expect("a lifted stamp merges with one at the anchor it was lifted to");
 }


### PR DESCRIPTION
`Bundle<ProofStamp>::lift` is the primary consumer api for use with whole consensus data.

consumers desiring more precise control may use
- `ProofStamp::lift` accepts witness data and builds `AnchorChain`
- `ProofStamp::prove_lift` accepts `AnchorChain` pcd directly

anchor advancement is now fallible, with `AnchorError`

additionally, `ProveError` unifies some cases to `MissingPcd`
