### PR TITLE
Tighten clippy lint

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -28,7 +28,7 @@ jobs:
   notify-website:
     name: Notify website to deploy
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'tachyon-zcash/tachyon'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger repository_dispatch in website

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ rc_mutex = "forbid"
 
 # -- deny: restrictions (may need localized #[expect]) -----------------------
 absolute_paths = "deny"
+arithmetic_side_effects = "deny"
 assertions_on_result_states = "deny"
 big_endian_bytes = "deny"
 cfg_not_test = "deny"
@@ -207,7 +208,6 @@ verbose_file_reads = "deny"
 
 # deny later
 arbitrary_source_item_ordering = "allow"
-arithmetic_side_effects = "allow"
 exhaustive_enums = "allow"
 exhaustive_structs = "allow"
 missing_errors_doc = "allow"

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ Stubbed (pending Ragu PCD and Poseidon integration):
 
 ## Development
 
-Requires Rust stable (1.85+) and nightly for formatting/linting.
+Requires Rust 1.97.1 (pinned in `rust-toolchain.toml`) and nightly for formatting.
 
 ```sh
 just test    # cargo test --workspace --all-features
-just lint    # cargo +nightly clippy --workspace --all-targets --all-features
+just lint    # cargo clippy --workspace --all-targets --all-features
 just fmt     # cargo +nightly fmt --all
 just doc     # cargo doc --workspace --no-deps
 ```

--- a/clippy.toml
+++ b/clippy.toml
@@ -16,6 +16,21 @@ disallowed-macros = [
 ]
 enforced-import-renames = [{ path = "derive_more::Eq", rename = "TotalEq" }]
 
