### PR TITLE
Introduce Anchor Types

### DIFF
--- a/crates/tachyon/src/bundle/mod.rs
+++ b/crates/tachyon/src/bundle/mod.rs
@@ -565,7 +565,7 @@ impl Bundle<ProofStamp> {
                     .map_err(LiftError::AnchorError);
 
                 Some(next_anchor.map(|anchor| {
-                    *scanning_anchor = anchor;
+                    *scanning_anchor = anchor.erase();
                     (prev_anchor, epoch, tachygram_set)
                 }))
             })

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -1,11 +1,16 @@
+use core::marker::PhantomData;
+
 use corez::io::{self, Read, Write};
-use derive_more::{Debug, Display, Eq as TotalEq, Error, From, Into, PartialEq};
+use derive_more::{Debug, Display, Eq as TotalEq, Error, PartialEq};
 use ff::Field as _;
 use group::{Curve as _, Group as _};
 use lazy_static::lazy_static;
 use pasta_curves::{Eq, Fp};
 
-use super::{EpochIndex, TachygramSetCommit};
+use super::{
+    EpochIndex, TachygramSetCommit,
+    anchor_kind::{AnchorKind, Erased, Sentinel, Stamped},
+};
 use crate::{digest::poseidon, serialization};
 
 lazy_static! {
@@ -27,11 +32,36 @@ pub enum AnchorError {
 }
 
 /// Running anchor over the consensus state.
-#[derive(Clone, Copy, Debug, From, Into, Ord, PartialEq, PartialOrd, TotalEq)]
-pub struct Anchor(pub Fp);
+///
+/// The kind parameter records provenance where it is statically known:
+/// [`next_stamp`](Self::next_stamp) mints an `Anchor<Stamped>` and
+/// [`next_epoch`](Self::next_epoch) mints an `Anchor<Sentinel>` — the two
+/// domain-separated hash advancements. The default [`Erased`] kind is for
+/// positions where provenance is not statically knowable (the wire, free step
+/// witnesses, and header slots admitting either kind); typed anchors enter
+/// those positions only through the explicit [`erase`](Self::erase) seam.
+///
+/// The kind never reaches circuits, hashes, or serialized bytes: every kind
+/// encodes to the same single [`Fp`], so header encodings and the wire format
+/// are identical to an untyped anchor's.
+///
+/// Typed kinds cannot be forged from a bare field element; only the erased
+/// kind can:
+///
+/// ```compile_fail
+/// use pasta_curves::Fp;
+/// use zcash_tachyon::{Anchor, anchor_kind::Sentinel};
+///
+/// let forged: Anchor<Sentinel> = Anchor::<Sentinel>::from(Fp::zero());
+/// ```
+#[derive(Clone, Copy, Debug, Ord, PartialEq, PartialOrd, TotalEq)]
+pub struct Anchor<K: AnchorKind = Erased>(Fp, #[debug(skip)] PhantomData<K>);
 
-impl Anchor {
+impl<K: AnchorKind> Anchor<K> {
     /// Advance the anchor to the next stamp in the present epoch.
+    ///
+    /// Available for every kind: an epoch's first stamp legitimately chains
+    /// off the sentinel that opened it.
     ///
     /// The present epoch index may be zero, within the genesis epoch.
     ///
@@ -43,36 +73,61 @@ impl Anchor {
         self,
         present_epoch: EpochIndex,
         &stamp_commit: &TachygramSetCommit,
-    ) -> Result<Self, AnchorError> {
+    ) -> Result<Anchor<Stamped>, AnchorError> {
         if *stamp_commit.as_ref() == Eq::identity() {
             Err(AnchorError::NextStampZero)
         } else if stamp_commit == TachygramSetCommit::default() {
             Err(AnchorError::NextStampEmpty)
         } else {
-            Ok(Self(poseidon::anchor_next_stamp(
-                self.0,
-                present_epoch.into(),
-                stamp_commit.as_ref().to_affine(),
-            )))
+            Ok(Anchor(
+                poseidon::anchor_next_stamp(
+                    self.0,
+                    present_epoch.into(),
+                    stamp_commit.as_ref().to_affine(),
+                ),
+                PhantomData,
+            ))
         }
     }
 
-    /// Advance the anchor to the next epoch boundary.
+    /// Advance the anchor to the next epoch boundary, minting that epoch's
+    /// sentinel.
+    ///
+    /// Available for every kind: a silent epoch's terminal anchor *is* the
+    /// sentinel that opened it, so a crossing may tick off a sentinel.
     ///
     /// # Errors
     ///
     /// Fails if `next_epoch` is zero.
-    pub fn next_epoch(self, next_epoch: EpochIndex) -> Result<Self, AnchorError> {
+    pub fn next_epoch(self, next_epoch: EpochIndex) -> Result<Anchor<Sentinel>, AnchorError> {
         if next_epoch == EpochIndex(0) {
             Err(AnchorError::NextEpochZero)
         } else {
-            Ok(Self(poseidon::anchor_next_epoch(self.0, next_epoch.into())))
+            Ok(Anchor(
+                poseidon::anchor_next_epoch(self.0, next_epoch.into()),
+                PhantomData,
+            ))
         }
     }
 
-    /// Read a 32-byte anchor.
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
-        serialization::read_fp(&mut reader).map(Self)
+    /// Forget this anchor's statically known provenance.
+    ///
+    /// This is the one-way seam through which typed anchors enter kind-unaware
+    /// positions (header data, wire values, free witnesses).
+    #[must_use]
+    pub const fn erase(self) -> Anchor<Erased> {
+        Anchor(self.0, PhantomData)
+    }
+
+    /// Assume a provenance for an anchor of unknown kind, without any check.
+    ///
+    /// Escape hatch for witness reconstruction and tests, where an anchor
+    /// arrives as a bare field element (the wire carries no kind tag). The
+    /// assumption is the caller's assertion; nothing verifies it, and
+    /// soundness must not rest on it.
+    #[must_use]
+    pub const fn assume(anchor: Anchor<Erased>) -> Self {
+        Self(anchor.0, PhantomData)
     }
 
     /// Write a 32-byte anchor.
@@ -81,10 +136,55 @@ impl Anchor {
     }
 }
 
-impl Default for Anchor {
+impl Anchor {
+    /// Read a 32-byte anchor.
+    ///
+    /// The wire carries no kind tag, so a parsed anchor is always [`Erased`].
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        serialization::read_fp(&mut reader).map(Self::from)
+    }
+}
+
+impl Anchor<Sentinel> {
     /// The leading epoch boundary for epoch zero.
+    #[must_use]
+    pub fn genesis() -> Self {
+        Self(*ANCHOR_GENESIS, PhantomData)
+    }
+}
+
+impl Default for Anchor {
+    /// The leading epoch boundary for epoch zero, with its sentinel kind
+    /// erased.
     fn default() -> Self {
-        Self(*ANCHOR_GENESIS)
+        Anchor::<Sentinel>::genesis().erase()
+    }
+}
+
+impl<K: AnchorKind> From<Anchor<K>> for Fp {
+    fn from(anchor: Anchor<K>) -> Self {
+        anchor.0
+    }
+}
+
+impl From<Fp> for Anchor {
+    /// Forge an anchor of unknown kind from a bare field element.
+    ///
+    /// Typed kinds cannot be forged this way; see [`Anchor::assume`].
+    fn from(fp: Fp) -> Self {
+        Self(fp, PhantomData)
+    }
+}
+
+impl From<Anchor<Stamped>> for Anchor {
+    fn from(anchor: Anchor<Stamped>) -> Self {
+        anchor.erase()
+    }
+}
+
+impl From<Anchor<Sentinel>> for Anchor {
+    fn from(anchor: Anchor<Sentinel>) -> Self {
+        anchor.erase()
     }
 }
 
@@ -123,7 +223,7 @@ mod tests {
 
         // The identity commitment is not a valid set
         {
-            let anchor = Anchor(Fp::random(&mut *rng));
+            let anchor = Anchor::from(Fp::random(&mut *rng));
             let zero_set = TachygramSetCommit::from(Eq::identity());
 
             let Err(AnchorError::NextStampZero) = anchor.next_stamp(EpochIndex(7), &zero_set)
@@ -134,7 +234,7 @@ mod tests {
 
         // An empty set commits to a constant polynomial
         {
-            let anchor = Anchor(Fp::random(&mut *rng));
+            let anchor = Anchor::from(Fp::random(&mut *rng));
             let one_set = TachygramSetCommit::default();
 
             let Err(AnchorError::NextStampEmpty) = anchor.next_stamp(EpochIndex(1), &one_set)
@@ -148,10 +248,55 @@ mod tests {
     fn next_epoch_rejects_epoch_zero() {
         let rng = &mut StdRng::seed_from_u64(0);
 
-        let anchor = Anchor(Fp::random(rng));
+        let anchor = Anchor::from(Fp::random(rng));
 
         let Err(AnchorError::NextEpochZero) = anchor.next_epoch(EpochIndex(0)) else {
             panic!("should not be able to advance to epoch zero");
         };
+    }
+
+    #[test]
+    fn genesis_matches_erased_default() {
+        assert_eq!(Anchor::<Sentinel>::genesis().erase(), Anchor::default());
+    }
+
+    #[test]
+    fn kinds_flow_through_advancement() {
+        let rng = &mut StdRng::seed_from_u64(0);
+        let commit = TachygramSetPoly::from_iter([Tachygram::random(rng)]).commit();
+
+        // An epoch's first stamp chains off a sentinel; further stamps chain
+        // off stamped anchors.
+        let genesis: Anchor<Sentinel> = Anchor::genesis();
+        let first: Anchor<Stamped> = genesis.next_stamp(EpochIndex(0), &commit).unwrap();
+        let second: Anchor<Stamped> = first.next_stamp(EpochIndex(0), &commit).unwrap();
+
+        // A silent epoch's crossing ticks a sentinel off a sentinel.
+        let silent: Anchor<Sentinel> = genesis.next_epoch(EpochIndex(1)).unwrap();
+        let after_silent: Anchor<Sentinel> = silent.next_epoch(EpochIndex(2)).unwrap();
+
+        // Erasure reaches the same values the untyped path computes.
+        assert_eq!(
+            second.erase(),
+            Anchor::default()
+                .next_stamp(EpochIndex(0), &commit)
+                .unwrap()
+                .next_stamp(EpochIndex(0), &commit)
+                .unwrap()
+                .erase(),
+        );
+        assert_eq!(
+            after_silent.erase(),
+            Anchor::default()
+                .next_epoch(EpochIndex(1))
+                .unwrap()
+                .next_epoch(EpochIndex(2))
+                .unwrap()
+                .erase(),
+        );
+
+        // An assumed kind round-trips the underlying value.
+        let assumed = Anchor::<Sentinel>::assume(silent.erase());
+        assert_eq!(assumed.erase(), silent.erase());
     }
 }

--- a/crates/tachyon/src/primitives/anchor_kind.rs
+++ b/crates/tachyon/src/primitives/anchor_kind.rs
@@ -1,0 +1,54 @@
+//! Compile-time provenance markers for anchors.
+//!
+//! [`Stamped`] and [`Sentinel`] are zero-sized marker types recording how an
+//! [`Anchor`](super::Anchor) was produced: [`Anchor::next_stamp`] mints a
+//! `Anchor<Stamped>` and [`Anchor::next_epoch`] mints a `Anchor<Sentinel>`, so
+//! a typed anchor certifies which domain-separated hash produced it. [`Erased`]
+//! marks the positions where an anchor's kind is not statically knowable: the
+//! wire (which carries no kind tag), free step witnesses, and header slots that
+//! legitimately admit either kind. Erasure is explicit and one-way via
+//! [`Anchor::erase`]; the reverse direction is the documented, unchecked
+//! [`Anchor::assume`].
+//!
+//! The markers never reach circuits, hashes, or serialized bytes; they are
+//! host-side API clarity only.
+//!
+//! [`Anchor::next_stamp`]: super::Anchor::next_stamp
+//! [`Anchor::next_epoch`]: super::Anchor::next_epoch
+//! [`Anchor::erase`]: super::Anchor::erase
+//! [`Anchor::assume`]: super::Anchor::assume
+
+use derive_more::{Debug, Eq as TotalEq, PartialEq};
+
+mod sealed {
+    pub trait Sealed: Copy {}
+    impl Sealed for super::Erased {}
+    impl Sealed for super::Stamped {}
+    impl Sealed for super::Sentinel {}
+}
+
+/// Sealed trait marking an anchor's provenance kind.
+pub trait AnchorKind: sealed::Sealed + Send + Sync + 'static {}
+
+/// Kind-unknown anchor marker: the wire, free witnesses, and mixed header
+/// slots.
+///
+/// This is the default kind, so a bare `Anchor` is an anchor of unknown
+/// provenance.
+#[derive(Clone, Copy, Debug, Ord, PartialEq, PartialOrd, TotalEq)]
+pub struct Erased;
+
+/// Marker for an anchor produced by a stamp advancement
+/// ([`Anchor::next_stamp`](super::Anchor::next_stamp)).
+#[derive(Clone, Copy, Debug, Ord, PartialEq, PartialOrd, TotalEq)]
+pub struct Stamped;
+
+/// Marker for an epoch-boundary anchor (a *sentinel*, also called the boundary
+/// domain), produced by an epoch tick
+/// ([`Anchor::next_epoch`](super::Anchor::next_epoch)).
+#[derive(Clone, Copy, Debug, Ord, PartialEq, PartialOrd, TotalEq)]
+pub struct Sentinel;
+
+impl AnchorKind for Erased {}
+impl AnchorKind for Stamped {}
+impl AnchorKind for Sentinel {}

--- a/crates/tachyon/src/primitives/mod.rs
+++ b/crates/tachyon/src/primitives/mod.rs
@@ -1,5 +1,6 @@
 mod action_digest;
 mod anchor;
+pub mod anchor_kind;
 mod block_height;
 pub mod effect;
 mod epoch;
@@ -9,6 +10,7 @@ mod tachygram;
 
 pub use action_digest::{ActionDigest, ActionDigestError};
 pub use anchor::{Anchor, AnchorError};
+pub use anchor_kind::AnchorKind;
 pub use block_height::BlockHeight;
 pub use effect::Effect;
 pub use epoch::{EpochDiff, EpochIndex};

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -177,7 +177,7 @@ impl StampState for ProofStamp {
     fn stamp_digest(&self) -> [u8; 64] {
         let stamp_data_digest: [u8; 32] = {
             let proof = self.proof.serialize();
-            let anchor: [u8; 32] = self.anchor.0.into();
+            let anchor: [u8; 32] = Fp::from(self.anchor).into();
 
             // Do NOT sort here: a constructed stamp should already be canonical.
             let tachygrams: Vec<[u8; 32]> = self
@@ -524,6 +524,9 @@ pub struct ProofStamp {
     pub coverage: [u8; 32],
 
     /// The historic pool state for which this stamp is valid.
+    ///
+    /// Kind-erased: the wire carries no kind tag, and a stamp may target a
+    /// sentinel (a stampless epoch-first block's anchor).
     pub anchor: Anchor,
 
     /// The commitment to this stamp's tachygram set.

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -31,6 +31,7 @@ use crate::{
     nullifier::Nullifier,
     primitives::{
         Anchor, EpochIndex, NfSeqCommit, NfSeqPoly, TachygramSetCommit, TachygramSetPoly,
+        anchor_kind::Stamped,
     },
     relations::enforce::enforce_poly_product,
 };
@@ -63,8 +64,9 @@ impl Header for AnchorChain {
     /// `(start, end)`. `start` roots in an unbound witness at [`AnchorSeed`]
     /// and flows to [`super::stamp::StampLift`] which must ultimately be
     /// checked by consensus. `end` is always computed in-circuit as
-    /// `start.next_stamp(epoch, ...)`.
-    type Data = (Anchor, Anchor);
+    /// `start.next_stamp(epoch, ...)` and is therefore statically
+    /// [`Stamped`]: no anchor-chain link is ever a sentinel.
+    type Data = (Anchor, Anchor<Stamped>);
 
     const SUFFIX: Suffix = Suffix::new(5);
 
@@ -214,7 +216,7 @@ impl Step for AnchorSeed {
             .next_stamp(epoch, &stamp_commit)
             .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
 
-        Ok(((start, end.erase()), ()))
+        Ok(((start, end), ()))
     }
 }
 

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -44,8 +44,8 @@ use crate::{
 ///
 /// Structurally intra-epoch: the sole builder ([`AnchorSeed`]) invokes only
 /// [`Anchor::next_stamp`], which binds an epoch. The [`Anchor::next_epoch`]
-/// boundary domain is distinct and never a chain link; it is folded at a
-/// crossing by [`EndEpochUnspentSeed`].
+/// sentinel (boundary) domain is distinct and never a chain link; it is
+/// folded at a crossing by [`EndEpochUnspentSeed`].
 ///
 /// The within-epoch property pairs with a consensus-side two-epoch
 /// tachygram scan that catches any tachygram already published earlier
@@ -214,7 +214,7 @@ impl Step for AnchorSeed {
             .next_stamp(epoch, &stamp_commit)
             .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
 
-        Ok(((start, end), ()))
+        Ok(((start, end.erase()), ()))
     }
 }
 
@@ -320,7 +320,7 @@ impl Step for UnspentSeed {
                 (epoch, nf),
                 elapsed_commit,
                 (epoch, nf),
-                tested_anchor,
+                tested_anchor.erase(),
             ),
             (),
         ))
@@ -328,12 +328,14 @@ impl Step for UnspentSeed {
 }
 
 /// Seed spanning one epoch boundary link, from an epoch's terminal anchor to
-/// the next epoch's opening boundary anchor.
+/// the next epoch's opening sentinel (boundary anchor).
 ///
 /// The segment covers exactly the tick `anchor_prev.next_epoch(epoch_prev +
 /// 1)`, so it covers two epochs and its `elapsed` is the two-member sequence
 /// `[nf_prev, nf]`: the nullifier tested in the epoch being left, and the one
-/// that opens the epoch being entered.
+/// that opens the epoch being entered. The minted tick is statically an
+/// `Anchor<Sentinel>`; `anchor_prev` stays kind-erased because a silent
+/// epoch's terminal anchor is itself the sentinel that opened it.
 ///
 /// # Soundness
 ///
@@ -378,6 +380,8 @@ impl Step for EndEpochUnspentSeed {
         )?;
 
         let epoch = epoch_prev.next();
+        // The minted tick is statically an `Anchor<Sentinel>`; its kind is
+        // erased only at header emission below.
         let anchor = anchor_prev
             .next_epoch(epoch)
             .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
@@ -419,7 +423,7 @@ impl Step for EndEpochUnspentSeed {
                 (epoch_prev, nf_prev),
                 elapsed_commit,
                 (epoch, nf),
-                anchor,
+                anchor.erase(),
             ),
             (),
         ))

--- a/crates/tachyon/src/stamp/proof/spendable.rs
+++ b/crates/tachyon/src/stamp/proof/spendable.rs
@@ -163,7 +163,7 @@ impl Step for SpendableInit {
             .next_stamp(creation_epoch, &creation_commit)
             .map_err(|_e| ragu::Error::InvalidWitness("invalid anchor step".into()))?;
 
-        Ok(((cm, (creation_epoch, present_nf), post_cm_anchor), ()))
+        Ok(((cm, (creation_epoch, present_nf), post_cm_anchor.erase()), ()))
     }
 }
 

--- a/crates/tachyon/src/stamp/proof/stamp.rs
+++ b/crates/tachyon/src/stamp/proof/stamp.rs
@@ -322,7 +322,9 @@ impl Step for StampLift {
             "StampLift: segment start must equal stamp old_anchor",
         )?;
 
-        let data = (left_action_commit, left_tachygram_commit, segment_end);
+        // The segment end is statically stamp-produced; its kind is erased
+        // because `StampHeader` anchors admit either kind.
+        let data = (left_action_commit, left_tachygram_commit, segment_end.erase());
         Ok((data, ()))
     }
 }

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -77,6 +77,9 @@ pub fn nullifier_fuse(
 
 /// Prepare the witness for [`UnspentSeed`]: `(anchor_prev, (epoch, nf),
 /// tg_set, elapsed_seq)`.
+///
+/// `anchor_prev` is kind-erased: a lineage resting on an epoch's sentinel
+/// legitimately walks a stamp out of it.
 #[must_use]
 pub fn unspent_seed(
     (_left, _right): (StepLeft<UnspentSeed>, StepRight<UnspentSeed>),
@@ -95,6 +98,9 @@ pub fn unspent_seed(
 
 /// Prepare the witness for [`EndEpochUnspentSeed`]:
 /// `(anchor_prev, (epoch_prev, nf_prev), nf, elapsed_seq)`.
+///
+/// `anchor_prev` is kind-erased: a silent epoch's terminal anchor is itself
+/// the sentinel that opened it.
 #[must_use]
 pub fn end_epoch_unspent_seed(
     (_left, _right): (
@@ -237,6 +243,8 @@ pub fn spend_bind(
 }
 
 /// Prepare the witness for [`AnchorSeed`]: `(start, epoch, stamp_commit)`.
+///
+/// `start` is kind-erased: an epoch's first segment roots on the sentinel.
 #[must_use]
 pub fn anchor_seed(
     (_left, _right): (StepLeft<AnchorSeed>, StepRight<AnchorSeed>),

--- a/crates/tachyon/tests/integration/fixtures.rs
+++ b/crates/tachyon/tests/integration/fixtures.rs
@@ -297,7 +297,7 @@ impl PoolSimBlock {
             .map(|tgs| {
                 let stamp_prev = anchor;
                 let commit = tgs.iter().copied().collect::<TachygramSetPoly>().commit();
-                let stamp_after = anchor.next_stamp(epoch, &commit).unwrap();
+                let stamp_after = anchor.next_stamp(epoch, &commit).unwrap().erase();
                 anchor = stamp_after;
                 (stamp_prev, tgs, commit, stamp_after)
             })
@@ -405,7 +405,7 @@ impl PoolSim {
         // Epoch-first blocks are preceded by a boundary anchor lift;
         // intra-epoch blocks advance directly from the previous tip.
         let prev = if new_height.is_epoch_first() {
-            old_tip.next_epoch(new_height.epoch()).unwrap()
+            old_tip.next_epoch(new_height.epoch()).unwrap().erase()
         } else {
             old_tip
         };
@@ -435,7 +435,7 @@ pub(crate) fn build_anchor_chain_pcd<RNG: CryptoRng>(
     loop {
         for tgs in &pool.block(height).tachygrams() {
             let witness = witness::anchor_seed(((), ()), state, height.epoch(), tgs);
-            let next_state = state.next_stamp(witness.1, &witness.2).unwrap();
+            let next_state = state.next_stamp(witness.1, &witness.2).unwrap().erase();
             let (seed, ()) = PROOF_SYSTEM
                 .seed(rng, pool::AnchorSeed, witness)
                 .expect("AnchorSeed");
@@ -840,7 +840,7 @@ impl WalletSim {
             let pre_cm_anchor = stamp_commits[..cm_idx]
                 .iter()
                 .fold(pool.block(init_height).prev, |anchor, commit| {
-                    anchor.next_stamp(init_height.epoch(), commit).unwrap()
+                    anchor.next_stamp(init_height.epoch(), commit).unwrap().erase()
                 });
 
             (pre_cm_anchor, stamps[cm_idx].clone())

--- a/crates/tachyon/tests/integration/proof.rs
+++ b/crates/tachyon/tests/integration/proof.rs
@@ -208,7 +208,8 @@ fn unspent_fuse_rejects_invalid_compositions() {
             EpochIndex(0),
             &TachygramSetPoly::from_iter(stamps_left.clone()).commit(),
         )
-        .unwrap();
+        .unwrap()
+        .erase();
 
     // nf mismatch: contiguous states but different nfs.
     {
@@ -261,7 +262,7 @@ fn anchor_chain_fuse_rejects_invalid_compositions() {
 
         let left = build_anchor_chain_pcd(rng, &pool, BlockHeight(0)..=BlockHeight(0));
 
-        let bogus_start = Anchor(Fp::random(&mut *rng));
+        let bogus_start = Anchor::from(Fp::random(&mut *rng));
         let stamps = pool.block(BlockHeight(1)).tachygrams();
         let (right, ()) = PROOF_SYSTEM
             .seed(
@@ -706,7 +707,8 @@ fn multi_epoch_fuse_setup(
             start_height.epoch(),
             &pool.block(start_height).stamp_commits()[0],
         )
-        .unwrap();
+        .unwrap()
+        .erase();
     let junction = pool
         .block(junction_height)
         .prev
@@ -714,7 +716,8 @@ fn multi_epoch_fuse_setup(
             junction_height.epoch(),
             &pool.block(junction_height).stamp_commits()[0],
         )
-        .unwrap();
+        .unwrap()
+        .erase();
     let end = pool
         .block(end_height)
         .prev
@@ -722,7 +725,8 @@ fn multi_epoch_fuse_setup(
             end_height.epoch(),
             &pool.block(end_height).stamp_commits()[0],
         )
-        .unwrap();
+        .unwrap()
+        .erase();
     let left = build_unspent_pcd_between_anchors(rng, &pool, &[nf0, nf1, nf2], (start, junction));
     let right = build_unspent_pcd_between_anchors(rng, &pool, &[nf2, nf3], (junction, end));
     assert_eq!(left.data().0, start, "left rooted at the sub-block start");
@@ -867,7 +871,8 @@ fn unspent_fuse_accepts_left_as_combined_for_one_member_right() {
             EpochIndex(0),
             &TachygramSetPoly::from_iter(stamps_left.clone()).commit(),
         )
-        .unwrap();
+        .unwrap()
+        .erase();
     let nf = Nullifier::from(Fp::random(&mut *rng));
     let left = build_unspent_seed_pcd(rng, start, EpochIndex(0), &stamps_left, nf);
     let right = build_unspent_seed_pcd(rng, mid, EpochIndex(0), &stamps_right, nf);
@@ -953,7 +958,8 @@ fn epoch_fuse_setup(
             start_height.epoch(),
             &pool.block(start_height).stamp_commits()[0],
         )
-        .unwrap();
+        .unwrap()
+        .erase();
     let end = pool
         .block(end_height)
         .prev
@@ -961,7 +967,8 @@ fn epoch_fuse_setup(
             end_height.epoch(),
             &pool.block(end_height).stamp_commits()[0],
         )
-        .unwrap();
+        .unwrap()
+        .erase();
     let left = build_unspent_pcd_between_anchors(
         rng,
         &pool,
@@ -1086,7 +1093,7 @@ fn end_epoch_unspent_seed_spans_one_boundary_link() {
     assert_eq!(anchor_prev, epoch_tip);
     assert_eq!(
         anchor_last,
-        epoch_tip.next_epoch(EpochIndex(5)).unwrap(),
+        epoch_tip.next_epoch(EpochIndex(5)).unwrap().erase(),
         "the segment covers the boundary tick"
     );
     assert_eq!(epoch_start, EpochIndex(4));
@@ -1149,7 +1156,7 @@ fn spendable_lift_advances_from_an_epoch_tip() {
         (
             note.commitment(),
             (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
-            epoch0_tip.next_epoch(EpochIndex(1)).unwrap()
+            epoch0_tip.next_epoch(EpochIndex(1)).unwrap().erase()
         ),
         "the tick advances epoch, nullifier and anchor together"
     );
@@ -2445,7 +2452,7 @@ fn crossing_seed_carries_a_terminal_anchor_to_a_spend() {
         (
             note.commitment(),
             (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
-            epoch0_tip.next_epoch(EpochIndex(1)).unwrap(),
+            epoch0_tip.next_epoch(EpochIndex(1)).unwrap().erase(),
         ),
         "the lift crosses to the boundary anchor"
     );

--- a/crates/tachyon/tests/integration/stamp.rs
+++ b/crates/tachyon/tests/integration/stamp.rs
@@ -800,7 +800,7 @@ fn lift_over_descriptors_then_verify() {
         .flat_map(|height| pool.block(BlockHeight(height)).stamp_commits())
         .scan(stamp.anchor, |anchor_before, tachygram_set| {
             let witness = (*anchor_before, epoch, tachygram_set);
-            *anchor_before = anchor_before.next_stamp(epoch, &tachygram_set).unwrap();
+            *anchor_before = anchor_before.next_stamp(epoch, &tachygram_set).unwrap().erase();
             Some(witness)
         })
         .collect();


### PR DESCRIPTION
Part of spec alignment, currently the only difference is whether `Anchor` is derived from `.next_stamp()` or `.next_epoch()` where the latter is the sentinel anchor. 

In the PR, we introduce a sealed, zero-sized type  `trait AnchorKind` and modify `struct Anchor<AnchorKind>` to make it type-level differentiable the type of anchor it is. 
There are three types `Stamped` (the normal anchor), `Sentinel` the beginning anchor of the next epoch, `Erased` is the type-erased variant that doesn't require any precedessor chain to instantiate, just an arbitrary value. 

At this point, this `AnchorKind` has no material changes to circuit logic or benefit yet. But this prepares us for the epoch-wide `AnchorChain` and `Tachygrams` evidence mentioned in #129. Because those headers require explicit sentinel anchors in their header, and not just any arbitrary ones. 