### PR TITLE
note: rename Positive to NonNegative

### DIFF
--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -143,7 +143,7 @@ mod tests {
         let ak = ask.derive_auth_public();
         let note = Note {
             pk: sk.derive_payment_key(),
-            value: value::Positive::try_from(1000u64).unwrap(),
+            value: value::NonNegative::try_from(1000u64).unwrap(),
             psi: nullifier::Trapdoor::random(rng),
             rcm: note::CommitmentTrapdoor::random(rng),
         };

--- a/crates/tachyon/src/note.rs
+++ b/crates/tachyon/src/note.rs
@@ -64,8 +64,9 @@ pub struct Note {
     /// The recipient's payment key.
     pub pk: PaymentKey,
 
-    /// The note value in zatoshis, less than 2.1e15
-    pub value: value::Positive,
+    /// The note value in zatoshis, less than 2.1e15. Zero-value notes
+    /// are legal (e.g. memo-only payments).
+    pub value: value::NonNegative,
 
     /// The nullifier trapdoor ($\psi$).
     pub psi: nullifier::Trapdoor,
@@ -116,26 +117,26 @@ mod tests {
     use crate::{constants::MAX_MONEY, value};
 
     #[test]
-    fn positive_value_accepts_max() {
-        value::Positive::try_from(MAX_MONEY).unwrap();
+    fn non_negative_value_accepts_max() {
+        value::NonNegative::try_from(MAX_MONEY).unwrap();
     }
 
     #[test]
-    fn positive_value_rejects_over_max() {
+    fn non_negative_value_rejects_over_max() {
         assert_eq!(
-            value::Positive::try_from(MAX_MONEY + 1),
+            value::NonNegative::try_from(MAX_MONEY + 1),
             Err(value::OutOfRange)
         );
     }
 
     #[test]
-    fn positive_value_accepts_zero() {
-        value::Positive::try_from(0u64).unwrap();
+    fn non_negative_value_accepts_zero() {
+        value::NonNegative::try_from(0u64).unwrap();
     }
 
     #[test]
-    fn positive_value_rejects_negative() {
-        assert_eq!(value::Positive::try_from(-1i64), Err(value::OutOfRange));
+    fn non_negative_value_rejects_negative() {
+        assert_eq!(value::NonNegative::try_from(-1i64), Err(value::OutOfRange));
     }
 
     /// Different trapdoors produce different commitments.
@@ -147,13 +148,13 @@ mod tests {
 
         let note1 = Note {
             pk,
-            value: value::Positive::try_from(100u64).unwrap(),
+            value: value::NonNegative::try_from(100u64).unwrap(),
             psi,
             rcm: CommitmentTrapdoor::random(rng),
         };
         let note2 = Note {
             pk,
-            value: value::Positive::try_from(100u64).unwrap(),
+            value: value::NonNegative::try_from(100u64).unwrap(),
             psi,
             rcm: CommitmentTrapdoor::random(rng),
         };

--- a/crates/tachyon/src/primitives/action_digest.rs
+++ b/crates/tachyon/src/primitives/action_digest.rs
@@ -61,7 +61,7 @@ mod tests {
         let sk = private::SpendingKey::random(rng);
         let note = Note {
             pk: sk.derive_payment_key(),
-            value: value::Positive::try_from(val).unwrap(),
+            value: value::NonNegative::try_from(val).unwrap(),
             psi: nullifier::Trapdoor::random(rng),
             rcm: note::CommitmentTrapdoor::random(rng),
         };

--- a/crates/tachyon/src/primitives/effect.rs
+++ b/crates/tachyon/src/primitives/effect.rs
@@ -27,7 +27,7 @@ pub trait Effect: sealed::Sealed {
 
     /// Commit to this effect's signed value contribution using the given
     /// trapdoor.
-    fn commit_value(rcv: value::Trapdoor, value: value::Positive) -> value::Commitment;
+    fn commit_value(rcv: value::Trapdoor, value: value::NonNegative) -> value::Commitment;
 }
 
 /// Spend effect marker.
@@ -43,7 +43,7 @@ impl Effect for Spend {
         Fq::from_uniform_bytes(&blake2b::alpha_spend(&theta.0, &Fp::from(cm).to_repr()))
     }
 
-    fn commit_value(rcv: value::Trapdoor, value: value::Positive) -> value::Commitment {
+    fn commit_value(rcv: value::Trapdoor, value: value::NonNegative) -> value::Commitment {
         rcv.commit(value)
     }
 }
@@ -53,7 +53,7 @@ impl Effect for Output {
         Fq::from_uniform_bytes(&blake2b::alpha_output(&theta.0, &Fp::from(cm).to_repr()))
     }
 
-    fn commit_value(rcv: value::Trapdoor, value: value::Positive) -> value::Commitment {
+    fn commit_value(rcv: value::Trapdoor, value: value::NonNegative) -> value::Commitment {
         rcv.commit(-value)
     }
 }

--- a/crates/tachyon/src/value.rs
+++ b/crates/tachyon/src/value.rs
@@ -21,10 +21,10 @@ pub type Commitment = ValueCommitment;
 pub type Balance = Value<{ -MAX_MONEY.cast_signed() }, { MAX_MONEY.cast_signed() }>;
 
 /// A non-negative integer not greater than `MAX_MONEY`.
-pub type Positive = Value<0, { MAX_MONEY.cast_signed() }>;
+pub type NonNegative = Value<0, { MAX_MONEY.cast_signed() }>;
 
 /// A non-positive integer not less than `-MAX_MONEY`.
-pub type Negative = Value<{ -MAX_MONEY.cast_signed() }, 0>;
+pub type NonPositive = Value<{ -MAX_MONEY.cast_signed() }, 0>;
 
 /// Shared with Orchard (§5.4.8.3).
 const VALUE_COMMITMENT_DOMAIN: &str = "z.cash:Orchard-cv";
@@ -100,14 +100,14 @@ impl From<Commitment> for EpAffine {
 #[derive(Clone, Copy, Debug, Into, Ord, PartialEq, PartialOrd, TotalEq)]
 pub struct Value<const MIN: i64, const MAX: i64>(i64);
 
-impl From<Negative> for Balance {
-    fn from(value: Negative) -> Self {
+impl From<NonPositive> for Balance {
+    fn from(value: NonPositive) -> Self {
         Self(value.0)
     }
 }
 
-impl From<Positive> for Balance {
-    fn from(value: Positive) -> Self {
+impl From<NonNegative> for Balance {
+    fn from(value: NonNegative) -> Self {
         Self(value.0)
     }
 }
@@ -227,16 +227,16 @@ impl ops::Neg for Balance {
     }
 }
 
-impl ops::Neg for Negative {
-    type Output = Positive;
+impl ops::Neg for NonPositive {
+    type Output = NonNegative;
 
     fn neg(self) -> Self::Output {
         self.negate()
     }
 }
 
-impl ops::Neg for Positive {
-    type Output = Negative;
+impl ops::Neg for NonNegative {
+    type Output = NonPositive;
 
     fn neg(self) -> Self::Output {
         self.negate()

--- a/crates/tachyon/tests/integration/fixtures.rs
+++ b/crates/tachyon/tests/integration/fixtures.rs
@@ -680,7 +680,7 @@ impl WalletSim {
             .or_insert_with(|| StdRng::from_seed(note_stream_seed(pk, value_amount)));
         Note {
             pk,
-            value: value::Positive::try_from(value_amount).expect("fixture value in range"),
+            value: value::NonNegative::try_from(value_amount).expect("fixture value in range"),
             psi: nullifier::Trapdoor::random(notes),
             rcm: note::CommitmentTrapdoor::random(notes),
         }

--- a/crates/tachyon/tests/integration/proof.rs
+++ b/crates/tachyon/tests/integration/proof.rs
@@ -375,7 +375,7 @@ fn spend_stamp_rejects_invalid_note() {
     let spend_epoch = height.epoch();
 
     let phantom = Note {
-        value: value::Positive::try_from(999_999u64).expect("test value in range"),
+        value: value::NonNegative::try_from(999_999u64).expect("test value in range"),
         rcm: note::CommitmentTrapdoor::random(rng),
         ..note
     };
@@ -387,7 +387,7 @@ fn spend_stamp_rejects_invalid_note() {
         "shared psi yields shared nullifiers"
     );
 
-    let wrong_value = value::Positive::try_from(999_999u64).expect("test value in range");
+    let wrong_value = value::NonNegative::try_from(999_999u64).expect("test value in range");
     assert_ne!(u64::from(wrong_value), u64::from(note.value));
 
     // The nullifier pair binds honestly at SpendBind; the note-level checks
@@ -542,7 +542,7 @@ fn step_accepts_zero_value_note() {
     {
         let zero_note = Note {
             pk: user.pak.derive_payment_key(),
-            value: value::Positive::try_from(0u64).expect("zero is in range"),
+            value: value::NonNegative::try_from(0u64).expect("zero is in range"),
             psi: nullifier::Trapdoor::random(rng),
             rcm: note::CommitmentTrapdoor::random(rng),
         };
@@ -667,7 +667,7 @@ fn notes_with_shared_psi_share_nullifiers() {
     let user = WalletSim::new(shared_sk());
     let note_a = user.random_note(500);
     let note_b = Note {
-        value: value::Positive::try_from(700u64).expect("test value in range"),
+        value: value::NonNegative::try_from(700u64).expect("test value in range"),
         rcm: note::CommitmentTrapdoor::random(rng),
         ..note_a
     };
@@ -1720,7 +1720,7 @@ fn spendable_lift_rejects_wrong_cm() {
     let mut pool = PoolSim::genesis(rng);
     let note = user.random_note(500);
     let phantom = Note {
-        value: value::Positive::try_from(700u64).expect("test value in range"),
+        value: value::NonNegative::try_from(700u64).expect("test value in range"),
         rcm: note::CommitmentTrapdoor::random(rng),
         ..note
     };


### PR DESCRIPTION
While #182 already allows zero-value for note. The name stayed as `Positive`. 

This chore PR did the following renaming:
- `Postive` -> `NonNegative`
- `Negative` -> `NonPositive`

no logic changes.