+# arithmetic
+# modular field/curve arithmetic cannot overflow by definition
+arithmetic-side-effects-allowed = [
+  "pasta_curves::Ep",
+  "pasta_curves::EpAffine",
+  "pasta_curves::Eq",
+  "pasta_curves::EqAffine",
+  "pasta_curves::Fp",
+  "pasta_curves::Fq",
+  "value::ValueCommitment",
+]
+# negation of a range-bounded value cannot overflow (see `Value::negate`);
+# binary ops on `Value` stay linted since none are implemented
+arithmetic-side-effects-allowed-unary = ["value::Value"]
+
 # error handling
 disallowed-methods = [
   { path = "subtle::CtOption::expect", replacement = "into_option().expect", reason = "convert to `Option` explicitly" },

--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -610,6 +610,10 @@ impl Bundle<ProofStamp> {
 
     /// Verify the stamp's coverage against the combined unique actions of this
     /// bundle and the provided bundles.
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "action counts are far below usize::MAX"
+    )]
     pub fn verify_coverage(
         &self,
         adjuncts: &[&Bundle<dyn StampState>],
@@ -797,7 +801,7 @@ impl<S: StampState> Bundle<S> {
         let mut chunk = [0u8; 64];
         #[expect(clippy::indexing_slicing, reason = "take is clamped to chunk.len()")]
         while memo.len() < n_memo {
-            let take = (n_memo - memo.len()).min(chunk.len());
+            let take = n_memo.saturating_sub(memo.len()).min(chunk.len());
             reader.read_exact(&mut chunk[..take])?;
             memo.extend_from_slice(&chunk[..take]);
         }

--- a/crates/tachyon/src/collections/indexed_multiset.rs
+++ b/crates/tachyon/src/collections/indexed_multiset.rs
@@ -153,7 +153,7 @@ mod tests {
             let m_ix_cube = poly_mul(&poly_mul(&m_ix, &m_ix), &m_ix);
 
             {
-                let mut coeffs = Vec::from_iter(m_ix_cube.iter_coeffs());
+                let mut coeffs: Vec<_> = m_ix_cube.iter_coeffs().collect();
                 coeffs[0] -= NON_RESIDUE;
                 Polynomial::from_coeffs(coeffs)
             }

--- a/crates/tachyon/src/collections/indexed_multiset.rs
+++ b/crates/tachyon/src/collections/indexed_multiset.rs
@@ -155,7 +155,7 @@ mod tests {
             let m_ix_cube = poly_mul(&poly_mul(&m_ix, &m_ix), &m_ix);
 
             {
-                let mut coeffs = Vec::from_iter(m_ix_cube.iter_coeffs());
+                let mut coeffs: Vec<_> = m_ix_cube.iter_coeffs().collect();
                 coeffs[0] -= NON_RESIDUE;
                 Polynomial::<Fp, ProductionRank>::from_coeffs(coeffs)
             }

--- a/crates/tachyon/src/collections/mod.rs
+++ b/crates/tachyon/src/collections/mod.rs
@@ -11,6 +11,10 @@ pub(crate) mod multiset;
 
 fn trim(coeffs: &mut Vec<Fp>) {
     if let Some(last_nonzero_idx) = coeffs.iter().rposition(|co| co != &Fp::ZERO) {
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "rposition returns an index below len"
+        )]
         coeffs.truncate(last_nonzero_idx + 1);
     }
 }
@@ -18,8 +22,8 @@ fn trim(coeffs: &mut Vec<Fp>) {
 pub(super) fn poly_mul(input_a: &Polynomial, input_b: &Polynomial) -> Polynomial {
     use ragu_arithmetic as arithmetic;
 
-    let mut a_coeffs = Vec::from_iter(input_a.iter_coeffs());
-    let mut b_coeffs = Vec::from_iter(input_b.iter_coeffs());
+    let mut a_coeffs: Vec<_> = input_a.iter_coeffs().collect();
+    let mut b_coeffs: Vec<_> = input_b.iter_coeffs().collect();
 
     trim(&mut a_coeffs);
     trim(&mut b_coeffs);

--- a/crates/tachyon/src/collections/mod.rs
+++ b/crates/tachyon/src/collections/mod.rs
@@ -13,6 +13,10 @@ pub(crate) mod qr;
 
 fn trim(coeffs: &mut Vec<Fp>) {
     if let Some(last_nonzero_idx) = coeffs.iter().rposition(|co| co != &Fp::ZERO) {
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "rposition returns an index below len"
+        )]
         coeffs.truncate(last_nonzero_idx + 1);
     }
 }
@@ -21,8 +25,8 @@ pub(super) fn poly_mul(
     input_a: &Polynomial<Fp, ProductionRank>,
     input_b: &Polynomial<Fp, ProductionRank>,
 ) -> Polynomial<Fp, ProductionRank> {
-    let mut a_coeffs = Vec::from_iter(input_a.iter_coeffs());
-    let mut b_coeffs = Vec::from_iter(input_b.iter_coeffs());
+    let mut a_coeffs: Vec<_> = input_a.iter_coeffs().collect();
+    let mut b_coeffs: Vec<_> = input_b.iter_coeffs().collect();
 
     trim(&mut a_coeffs);
     trim(&mut b_coeffs);

--- a/crates/tachyon/src/collections/qr.rs
+++ b/crates/tachyon/src/collections/qr.rs
@@ -249,8 +249,12 @@ mod tests {
     /// Collects a polynomial's coefficients with the sparse capacity padding
     /// trimmed; the zero polynomial densifies to `[0]`.
     fn dense(poly: &Polynomial<Fp, ProductionRank>) -> Vec<Fp> {
-        let mut coeffs = Vec::from_iter(poly.iter_coeffs());
+        let mut coeffs: Vec<_> = poly.iter_coeffs().collect();
         let last_nonzero = coeffs.iter().rposition(|coeff| coeff != &Fp::ZERO);
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "rposition returns an index below len"
+        )]
         coeffs.truncate(last_nonzero.map_or(1, |idx| idx + 1));
         coeffs
     }

--- a/crates/tachyon/src/keys/master.rs
+++ b/crates/tachyon/src/keys/master.rs
@@ -29,11 +29,12 @@ impl NoteMasterKey {
     /// Derive the nullifier for a single epoch.
     #[must_use]
     #[expect(
+        clippy::arithmetic_side_effects,
         clippy::as_conversions,
         clippy::cast_possible_truncation,
         clippy::indexing_slicing,
         clippy::integer_division_remainder_used,
-        reason = "the remainder indexes an array of PoseidonFp::RATE"
+        reason = "the remainder indexes an array of PoseidonFp::RATE and never exceeds the epoch"
     )]
     pub fn derive_nullifier(&self, epoch: EpochIndex) -> Nullifier {
         let inner_index = epoch.0 as usize % PoseidonFp::RATE;
@@ -51,6 +52,7 @@ impl NoteMasterKey {
     /// `NF_DERIVATION_WIDTH / PoseidonFp::RATE` permutations each way.
     #[must_use]
     #[expect(
+        clippy::arithmetic_side_effects,
         clippy::as_conversions,
         clippy::cast_possible_truncation,
         clippy::indexing_slicing,
@@ -66,7 +68,14 @@ impl NoteMasterKey {
         );
         let groups: [[Fp; PoseidonFp::RATE]; NF_DERIVATION_WIDTH / PoseidonFp::RATE] =
             array::from_fn(|offset| {
-                let group_start = epoch_start.0 + (offset * PoseidonFp::RATE) as u32;
+                #[expect(
+                    clippy::expect_used,
+                    reason = "a window past the epoch range is a caller bug; NfDerive rejects such witnesses up front"
+                )]
+                let group_start = epoch_start
+                    .0
+                    .checked_add((offset * PoseidonFp::RATE) as u32)
+                    .expect("derivation window exceeds the epoch range");
                 poseidon::nullifier_group(self.0, Fp::from(EpochIndex(group_start)))
             });
         array::from_fn(|slot| {

--- a/crates/tachyon/src/primitives/epoch.rs
+++ b/crates/tachyon/src/primitives/epoch.rs
@@ -26,19 +26,37 @@ impl EpochIndex {
     /// Returns the next epoch index.
     #[must_use]
     pub const fn next(self) -> Self {
-        Self(self.0 + 1)
+        #[expect(
+            clippy::expect_used,
+            reason = "wrapping would alias epoch 0; panic instead at the end of the epoch space"
+        )]
+        Self(self.0.checked_add(1).expect("epoch index overflow"))
     }
 
     /// Returns the first block height of the epoch.
     #[must_use]
     pub const fn first_block(self) -> BlockHeight {
-        BlockHeight(self.0 * EPOCH_SIZE)
+        #[expect(
+            clippy::expect_used,
+            reason = "wrapping would alias an earlier block; panic instead past the last representable height"
+        )]
+        BlockHeight(self.0.checked_mul(EPOCH_SIZE).expect("block height overflow"))
     }
 
     /// Returns the last block height of the epoch.
     #[must_use]
     pub const fn last_block(self) -> BlockHeight {
-        BlockHeight(self.next().first_block().0 - 1)
+        #[expect(
+            clippy::expect_used,
+            reason = "the next epoch's first block is at least EPOCH_SIZE, so the subtraction cannot fail"
+        )]
+        BlockHeight(
+            self.next()
+                .first_block()
+                .0
+                .checked_sub(1)
+                .expect("the next epoch's first block is positive"),
+        )
     }
 }
 

--- a/crates/tachyon/src/primitives/epoch.rs
+++ b/crates/tachyon/src/primitives/epoch.rs
@@ -4,7 +4,7 @@ use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use pasta_curves::Fp;
 
 use super::BlockHeight;
-use crate::constants::EPOCH_SIZE;
+use crate::constants::{EPOCH_MAX, EPOCH_SIZE};
 
 /// A tachyon epoch — a point in the accumulator's history.
 ///
@@ -24,13 +24,17 @@ pub struct EpochDiff(u32);
 
 impl EpochIndex {
     /// Returns the next epoch index.
+    ///
+    /// Panics rather than step past [`EPOCH_MAX`]: indexes beyond it map to
+    /// no block height in the protocol's range.
     #[must_use]
     pub const fn next(self) -> Self {
+        assert!(self.0 < EPOCH_MAX, "epoch index past EPOCH_MAX");
         #[expect(
-            clippy::expect_used,
-            reason = "wrapping would alias epoch 0; panic instead at the end of the epoch space"
+            clippy::arithmetic_side_effects,
+            reason = "the assert above bounds the index below EPOCH_MAX"
         )]
-        Self(self.0.checked_add(1).expect("epoch index overflow"))
+        Self(self.0 + 1)
     }
 
     /// Returns the first block height of the epoch.
@@ -44,18 +48,20 @@ impl EpochIndex {
     }
 
     /// Returns the last block height of the epoch.
+    ///
+    /// Computed from this epoch's own first block, so the final epoch
+    /// ([`EPOCH_MAX`], whose last block is `BLOCK_MAX`) does not overflow.
     #[must_use]
     pub const fn last_block(self) -> BlockHeight {
         #[expect(
             clippy::expect_used,
-            reason = "the next epoch's first block is at least EPOCH_SIZE, so the subtraction cannot fail"
+            reason = "every epoch index up to EPOCH_MAX ends at or below BLOCK_MAX"
         )]
         BlockHeight(
-            self.next()
-                .first_block()
+            self.first_block()
                 .0
-                .checked_sub(1)
-                .expect("the next epoch's first block is positive"),
+                .checked_add(EPOCH_SIZE - 1)
+                .expect("block height overflow"),
         )
     }
 }
@@ -100,5 +106,21 @@ mod tests {
     fn epoch_difference_rejects_reversed_operands() {
         let reversed = EpochIndex(3) - EpochIndex(7);
         panic!("reversed operands must not produce a difference, got {reversed:?}");
+    }
+
+    #[test]
+    fn final_epoch_ends_at_the_final_block() {
+        use crate::constants::BLOCK_MAX;
+
+        assert_eq!(EpochIndex(EPOCH_MAX).last_block(), BlockHeight(BLOCK_MAX));
+        assert_eq!(EpochIndex(EPOCH_MAX - 1).next(), EpochIndex(EPOCH_MAX));
+        assert_eq!(BlockHeight(BLOCK_MAX).epoch(), EpochIndex(EPOCH_MAX));
+    }
+
+    #[test]
+    #[should_panic(expected = "epoch index past EPOCH_MAX")]
+    fn next_rejects_the_final_epoch() {
+        let past_the_end = EpochIndex(EPOCH_MAX).next();
+        panic!("the final epoch must have no successor, got {past_the_end:?}");
     }
 }

--- a/crates/tachyon/src/primitives/epoch.rs
+++ b/crates/tachyon/src/primitives/epoch.rs
@@ -23,18 +23,38 @@ pub struct EpochIndex(pub u32);
 pub struct EpochDiff(u32);
 
 impl EpochIndex {
+    /// Returns the next epoch index, or `None` for the final epoch.
+    ///
+    /// Indexes past [`EPOCH_MAX`] map to no block height in the protocol's
+    /// range, so the final epoch has no successor.
+    #[must_use]
+    pub const fn checked_next(self) -> Option<Self> {
+        #[expect(
+            clippy::if_then_some_else_none,
+            reason = "bool::then takes a closure, which is not const"
+        )]
+        if self.0 < EPOCH_MAX {
+            #[expect(
+                clippy::arithmetic_side_effects,
+                reason = "the branch condition bounds the index below EPOCH_MAX"
+            )]
+            Some(Self(self.0 + 1))
+        } else {
+            None
+        }
+    }
+
     /// Returns the next epoch index.
     ///
-    /// Panics rather than step past [`EPOCH_MAX`]: indexes beyond it map to
-    /// no block height in the protocol's range.
+    /// Panics rather than step past [`EPOCH_MAX`]; callers for which the
+    /// final epoch is ordinary input use [`Self::checked_next`] instead.
     #[must_use]
     pub const fn next(self) -> Self {
-        assert!(self.0 < EPOCH_MAX, "epoch index past EPOCH_MAX");
         #[expect(
-            clippy::arithmetic_side_effects,
-            reason = "the assert above bounds the index below EPOCH_MAX"
+            clippy::expect_used,
+            reason = "stepping past the final epoch is a caller bug"
         )]
-        Self(self.0 + 1)
+        self.checked_next().expect("epoch index past EPOCH_MAX")
     }
 
     /// Returns the first block height of the epoch.
@@ -115,6 +135,15 @@ mod tests {
         assert_eq!(EpochIndex(EPOCH_MAX).last_block(), BlockHeight(BLOCK_MAX));
         assert_eq!(EpochIndex(EPOCH_MAX - 1).next(), EpochIndex(EPOCH_MAX));
         assert_eq!(BlockHeight(BLOCK_MAX).epoch(), EpochIndex(EPOCH_MAX));
+    }
+
+    #[test]
+    fn checked_next_stops_at_the_final_epoch() {
+        assert_eq!(
+            EpochIndex(EPOCH_MAX - 1).checked_next(),
+            Some(EpochIndex(EPOCH_MAX))
+        );
+        assert_eq!(EpochIndex(EPOCH_MAX).checked_next(), None);
     }
 
     #[test]

--- a/crates/tachyon/src/primitives/qr.rs
+++ b/crates/tachyon/src/primitives/qr.rs
@@ -109,6 +109,10 @@ impl QrProfile {
             self.depth < u32::BITS,
             "profile has no bit left for another side"
         );
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "the assert above leaves room for another level"
+        )]
         Self {
             depth: self.depth + 1,
             bits: (self.bits << 1) | u32::from(bit),

--- a/crates/tachyon/src/primitives/sets.rs
+++ b/crates/tachyon/src/primitives/sets.rs
@@ -32,7 +32,7 @@ impl TachygramSetCommit {
 impl Default for TachygramSetCommit {
     /// A commitment to an empty set.
     fn default() -> Self {
-        TachygramSetPoly::from_iter(iter::empty()).commit()
+        iter::empty().collect::<TachygramSetPoly>().commit()
     }
 }
 
@@ -57,7 +57,7 @@ impl ActionSetCommit {
 impl Default for ActionSetCommit {
     /// A commitment to an empty set.
     fn default() -> Self {
-        ActionSetPoly::from_iter(iter::empty()).commit()
+        iter::empty().collect::<ActionSetPoly>().commit()
     }
 }
 

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -379,7 +379,7 @@ impl Plan {
         // lists. Digests are computed once per leaf and carried through the
         // fold rather than re-derived at each merge step. The covered-actions
         // digest is computed once, on the final stamp.
-        let mut entries = Vec::with_capacity(self.spends.len() + self.outputs.len());
+        let mut entries = Vec::with_capacity(self.spends.len().saturating_add(self.outputs.len()));
 
         if self.spends.len() != spend_pcds.len() {
             return Err(ProveError::MissingPcd(

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -23,6 +23,7 @@ use crate::{
     collections::indexed_multiset,
     keys::{NoteMasterKey, ProofAuthorizingKey},
     note::{self, Note},
+    nullifier::NF_DERIVATION_WIDTH,
     primitives::{EpochIndex, NfSeqCommit, NfSeqPoly},
     relations::enforce::enforce_poly_product,
 };
@@ -177,6 +178,7 @@ impl Step for NfDerive {
         _right: <Self::Right as Header>::Data,
     ) -> ragu::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         #[expect(
+            clippy::arithmetic_side_effects,
             clippy::as_conversions,
             clippy::integer_division_remainder_used,
             reason = "the group width is a small constant"
@@ -186,15 +188,24 @@ impl Step for NfDerive {
             "NfDerive: epoch_start is not group-aligned",
         )?;
 
-        // NF_DERIVATION_WIDTH nullifiers, PoseidonFp::RATE per sponge.
-        let nullifiers = mk.derive_window(epoch_start);
-
+        // The witnessed start epoch must leave room for the whole window;
+        // `derive_window` relies on this bound.
         #[expect(
             clippy::as_conversions,
             clippy::cast_possible_truncation,
-            reason = "constant length"
+            reason = "the window width is a small constant"
         )]
-        let epoch_end = EpochIndex(epoch_start.0 + nullifiers.len() as u32);
+        let epoch_end = EpochIndex(
+            epoch_start
+                .0
+                .checked_add(NF_DERIVATION_WIDTH as u32)
+                .ok_or_else(|| {
+                    ragu::Error::InvalidWitness("NfDerive: window exceeds the epoch range".into())
+                })?,
+        );
+
+        // NF_DERIVATION_WIDTH nullifiers, PoseidonFp::RATE per sponge.
+        let nullifiers = mk.derive_window(epoch_start);
 
         // `z`: a fresh transcript challenge over the sequence commitment. The
         // polynomial is fixed before it exists, so the single opening below

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -198,7 +198,7 @@ impl Step for NfDerive {
                 .0
                 .checked_add(NF_DERIVATION_WIDTH as u32)
                 .ok_or_else(|| {
-                    ragu::Error::InvalidWitness("NfDerive: window exceeds the epoch range".into())
+                    ragu_core::Error::InvalidWitness("NfDerive: window exceeds the epoch range".into())
                 })?,
         );
 

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -20,6 +20,7 @@ use crate::{
     collections::indexed_multiset,
     keys::{NoteMasterKey, ProofAuthorizingKey},
     note::{self, Note},
+    nullifier::NF_DERIVATION_WIDTH,
     primitives::{EpochIndex, NfSeqCommit, NfSeqPoly},
     ragu_constraint::{enforce_equal_point, enforce_zero},
     relations::enforce::enforce_poly_product,
@@ -175,6 +176,7 @@ impl Step for NfDerive {
         _right: <Self::Right as Header>::Data,
     ) -> ragu_core::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         #[expect(
+            clippy::arithmetic_side_effects,
             clippy::as_conversions,
             clippy::integer_division_remainder_used,
             reason = "the group width is a small constant"
@@ -184,15 +186,24 @@ impl Step for NfDerive {
             "NfDerive: epoch_start is not group-aligned",
         )?;
 
-        // NF_DERIVATION_WIDTH nullifiers, PoseidonFp::RATE per sponge.
-        let nullifiers = mk.derive_window(epoch_start);
-
+        // The witnessed start epoch must leave room for the whole window;
+        // `derive_window` relies on this bound.
         #[expect(
             clippy::as_conversions,
             clippy::cast_possible_truncation,
-            reason = "constant length"
+            reason = "the window width is a small constant"
         )]
-        let epoch_end = EpochIndex(epoch_start.0 + nullifiers.len() as u32);
+        let epoch_end = EpochIndex(
+            epoch_start
+                .0
+                .checked_add(NF_DERIVATION_WIDTH as u32)
+                .ok_or_else(|| {
+                    ragu::Error::InvalidWitness("NfDerive: window exceeds the epoch range".into())
+                })?,
+        );
+
+        // NF_DERIVATION_WIDTH nullifiers, PoseidonFp::RATE per sponge.
+        let nullifiers = mk.derive_window(epoch_start);
 
         // `z`: a fresh transcript challenge over the sequence commitment. The
         // polynomial is fixed before it exists, so the single opening below

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -379,7 +379,11 @@ impl Step for EndEpochUnspentSeed {
             "EndEpochUnspentSeed: incoming nullifier is zero",
         )?;
 
-        let epoch = epoch_prev.next();
+        let epoch = epoch_prev.checked_next().ok_or_else(|| {
+            ragu_core::Error::InvalidWitness(
+                "EndEpochUnspentSeed: crossing past the final epoch".into(),
+            )
+        })?;
         let anchor = anchor_prev
             .next_epoch(epoch)
             .map_err(|_e| ragu_core::Error::InvalidWitness("invalid anchor step".into()))?;

--- a/crates/tachyon/src/stamp/proof/qr.rs
+++ b/crates/tachyon/src/stamp/proof/qr.rs
@@ -564,12 +564,16 @@ impl Step for QrBucketSeal {
                 - poseidon::anchor_next_epoch(Fp::from(prev_last), Fp::from(u64::from(epoch.0))),
             "QrBucketSeal: intake does not begin at the epoch boundary",
         )?;
+        // Computed in the widened domain: a bucket sealed at the final epoch
+        // has a closing tick even though that epoch has no successor.
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "a u32 widened to u64 cannot overflow on increment"
+        )]
+        let closing_tick = Fp::from(u64::from(epoch.0) + 1);
         enforce_zero(
             Fp::from(discriminant)
-                - poseidon::anchor_next_epoch(
-                    Fp::from(anchor_last),
-                    Fp::from(u64::from(epoch.next().0)),
-                ),
+                - poseidon::anchor_next_epoch(Fp::from(anchor_last), closing_tick),
             "QrBucketSeal: discriminant is not the span's closing tick",
         )?;
 

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -123,10 +123,14 @@ impl Step for SpendBind {
         let nf_seq_at_z = nf_seq.eval(z);
         let complement_at_z = complement_seq.eval(z);
 
+        // The pair read needs a following epoch; the final epoch has none.
+        let next_epoch = spendable_epoch.checked_next().ok_or_else(|| {
+            ragu_core::Error::InvalidWitness("SpendBind: no epoch follows the spend epoch".into())
+        })?;
         let pair_at_z = indexed_multiset::direct_eval(
             [
                 (spendable_epoch.into(), present_nf.into()),
-                (spendable_epoch.next().into(), nf_next.into()),
+                (next_epoch.into(), nf_next.into()),
             ],
             z,
         );

--- a/crates/tachyon/src/value.rs
+++ b/crates/tachyon/src/value.rs
@@ -154,6 +154,10 @@ impl<const MIN: i64, const MAX: i64> Value<MIN, MAX> {
                 "NEG_MAX must be -MAX and NEG_MIN must be -MIN"
             );
         }
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "the const assert above rejects negation overflows"
+        )]
         Value(-self.0)
     }
 }

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -149,6 +149,7 @@ pub fn unspent_fuse(
 /// sides of the unspent's span, multiplied.
 #[must_use]
 #[expect(
+    clippy::arithmetic_side_effects,
     clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
@@ -181,6 +182,7 @@ pub fn unspent_bind(
 /// epoch, multiplied.
 #[must_use]
 #[expect(
+    clippy::arithmetic_side_effects,
     clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
@@ -216,6 +218,7 @@ pub fn spendable_init(
 /// least one epoch past the spendable's epoch.
 #[must_use]
 #[expect(
+    clippy::arithmetic_side_effects,
     clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
@@ -228,7 +231,7 @@ pub fn spend_bind(
     let (_, deriv_start, ..) = deriv;
     let lo = (epoch.0 - deriv_start.0) as usize;
     let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(EpochIndex(epoch.0 + 2), &window[lo + 2..]);
+        * NfSeqPoly::new(epoch.next().next(), &window[lo + 2..]);
     (
         NfSeqPoly::new(deriv_start, window),
         complement_seq,

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -160,6 +160,7 @@ pub fn unspent_fuse(
 /// sides of the unspent's span, multiplied.
 #[must_use]
 #[expect(
+    clippy::arithmetic_side_effects,
     clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
@@ -192,6 +193,7 @@ pub fn unspent_bind(
 /// epoch, multiplied.
 #[must_use]
 #[expect(
+    clippy::arithmetic_side_effects,
     clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
@@ -227,6 +229,7 @@ pub fn spendable_init(
 /// least one epoch past the spendable's epoch.
 #[must_use]
 #[expect(
+    clippy::arithmetic_side_effects,
     clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
@@ -239,7 +242,7 @@ pub fn spend_bind(
     let (_, deriv_start, ..) = deriv;
     let lo = (epoch.0 - deriv_start.0) as usize;
     let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(EpochIndex(epoch.0 + 2), &window[lo + 2..]);
+        * NfSeqPoly::new(epoch.next().next(), &window[lo + 2..]);
     (
         NfSeqPoly::new(deriv_start, window),
         complement_seq,

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -151,6 +151,19 @@ pub fn unspent_fuse(
     )
 }
 
+/// The complement's run after the covered span: the window members past
+/// `span_last`, positioned one epoch after it.
+///
+/// An empty run is the multiplicative identity and needs no position, so
+/// the span may end at the final epoch, which has no successor.
+fn complement_tail(span_last: EpochIndex, tail: &[Nullifier]) -> NfSeqPoly {
+    if tail.is_empty() {
+        NfSeqPoly::default()
+    } else {
+        NfSeqPoly::new(span_last.next(), tail)
+    }
+}
+
 /// Prepare the witness for [`UnspentBind`]:
 /// `(elapsed_seq, nf_seq, complement_seq)`.
 ///
@@ -173,9 +186,9 @@ pub fn unspent_bind(
     let (_, (epoch_start, _), _, (epoch_last, _), _) = unspent;
     let (_, deriv_start, ..) = deriv;
     let lo = (epoch_start.0 - deriv_start.0) as usize;
-    let hi = (epoch_last.next().0 - deriv_start.0) as usize;
-    let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(epoch_last.next(), &window[hi..]);
+    let hi = (epoch_last.0 - deriv_start.0) as usize + 1;
+    let complement_seq =
+        NfSeqPoly::new(deriv_start, &window[..lo]) * complement_tail(epoch_last, &window[hi..]);
     (
         NfSeqPoly::new(epoch_start, elapsed),
         NfSeqPoly::new(deriv_start, window),
@@ -208,7 +221,7 @@ pub fn spendable_init(
     let (_, deriv_start, ..) = deriv;
     let lo = (creation_epoch.0 - deriv_start.0) as usize;
     let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(creation_epoch.next(), &window[lo + 1..]);
+        * complement_tail(creation_epoch, &window[lo + 1..]);
     (
         pre_cm_anchor,
         creation_tgs.iter().copied().collect::<TachygramSetPoly>(),
@@ -242,7 +255,7 @@ pub fn spend_bind(
     let (_, deriv_start, ..) = deriv;
     let lo = (epoch.0 - deriv_start.0) as usize;
     let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(epoch.next().next(), &window[lo + 2..]);
+        * complement_tail(epoch.next(), &window[lo + 2..]);
     (
         NfSeqPoly::new(deriv_start, window),
         complement_seq,
@@ -321,6 +334,7 @@ pub fn summary_unspent_init(
 /// [`spendable_init`].
 #[must_use]
 #[expect(
+    clippy::arithmetic_side_effects,
     clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
@@ -337,7 +351,7 @@ pub fn summary_spendable_init(
     let (_, deriv_start, ..) = deriv;
     let lo = (creation_epoch.0 - deriv_start.0) as usize;
     let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(creation_epoch.next(), &window[lo + 1..]);
+        * complement_tail(creation_epoch, &window[lo + 1..]);
     (
         creation_epoch,
         window[lo],
@@ -532,4 +546,23 @@ pub fn merge_stamp(
             right_tgs.iter().copied().collect::<TachygramSetPoly>(),
         ),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::EPOCH_MAX;
+
+    #[test]
+    fn complement_tail_may_end_at_the_final_epoch() {
+        let empty = complement_tail(EpochIndex(EPOCH_MAX), &[]);
+        assert_eq!(empty.commit(), NfSeqPoly::default().commit());
+    }
+
+    #[test]
+    fn complement_tail_positions_members_after_the_span() {
+        let nf = Nullifier::from(Fp::from(7u64));
+        let tail = complement_tail(EpochIndex(41), &[nf]);
+        assert_eq!(tail.commit(), NfSeqPoly::new(EpochIndex(42), &[nf]).commit());
+    }
 }

--- a/crates/tachyon/tests/integration/main.rs
+++ b/crates/tachyon/tests/integration/main.rs
@@ -1,4 +1,5 @@
 #![allow(
+    clippy::arithmetic_side_effects,
     clippy::as_conversions,
     clippy::cast_possible_truncation,
     clippy::expect_used,

--- a/crates/tachyon/tests/integration/proof.rs
+++ b/crates/tachyon/tests/integration/proof.rs
@@ -14,7 +14,7 @@ use rand::{SeedableRng as _, rngs::StdRng};
 use rand_core::CryptoRng;
 use zcash_tachyon::{
     ActionSetPoly, Anchor, BlockHeight, EpochIndex, NfSeqPoly, Note, Tachygram, TachygramSetPoly,
-    constants::EPOCH_SIZE,
+    constants::{EPOCH_MAX, EPOCH_SIZE},
     digest::poseidon,
     effect,
     entropy::ActionEntropy,
@@ -1412,6 +1412,41 @@ fn unspent_bind_rejects_tip_mismatch() {
         inner.to_string(),
         "UnspentBind: sequence does not match the derivation"
     );
+}
+
+#[test]
+fn unspent_bind_window_may_end_at_the_final_epoch() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    // The epoch space's last derivation window: the unspent span covers all
+    // of it, ending at the final epoch, which has no successor.
+    let epoch_start = EpochIndex(EPOCH_MAX + 1 - NF_DERIVATION_WIDTH as u32);
+    let epoch_last = EpochIndex(EPOCH_MAX);
+    let range = user.derivation_pcd(rng, note, epoch_start, epoch_last);
+
+    let elapsed: Vec<Nullifier> = (epoch_start.0..=epoch_last.0)
+        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .collect();
+    let synthetic_unspent = (
+        Anchor::from(Fp::ZERO),
+        (epoch_start, elapsed[0]),
+        NfSeqPoly::new(epoch_start, &elapsed).commit(),
+        (epoch_last, elapsed[elapsed.len() - 1]),
+        Anchor::from(Fp::ZERO),
+    );
+
+    let (elapsed_seq, nf_seq, complement_seq) = witness::unspent_bind(
+        (synthetic_unspent, *range.data()),
+        &user.covering_window(&note, &range),
+        &elapsed,
+    );
+
+    // The span covers the whole window, so the complement is empty on both
+    // sides: the multiplicative identity.
+    assert_eq!(complement_seq.commit(), NfSeqPoly::default().commit());
+    assert_eq!(elapsed_seq.commit(), nf_seq.commit());
 }
 
 #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,13 @@
 [toolchain]
-channel = "stable"
+channel = "1.97.1"
 components = [
     "clippy",
     "rust-src",
     "rust-docs",
 ]
 profile = "minimal"
+
+# Bumping MSRV
+# * update `toolchain.channel` key in `rust-toolchain.toml` (this file)
+# * update `workspace.package.rust-version` key in root `Cargo.toml`
+# * update the requirements line in `README.md`


### PR DESCRIPTION
Some code quality chores as I scan through the repo.

For consensus/critical/crypto libraries, I think it's better to set `arithmetic_side_effects = "deny"` (with all upstream field arithmetic as whitelist exceptions). 
This nudge us to correctly use unambiguous `saturating_*()` or `.wrapping_*()` or justify with reason or avoid them completely.  