### PR TITLE
Return `Option` from `EpochIndex::next` and `BlockHeight::next`

### DIFF
--- a/book/src/proof-tree.md
+++ b/book/src/proof-tree.md
@@ -16,8 +16,8 @@ Multiple parties execute the proof tree.
 A wallet proves a window of its note's nullifiers were correctly derived[^nullifiers].
 `NfMasterSeed` witnesses the note and the proof-authorizing key `pak`, checks `note.pk == pak.derive_payment_key()` (which pins `nk`, and through `nk` the commitment `cm`), derives the master key `mk` and `cm`, and emits an `NfMasterHeader` carrying `(cm, mk)`. `nk` never leaves the step.
 `NfDerive` consumes that seed. It witnesses the window's start epoch (constrained group-aligned) and its sequence, runs four sponges over $(\texttt{Tachyon-NfDerive}, \mathsf{mk}, w)$ to squeeze the window's 16 nullifiers natively, and binds the sequence to them with one opening at a free challenge (below). It exports the whole window, so the range it announces is derived rather than witnessed.
-`NullifierFuse` concatenates two adjacent nullifier sequences into one, requiring the same `cm` and contiguity (`right.epoch_start == left.epoch_end`).
-The result is a `NullifierDerivation` proving the range `[epoch_start, epoch_end)` commits to the genuine nullifiers of the note identified by `cm`, one factor per covered epoch.
+`NullifierFuse` concatenates two adjacent nullifier sequences into one, requiring the same `cm` and contiguity (`right.epoch_start == left.epoch_last + 1`).
+The result is a `NullifierDerivation` proving the range `[epoch_start, epoch_last]` commits to the genuine nullifiers of the note identified by `cm`, one factor per covered epoch.
 
 ### Bootstrapping a spendable
 
@@ -433,7 +433,7 @@ flowchart LR
 | ArbitraryUnspent | (anchor_prev, (epoch_start, nf_start), elapsed, (epoch_last, nf_last), anchor_last) |
 | Unspent | (cm, anchor_prev, (epoch_start, nf_start), (epoch_last, nf_last), anchor_last) |
 | NfMasterHeader | (cm, mk) |
-| NullifierDerivation | (cm, epoch_start, nf_commit, epoch_end) |
+| NullifierDerivation | (cm, epoch_start, nf_commit, epoch_last) |
 | SpendableHeader | (cm, (epoch, present_nf), anchor) |
 | OutputHeader | (cm, pad) |
 | SpendHeader | (cm, present_nf, nf_next, anchor) |

--- a/crates/tachyon/src/keys/master.rs
+++ b/crates/tachyon/src/keys/master.rs
@@ -36,8 +36,9 @@ impl NoteMasterKey {
         reason = "the remainder indexes an array of PoseidonFp::RATE"
     )]
     pub fn derive_nullifier(&self, epoch: EpochIndex) -> Nullifier {
-        let inner_index = epoch.0 as usize % PoseidonFp::RATE;
-        let epoch_start = EpochIndex(epoch.0 - (inner_index as u32));
+        let index = u32::from(epoch);
+        let inner_index = index as usize % PoseidonFp::RATE;
+        let epoch_start = EpochIndex::new(index - (inner_index as u32));
         Nullifier::from(poseidon::nullifier_group(self.0, epoch_start.into())[inner_index])
     }
 
@@ -49,6 +50,10 @@ impl NoteMasterKey {
     /// witnessed start epoch accordingly. Group alignment makes the sponge
     /// count a compile-time constant inside the step:
     /// `NF_DERIVATION_WIDTH / PoseidonFp::RATE` permutations each way.
+    ///
+    /// # Panics
+    ///
+    /// If the window would run past [`EPOCH_MAX`](crate::constants::EPOCH_MAX).
     #[must_use]
     #[expect(
         clippy::as_conversions,
@@ -60,14 +65,14 @@ impl NoteMasterKey {
     )]
     pub fn derive_window(&self, epoch_start: EpochIndex) -> [Nullifier; NF_DERIVATION_WIDTH] {
         debug_assert_eq!(
-            epoch_start.0 % (PoseidonFp::RATE as u32),
+            u32::from(epoch_start) % (PoseidonFp::RATE as u32),
             0,
             "epoch_start must be group-aligned"
         );
         let groups: [[Fp; PoseidonFp::RATE]; NF_DERIVATION_WIDTH / PoseidonFp::RATE] =
             array::from_fn(|offset| {
-                let group_start = epoch_start.0 + (offset * PoseidonFp::RATE) as u32;
-                poseidon::nullifier_group(self.0, Fp::from(EpochIndex(group_start)))
+                let group_start = u32::from(epoch_start) + (offset * PoseidonFp::RATE) as u32;
+                poseidon::nullifier_group(self.0, Fp::from(EpochIndex::new(group_start)))
             });
         array::from_fn(|slot| {
             Nullifier::from(groups[slot / PoseidonFp::RATE][slot % PoseidonFp::RATE])

--- a/crates/tachyon/src/keys/mod.rs
+++ b/crates/tachyon/src/keys/mod.rs
@@ -163,12 +163,26 @@ mod tests {
     #[test]
     fn window_matches_per_epoch_derivation() {
         let mk = NoteMasterKey(Fp::random(&mut StdRng::seed_from_u64(0)));
-        let epoch_start = EpochIndex(96);
+        let epoch_start = EpochIndex::new(96);
 
-        let epochs = (epoch_start.0..).map(EpochIndex);
+        let epochs = (u32::from(epoch_start)..).map(EpochIndex::new);
         for (epoch, nf) in epochs.zip(mk.derive_window(epoch_start)) {
-            assert_eq!(nf, mk.derive_nullifier(epoch), "epoch {}", epoch.0);
+            assert_eq!(nf, mk.derive_nullifier(epoch), "epoch {}", u32::from(epoch));
         }
+    }
+
+    /// A window that would run past the epoch range names epochs that map to
+    /// no block height, so there is nothing to derive.
+    #[test]
+    #[should_panic(expected = "epoch index above EPOCH_MAX")]
+    fn window_rejects_a_start_too_close_to_the_final_epoch() {
+        use crate::constants::EPOCH_MAX;
+
+        let mk = NoteMasterKey(Fp::random(&mut StdRng::seed_from_u64(0)));
+        // Group-aligned for any EPOCH_MAX of the form `2^k - 1`, and short of
+        // a whole window by three epochs.
+        let window = mk.derive_window(EpochIndex::new(EPOCH_MAX - 3));
+        panic!("a window past the final epoch must not derive, got {window:?}");
     }
 
     #[test]

--- a/crates/tachyon/src/keys/note.rs
+++ b/crates/tachyon/src/keys/note.rs
@@ -155,8 +155,8 @@ mod tests {
         let psi = nullifier::Trapdoor::random(rng);
         let mk = nk.derive_note_private(psi);
         assert_ne!(
-            mk.derive_nullifier(EpochIndex(0u32)),
-            mk.derive_nullifier(EpochIndex(1u32)),
+            mk.derive_nullifier(EpochIndex::new(0u32)),
+            mk.derive_nullifier(EpochIndex::new(1u32)),
         );
     }
 }

--- a/crates/tachyon/src/primitives/anchor.rs
+++ b/crates/tachyon/src/primitives/anchor.rs
@@ -63,7 +63,7 @@ impl Anchor {
     ///
     /// Fails if `next_epoch` is zero.
     pub fn next_epoch(self, next_epoch: EpochIndex) -> Result<Self, AnchorError> {
-        if next_epoch == EpochIndex(0) {
+        if next_epoch == EpochIndex::new(0) {
             Err(AnchorError::NextEpochZero)
         } else {
             Ok(Self(poseidon::anchor_next_epoch(self.0, next_epoch.into())))
@@ -103,15 +103,15 @@ mod tests {
         let second = TachygramSetPoly::from_iter([Tachygram::random(&mut *rng)]).commit();
 
         let forward = Anchor::default()
-            .next_stamp(EpochIndex(7), &first)
+            .next_stamp(EpochIndex::new(7), &first)
             .unwrap()
-            .next_stamp(EpochIndex(7), &second)
+            .next_stamp(EpochIndex::new(7), &second)
             .unwrap();
 
         let reverse = Anchor::default()
-            .next_stamp(EpochIndex(7), &second)
+            .next_stamp(EpochIndex::new(7), &second)
             .unwrap()
-            .next_stamp(EpochIndex(7), &first)
+            .next_stamp(EpochIndex::new(7), &first)
             .unwrap();
 
         assert_ne!(forward, reverse);
@@ -126,7 +126,7 @@ mod tests {
             let anchor = Anchor(Fp::random(&mut *rng));
             let zero_set = TachygramSetCommit::from(Eq::identity());
 
-            let Err(AnchorError::NextStampZero) = anchor.next_stamp(EpochIndex(7), &zero_set)
+            let Err(AnchorError::NextStampZero) = anchor.next_stamp(EpochIndex::new(7), &zero_set)
             else {
                 panic!("should not be able to advance with an identity stamp");
             };
@@ -137,7 +137,7 @@ mod tests {
             let anchor = Anchor(Fp::random(&mut *rng));
             let one_set = TachygramSetCommit::default();
 
-            let Err(AnchorError::NextStampEmpty) = anchor.next_stamp(EpochIndex(1), &one_set)
+            let Err(AnchorError::NextStampEmpty) = anchor.next_stamp(EpochIndex::new(1), &one_set)
             else {
                 panic!("should not be able to advance with an empty stamp");
             };
@@ -150,7 +150,7 @@ mod tests {
 
         let anchor = Anchor(Fp::random(rng));
 
-        let Err(AnchorError::NextEpochZero) = anchor.next_epoch(EpochIndex(0)) else {
+        let Err(AnchorError::NextEpochZero) = anchor.next_epoch(EpochIndex::new(0)) else {
             panic!("should not be able to advance to epoch zero");
         };
     }

--- a/crates/tachyon/src/primitives/block_height.rs
+++ b/crates/tachyon/src/primitives/block_height.rs
@@ -26,18 +26,24 @@ impl From<usize> for BlockHeight {
 }
 
 impl BlockHeight {
-    /// Returns the next block height.
+    /// Returns the next block height, or `None` for [`BLOCK_MAX`].
+    ///
+    /// [`BLOCK_MAX`]: crate::constants::BLOCK_MAX
     #[must_use]
-    pub const fn next(self) -> Self {
-        #[expect(clippy::expect_used, reason = "don't go above u32::MAX")]
-        Self(self.0.checked_add(1).expect("do not exceed u32::MAX"))
+    pub const fn next(self) -> Option<Self> {
+        match self.0.checked_add(1) {
+            Some(height) => Some(Self(height)),
+            None => None,
+        }
     }
 
-    /// Returns the previous block height.
+    /// Returns the previous block height, or `None` for the genesis block.
     #[must_use]
-    pub const fn prev(self) -> Self {
-        #[expect(clippy::expect_used, reason = "don't go below u32::MIN")]
-        Self(self.0.checked_sub(1).expect("do not subceed u32::MIN"))
+    pub const fn prev(self) -> Option<Self> {
+        match self.0.checked_sub(1) {
+            Some(height) => Some(Self(height)),
+            None => None,
+        }
     }
 
     /// Epoch index for this block height.
@@ -56,5 +62,26 @@ impl BlockHeight {
     #[must_use]
     pub const fn is_epoch_first(self) -> bool {
         self.0 & (EPOCH_SIZE - 1) == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::BLOCK_MAX;
+
+    #[test]
+    fn next_stops_at_the_final_block() {
+        assert_eq!(
+            BlockHeight(BLOCK_MAX - 1).next(),
+            Some(BlockHeight(BLOCK_MAX))
+        );
+        assert_eq!(BlockHeight(BLOCK_MAX).next(), None);
+    }
+
+    #[test]
+    fn prev_stops_at_the_genesis_block() {
+        assert_eq!(BlockHeight(1).prev(), Some(BlockHeight(0)));
+        assert_eq!(BlockHeight(0).prev(), None);
     }
 }

--- a/crates/tachyon/src/primitives/block_height.rs
+++ b/crates/tachyon/src/primitives/block_height.rs
@@ -49,7 +49,7 @@ impl BlockHeight {
     /// Epoch index for this block height.
     #[must_use]
     pub const fn epoch(self) -> EpochIndex {
-        EpochIndex(self.0.div_euclid(EPOCH_SIZE))
+        EpochIndex::new(self.0.div_euclid(EPOCH_SIZE))
     }
 
     /// Whether this is the last block of its epoch.

--- a/crates/tachyon/src/primitives/epoch.rs
+++ b/crates/tachyon/src/primitives/epoch.rs
@@ -1,6 +1,6 @@
 use core::ops;
 
-use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
+use derive_more::{Debug, Eq as TotalEq, Into, PartialEq};
 use pasta_curves::Fp;
 
 use super::BlockHeight;
@@ -14,15 +14,29 @@ use crate::constants::{EPOCH_MAX, EPOCH_SIZE};
 /// Indexes nullifier derivation: $mk = \text{KDF}(\psi, nk)$, then
 /// $nf_e = F_{mk}(e)$. Different epochs produce different nullifiers for
 /// the same note, enabling range-restricted delegation via the GGM tree PRF.
-#[derive(Clone, Copy, Debug, From, Into, Ord, PartialEq, PartialOrd, TotalEq)]
-pub struct EpochIndex(pub u32);
+///
+/// Always in `0..=EPOCH_MAX`: every index maps to a block height in the
+/// protocol's range.
+#[derive(Clone, Copy, Debug, Into, Ord, PartialEq, PartialOrd, TotalEq)]
+pub struct EpochIndex(u32);
 
 /// A non-negative distance between two [`EpochIndex`]es, from subtraction.
 #[derive(Clone, Copy, Debug, Into, Ord, PartialEq, PartialOrd, TotalEq)]
-#[into(u64)]
+#[into(u32, u64)]
 pub struct EpochDiff(u32);
 
 impl EpochIndex {
+    /// The epoch at `index`.
+    ///
+    /// # Panics
+    ///
+    /// Above [`EPOCH_MAX`], which maps to no block height.
+    #[must_use]
+    pub const fn new(index: u32) -> Self {
+        assert!(index <= EPOCH_MAX, "epoch index above EPOCH_MAX");
+        Self(index)
+    }
+
     /// Returns the next epoch index, or `None` for the final epoch.
     ///
     /// Indexes past [`EPOCH_MAX`] map to no block height in the protocol's
@@ -92,6 +106,13 @@ mod tests {
     fn epoch_difference_rejects_reversed_operands() {
         let reversed = EpochIndex(3) - EpochIndex(7);
         panic!("reversed operands must not produce a difference, got {reversed:?}");
+    }
+
+    #[test]
+    #[should_panic(expected = "epoch index above EPOCH_MAX")]
+    fn new_rejects_an_index_past_the_final_epoch() {
+        let past_the_end = EpochIndex::new(EPOCH_MAX + 1);
+        panic!("an index above EPOCH_MAX is not an epoch, got {past_the_end:?}");
     }
 
     #[test]

--- a/crates/tachyon/src/primitives/epoch.rs
+++ b/crates/tachyon/src/primitives/epoch.rs
@@ -4,7 +4,7 @@ use derive_more::{Debug, Eq as TotalEq, From, Into, PartialEq};
 use pasta_curves::Fp;
 
 use super::BlockHeight;
-use crate::constants::EPOCH_SIZE;
+use crate::constants::{EPOCH_MAX, EPOCH_SIZE};
 
 /// A tachyon epoch — a point in the accumulator's history.
 ///
@@ -23,10 +23,17 @@ pub struct EpochIndex(pub u32);
 pub struct EpochDiff(u32);
 
 impl EpochIndex {
-    /// Returns the next epoch index.
+    /// Returns the next epoch index, or `None` for the final epoch.
+    ///
+    /// Indexes past [`EPOCH_MAX`] map to no block height in the protocol's
+    /// range, so the final epoch has no successor.
     #[must_use]
-    pub const fn next(self) -> Self {
-        Self(self.0 + 1)
+    pub const fn next(self) -> Option<Self> {
+        if self.0 < EPOCH_MAX {
+            Some(Self(self.0 + 1))
+        } else {
+            None
+        }
     }
 
     /// Returns the first block height of the epoch.
@@ -36,9 +43,12 @@ impl EpochIndex {
     }
 
     /// Returns the last block height of the epoch.
+    ///
+    /// Computed from this epoch's own first block, so the final epoch
+    /// ([`EPOCH_MAX`], whose last block is `BLOCK_MAX`) does not overflow.
     #[must_use]
     pub const fn last_block(self) -> BlockHeight {
-        BlockHeight(self.next().first_block().0 - 1)
+        BlockHeight(self.first_block().0 + (EPOCH_SIZE - 1))
     }
 }
 
@@ -82,5 +92,22 @@ mod tests {
     fn epoch_difference_rejects_reversed_operands() {
         let reversed = EpochIndex(3) - EpochIndex(7);
         panic!("reversed operands must not produce a difference, got {reversed:?}");
+    }
+
+    #[test]
+    fn final_epoch_ends_at_the_final_block() {
+        use crate::constants::BLOCK_MAX;
+
+        assert_eq!(EpochIndex(EPOCH_MAX).last_block(), BlockHeight(BLOCK_MAX));
+        assert_eq!(BlockHeight(BLOCK_MAX).epoch(), EpochIndex(EPOCH_MAX));
+    }
+
+    #[test]
+    fn next_stops_at_the_final_epoch() {
+        assert_eq!(
+            EpochIndex(EPOCH_MAX - 1).next(),
+            Some(EpochIndex(EPOCH_MAX))
+        );
+        assert_eq!(EpochIndex(EPOCH_MAX).next(), None);
     }
 }

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -400,8 +400,8 @@ impl Plan {
             // note's master key (the succinct header carries only the
             // commitment); the witness segments its read and complement.
             let mk = pak.nk.derive_note_private(note.psi);
-            let (_, deriv_start, _, deriv_end) = *range_pcd.data();
-            let window: Vec<Nullifier> = (deriv_start.0..deriv_end.0)
+            let (_, deriv_start, _, deriv_last) = *range_pcd.data();
+            let window: Vec<Nullifier> = (deriv_start.0..=deriv_last.0)
                 .map(|epoch| mk.derive_nullifier(EpochIndex(epoch)))
                 .collect();
             let bind_witness =

--- a/crates/tachyon/src/stamp/mod.rs
+++ b/crates/tachyon/src/stamp/mod.rs
@@ -401,8 +401,8 @@ impl Plan {
             // commitment); the witness segments its read and complement.
             let mk = pak.nk.derive_note_private(note.psi);
             let (_, deriv_start, _, deriv_last) = *range_pcd.data();
-            let window: Vec<Nullifier> = (deriv_start.0..=deriv_last.0)
-                .map(|epoch| mk.derive_nullifier(EpochIndex(epoch)))
+            let window: Vec<Nullifier> = (u32::from(deriv_start)..=u32::from(deriv_last))
+                .map(|epoch| mk.derive_nullifier(EpochIndex::new(epoch)))
                 .collect();
             let bind_witness =
                 witness::spend_bind((*spendable_pcd.data(), *range_pcd.data()), &window);

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 
 use alloc::{vec, vec::Vec};
 
+use ff::Field as _;
 use pasta_curves::{Ep, Eq, Fp, Fq};
 use ragu::{Header, Index, Step, Suffix};
 use ragu_arithmetic::PoseidonPermutation as _;
@@ -18,8 +19,10 @@ use ragu_pasta::PoseidonFp;
 
 use crate::{
     collections::indexed_multiset,
+    constants::EPOCH_MAX,
     keys::{NoteMasterKey, ProofAuthorizingKey},
     note::{self, Note},
+    nullifier::NF_DERIVATION_WIDTH,
     primitives::{EpochIndex, NfSeqCommit, NfSeqPoly},
     ragu_constraint::{enforce_equal_point, enforce_zero},
     relations::enforce::enforce_poly_product,
@@ -48,8 +51,8 @@ impl Header for NfMasterHeader {
 
 /// A proven contiguous range of derived nullifiers (wallet-only).
 ///
-/// `(cm, epoch_start, nf_commit, epoch_end)`: covers epochs
-/// `[epoch_start, epoch_end)`; `nf_commit` commits the range's nullifier
+/// `(cm, epoch_start, nf_commit, epoch_last)`: covers epochs
+/// `[epoch_start, epoch_last]`; `nf_commit` commits the range's nullifier
 /// sequence as an [`NfSeqPoly`], exactly one member per covered epoch. That
 /// invariant is established at [`NfDerive`], preserved by
 /// [`NullifierFuse`]'s contiguity check, and what the divisibility binds
@@ -66,15 +69,15 @@ impl Header for NfMasterHeader {
 pub struct NullifierDerivation;
 
 impl Header for NullifierDerivation {
-    /// `(cm, epoch_start, nf_commit, epoch_end)`. `epoch_end` is exclusive.
+    /// `(cm, epoch_start, nf_commit, epoch_last)`. `epoch_last` is inclusive.
     type Data = (note::Commitment, EpochIndex, NfSeqCommit, EpochIndex);
 
     const SUFFIX: Suffix = Suffix::new(3);
 
     fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
-        let (cm, epoch_start, nf_commit, epoch_end) = *data;
+        let (cm, epoch_start, nf_commit, epoch_last) = *data;
         (
-            vec![Fp::from(cm), Fp::from(epoch_start), Fp::from(epoch_end)],
+            vec![Fp::from(cm), Fp::from(epoch_start), Fp::from(epoch_last)],
             Vec::new(),
             Vec::new(),
             vec![Eq::from(nf_commit)],
@@ -184,15 +187,24 @@ impl Step for NfDerive {
             "NfDerive: epoch_start is not group-aligned",
         )?;
 
-        // NF_DERIVATION_WIDTH nullifiers, PoseidonFp::RATE per sponge.
-        let nullifiers = mk.derive_window(epoch_start);
-
+        // The whole window must land inside the epoch range: an index past
+        // EPOCH_MAX maps to no block height, so it labels nothing.
         #[expect(
             clippy::as_conversions,
             clippy::cast_possible_truncation,
-            reason = "constant length"
+            reason = "the window width is a small constant"
         )]
-        let epoch_end = EpochIndex(epoch_start.0 + nullifiers.len() as u32);
+        let epoch_last = epoch_start
+            .0
+            .checked_add(NF_DERIVATION_WIDTH as u32 - 1)
+            .filter(|last| *last <= EPOCH_MAX)
+            .map(EpochIndex)
+            .ok_or_else(|| {
+                ragu_core::Error::InvalidWitness("NfDerive: window exceeds the epoch range".into())
+            })?;
+
+        // NF_DERIVATION_WIDTH nullifiers, PoseidonFp::RATE per sponge.
+        let nullifiers = mk.derive_window(epoch_start);
 
         // `z`: a fresh transcript challenge over the sequence commitment. The
         // polynomial is fixed before it exists, so the single opening below
@@ -211,14 +223,14 @@ impl Step for NfDerive {
             "NfDerive: sequence does not match the derived window",
         )?;
 
-        Ok(((cm, epoch_start, seq.commit(), epoch_end), ()))
+        Ok(((cm, epoch_start, seq.commit(), epoch_last), ()))
     }
 }
 
 /// Merge two adjacent derived ranges into one (`left ++ right`).
 ///
 /// Requires the same `cm` and contiguity (`right.epoch_start ==
-/// left.epoch_end`). Witnesses the two range polynomials and their
+/// left.epoch_last + 1`). Witnesses the two range polynomials and their
 /// concatenation, binds each by commit-equality, and proves the concat as the
 /// product
 ///
@@ -231,7 +243,7 @@ impl Step for NfDerive {
 /// All three operands are committed and absorbed into the challenge, so the
 /// product identity pins `merged`'s member multiset to the union of the
 /// halves'. The contiguity check preserves the header invariant established
-/// at the leaf: exactly one member per epoch in `[epoch_start, epoch_end)`,
+/// at the leaf: exactly one member per epoch in `[epoch_start, epoch_last]`,
 /// so the announced range labels the member multiset truthfully.
 #[derive(Debug)]
 pub struct NullifierFuse;
@@ -250,15 +262,15 @@ impl Step for NullifierFuse {
         &self,
         ctx: &mut ragu::StepCtx<'_>,
         (left_seq, merged_seq, right_seq): Self::Witness<'source>,
-        (left_cm, left_epoch_start, left_nf_commit, left_epoch_end): <Self::Left as Header>::Data,
-        (right_cm, right_epoch_start, right_nf_commit, right_epoch_end): <Self::Right as Header>::Data,
+        (left_cm, left_epoch_start, left_nf_commit, left_epoch_last): <Self::Left as Header>::Data,
+        (right_cm, right_epoch_start, right_nf_commit, right_epoch_last): <Self::Right as Header>::Data,
     ) -> ragu_core::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         enforce_zero(
             Fp::from(left_cm) - Fp::from(right_cm),
             "NullifierFuse: note commitments differ",
         )?;
         enforce_zero(
-            Fp::from(right_epoch_start) - Fp::from(left_epoch_end),
+            Fp::from(right_epoch_start) - Fp::from(left_epoch_last) - Fp::ONE,
             "NullifierFuse: ranges not contiguous",
         )?;
         enforce_equal_point(
@@ -280,7 +292,12 @@ impl Step for NullifierFuse {
             "NullifierFuse: merged is not the concat of the halves",
         )?;
         Ok((
-            (left_cm, left_epoch_start, merged_nf_commit, right_epoch_end),
+            (
+                left_cm,
+                left_epoch_start,
+                merged_nf_commit,
+                right_epoch_last,
+            ),
             (),
         ))
     }

--- a/crates/tachyon/src/stamp/proof/delegation.rs
+++ b/crates/tachyon/src/stamp/proof/delegation.rs
@@ -183,22 +183,23 @@ impl Step for NfDerive {
             reason = "the group width is a small constant"
         )]
         enforce_zero(
-            Fp::from(u64::from(epoch_start.0) % (PoseidonFp::RATE as u64)),
+            Fp::from(u64::from(epoch_start) % (PoseidonFp::RATE as u64)),
             "NfDerive: epoch_start is not group-aligned",
         )?;
 
         // The whole window must land inside the epoch range: an index past
-        // EPOCH_MAX maps to no block height, so it labels nothing.
+        // EPOCH_MAX maps to no block height, so it labels nothing. Unreachable
+        // through `EpochIndex`, which cannot hold such an index; a real
+        // circuit sees a raw field element and needs the check.
         #[expect(
             clippy::as_conversions,
             clippy::cast_possible_truncation,
             reason = "the window width is a small constant"
         )]
-        let epoch_last = epoch_start
-            .0
+        let epoch_last = u32::from(epoch_start)
             .checked_add(NF_DERIVATION_WIDTH as u32 - 1)
             .filter(|last| *last <= EPOCH_MAX)
-            .map(EpochIndex)
+            .map(EpochIndex::new)
             .ok_or_else(|| {
                 ragu_core::Error::InvalidWitness("NfDerive: window exceeds the epoch range".into())
             })?;

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -379,7 +379,11 @@ impl Step for EndEpochUnspentSeed {
             "EndEpochUnspentSeed: incoming nullifier is zero",
         )?;
 
-        let epoch = epoch_prev.next();
+        let epoch = epoch_prev.next().ok_or_else(|| {
+            ragu_core::Error::InvalidWitness(
+                "EndEpochUnspentSeed: crossing past the final epoch".into(),
+            )
+        })?;
         let anchor = anchor_prev
             .next_epoch(epoch)
             .map_err(|_e| ragu_core::Error::InvalidWitness("invalid anchor step".into()))?;

--- a/crates/tachyon/src/stamp/proof/pool.rs
+++ b/crates/tachyon/src/stamp/proof/pool.rs
@@ -130,9 +130,9 @@ impl Header for ArbitraryUnspent {
         (
             vec![
                 Fp::from(anchor_prev),
-                Fp::from(u64::from(epoch_start.0)),
+                Fp::from(epoch_start),
                 Fp::from(nf_start),
-                Fp::from(u64::from(epoch_last.0)),
+                Fp::from(epoch_last),
                 Fp::from(nf_last),
                 Fp::from(anchor_last),
             ],
@@ -169,9 +169,9 @@ impl Header for Unspent {
             vec![
                 Fp::from(cm),
                 Fp::from(anchor_prev),
-                Fp::from(u64::from(epoch_start.0)),
+                Fp::from(epoch_start),
                 Fp::from(nf_start),
-                Fp::from(u64::from(epoch_last.0)),
+                Fp::from(epoch_last),
                 Fp::from(nf_last),
                 Fp::from(anchor_last),
             ],

--- a/crates/tachyon/src/stamp/proof/qr.rs
+++ b/crates/tachyon/src/stamp/proof/qr.rs
@@ -69,7 +69,7 @@ impl Header for QrIntake {
         let (epoch, anchor_prev, anchor_last, discriminant, profile, contents) = *data;
         (
             vec![
-                Fp::from(u64::from(epoch.0)),
+                Fp::from(epoch),
                 Fp::from(anchor_prev),
                 Fp::from(anchor_last),
                 Fp::from(discriminant),
@@ -108,7 +108,7 @@ impl Header for QrIntakeSides {
         let (epoch, anchor_prev, anchor_last, discriminant, profile, residue, non_residue) = *data;
         (
             vec![
-                Fp::from(u64::from(epoch.0)),
+                Fp::from(epoch),
                 Fp::from(anchor_prev),
                 Fp::from(anchor_last),
                 Fp::from(discriminant),
@@ -243,7 +243,7 @@ impl Step for QrIntakeMerge {
         ): <Self::Right as Header>::Data,
     ) -> ragu_core::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         enforce_zero(
-            Fp::from(u64::from(epoch.0)) - Fp::from(u64::from(right_epoch.0)),
+            Fp::from(epoch) - Fp::from(right_epoch),
             "QrIntakeMerge: inputs cover different epochs",
         )?;
         enforce_zero(
@@ -497,7 +497,7 @@ impl Header for QrBucket {
         let (epoch, anchor_prev, anchor_last, discriminant, profile, contents) = *data;
         (
             vec![
-                Fp::from(u64::from(epoch.0)),
+                Fp::from(epoch),
                 Fp::from(anchor_prev),
                 Fp::from(anchor_last),
                 Fp::from(discriminant),
@@ -561,12 +561,12 @@ impl Step for QrBucketSeal {
     ) -> ragu_core::Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
         enforce_zero(
             Fp::from(anchor_prev)
-                - poseidon::anchor_next_epoch(Fp::from(prev_last), Fp::from(u64::from(epoch.0))),
+                - poseidon::anchor_next_epoch(Fp::from(prev_last), Fp::from(epoch)),
             "QrBucketSeal: intake does not begin at the epoch boundary",
         )?;
         // Computed in the widened domain: a bucket sealed at the final epoch
         // has a closing tick even though that epoch has no successor.
-        let closing_tick = Fp::from(u64::from(epoch.0) + 1);
+        let closing_tick = Fp::from(epoch) + Fp::ONE;
         enforce_zero(
             Fp::from(discriminant)
                 - poseidon::anchor_next_epoch(Fp::from(anchor_last), closing_tick),

--- a/crates/tachyon/src/stamp/proof/qr.rs
+++ b/crates/tachyon/src/stamp/proof/qr.rs
@@ -564,12 +564,12 @@ impl Step for QrBucketSeal {
                 - poseidon::anchor_next_epoch(Fp::from(prev_last), Fp::from(u64::from(epoch.0))),
             "QrBucketSeal: intake does not begin at the epoch boundary",
         )?;
+        // Computed in the widened domain: a bucket sealed at the final epoch
+        // has a closing tick even though that epoch has no successor.
+        let closing_tick = Fp::from(u64::from(epoch.0) + 1);
         enforce_zero(
             Fp::from(discriminant)
-                - poseidon::anchor_next_epoch(
-                    Fp::from(anchor_last),
-                    Fp::from(u64::from(epoch.next().0)),
-                ),
+                - poseidon::anchor_next_epoch(Fp::from(anchor_last), closing_tick),
             "QrBucketSeal: discriminant is not the span's closing tick",
         )?;
 

--- a/crates/tachyon/src/stamp/proof/spend.rs
+++ b/crates/tachyon/src/stamp/proof/spend.rs
@@ -123,10 +123,14 @@ impl Step for SpendBind {
         let nf_seq_at_z = nf_seq.eval(z);
         let complement_at_z = complement_seq.eval(z);
 
+        // The pair read needs a following epoch; the final epoch has none.
+        let next_epoch = spendable_epoch.next().ok_or_else(|| {
+            ragu_core::Error::InvalidWitness("SpendBind: no epoch follows the spend epoch".into())
+        })?;
         let pair_at_z = indexed_multiset::direct_eval(
             [
                 (spendable_epoch.into(), present_nf.into()),
-                (spendable_epoch.next().into(), nf_next.into()),
+                (next_epoch.into(), nf_next.into()),
             ],
             z,
         );

--- a/crates/tachyon/src/stamp/proof/summary.rs
+++ b/crates/tachyon/src/stamp/proof/summary.rs
@@ -37,7 +37,7 @@ impl Header for Summary {
         let (epoch, anchor_prev, anchor_last, acc_commit) = *data;
         (
             vec![
-                Fp::from(u64::from(epoch.0)),
+                Fp::from(epoch),
                 Fp::from(anchor_prev),
                 Fp::from(anchor_last),
             ],

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -170,7 +170,7 @@ pub fn unspent_bind(
 ) -> StepWitness<'static, UnspentBind> {
     let (_, (epoch_start, _), _, (epoch_last, _), _) = unspent;
     let (_, deriv_start, ..) = deriv;
-    let lo = (epoch_start.0 - deriv_start.0) as usize;
+    let lo = u32::from(epoch_start - deriv_start) as usize;
     let (head, from_span) = window.split_at(lo);
     let (_span, tail) = from_span.split_at(elapsed.len());
     let complement_seq = NfSeqPoly::new(deriv_start, head)
@@ -209,7 +209,7 @@ pub fn spendable_init(
     window: &[Nullifier],
 ) -> StepWitness<'static, SpendableInit> {
     let (_, deriv_start, ..) = deriv;
-    let lo = (creation_epoch.0 - deriv_start.0) as usize;
+    let lo = u32::from(creation_epoch - deriv_start) as usize;
     let (head, from_creation) = window.split_at(lo);
     let Some((present_nf, tail)) = from_creation.split_first() else {
         unreachable!("the creation epoch's member is in the window");
@@ -251,7 +251,7 @@ pub fn spend_bind(
 ) -> StepWitness<'static, SpendBind> {
     let (_, (epoch, _), _) = spendable;
     let (_, deriv_start, ..) = deriv;
-    let lo = (epoch.0 - deriv_start.0) as usize;
+    let lo = u32::from(epoch - deriv_start) as usize;
     let (head, from_spend) = window.split_at(lo);
     let (pair, tail) = from_spend.split_at(2);
     let Some(nf_next) = pair.last() else {
@@ -356,7 +356,7 @@ pub fn summary_spendable_init(
     window: &[Nullifier],
 ) -> StepWitness<'static, SummarySpendableInit> {
     let (_, deriv_start, ..) = deriv;
-    let lo = (creation_epoch.0 - deriv_start.0) as usize;
+    let lo = u32::from(creation_epoch - deriv_start) as usize;
     let (head, from_creation) = window.split_at(lo);
     let Some((present_nf, tail)) = from_creation.split_first() else {
         unreachable!("the creation epoch's member is in the window");

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -239,7 +239,8 @@ pub fn spendable_init(
 /// derivation header's range; `nf_next` is the next epoch's member, and the
 /// complement is the window's runs on both sides of the read pair,
 /// multiplied. The pair read requires the derivation range to extend at
-/// least one epoch past the spendable's epoch.
+/// least one epoch past the spendable's epoch, which bounds the spendable
+/// epoch at `EPOCH_MAX - 1`: the final epoch has no member to pair with.
 #[must_use]
 #[expect(
     clippy::as_conversions,

--- a/crates/tachyon/src/witness.rs
+++ b/crates/tachyon/src/witness.rs
@@ -160,7 +160,6 @@ pub fn unspent_fuse(
 /// sides of the unspent's span, multiplied.
 #[must_use]
 #[expect(
-    clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
 )]
@@ -172,9 +171,16 @@ pub fn unspent_bind(
     let (_, (epoch_start, _), _, (epoch_last, _), _) = unspent;
     let (_, deriv_start, ..) = deriv;
     let lo = (epoch_start.0 - deriv_start.0) as usize;
-    let hi = (epoch_last.next().0 - deriv_start.0) as usize;
-    let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(epoch_last.next(), &window[hi..]);
+    let (head, from_span) = window.split_at(lo);
+    let (_span, tail) = from_span.split_at(elapsed.len());
+    let complement_seq = NfSeqPoly::new(deriv_start, head)
+        * epoch_last.next().map_or_else(
+            || {
+                debug_assert!(tail.is_empty(), "no tail can follow the final epoch");
+                NfSeqPoly::default()
+            },
+            |tail_start| NfSeqPoly::new(tail_start, tail),
+        );
     (
         NfSeqPoly::new(epoch_start, elapsed),
         NfSeqPoly::new(deriv_start, window),
@@ -192,7 +198,6 @@ pub fn unspent_bind(
 /// epoch, multiplied.
 #[must_use]
 #[expect(
-    clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
 )]
@@ -205,13 +210,23 @@ pub fn spendable_init(
 ) -> StepWitness<'static, SpendableInit> {
     let (_, deriv_start, ..) = deriv;
     let lo = (creation_epoch.0 - deriv_start.0) as usize;
-    let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(creation_epoch.next(), &window[lo + 1..]);
+    let (head, from_creation) = window.split_at(lo);
+    let Some((present_nf, tail)) = from_creation.split_first() else {
+        unreachable!("the creation epoch's member is in the window");
+    };
+    let complement_seq = NfSeqPoly::new(deriv_start, head)
+        * creation_epoch.next().map_or_else(
+            || {
+                debug_assert!(tail.is_empty(), "no tail can follow the final epoch");
+                NfSeqPoly::default()
+            },
+            |tail_start| NfSeqPoly::new(tail_start, tail),
+        );
     (
         pre_cm_anchor,
         creation_tgs.iter().copied().collect::<TachygramSetPoly>(),
         creation_epoch,
-        window[lo],
+        *present_nf,
         NfSeqPoly::new(deriv_start, window),
         complement_seq,
     )
@@ -227,7 +242,6 @@ pub fn spendable_init(
 /// least one epoch past the spendable's epoch.
 #[must_use]
 #[expect(
-    clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
 )]
@@ -238,12 +252,23 @@ pub fn spend_bind(
     let (_, (epoch, _), _) = spendable;
     let (_, deriv_start, ..) = deriv;
     let lo = (epoch.0 - deriv_start.0) as usize;
-    let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(EpochIndex(epoch.0 + 2), &window[lo + 2..]);
+    let (head, from_spend) = window.split_at(lo);
+    let (pair, tail) = from_spend.split_at(2);
+    let Some(nf_next) = pair.last() else {
+        unreachable!("the read pair is in the window");
+    };
+    let complement_seq = NfSeqPoly::new(deriv_start, head)
+        * epoch.next().and_then(EpochIndex::next).map_or_else(
+            || {
+                debug_assert!(tail.is_empty(), "no tail can follow the final epoch");
+                NfSeqPoly::default()
+            },
+            |tail_start| NfSeqPoly::new(tail_start, tail),
+        );
     (
         NfSeqPoly::new(deriv_start, window),
         complement_seq,
-        window[lo + 1],
+        *nf_next,
     )
 }
 
@@ -318,7 +343,6 @@ pub fn summary_unspent_init(
 /// [`spendable_init`].
 #[must_use]
 #[expect(
-    clippy::indexing_slicing,
     clippy::as_conversions,
     reason = "the derivation header's range covers the window"
 )]
@@ -333,11 +357,21 @@ pub fn summary_spendable_init(
 ) -> StepWitness<'static, SummarySpendableInit> {
     let (_, deriv_start, ..) = deriv;
     let lo = (creation_epoch.0 - deriv_start.0) as usize;
-    let complement_seq = NfSeqPoly::new(deriv_start, &window[..lo])
-        * NfSeqPoly::new(creation_epoch.next(), &window[lo + 1..]);
+    let (head, from_creation) = window.split_at(lo);
+    let Some((present_nf, tail)) = from_creation.split_first() else {
+        unreachable!("the creation epoch's member is in the window");
+    };
+    let complement_seq = NfSeqPoly::new(deriv_start, head)
+        * creation_epoch.next().map_or_else(
+            || {
+                debug_assert!(tail.is_empty(), "no tail can follow the final epoch");
+                NfSeqPoly::default()
+            },
+            |tail_start| NfSeqPoly::new(tail_start, tail),
+        );
     (
         creation_epoch,
-        window[lo],
+        *present_nf,
         NfSeqPoly::new(deriv_start, window),
         complement_seq,
         summary_tgs.iter().copied().collect::<TachygramSetPoly>(),

--- a/crates/tachyon/tests/integration/bundle.rs
+++ b/crates/tachyon/tests/integration/bundle.rs
@@ -597,9 +597,10 @@ fn duplicated_spend_cannot_inflate() {
         pool.advance(1, |_| random_block(rng, 1, 2));
     }
     let init = wallet.spendable_init(rng, &note, &pool, cm_height);
-    let spendable = wallet.lift_to_epoch(rng, &pool, &note, init, cm_height.epoch().next());
+    let spendable =
+        wallet.lift_to_epoch(rng, &pool, &note, init, cm_height.epoch().next().unwrap());
     let anchor = spendable.data().2;
-    let spend_epoch = cm_height.epoch().next();
+    let spend_epoch = cm_height.epoch().next().unwrap();
 
     // Build one honest spend with a trapdoor and randomizer we control, so the
     // duplicated bundle's binding and action signatures can be reproduced.
@@ -826,14 +827,26 @@ fn innocent_aggregate_from_two_autonomes() {
     }
 
     let init_a = wallet.spendable_init(rng, &spend_a, &pool, cm_height);
-    let sp_a = wallet.lift_to_epoch(rng, &pool, &spend_a, init_a, cm_height.epoch().next());
+    let sp_a = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &spend_a,
+        init_a,
+        cm_height.epoch().next().unwrap(),
+    );
     let init_b = wallet.spendable_init(rng, &spend_b, &pool, cm_height);
-    let sp_b = wallet.lift_to_epoch(rng, &pool, &spend_b, init_b, cm_height.epoch().next());
+    let sp_b = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &spend_b,
+        init_b,
+        cm_height.epoch().next().unwrap(),
+    );
     let anchor_a = sp_a.data().2;
     let anchor_b = sp_b.data().2;
     assert_eq!(anchor_a, anchor_b, "lifts land on a common anchor");
 
-    let spend_epoch = cm_height.epoch().next();
+    let spend_epoch = cm_height.epoch().next().unwrap();
     let autonome_a = wallet.autonome(
         rng,
         anchor_a,
@@ -920,17 +933,29 @@ fn based_aggregate_with_two_adjuncts() {
         &pool,
         &based_spend,
         based_init,
-        cm_height.epoch().next(),
+        cm_height.epoch().next().unwrap(),
     );
     let a_init = wallet.spendable_init(rng, &a_spend, &pool, cm_height);
-    let a_sp = wallet.lift_to_epoch(rng, &pool, &a_spend, a_init, cm_height.epoch().next());
+    let a_sp = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &a_spend,
+        a_init,
+        cm_height.epoch().next().unwrap(),
+    );
     let b_init = wallet.spendable_init(rng, &b_spend, &pool, cm_height);
-    let b_sp = wallet.lift_to_epoch(rng, &pool, &b_spend, b_init, cm_height.epoch().next());
+    let b_sp = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &b_spend,
+        b_init,
+        cm_height.epoch().next().unwrap(),
+    );
     let anchor = based_sp.data().2;
     assert_eq!(anchor, a_sp.data().2, "lifts land on a common anchor");
     assert_eq!(anchor, b_sp.data().2, "lifts land on a common anchor");
 
-    let spend_epoch = cm_height.epoch().next();
+    let spend_epoch = cm_height.epoch().next().unwrap();
     let mut becomes_based = wallet.autonome(
         rng,
         anchor,
@@ -1549,15 +1574,27 @@ fn coverage_check_matches_stamp_actions() {
         &pool,
         &based_spend,
         based_init,
-        cm_height.epoch().next(),
+        cm_height.epoch().next().unwrap(),
     );
     let a_init = wallet.spendable_init(rng, &a_spend, &pool, cm_height);
-    let a_sp = wallet.lift_to_epoch(rng, &pool, &a_spend, a_init, cm_height.epoch().next());
+    let a_sp = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &a_spend,
+        a_init,
+        cm_height.epoch().next().unwrap(),
+    );
     let b_init = wallet.spendable_init(rng, &b_spend, &pool, cm_height);
-    let b_sp = wallet.lift_to_epoch(rng, &pool, &b_spend, b_init, cm_height.epoch().next());
+    let b_sp = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &b_spend,
+        b_init,
+        cm_height.epoch().next().unwrap(),
+    );
     let anchor = based_sp.data().2;
 
-    let spend_epoch = cm_height.epoch().next();
+    let spend_epoch = cm_height.epoch().next().unwrap();
     let mut becomes_based = wallet.autonome(
         rng,
         anchor,
@@ -2131,12 +2168,24 @@ fn bundle_lift_over_an_aggregate() {
     }
 
     let init_a = wallet.spendable_init(rng, &spend_a, &pool, cm_height);
-    let sp_a = wallet.lift_to_epoch(rng, &pool, &spend_a, init_a, cm_height.epoch().next());
+    let sp_a = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &spend_a,
+        init_a,
+        cm_height.epoch().next().unwrap(),
+    );
     let init_b = wallet.spendable_init(rng, &spend_b, &pool, cm_height);
-    let sp_b = wallet.lift_to_epoch(rng, &pool, &spend_b, init_b, cm_height.epoch().next());
+    let sp_b = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &spend_b,
+        init_b,
+        cm_height.epoch().next().unwrap(),
+    );
     let anchor = sp_a.data().2;
 
-    let spend_epoch = cm_height.epoch().next();
+    let spend_epoch = cm_height.epoch().next().unwrap();
     let autonome_a = wallet.autonome(
         rng,
         anchor,

--- a/crates/tachyon/tests/integration/bundle.rs
+++ b/crates/tachyon/tests/integration/bundle.rs
@@ -604,7 +604,7 @@ fn duplicated_spend_cannot_inflate() {
 
     // Build one honest spend with a trapdoor and randomizer we control, so the
     // duplicated bundle's binding and action signatures can be reproduced.
-    let range = wallet.derivation_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
+    let range = wallet.derivation_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 1));
     let rcv = value::Trapdoor::random(rng);
     let theta = ActionEntropy::random(rng);
     let plan = action::Plan::spend(note, theta, rcv, |alpha| {

--- a/crates/tachyon/tests/integration/bundle.rs
+++ b/crates/tachyon/tests/integration/bundle.rs
@@ -604,7 +604,12 @@ fn duplicated_spend_cannot_inflate() {
 
     // Build one honest spend with a trapdoor and randomizer we control, so the
     // duplicated bundle's binding and action signatures can be reproduced.
-    let range = wallet.derivation_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 1));
+    let range = wallet.derivation_pcd(
+        rng,
+        note,
+        spend_epoch,
+        EpochIndex::new(u32::from(spend_epoch) + 1),
+    );
     let rcv = value::Trapdoor::random(rng);
     let theta = ActionEntropy::random(rng);
     let plan = action::Plan::spend(note, theta, rcv, |alpha| {

--- a/crates/tachyon/tests/integration/fixtures.rs
+++ b/crates/tachyon/tests/integration/fixtures.rs
@@ -919,11 +919,12 @@ pub(crate) fn build_unspent_pcd_between_anchors<RNG: CryptoRng>(
     // A span between two anchors is an interval of stamps. Cut that interval by
     // epoch. Each epoch after the first segment begins with a crossing out of
     // the one before it.
-    let leaves: Vec<Pcd<pool::ArbitraryUnspent>> = (base_epoch.0..=end_height.epoch().0)
-        .map(EpochIndex)
+    let leaves: Vec<Pcd<pool::ArbitraryUnspent>> = (u32::from(base_epoch)
+        ..=u32::from(end_height.epoch()))
+        .map(EpochIndex::new)
         .map(|epoch| {
             let crossing = (epoch != base_epoch).then(|| {
-                let leaving = EpochIndex(epoch.0 - 1);
+                let leaving = EpochIndex::new(u32::from(epoch) - 1);
                 (leaving, pool.block(leaving.last_block()).anchor())
             });
             let stamps: Vec<_> = (start_height.0.max(epoch.first_block().0)
@@ -1004,7 +1005,8 @@ fn fuse_unspent_tree<RNG: CryptoRng>(
     let left_el = elapsed_slice(left_epoch_start, left_epoch_last);
     let right_el = elapsed_slice(right_epoch_start, right_epoch_last);
     assert_eq!(
-        right_epoch_start.0, left_epoch_last.0,
+        u32::from(right_epoch_start),
+        u32::from(left_epoch_last),
         "fused chains must meet inside one epoch"
     );
     let witness = witness::unspent_fuse((*left.data(), *right.data()), left_el, right_el);
@@ -1104,8 +1106,8 @@ impl WalletSim {
         range: &Pcd<delegation::NullifierDerivation>,
     ) -> Vec<Nullifier> {
         let (_, start, _, last) = *range.data();
-        (start.0..=last.0)
-            .map(|epoch| self.nf_at(note, EpochIndex(epoch)))
+        (u32::from(start)..=u32::from(last))
+            .map(|epoch| self.nf_at(note, EpochIndex::new(epoch)))
             .collect()
     }
 
@@ -1150,8 +1152,8 @@ impl WalletSim {
         epoch_start: EpochIndex,
         epoch_last: EpochIndex,
     ) -> Pcd<delegation::NullifierDerivation> {
-        let base = epoch_start.0 - epoch_start.0 % PoseidonFp::RATE as u32;
-        let windows = (epoch_last.0 - base + 1).div_ceil(NF_DERIVATION_WIDTH as u32);
+        let base = u32::from(epoch_start) - u32::from(epoch_start) % PoseidonFp::RATE as u32;
+        let windows = (u32::from(epoch_last) - base + 1).div_ceil(NF_DERIVATION_WIDTH as u32);
         let cover_last = base + windows * NF_DERIVATION_WIDTH as u32 - 1;
         let key = (Tachygram::from(note.commitment()), base, cover_last);
         if let Some(pcd) = self.derivations.borrow().get(&key) {
@@ -1161,8 +1163,9 @@ impl WalletSim {
 
         let mut merged: Option<Pcd<delegation::NullifierDerivation>> = None;
         for window in 0..windows {
-            let chunk_start = EpochIndex(base + window * NF_DERIVATION_WIDTH as u32);
-            let chunk_last = EpochIndex(chunk_start.0 + NF_DERIVATION_WIDTH as u32 - 1);
+            let chunk_start = EpochIndex::new(base + window * NF_DERIVATION_WIDTH as u32);
+            let chunk_last =
+                EpochIndex::new(u32::from(chunk_start) + NF_DERIVATION_WIDTH as u32 - 1);
             let (leaf, ()) = PROOF_SYSTEM
                 .fuse(
                     rng,
@@ -1175,11 +1178,12 @@ impl WalletSim {
             merged = Some(match merged {
                 None => leaf,
                 Some(left) => {
-                    let left_nfs: Vec<Nullifier> = (base..chunk_start.0)
-                        .map(|epoch| self.nf_at(&note, EpochIndex(epoch)))
+                    let left_nfs: Vec<Nullifier> = (base..u32::from(chunk_start))
+                        .map(|epoch| self.nf_at(&note, EpochIndex::new(epoch)))
                         .collect();
-                    let right_nfs: Vec<Nullifier> = (chunk_start.0..=chunk_last.0)
-                        .map(|epoch| self.nf_at(&note, EpochIndex(epoch)))
+                    let right_nfs: Vec<Nullifier> = (u32::from(chunk_start)
+                        ..=u32::from(chunk_last))
+                        .map(|epoch| self.nf_at(&note, EpochIndex::new(epoch)))
                         .collect();
                     let (fused, ()) = PROOF_SYSTEM
                         .fuse(
@@ -1270,8 +1274,8 @@ impl WalletSim {
     ) -> Pcd<pool::Unspent> {
         let (_, (epoch_start, _), _, (present_epoch, _), _) = *arbitrary.data();
         let range = self.derivation_pcd(rng, *note, epoch_start, present_epoch);
-        let elapsed: Vec<Nullifier> = (epoch_start.0..=present_epoch.0)
-            .map(|epoch| self.nf_at(note, EpochIndex(epoch)))
+        let elapsed: Vec<Nullifier> = (u32::from(epoch_start)..=u32::from(present_epoch))
+            .map(|epoch| self.nf_at(note, EpochIndex::new(epoch)))
             .collect();
         let (unspent, ()) = PROOF_SYSTEM
             .fuse(
@@ -1317,8 +1321,8 @@ impl WalletSim {
         target: EpochIndex,
     ) -> Pcd<spendable::SpendableHeader> {
         let (_, (epoch, _), start_anchor) = *spendable.data();
-        let elapsed: Vec<Nullifier> = (epoch.0..=target.0)
-            .map(|index| self.nf_at(note, EpochIndex(index)))
+        let elapsed: Vec<Nullifier> = (u32::from(epoch)..=u32::from(target))
+            .map(|index| self.nf_at(note, EpochIndex::new(index)))
             .collect();
         let unspent = build_unspent_pcd_between_anchors(
             rng,
@@ -1341,8 +1345,12 @@ impl WalletSim {
         let mut spend_plans = Vec::with_capacity(spends.len());
         let mut spend_pcds = Vec::with_capacity(spends.len());
         for (note, spendable_pcd, spend_epoch) in spends {
-            let range_pcd =
-                self.derivation_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 1));
+            let range_pcd = self.derivation_pcd(
+                rng,
+                note,
+                spend_epoch,
+                EpochIndex::new(u32::from(spend_epoch) + 1),
+            );
             let rcv = value::Trapdoor::random(rng);
             let theta = ActionEntropy::random(rng);
             let plan = action::Plan::spend(note, theta, rcv, |alpha| {
@@ -1449,7 +1457,8 @@ impl SyncSim {
             &entry.nfs[nfs_from..],
             (entry.cursor_anchor, pool.block(target_height).anchor()),
         );
-        let new_consumed = entry.consumed + (target_height.epoch().0 - entry.next_height.epoch().0);
+        let new_consumed =
+            entry.consumed + u32::from(target_height.epoch() - entry.next_height.epoch());
         self.entries[idx].consumed = new_consumed;
         self.entries[idx].next_height = BlockHeight(target_height.0 + 1);
         self.entries[idx].cursor_anchor = pool.block(target_height).anchor();

--- a/crates/tachyon/tests/integration/fixtures.rs
+++ b/crates/tachyon/tests/integration/fixtures.rs
@@ -505,7 +505,7 @@ pub(crate) fn build_anchor_chain_pcd<RNG: CryptoRng>(
         if height >= end {
             break;
         }
-        height = height.next();
+        height = height.next().unwrap();
     }
 
     chain.expect("AnchorChain range must cover at least one stamp")
@@ -601,7 +601,7 @@ pub(crate) fn seal_qr_intake<RNG: CryptoRng>(
 /// its terminal anchor `terminal` ticks to.
 pub(crate) fn qr_discriminant_of(pool: &PoolSim, terminal: Anchor) -> QrDiscriminant {
     terminal
-        .next_epoch(pool.epoch_at(terminal).next())
+        .next_epoch(pool.epoch_at(terminal).next().unwrap())
         .expect("epoch after the terminal is nonzero")
         .into()
 }
@@ -1230,7 +1230,7 @@ impl WalletSim {
 
             (pre_cm_anchor, stamps[cm_idx].clone())
         };
-        let deriv = self.derivation_pcd(rng, *note, epoch, epoch.next());
+        let deriv = self.derivation_pcd(rng, *note, epoch, epoch.next().unwrap());
 
         let (spendable, ()) = PROOF_SYSTEM
             .fuse(
@@ -1269,7 +1269,7 @@ impl WalletSim {
         note: &Note,
     ) -> Pcd<pool::Unspent> {
         let (_, (epoch_start, _), _, (present_epoch, _), _) = *arbitrary.data();
-        let range = self.derivation_pcd(rng, *note, epoch_start, present_epoch.next());
+        let range = self.derivation_pcd(rng, *note, epoch_start, present_epoch.next().unwrap());
         let elapsed: Vec<Nullifier> = (epoch_start.0..=present_epoch.0)
             .map(|epoch| self.nf_at(note, EpochIndex(epoch)))
             .collect();

--- a/crates/tachyon/tests/integration/fixtures.rs
+++ b/crates/tachyon/tests/integration/fixtures.rs
@@ -1051,7 +1051,7 @@ pub struct WalletSim {
     /// Per-note master seed PCDs, keyed by the note's `cm` tachygram.
     pub masters: RefCell<BTreeMap<Tachygram, Pcd<delegation::NfMasterHeader>>>,
     /// Per-(note, range) derivation PCDs, keyed by `(cm, epoch_start,
-    /// epoch_end)`: repeated derivations of the same exact range share the
+    /// epoch_last)`: repeated derivations of the same exact range share the
     /// proof.
     pub derivations: RefCell<BTreeMap<(Tachygram, u32, u32), Pcd<delegation::NullifierDerivation>>>,
 }
@@ -1103,8 +1103,8 @@ impl WalletSim {
         note: &Note,
         range: &Pcd<delegation::NullifierDerivation>,
     ) -> Vec<Nullifier> {
-        let (_, start, _, end) = *range.data();
-        (start.0..end.0)
+        let (_, start, _, last) = *range.data();
+        (start.0..=last.0)
             .map(|epoch| self.nf_at(note, EpochIndex(epoch)))
             .collect()
     }
@@ -1136,7 +1136,7 @@ impl WalletSim {
         pcd
     }
 
-    /// The certified derivation PCD covering `[epoch_start, epoch_end)`,
+    /// The certified derivation PCD covering `[epoch_start, epoch_last]`,
     /// built from whole windows and cached by the covering range.
     ///
     /// The first window is the one opened by `epoch_start`'s group; further
@@ -1148,12 +1148,12 @@ impl WalletSim {
         rng: &mut RNG,
         note: Note,
         epoch_start: EpochIndex,
-        epoch_end: EpochIndex,
+        epoch_last: EpochIndex,
     ) -> Pcd<delegation::NullifierDerivation> {
         let base = epoch_start.0 - epoch_start.0 % PoseidonFp::RATE as u32;
-        let windows = (epoch_end.0 - base).div_ceil(NF_DERIVATION_WIDTH as u32);
-        let cover_end = base + windows * NF_DERIVATION_WIDTH as u32;
-        let key = (Tachygram::from(note.commitment()), base, cover_end);
+        let windows = (epoch_last.0 - base + 1).div_ceil(NF_DERIVATION_WIDTH as u32);
+        let cover_last = base + windows * NF_DERIVATION_WIDTH as u32 - 1;
+        let key = (Tachygram::from(note.commitment()), base, cover_last);
         if let Some(pcd) = self.derivations.borrow().get(&key) {
             return pcd.clone();
         }
@@ -1162,7 +1162,7 @@ impl WalletSim {
         let mut merged: Option<Pcd<delegation::NullifierDerivation>> = None;
         for window in 0..windows {
             let chunk_start = EpochIndex(base + window * NF_DERIVATION_WIDTH as u32);
-            let chunk_end = EpochIndex(chunk_start.0 + NF_DERIVATION_WIDTH as u32);
+            let chunk_last = EpochIndex(chunk_start.0 + NF_DERIVATION_WIDTH as u32 - 1);
             let (leaf, ()) = PROOF_SYSTEM
                 .fuse(
                     rng,
@@ -1178,7 +1178,7 @@ impl WalletSim {
                     let left_nfs: Vec<Nullifier> = (base..chunk_start.0)
                         .map(|epoch| self.nf_at(&note, EpochIndex(epoch)))
                         .collect();
-                    let right_nfs: Vec<Nullifier> = (chunk_start.0..chunk_end.0)
+                    let right_nfs: Vec<Nullifier> = (chunk_start.0..=chunk_last.0)
                         .map(|epoch| self.nf_at(&note, EpochIndex(epoch)))
                         .collect();
                     let (fused, ()) = PROOF_SYSTEM
@@ -1230,7 +1230,7 @@ impl WalletSim {
 
             (pre_cm_anchor, stamps[cm_idx].clone())
         };
-        let deriv = self.derivation_pcd(rng, *note, epoch, epoch.next().unwrap());
+        let deriv = self.derivation_pcd(rng, *note, epoch, epoch);
 
         let (spendable, ()) = PROOF_SYSTEM
             .fuse(
@@ -1269,7 +1269,7 @@ impl WalletSim {
         note: &Note,
     ) -> Pcd<pool::Unspent> {
         let (_, (epoch_start, _), _, (present_epoch, _), _) = *arbitrary.data();
-        let range = self.derivation_pcd(rng, *note, epoch_start, present_epoch.next().unwrap());
+        let range = self.derivation_pcd(rng, *note, epoch_start, present_epoch);
         let elapsed: Vec<Nullifier> = (epoch_start.0..=present_epoch.0)
             .map(|epoch| self.nf_at(note, EpochIndex(epoch)))
             .collect();
@@ -1342,7 +1342,7 @@ impl WalletSim {
         let mut spend_pcds = Vec::with_capacity(spends.len());
         for (note, spendable_pcd, spend_epoch) in spends {
             let range_pcd =
-                self.derivation_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
+                self.derivation_pcd(rng, note, spend_epoch, EpochIndex(spend_epoch.0 + 1));
             let rcv = value::Trapdoor::random(rng);
             let theta = ActionEntropy::random(rng);
             let plan = action::Plan::spend(note, theta, rcv, |alpha| {

--- a/crates/tachyon/tests/integration/proof.rs
+++ b/crates/tachyon/tests/integration/proof.rs
@@ -1471,6 +1471,44 @@ fn unspent_bind_window_may_end_at_the_final_epoch() {
     assert_eq!(elapsed_seq.commit(), nf_seq.commit());
 }
 
+/// The largest spendable epoch is `EPOCH_MAX - 1`: the pair read needs a
+/// following epoch's member, so the final epoch's own window is the last one
+/// that can serve a spend. Its complement has a lower run and no tail.
+#[test]
+fn spend_bind_reads_the_last_pair_in_the_epoch_space() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    let epoch_start = EpochIndex::new(EPOCH_MAX + 1 - NF_DERIVATION_WIDTH as u32);
+    let spend_epoch = EpochIndex::new(EPOCH_MAX - 1);
+    let range = user.derivation_pcd(rng, note, epoch_start, EpochIndex::new(EPOCH_MAX));
+    let window = user.covering_window(&note, &range);
+
+    let synthetic_spendable = (
+        note.commitment(),
+        (spend_epoch, user.nf_at(&note, spend_epoch)),
+        Anchor::from(Fp::ZERO),
+    );
+    let (nf_seq, complement_seq, nf_next) =
+        witness::spend_bind((synthetic_spendable, *range.data()), &window);
+
+    assert_eq!(
+        nf_next,
+        user.nf_at(&note, EpochIndex::new(EPOCH_MAX)),
+        "the pair's second half is the final epoch's member"
+    );
+    assert_eq!(
+        nf_seq.commit(),
+        NfSeqPoly::new(epoch_start, &window).commit()
+    );
+    assert_eq!(
+        complement_seq.commit(),
+        NfSeqPoly::new(epoch_start, &window[..window.len() - 2]).commit(),
+        "the read pair ends the window, so the complement is its lower run alone"
+    );
+}
+
 #[test]
 fn unspent_bind_rejects_elapsed_mismatch() {
     let rng = &mut StdRng::seed_from_u64(0);

--- a/crates/tachyon/tests/integration/proof.rs
+++ b/crates/tachyon/tests/integration/proof.rs
@@ -46,7 +46,11 @@ fn mine_cm_in_epoch_one<RNG: CryptoRng>(
     }
     pool.mine(random_block_with(rng, &[alloc::vec![cm]], 4));
     let cm_height = pool.height();
-    assert_eq!(cm_height.epoch().0, 1, "cm-block is in epoch 1");
+    assert_eq!(
+        cm_height.epoch(),
+        EpochIndex::new(1),
+        "cm-block is in epoch 1"
+    );
     cm_height
 }
 
@@ -57,7 +61,12 @@ fn honest_spend_bind(
     spendable: Pcd<spendable::SpendableHeader>,
     spend_epoch: EpochIndex,
 ) -> Pcd<spend::SpendHeader> {
-    let derived = user.derivation_pcd(rng, *note, spend_epoch, EpochIndex(spend_epoch.0 + 1));
+    let derived = user.derivation_pcd(
+        rng,
+        *note,
+        spend_epoch,
+        EpochIndex::new(u32::from(spend_epoch) + 1),
+    );
     let witness = witness::spend_bind(
         (*spendable.data(), *derived.data()),
         &user.covering_window(note, &derived),
@@ -148,7 +157,7 @@ fn spendable_init_rejects_tg_absent() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
+    let nf_header = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(0));
     let absent_tg = Tachygram::from(Fp::random(&mut *rng));
 
     let err = PROOF_SYSTEM
@@ -159,7 +168,7 @@ fn spendable_init_rejects_tg_absent() {
                 (*nf_header.data(), ()),
                 Anchor::default(),
                 &[absent_tg],
-                EpochIndex(0),
+                EpochIndex::new(0),
                 &user.covering_window(&note, &nf_header),
             ),
             nf_header,
@@ -179,7 +188,7 @@ fn unspent_seed_rejects_tg_present() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
     let mk = user.pak.nk.derive_note_private(note.psi);
-    let nf = mk.derive_nullifier(EpochIndex(0));
+    let nf = mk.derive_nullifier(EpochIndex::new(0));
 
     let start = Anchor::default();
 
@@ -187,7 +196,7 @@ fn unspent_seed_rejects_tg_present() {
         .seed(
             rng,
             pool::UnspentSeed,
-            witness::unspent_seed(((), ()), start, EpochIndex(0), &[nf.into()], nf),
+            witness::unspent_seed(((), ()), start, EpochIndex::new(0), &[nf.into()], nf),
         )
         .err()
         .unwrap();
@@ -205,7 +214,7 @@ fn unspent_fuse_rejects_invalid_compositions() {
     let start = Anchor::default();
     let mid = start
         .next_stamp(
-            EpochIndex(0),
+            EpochIndex::new(0),
             &TachygramSetPoly::from_iter(stamps_left.clone()).commit(),
         )
         .unwrap();
@@ -214,8 +223,10 @@ fn unspent_fuse_rejects_invalid_compositions() {
     {
         let nf_a = Nullifier::from(Fp::random(&mut *rng));
         let nf_b = Nullifier::from(Fp::random(&mut *rng));
-        let shard_a = build_unspent_seed_pcd(rng, start, EpochIndex(0), &stamps_left.clone(), nf_a);
-        let shard_b = build_unspent_seed_pcd(rng, mid, EpochIndex(0), &stamps_right.clone(), nf_b);
+        let shard_a =
+            build_unspent_seed_pcd(rng, start, EpochIndex::new(0), &stamps_left.clone(), nf_a);
+        let shard_b =
+            build_unspent_seed_pcd(rng, mid, EpochIndex::new(0), &stamps_right.clone(), nf_b);
         let w = witness::unspent_fuse((*shard_a.data(), *shard_b.data()), &[nf_a], &[nf_b]);
         let err = PROOF_SYSTEM
             .fuse(rng, pool::UnspentFuse, w, shard_a, shard_b)
@@ -234,8 +245,8 @@ fn unspent_fuse_rejects_invalid_compositions() {
     // instead of `left.end`.
     {
         let nf = Nullifier::from(Fp::random(&mut *rng));
-        let shard_a = build_unspent_seed_pcd(rng, start, EpochIndex(0), &stamps_left, nf);
-        let shard_b = build_unspent_seed_pcd(rng, start, EpochIndex(0), &stamps_right, nf);
+        let shard_a = build_unspent_seed_pcd(rng, start, EpochIndex::new(0), &stamps_left, nf);
+        let shard_b = build_unspent_seed_pcd(rng, start, EpochIndex::new(0), &stamps_right, nf);
         let w = witness::unspent_fuse((*shard_a.data(), *shard_b.data()), &[nf], &[nf]);
         let err = PROOF_SYSTEM
             .fuse(rng, pool::UnspentFuse, w, shard_a, shard_b)
@@ -514,8 +525,8 @@ fn spend_after_lift_publishes_anchor_epoch_nullifiers() {
     sync.accept_delegation(
         0,
         alloc::vec![
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1))
+            user.nf_at(&note, EpochIndex::new(0)),
+            user.nf_at(&note, EpochIndex::new(1))
         ],
         cm_height,
         start_anchor,
@@ -523,23 +534,23 @@ fn spend_after_lift_publishes_anchor_epoch_nullifiers() {
     let unspent = sync.build_next_unspent(rng, 0, &pool, target_height);
     let lifted = user.lift(rng, spendable, unspent, &note);
 
-    let bind_pcd = honest_spend_bind(rng, &user, &note, lifted, EpochIndex(1));
+    let bind_pcd = honest_spend_bind(rng, &user, &note, lifted, EpochIndex::new(1));
     let (_cm, present_nf, _nf_next, _anchor) = *bind_pcd.data();
     assert_eq!(
         present_nf,
-        user.nf_at(&note, EpochIndex(1)),
+        user.nf_at(&note, EpochIndex::new(1)),
         "publishes the epoch-1 nf"
     );
     assert_ne!(
         present_nf,
-        user.nf_at(&note, EpochIndex(0)),
+        user.nf_at(&note, EpochIndex::new(0)),
         "nf_0 was consumed by the lift"
     );
 
     let stamp = honest_spend_stamp(rng, &user, &note, bind_pcd);
     let expected = TachygramSetPoly::from_iter([
-        user.nf_at(&note, EpochIndex(1)).into(),
-        user.nf_at(&note, EpochIndex(2)).into(),
+        user.nf_at(&note, EpochIndex::new(1)).into(),
+        user.nf_at(&note, EpochIndex::new(2)).into(),
     ])
     .commit();
     assert_eq!(stamp.data().1, expected);
@@ -582,8 +593,8 @@ fn sync_sim_builds_unspent_for_wallet_lift_across_epochs() {
     sync.accept_delegation(
         0,
         alloc::vec![
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1))
+            user.nf_at(&note, EpochIndex::new(0)),
+            user.nf_at(&note, EpochIndex::new(1))
         ],
         init_height,
         start_anchor,
@@ -601,7 +612,7 @@ fn sync_sim_builds_unspent_for_wallet_lift_across_epochs() {
 
     assert_eq!(
         lifted.data().1,
-        (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
+        (EpochIndex::new(1), user.nf_at(&note, EpochIndex::new(1))),
         "tip advanced to nf_1"
     );
     assert_eq!(
@@ -621,7 +632,7 @@ fn unspent_lift_spans_partial_and_whole_epochs() {
     // cm in a multi-stamp block mid-epoch 0: the spendable anchor sits mid-block,
     // so the lineage's first epoch is partial (the post-cm prefix).
     let init_height = mine_cm_block(rng, &mut pool, note.commitment());
-    assert_eq!(init_height.epoch().0, 0, "cm in epoch 0");
+    assert_eq!(init_height.epoch(), EpochIndex::new(0), "cm in epoch 0");
     let spendable = user.spendable_init(rng, &note, &pool, init_height);
     let start_anchor = spendable.data().2;
 
@@ -629,10 +640,10 @@ fn unspent_lift_spans_partial_and_whole_epochs() {
     sync.accept_delegation(
         0,
         alloc::vec![
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1)),
-            user.nf_at(&note, EpochIndex(2)),
-            user.nf_at(&note, EpochIndex(3)),
+            user.nf_at(&note, EpochIndex::new(0)),
+            user.nf_at(&note, EpochIndex::new(1)),
+            user.nf_at(&note, EpochIndex::new(2)),
+            user.nf_at(&note, EpochIndex::new(3)),
         ],
         init_height,
         start_anchor,
@@ -663,7 +674,7 @@ fn unspent_lift_spans_partial_and_whole_epochs() {
     let lifted = user.lift(rng, spendable, unspent, &note);
     assert_eq!(
         lifted.data().1,
-        (EpochIndex(3), user.nf_at(&note, EpochIndex(3))),
+        (EpochIndex::new(3), user.nf_at(&note, EpochIndex::new(3))),
         "tip advanced to nf_3 across partial first/last and whole interior epochs"
     );
     assert_eq!(
@@ -755,14 +766,15 @@ fn unspent_fuse_composes() {
     assert_eq!(anchor_last, end);
     assert_eq!(
         elapsed,
-        NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2, nf3]).commit(),
+        NfSeqPoly::new(EpochIndex::new(0), &[nf0, nf1, nf2, nf3]).commit(),
         "the junction member appears once in the combined sequence"
     );
     assert_eq!(nf_start, nf0);
     assert_eq!(nf_last, nf3, "tip advances to the right half's present nf");
-    assert_eq!(epoch_start.0, 0);
+    assert_eq!(u32::from(epoch_start), 0);
     assert_eq!(
-        epoch_last.0, 3,
+        u32::from(epoch_last),
+        3,
         "merged range spans the boundary the right half crossed"
     );
 }
@@ -776,9 +788,9 @@ fn unspent_fuse_rejects_wrong_left_seq() {
             rng,
             pool::UnspentFuse,
             (
-                NfSeqPoly::new(EpochIndex(0), &[nf1, nf0, nf2]),
-                NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2, nf3]),
-                NfSeqPoly::new(EpochIndex(2), &[nf2, nf3]),
+                NfSeqPoly::new(EpochIndex::new(0), &[nf1, nf0, nf2]),
+                NfSeqPoly::new(EpochIndex::new(0), &[nf0, nf1, nf2, nf3]),
+                NfSeqPoly::new(EpochIndex::new(2), &[nf2, nf3]),
             ),
             left,
             right,
@@ -803,9 +815,9 @@ fn unspent_fuse_rejects_wrong_right_seq() {
             rng,
             pool::UnspentFuse,
             (
-                NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2]),
-                NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2, nf3]),
-                NfSeqPoly::new(EpochIndex(2), &[nf3, nf2]),
+                NfSeqPoly::new(EpochIndex::new(0), &[nf0, nf1, nf2]),
+                NfSeqPoly::new(EpochIndex::new(0), &[nf0, nf1, nf2, nf3]),
+                NfSeqPoly::new(EpochIndex::new(2), &[nf3, nf2]),
             ),
             left,
             right,
@@ -833,9 +845,9 @@ fn unspent_fuse_rejects_wrong_combined() {
             rng,
             pool::UnspentFuse,
             (
-                NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2]),
-                NfSeqPoly::new(EpochIndex(2), &[nf2, nf3]),
-                NfSeqPoly::new(EpochIndex(2), &[nf2, nf3]),
+                NfSeqPoly::new(EpochIndex::new(0), &[nf0, nf1, nf2]),
+                NfSeqPoly::new(EpochIndex::new(2), &[nf2, nf3]),
+                NfSeqPoly::new(EpochIndex::new(2), &[nf2, nf3]),
             ),
             left,
             right,
@@ -864,13 +876,13 @@ fn unspent_fuse_accepts_left_as_combined_for_one_member_right() {
     let start = Anchor::default();
     let mid = start
         .next_stamp(
-            EpochIndex(0),
+            EpochIndex::new(0),
             &TachygramSetPoly::from_iter(stamps_left.clone()).commit(),
         )
         .unwrap();
     let nf = Nullifier::from(Fp::random(&mut *rng));
-    let left = build_unspent_seed_pcd(rng, start, EpochIndex(0), &stamps_left, nf);
-    let right = build_unspent_seed_pcd(rng, mid, EpochIndex(0), &stamps_right, nf);
+    let left = build_unspent_seed_pcd(rng, start, EpochIndex::new(0), &stamps_left, nf);
+    let right = build_unspent_seed_pcd(rng, mid, EpochIndex::new(0), &stamps_right, nf);
 
     let (fused, ()) = PROOF_SYSTEM
         .fuse(
@@ -883,7 +895,7 @@ fn unspent_fuse_accepts_left_as_combined_for_one_member_right() {
         .expect("one-member halves fuse");
     assert_eq!(
         fused.data().2,
-        NfSeqPoly::new(EpochIndex(0), &[nf]).commit(),
+        NfSeqPoly::new(EpochIndex::new(0), &[nf]).commit(),
         "combined equals the left sequence"
     );
 }
@@ -908,7 +920,7 @@ fn unspent_fuse_rejects_epoch_boundary_crossing() {
     // `next_epoch` fold). The anchors line up, but the epoch labels reveal a
     // boundary the fuse refuses to cross: a crossing needs its own segment.
     let stamp = [Tachygram::from(Fp::random(&mut *rng))];
-    let forged_right = build_unspent_seed_pcd(rng, left_end, EpochIndex(1), &stamp, nf1);
+    let forged_right = build_unspent_seed_pcd(rng, left_end, EpochIndex::new(1), &stamp, nf1);
 
     let err = PROOF_SYSTEM
         .fuse(
@@ -995,7 +1007,7 @@ fn end_epoch_unspent_seed_composes_across_a_boundary() {
         .seed(
             rng,
             pool::EndEpochUnspentSeed,
-            witness::end_epoch_unspent_seed(((), ()), left.data().4, EpochIndex(2), nf2, nf3),
+            witness::end_epoch_unspent_seed(((), ()), left.data().4, EpochIndex::new(2), nf2, nf3),
         )
         .expect("EndEpochUnspentSeed");
     let (crossed, ()) = PROOF_SYSTEM
@@ -1026,13 +1038,13 @@ fn end_epoch_unspent_seed_composes_across_a_boundary() {
         *fused.data();
     assert_eq!(anchor_prev, start);
     assert_eq!(anchor_last, end);
-    assert_eq!(epoch_start.0, 0);
+    assert_eq!(u32::from(epoch_start), 0);
     assert_eq!(nf_start, nf0);
-    assert_eq!(epoch_last.0, 4);
+    assert_eq!(u32::from(epoch_last), 4);
     assert_eq!(nf_last, nf4, "tip is the right half's present nf");
     assert_eq!(
         elapsed,
-        NfSeqPoly::new(EpochIndex(0), &[nf0, nf1, nf2, nf3, nf4]).commit(),
+        NfSeqPoly::new(EpochIndex::new(0), &[nf0, nf1, nf2, nf3, nf4]).commit(),
         "the crossing seed shares a member with each half it joins"
     );
 }
@@ -1054,7 +1066,13 @@ fn end_epoch_unspent_seed_rejects_a_zero_member() {
             .seed(
                 rng,
                 pool::EndEpochUnspentSeed,
-                witness::end_epoch_unspent_seed(((), ()), anchor, EpochIndex(4), nf_prev, incoming),
+                witness::end_epoch_unspent_seed(
+                    ((), ()),
+                    anchor,
+                    EpochIndex::new(4),
+                    nf_prev,
+                    incoming,
+                ),
             )
             .err()
             .unwrap_or_else(|| panic!("EndEpochUnspentSeed accepted {expected}"));
@@ -1077,7 +1095,7 @@ fn end_epoch_unspent_seed_spans_one_boundary_link() {
         .seed(
             rng,
             pool::EndEpochUnspentSeed,
-            witness::end_epoch_unspent_seed(((), ()), epoch_tip, EpochIndex(4), nf_prev, nf),
+            witness::end_epoch_unspent_seed(((), ()), epoch_tip, EpochIndex::new(4), nf_prev, nf),
         )
         .expect("EndEpochUnspentSeed");
 
@@ -1086,16 +1104,16 @@ fn end_epoch_unspent_seed_spans_one_boundary_link() {
     assert_eq!(anchor_prev, epoch_tip);
     assert_eq!(
         anchor_last,
-        epoch_tip.next_epoch(EpochIndex(5)).unwrap(),
+        epoch_tip.next_epoch(EpochIndex::new(5)).unwrap(),
         "the segment covers the boundary tick"
     );
-    assert_eq!(epoch_start, EpochIndex(4));
-    assert_eq!(epoch_last, EpochIndex(5), "one boundary crossed");
+    assert_eq!(epoch_start, EpochIndex::new(4));
+    assert_eq!(epoch_last, EpochIndex::new(5), "one boundary crossed");
     assert_eq!(seed_nf_start, nf_prev);
     assert_eq!(nf_last, nf);
     assert_eq!(
         elapsed,
-        NfSeqPoly::new(EpochIndex(4), &[nf_prev, nf]).commit(),
+        NfSeqPoly::new(EpochIndex::new(4), &[nf_prev, nf]).commit(),
         "the crossing records the epoch it leaves and the one it enters"
     );
 }
@@ -1120,13 +1138,13 @@ fn spendable_lift_advances_from_an_epoch_tip() {
     let epoch0_tip = spendable.data().2;
     assert_eq!(
         epoch0_tip,
-        pool.block(EpochIndex(0).last_block()).anchor(),
+        pool.block(EpochIndex::new(0).last_block()).anchor(),
         "the lineage sits on the epoch tip"
     );
 
     pool.advance(1, |_| random_block(rng, 1, 2));
     let target_height = pool.height();
-    assert_eq!(target_height.epoch(), EpochIndex(1));
+    assert_eq!(target_height.epoch(), EpochIndex::new(1));
 
     // The crossing is an ordinary segment, so an ordinary lift carries the
     // lineage over it.
@@ -1137,9 +1155,9 @@ fn spendable_lift_advances_from_an_epoch_tip() {
             witness::end_epoch_unspent_seed(
                 ((), ()),
                 epoch0_tip,
-                EpochIndex(0),
-                user.nf_at(&note, EpochIndex(0)),
-                user.nf_at(&note, EpochIndex(1)),
+                EpochIndex::new(0),
+                user.nf_at(&note, EpochIndex::new(0)),
+                user.nf_at(&note, EpochIndex::new(1)),
             ),
         )
         .expect("EndEpochUnspentSeed");
@@ -1148,8 +1166,8 @@ fn spendable_lift_advances_from_an_epoch_tip() {
         *at_boundary.data(),
         (
             note.commitment(),
-            (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
-            epoch0_tip.next_epoch(EpochIndex(1)).unwrap()
+            (EpochIndex::new(1), user.nf_at(&note, EpochIndex::new(1))),
+            epoch0_tip.next_epoch(EpochIndex::new(1)).unwrap()
         ),
         "the tick advances epoch, nullifier and anchor together"
     );
@@ -1158,14 +1176,14 @@ fn spendable_lift_advances_from_an_epoch_tip() {
     let arbitrary = build_unspent_pcd_between_anchors(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(1))],
+        &[user.nf_at(&note, EpochIndex::new(1))],
         (at_boundary.data().2, pool.block(target_height).anchor()),
     );
     let lifted = user.lift(rng, at_boundary, arbitrary, &note);
 
     assert_eq!(
         lifted.data().1,
-        (EpochIndex(1), user.nf_at(&note, EpochIndex(1)))
+        (EpochIndex::new(1), user.nf_at(&note, EpochIndex::new(1)))
     );
     assert_eq!(lifted.data().2, pool.block(target_height).anchor());
 }
@@ -1194,9 +1212,9 @@ fn unspent_span_starting_on_a_boundary_anchor() {
             witness::end_epoch_unspent_seed(
                 ((), ()),
                 epoch0_tip,
-                EpochIndex(0),
-                user.nf_at(&note, EpochIndex(0)),
-                user.nf_at(&note, EpochIndex(1)),
+                EpochIndex::new(0),
+                user.nf_at(&note, EpochIndex::new(0)),
+                user.nf_at(&note, EpochIndex::new(1)),
             ),
         )
         .expect("EndEpochUnspentSeed");
@@ -1209,32 +1227,32 @@ fn unspent_span_starting_on_a_boundary_anchor() {
     }
     pool.advance(1, |_| random_block(rng, 1, 2));
     let target_height = pool.height();
-    assert_eq!(target_height.epoch(), EpochIndex(2));
+    assert_eq!(target_height.epoch(), EpochIndex::new(2));
 
     let start_anchor = at_boundary.data().2;
     assert_eq!(
         start_anchor,
-        pool.block(EpochIndex(1).last_block()).anchor()
+        pool.block(EpochIndex::new(1).last_block()).anchor()
     );
     let arbitrary = build_unspent_pcd_between_anchors(
         rng,
         &pool,
         &[
-            user.nf_at(&note, EpochIndex(1)),
-            user.nf_at(&note, EpochIndex(2)),
+            user.nf_at(&note, EpochIndex::new(1)),
+            user.nf_at(&note, EpochIndex::new(2)),
         ],
         (start_anchor, pool.block(target_height).anchor()),
     );
     let (_, (epoch_start, _), elapsed, (epoch_last, _), _) = *arbitrary.data();
-    assert_eq!(epoch_start, EpochIndex(1));
-    assert_eq!(epoch_last, EpochIndex(2));
+    assert_eq!(epoch_start, EpochIndex::new(1));
+    assert_eq!(epoch_last, EpochIndex::new(2));
     assert_eq!(
         elapsed,
         NfSeqPoly::new(
-            EpochIndex(1),
+            EpochIndex::new(1),
             &[
-                user.nf_at(&note, EpochIndex(1)),
-                user.nf_at(&note, EpochIndex(2)),
+                user.nf_at(&note, EpochIndex::new(1)),
+                user.nf_at(&note, EpochIndex::new(2)),
             ],
         )
         .commit(),
@@ -1244,7 +1262,7 @@ fn unspent_span_starting_on_a_boundary_anchor() {
     let lifted = user.lift(rng, at_boundary, arbitrary, &note);
     assert_eq!(
         lifted.data().1,
-        (EpochIndex(2), user.nf_at(&note, EpochIndex(2)))
+        (EpochIndex::new(2), user.nf_at(&note, EpochIndex::new(2)))
     );
     assert_eq!(lifted.data().2, pool.block(target_height).anchor());
 }
@@ -1268,10 +1286,10 @@ fn unspent_span_ending_on_a_boundary_anchor() {
     }
     pool.advance(1, |_| Vec::new());
     let target_height = pool.height();
-    assert_eq!(target_height.epoch(), EpochIndex(1));
+    assert_eq!(target_height.epoch(), EpochIndex::new(1));
     assert_eq!(
         pool.block(target_height).anchor(),
-        pool.block(EpochIndex(1).first_block()).anchor(),
+        pool.block(EpochIndex::new(1).first_block()).anchor(),
         "a silent epoch-first block rests on the boundary anchor"
     );
 
@@ -1279,22 +1297,26 @@ fn unspent_span_ending_on_a_boundary_anchor() {
         rng,
         &pool,
         &[
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1)),
+            user.nf_at(&note, EpochIndex::new(0)),
+            user.nf_at(&note, EpochIndex::new(1)),
         ],
         (spendable.data().2, pool.block(target_height).anchor()),
     );
     let (_, (epoch_start, _), elapsed, (epoch_last, _), anchor_last) = *arbitrary.data();
-    assert_eq!(epoch_start, EpochIndex(0));
-    assert_eq!(epoch_last, EpochIndex(1), "the span stops on the crossing");
+    assert_eq!(epoch_start, EpochIndex::new(0));
+    assert_eq!(
+        epoch_last,
+        EpochIndex::new(1),
+        "the span stops on the crossing"
+    );
     assert_eq!(anchor_last, pool.block(target_height).anchor());
     assert_eq!(
         elapsed,
         NfSeqPoly::new(
-            EpochIndex(0),
+            EpochIndex::new(0),
             &[
-                user.nf_at(&note, EpochIndex(0)),
-                user.nf_at(&note, EpochIndex(1)),
+                user.nf_at(&note, EpochIndex::new(0)),
+                user.nf_at(&note, EpochIndex::new(1)),
             ],
         )
         .commit()
@@ -1303,7 +1325,7 @@ fn unspent_span_ending_on_a_boundary_anchor() {
     let lifted = user.lift(rng, spendable, arbitrary, &note);
     assert_eq!(
         lifted.data().1,
-        (EpochIndex(1), user.nf_at(&note, EpochIndex(1)))
+        (EpochIndex::new(1), user.nf_at(&note, EpochIndex::new(1)))
     );
     assert_eq!(lifted.data().2, pool.block(target_height).anchor());
 }
@@ -1329,29 +1351,29 @@ fn end_epoch_unspent_seed_crosses_a_stampless_epoch() {
     }
     pool.advance(1, |_| random_block(rng, 1, 2));
     let target_height = pool.height();
-    assert_eq!(target_height.epoch(), EpochIndex(2));
+    assert_eq!(target_height.epoch(), EpochIndex::new(2));
 
     let arbitrary = build_unspent_pcd_between_anchors(
         rng,
         &pool,
         &[
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1)),
-            user.nf_at(&note, EpochIndex(2)),
+            user.nf_at(&note, EpochIndex::new(0)),
+            user.nf_at(&note, EpochIndex::new(1)),
+            user.nf_at(&note, EpochIndex::new(2)),
         ],
         (spendable.data().2, pool.block(target_height).anchor()),
     );
     let (_, (epoch_start, _), elapsed, (epoch_last, _), _) = *arbitrary.data();
-    assert_eq!(epoch_start, EpochIndex(0));
-    assert_eq!(epoch_last, EpochIndex(2));
+    assert_eq!(epoch_start, EpochIndex::new(0));
+    assert_eq!(epoch_last, EpochIndex::new(2));
     assert_eq!(
         elapsed,
         NfSeqPoly::new(
-            EpochIndex(0),
+            EpochIndex::new(0),
             &[
-                user.nf_at(&note, EpochIndex(0)),
-                user.nf_at(&note, EpochIndex(1)),
-                user.nf_at(&note, EpochIndex(2)),
+                user.nf_at(&note, EpochIndex::new(0)),
+                user.nf_at(&note, EpochIndex::new(1)),
+                user.nf_at(&note, EpochIndex::new(2)),
             ],
         )
         .commit(),
@@ -1361,7 +1383,7 @@ fn end_epoch_unspent_seed_crosses_a_stampless_epoch() {
     let lifted = user.lift(rng, spendable, arbitrary, &note);
     assert_eq!(
         lifted.data().1,
-        (EpochIndex(2), user.nf_at(&note, EpochIndex(2)))
+        (EpochIndex::new(2), user.nf_at(&note, EpochIndex::new(2)))
     );
     assert_eq!(lifted.data().2, pool.block(target_height).anchor());
 }
@@ -1380,7 +1402,7 @@ fn unspent_bind_rejects_tip_mismatch() {
     let mut sync = SyncSim::new();
     sync.accept_delegation(
         0,
-        alloc::vec![user.nf_at(&note, EpochIndex(0)), wrong_tip],
+        alloc::vec![user.nf_at(&note, EpochIndex::new(0)), wrong_tip],
         init_height,
         start_anchor,
     );
@@ -1394,11 +1416,11 @@ fn unspent_bind_rejects_tip_mismatch() {
     // final member, so the poly bind passes; the divisibility read then
     // finds no such member in the genuine sequence and rejects it.
     let (_, _, _, (unspent_last, _), _) = *unspent.data();
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), unspent_last);
+    let range = user.derivation_pcd(rng, note, EpochIndex::new(0), unspent_last);
     let witness = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&note, &range),
-        &[user.nf_at(&note, EpochIndex(0)), wrong_tip],
+        &[user.nf_at(&note, EpochIndex::new(0)), wrong_tip],
     );
 
     let err = PROOF_SYSTEM
@@ -1422,12 +1444,12 @@ fn unspent_bind_window_may_end_at_the_final_epoch() {
 
     // The epoch space's last derivation window: the unspent span covers all
     // of it, ending at the final epoch, which has no successor.
-    let epoch_start = EpochIndex(EPOCH_MAX + 1 - NF_DERIVATION_WIDTH as u32);
-    let epoch_last = EpochIndex(EPOCH_MAX);
+    let epoch_start = EpochIndex::new(EPOCH_MAX + 1 - NF_DERIVATION_WIDTH as u32);
+    let epoch_last = EpochIndex::new(EPOCH_MAX);
     let range = user.derivation_pcd(rng, note, epoch_start, epoch_last);
 
-    let elapsed: Vec<Nullifier> = (epoch_start.0..=epoch_last.0)
-        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+    let elapsed: Vec<Nullifier> = (u32::from(epoch_start)..=u32::from(epoch_last))
+        .map(|epoch| user.nf_at(&note, EpochIndex::new(epoch)))
         .collect();
     let synthetic_unspent = (
         Anchor::from(Fp::ZERO),
@@ -1461,16 +1483,19 @@ fn unspent_bind_rejects_elapsed_mismatch() {
     let unspent = build_unspent_pcd_between_blocks(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
         BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
     );
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
+    let range = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(0));
     let (_honest_elapsed_seq, nf_seq, complement_seq) = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&note, &range),
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
     );
-    let bogus_elapsed = NfSeqPoly::new(EpochIndex(0), &[Nullifier::from(Fp::random(&mut *rng))]);
+    let bogus_elapsed = NfSeqPoly::new(
+        EpochIndex::new(0),
+        &[Nullifier::from(Fp::random(&mut *rng))],
+    );
 
     let err = PROOF_SYSTEM
         .fuse(
@@ -1503,19 +1528,19 @@ fn unspent_bind_rejects_uncovered_start() {
     let unspent = build_unspent_pcd_between_blocks(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
         BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
     );
     // A derivation whose coverage begins after the unspent's start epoch (a
     // later window) cannot cover it.
     // The builder would segment out of range, so the witness is assembled
     // by hand: the genuine covering sequence, an empty complement.
-    let range = user.derivation_pcd(rng, note, EpochIndex(64), EpochIndex(64));
+    let range = user.derivation_pcd(rng, note, EpochIndex::new(64), EpochIndex::new(64));
     let window = user.covering_window(&note, &range);
     let witness = (
-        NfSeqPoly::new(EpochIndex(0), &[user.nf_at(&note, EpochIndex(0))]),
-        NfSeqPoly::new(EpochIndex(64), &window),
-        NfSeqPoly::new(EpochIndex(64), &[]),
+        NfSeqPoly::new(EpochIndex::new(0), &[user.nf_at(&note, EpochIndex::new(0))]),
+        NfSeqPoly::new(EpochIndex::new(64), &window),
+        NfSeqPoly::new(EpochIndex::new(64), &[]),
     );
 
     let err = PROOF_SYSTEM
@@ -1540,7 +1565,7 @@ fn unspent_bind_rejects_uncovered_end() {
     let note = user.random_note(500);
     // A crossing out of the window's last epoch: its tip sits at the first
     // epoch the derivation does not reach.
-    let last = EpochIndex(NF_DERIVATION_WIDTH as u32 - 1);
+    let last = EpochIndex::new(NF_DERIVATION_WIDTH as u32 - 1);
     let anchor = Anchor::from(Fp::random(&mut *rng));
     let (unspent, ()) = PROOF_SYSTEM
         .seed(
@@ -1556,7 +1581,7 @@ fn unspent_bind_rejects_uncovered_end() {
         )
         .expect("EndEpochUnspentSeed");
 
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
+    let range = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(0));
     let window = user.covering_window(&note, &range);
     // The builder would segment out of range, so the witness is assembled
     // by hand: the genuine elapsed and covering sequence, an empty
@@ -1569,8 +1594,8 @@ fn unspent_bind_rejects_uncovered_end() {
                 user.nf_at(&note, last.next().unwrap()),
             ],
         ),
-        NfSeqPoly::new(EpochIndex(0), &window),
-        NfSeqPoly::new(EpochIndex(0), &[]),
+        NfSeqPoly::new(EpochIndex::new(0), &window),
+        NfSeqPoly::new(EpochIndex::new(0), &[]),
     );
 
     let err = PROOF_SYSTEM
@@ -1605,8 +1630,8 @@ fn spendable_lift_rejects_wrong_cm() {
     sync.accept_delegation(
         0,
         alloc::vec![
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1))
+            user.nf_at(&note, EpochIndex::new(0)),
+            user.nf_at(&note, EpochIndex::new(1))
         ],
         init_height,
         start_anchor,
@@ -1644,7 +1669,7 @@ fn spendable_lift_rejects_non_adjacent_unspent() {
     let arbitrary = build_unspent_pcd_between_blocks(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
         init_height..=init_height,
     );
     let unspent = user.unspent_bind(rng, arbitrary, &note);
@@ -1731,7 +1756,7 @@ fn nf_derive_rejects_a_foreign_sequence() {
     let master_a = honest_master(rng, &user, note_a);
     let (cm_a, _) = *master_a.data();
     let (epoch_start, foreign_seq) =
-        witness::nf_derive(((cm_a, user.mk(&note_b)), ()), EpochIndex(16));
+        witness::nf_derive(((cm_a, user.mk(&note_b)), ()), EpochIndex::new(16));
     expect_invalid(
         rng,
         delegation::NfDerive,
@@ -1750,11 +1775,11 @@ fn nf_derive_rejects_a_misaligned_epoch_start() {
     let note = user.random_note(500);
 
     let master = honest_master(rng, &user, note);
-    let (_, seq) = witness::nf_derive((*master.data(), ()), EpochIndex(12));
+    let (_, seq) = witness::nf_derive((*master.data(), ()), EpochIndex::new(12));
     expect_invalid(
         rng,
         delegation::NfDerive,
-        (EpochIndex(14), seq),
+        (EpochIndex::new(14), seq),
         master,
         Proof::trivial().carry::<()>(()),
         "NfDerive: epoch_start is not group-aligned",
@@ -1776,7 +1801,7 @@ fn nf_derive_rejects_a_window_past_the_final_epoch() {
 
     // Group-aligned for any EPOCH_MAX of the form `2^k - 1`, and short of a
     // whole window by three epochs.
-    let epoch_start = EpochIndex(EPOCH_MAX - 3);
+    let epoch_start = EpochIndex::new(EPOCH_MAX - 3);
     let master = honest_master(rng, &user, note);
 
     let err = PROOF_SYSTEM
@@ -1806,8 +1831,8 @@ fn derivation_exports_the_whole_window() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let epoch_start = EpochIndex(12);
-    let epoch_last = EpochIndex(epoch_start.0 + NF_DERIVATION_WIDTH as u32 - 1);
+    let epoch_start = EpochIndex::new(12);
+    let epoch_last = EpochIndex::new(u32::from(epoch_start) + NF_DERIVATION_WIDTH as u32 - 1);
     let range = user.derivation_pcd(rng, note, epoch_start, epoch_last);
     let (cm, start, commit, range_last) = *range.data();
 
@@ -1820,8 +1845,8 @@ fn derivation_exports_the_whole_window() {
     let far = user.derivation_pcd(
         rng,
         note,
-        EpochIndex(100_000),
-        EpochIndex(100_000 + NF_DERIVATION_WIDTH as u32 - 1),
+        EpochIndex::new(100_000),
+        EpochIndex::new(100_000 + NF_DERIVATION_WIDTH as u32 - 1),
     );
     assert_eq!(cm, far.data().0, "same note cm");
 }
@@ -1835,23 +1860,23 @@ fn derivation_covers_with_whole_windows() {
     let note = user.random_note(500);
 
     // Spans two windows: the fixture fuses whole-window leaves internally.
-    let start = EpochIndex(NF_DERIVATION_WIDTH as u32 - 2);
-    let last = EpochIndex(NF_DERIVATION_WIDTH as u32 + 2);
+    let start = EpochIndex::new(NF_DERIVATION_WIDTH as u32 - 2);
+    let last = EpochIndex::new(NF_DERIVATION_WIDTH as u32 + 2);
     let range = user.derivation_pcd(rng, note, start, last);
     let (cm, cover_start, commit, cover_last) = *range.data();
 
     assert_eq!(Tachygram::from(cm), note.commitment().into());
     assert!(
-        cover_start.0 <= start.0 && last.0 <= cover_last.0,
+        cover_start <= start && last <= cover_last,
         "covers the requested range"
     );
     assert_eq!(
-        (cover_last.0 - cover_start.0 + 1) % NF_DERIVATION_WIDTH as u32,
+        (u32::from(cover_last) - u32::from(cover_start) + 1) % NF_DERIVATION_WIDTH as u32,
         0,
         "whole windows"
     );
-    let members: Vec<Nullifier> = (cover_start.0..=cover_last.0)
-        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+    let members: Vec<Nullifier> = (u32::from(cover_start)..=u32::from(cover_last))
+        .map(|epoch| user.nf_at(&note, EpochIndex::new(epoch)))
         .collect();
     let seq = NfSeqPoly::new(cover_start, &members);
     assert_eq!(commit, seq.commit(), "merged commit is the concat sequence");
@@ -1865,9 +1890,9 @@ fn nullifier_fuse_rejects_non_contiguous() {
 
     // Windows separated by a gap: the left window covers `[0, 16)`, the right
     // starts at 32, so the halves are not adjacent.
-    let (left_start, right_start) = (EpochIndex(0), EpochIndex(32));
-    let range_a = user.derivation_pcd(rng, note, left_start, EpochIndex(15));
-    let range_b = user.derivation_pcd(rng, note, right_start, EpochIndex(47));
+    let (left_start, right_start) = (EpochIndex::new(0), EpochIndex::new(32));
+    let range_a = user.derivation_pcd(rng, note, left_start, EpochIndex::new(15));
+    let range_b = user.derivation_pcd(rng, note, right_start, EpochIndex::new(47));
     let witness = witness::nullifier_fuse(
         (*range_a.data(), *range_b.data()),
         &user.covering_window(&note, &range_a),
@@ -1891,9 +1916,9 @@ fn nullifier_fuse_rejects_wrong_cm() {
     let note_a = user.random_note(500);
     let note_b = user.random_note(700);
 
-    let (left_start, right_start) = (EpochIndex(0), EpochIndex(16));
-    let range_a = user.derivation_pcd(rng, note_a, left_start, EpochIndex(15));
-    let range_b = user.derivation_pcd(rng, note_b, right_start, EpochIndex(31));
+    let (left_start, right_start) = (EpochIndex::new(0), EpochIndex::new(16));
+    let range_a = user.derivation_pcd(rng, note_a, left_start, EpochIndex::new(15));
+    let range_b = user.derivation_pcd(rng, note_b, right_start, EpochIndex::new(31));
     let witness = witness::nullifier_fuse(
         (*range_a.data(), *range_b.data()),
         &user.covering_window(&note_a, &range_a),
@@ -1925,7 +1950,7 @@ fn spend_bind_parts(
     let init_height = mine_cm_block(rng, &mut pool, note.commitment());
     let epoch = init_height.epoch();
     let spendable = user.spendable_init(rng, note, &pool, init_height);
-    let derived = user.derivation_pcd(rng, *note, epoch, EpochIndex(epoch.0 + 1));
+    let derived = user.derivation_pcd(rng, *note, epoch, EpochIndex::new(u32::from(epoch) + 1));
     (spendable, derived, epoch)
 }
 
@@ -1961,8 +1986,9 @@ fn spend_bind_rejects_uncovering_range() {
     let note = user.random_note(500);
 
     let (spendable, _derived, epoch) = spend_bind_parts(rng, &user, &note);
-    let ahead = EpochIndex(epoch.0 + NF_DERIVATION_WIDTH as u32);
-    let derived_ahead = user.derivation_pcd(rng, note, ahead, EpochIndex(ahead.0 + 1));
+    let ahead = EpochIndex::new(u32::from(epoch) + NF_DERIVATION_WIDTH as u32);
+    let derived_ahead =
+        user.derivation_pcd(rng, note, ahead, EpochIndex::new(u32::from(ahead) + 1));
     // The builder would segment out of range, so the witness is assembled
     // by hand: the genuine covering sequence, an empty complement.
     let window = user.covering_window(&note, &derived_ahead);
@@ -1990,7 +2016,7 @@ fn spend_bind_rejects_a_foreign_range() {
     let other = user.random_note(700);
 
     let (spendable, _derived, epoch) = spend_bind_parts(rng, &user, &note);
-    let foreign = user.derivation_pcd(rng, other, epoch, EpochIndex(epoch.0 + 1));
+    let foreign = user.derivation_pcd(rng, other, epoch, EpochIndex::new(u32::from(epoch) + 1));
     let witness = witness::spend_bind(
         (*spendable.data(), *foreign.data()),
         &user.covering_window(&other, &foreign),
@@ -2037,13 +2063,13 @@ fn spendable_init_rejects_a_forged_nullifier() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
+    let nf_header = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(0));
     let dummy_tg = Tachygram::from(Fp::random(&mut *rng));
     let (_, _, _, _, nf_seq, complement_seq) = witness::spendable_init(
         (*nf_header.data(), ()),
         Anchor::default(),
         &[dummy_tg],
-        EpochIndex(0),
+        EpochIndex::new(0),
         &user.covering_window(&note, &nf_header),
     );
     let forged = Nullifier::from(Fp::random(&mut *rng));
@@ -2053,7 +2079,7 @@ fn spendable_init_rejects_a_forged_nullifier() {
         (
             Anchor::default(),
             TachygramSetPoly::from_iter([dummy_tg]),
-            EpochIndex(0),
+            EpochIndex::new(0),
             forged,
             nf_seq,
             complement_seq,
@@ -2072,8 +2098,8 @@ fn spendable_init_rejects_an_uncovering_range() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
-    let past = EpochIndex(NF_DERIVATION_WIDTH as u32);
+    let nf_header = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(0));
+    let past = EpochIndex::new(NF_DERIVATION_WIDTH as u32);
     let dummy_tg = Tachygram::from(Fp::random(&mut *rng));
     // The builder would segment out of range, so the witness is assembled
     // by hand: the genuine covering sequence, the whole window as the
@@ -2084,8 +2110,8 @@ fn spendable_init_rejects_an_uncovering_range() {
         TachygramSetPoly::from_iter([dummy_tg]),
         past,
         user.nf_at(&note, past),
-        NfSeqPoly::new(EpochIndex(0), &window),
-        NfSeqPoly::new(EpochIndex(0), &window),
+        NfSeqPoly::new(EpochIndex::new(0), &window),
+        NfSeqPoly::new(EpochIndex::new(0), &window),
     );
     expect_invalid(
         rng,
@@ -2112,14 +2138,14 @@ fn unspent_bind_rejects_a_foreign_sequence() {
     let unspent = build_unspent_pcd_between_blocks(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
         BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
     );
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
+    let range = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(0));
     let witness = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&other, &range),
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
     );
     expect_invalid(
         rng,
@@ -2148,9 +2174,9 @@ fn multi_chunk_lift_uses_per_chunk_windows() {
     sync.accept_delegation(
         0,
         alloc::vec![
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1)),
-            user.nf_at(&note, EpochIndex(2)),
+            user.nf_at(&note, EpochIndex::new(0)),
+            user.nf_at(&note, EpochIndex::new(1)),
+            user.nf_at(&note, EpochIndex::new(2)),
         ],
         init_height,
         start_anchor,
@@ -2165,7 +2191,7 @@ fn multi_chunk_lift_uses_per_chunk_windows() {
     let lifted_one = user.lift(rng, spendable, unspent_one, &note);
     assert_eq!(
         lifted_one.data().1,
-        (EpochIndex(1), user.nf_at(&note, EpochIndex(1)))
+        (EpochIndex::new(1), user.nf_at(&note, EpochIndex::new(1)))
     );
 
     // Second chunk: epochs 1 to 2, bound against a fresh window based at
@@ -2179,7 +2205,7 @@ fn multi_chunk_lift_uses_per_chunk_windows() {
 
     assert_eq!(
         lifted_two.data().1,
-        (EpochIndex(2), user.nf_at(&note, EpochIndex(2))),
+        (EpochIndex::new(2), user.nf_at(&note, EpochIndex::new(2))),
         "tip advanced across two chunks"
     );
     assert_eq!(
@@ -2267,13 +2293,13 @@ fn nullifier_fuse_composes() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let left = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(15));
-    let right = user.derivation_pcd(rng, note, EpochIndex(16), EpochIndex(31));
+    let left = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(15));
+    let right = user.derivation_pcd(rng, note, EpochIndex::new(16), EpochIndex::new(31));
     let left_nfs: Vec<Nullifier> = (0..16)
-        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .map(|epoch| user.nf_at(&note, EpochIndex::new(epoch)))
         .collect();
     let right_nfs: Vec<Nullifier> = (16..32)
-        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .map(|epoch| user.nf_at(&note, EpochIndex::new(epoch)))
         .collect();
     let fuse_witness =
         witness::nullifier_fuse((*left.data(), *right.data()), &left_nfs, &right_nfs);
@@ -2283,11 +2309,11 @@ fn nullifier_fuse_composes() {
 
     let (cm, start, commit, last) = *merged.data();
     assert_eq!(cm, note.commitment());
-    assert_eq!((start, last), (EpochIndex(0), EpochIndex(31)));
+    assert_eq!((start, last), (EpochIndex::new(0), EpochIndex::new(31)));
     let members: Vec<Nullifier> = (0..32)
-        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .map(|epoch| user.nf_at(&note, EpochIndex::new(epoch)))
         .collect();
-    let expected = NfSeqPoly::new(EpochIndex(0), &members);
+    let expected = NfSeqPoly::new(EpochIndex::new(0), &members);
     assert_eq!(
         commit,
         expected.commit(),
@@ -2303,13 +2329,13 @@ fn nullifier_fuse_rejects_a_wrong_merged() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let left = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(15));
-    let right = user.derivation_pcd(rng, note, EpochIndex(16), EpochIndex(31));
+    let left = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(15));
+    let right = user.derivation_pcd(rng, note, EpochIndex::new(16), EpochIndex::new(31));
     let left_nfs: Vec<Nullifier> = (0..16)
-        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .map(|epoch| user.nf_at(&note, EpochIndex::new(epoch)))
         .collect();
     let right_nfs: Vec<Nullifier> = (16..32)
-        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .map(|epoch| user.nf_at(&note, EpochIndex::new(epoch)))
         .collect();
     let (left_seq, _merged, right_seq) =
         witness::nullifier_fuse((*left.data(), *right.data()), &left_nfs, &right_nfs);
@@ -2317,7 +2343,7 @@ fn nullifier_fuse_rejects_a_wrong_merged() {
         iter::repeat_with(|| Nullifier::from(Fp::random(&mut *rng)))
             .take(32)
             .collect();
-    let wrong = NfSeqPoly::new(EpochIndex(0), &wrong_members);
+    let wrong = NfSeqPoly::new(EpochIndex::new(0), &wrong_members);
     expect_invalid(
         rng,
         delegation::NullifierFuse,
@@ -2351,7 +2377,12 @@ fn spend_bind_rejects_a_forged_next_over_a_garbage_complement() {
     let init_height = mine_cm_block(rng, &mut pool, note.commitment());
     let epoch = init_height.epoch();
     let spendable = user.spendable_init(rng, &note, &pool, init_height);
-    let derived = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(epoch.0 + 1));
+    let derived = user.derivation_pcd(
+        rng,
+        note,
+        EpochIndex::new(0),
+        EpochIndex::new(u32::from(epoch) + 1),
+    );
 
     let (nf_seq, _complement_seq, _nf_next) = witness::spend_bind(
         (*spendable.data(), *derived.data()),
@@ -2361,16 +2392,16 @@ fn spend_bind_rejects_a_forged_next_over_a_garbage_complement() {
     // Garbage complement: another note's members in place of this note's.
     let (_, deriv_start, _, deriv_last) = *derived.data();
     let stranger_mk = user.mk(&stranger);
-    let older_members: Vec<Nullifier> = (deriv_start.0..epoch.0)
-        .map(|epoch_idx| stranger_mk.derive_nullifier(EpochIndex(epoch_idx)))
+    let older_members: Vec<Nullifier> = (u32::from(deriv_start)..u32::from(epoch))
+        .map(|epoch_idx| stranger_mk.derive_nullifier(EpochIndex::new(epoch_idx)))
         .collect();
-    let newer_members: Vec<Nullifier> = (epoch.0 + 2..=deriv_last.0)
-        .map(|epoch_idx| stranger_mk.derive_nullifier(EpochIndex(epoch_idx)))
+    let newer_members: Vec<Nullifier> = (u32::from(epoch) + 2..=u32::from(deriv_last))
+        .map(|epoch_idx| stranger_mk.derive_nullifier(EpochIndex::new(epoch_idx)))
         .collect();
     assert!(!older_members.is_empty(), "lower run must carry members");
     assert!(!newer_members.is_empty(), "upper run must carry members");
     let complement_seq = NfSeqPoly::new(deriv_start, &older_members)
-        * NfSeqPoly::new(EpochIndex(epoch.0 + 2), &newer_members);
+        * NfSeqPoly::new(EpochIndex::new(u32::from(epoch) + 2), &newer_members);
 
     let forged = Nullifier::from(Fp::random(&mut *rng));
     expect_invalid(
@@ -2402,7 +2433,7 @@ fn spendable_lift_rejects_a_wrong_start() {
     let arbitrary = build_unspent_pcd_between_blocks(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(1))],
+        &[user.nf_at(&note, EpochIndex::new(1))],
         epoch1_height..=epoch1_height,
     );
     let unspent = user.unspent_bind(rng, arbitrary, &note);
@@ -2438,20 +2469,20 @@ fn unspent_walk_from_an_epoch_tip_opens_on_the_tip() {
     let epoch0_tip = spendable.data().2;
     assert_eq!(
         epoch0_tip,
-        pool.block(EpochIndex(0).last_block()).anchor(),
+        pool.block(EpochIndex::new(0).last_block()).anchor(),
         "the lineage sits on the epoch tip"
     );
 
     pool.advance(1, |_| random_block(rng, 1, 2));
     let target_height = pool.height();
-    assert_eq!(target_height.epoch(), EpochIndex(1));
+    assert_eq!(target_height.epoch(), EpochIndex::new(1));
 
     let arbitrary = build_unspent_pcd_between_anchors(
         rng,
         &pool,
         &[
-            user.nf_at(&note, EpochIndex(0)),
-            user.nf_at(&note, EpochIndex(1)),
+            user.nf_at(&note, EpochIndex::new(0)),
+            user.nf_at(&note, EpochIndex::new(1)),
         ],
         (epoch0_tip, pool.block(target_height).anchor()),
     );
@@ -2464,12 +2495,12 @@ fn unspent_walk_from_an_epoch_tip_opens_on_the_tip() {
     );
     assert_eq!(
         unspent.data().2,
-        (EpochIndex(0), user.nf_at(&note, EpochIndex(0))),
+        (EpochIndex::new(0), user.nf_at(&note, EpochIndex::new(0))),
         "the span begins in the epoch being left"
     );
     assert_eq!(
         unspent.data().3,
-        (EpochIndex(1), user.nf_at(&note, EpochIndex(1)))
+        (EpochIndex::new(1), user.nf_at(&note, EpochIndex::new(1)))
     );
     assert_eq!(unspent.data().4, pool.block(target_height).anchor());
 }
@@ -2495,7 +2526,7 @@ fn crossing_seed_carries_a_terminal_anchor_to_a_spend() {
     let epoch0_tip = spendable.data().2;
     assert_eq!(
         epoch0_tip,
-        pool.block(EpochIndex(0).last_block()).anchor(),
+        pool.block(EpochIndex::new(0).last_block()).anchor(),
         "the lineage sits on the epoch tip"
     );
 
@@ -2508,9 +2539,9 @@ fn crossing_seed_carries_a_terminal_anchor_to_a_spend() {
             witness::end_epoch_unspent_seed(
                 ((), ()),
                 epoch0_tip,
-                EpochIndex(0),
-                user.nf_at(&note, EpochIndex(0)),
-                user.nf_at(&note, EpochIndex(1)),
+                EpochIndex::new(0),
+                user.nf_at(&note, EpochIndex::new(0)),
+                user.nf_at(&note, EpochIndex::new(1)),
             ),
         )
         .expect("EndEpochUnspentSeed");
@@ -2519,8 +2550,8 @@ fn crossing_seed_carries_a_terminal_anchor_to_a_spend() {
         *lifted.data(),
         (
             note.commitment(),
-            (EpochIndex(1), user.nf_at(&note, EpochIndex(1))),
-            epoch0_tip.next_epoch(EpochIndex(1)).unwrap(),
+            (EpochIndex::new(1), user.nf_at(&note, EpochIndex::new(1))),
+            epoch0_tip.next_epoch(EpochIndex::new(1)).unwrap(),
         ),
         "the lift crosses to the boundary anchor"
     );
@@ -2528,20 +2559,20 @@ fn crossing_seed_carries_a_terminal_anchor_to_a_spend() {
     // Walk through epoch 1 from the boundary anchor the lift landed on.
     pool.advance(1, |_| random_block(rng, 1, 2));
     let end_height = pool.height();
-    assert_eq!(end_height.epoch(), EpochIndex(1));
+    assert_eq!(end_height.epoch(), EpochIndex::new(1));
     let arbitrary = build_unspent_pcd_between_anchors(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(1))],
+        &[user.nf_at(&note, EpochIndex::new(1))],
         (lifted.data().2, pool.block(end_height).anchor()),
     );
     let walked = user.lift(rng, lifted, arbitrary, &note);
-    let bind_pcd = honest_spend_bind(rng, &user, &note, walked, EpochIndex(1));
+    let bind_pcd = honest_spend_bind(rng, &user, &note, walked, EpochIndex::new(1));
     let stamp = honest_spend_stamp(rng, &user, &note, bind_pcd);
 
     let expected = TachygramSetPoly::from_iter([
-        user.nf_at(&note, EpochIndex(1)).into(),
-        user.nf_at(&note, EpochIndex(2)).into(),
+        user.nf_at(&note, EpochIndex::new(1)).into(),
+        user.nf_at(&note, EpochIndex::new(2)).into(),
     ])
     .commit();
     assert_eq!(stamp.data().1, expected, "publishes {{N_1, N_2}}");
@@ -2561,18 +2592,21 @@ fn unspent_bind_rejects_a_forged_complement() {
     let unspent = build_unspent_pcd_between_blocks(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
         BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
     );
     // A two-epoch derivation, so the honest complement is nonempty and the
     // forgery cannot hide behind the constant 1.
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let range = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(1));
     let (elapsed_seq, nf_seq, _complement_seq) = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&note, &range),
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
     );
-    let forged = NfSeqPoly::new(EpochIndex(1), &[Nullifier::from(Fp::random(&mut *rng))]);
+    let forged = NfSeqPoly::new(
+        EpochIndex::new(1),
+        &[Nullifier::from(Fp::random(&mut *rng))],
+    );
     expect_invalid(
         rng,
         pool::UnspentBind,
@@ -2602,13 +2636,14 @@ fn unspent_bind_rejects_a_wrong_epoch_member() {
     let unspent = build_unspent_pcd_between_blocks(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
         epoch1_height..=epoch1_height,
     );
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
-    let elapsed_seq = NfSeqPoly::new(EpochIndex(1), &[user.nf_at(&note, EpochIndex(0))]);
-    let complement_seq = NfSeqPoly::new(EpochIndex(0), &[user.nf_at(&note, EpochIndex(0))]);
-    let nf_seq = NfSeqPoly::new(EpochIndex(0), &user.covering_window(&note, &range));
+    let range = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(1));
+    let elapsed_seq = NfSeqPoly::new(EpochIndex::new(1), &[user.nf_at(&note, EpochIndex::new(0))]);
+    let complement_seq =
+        NfSeqPoly::new(EpochIndex::new(0), &[user.nf_at(&note, EpochIndex::new(0))]);
+    let nf_seq = NfSeqPoly::new(EpochIndex::new(0), &user.covering_window(&note, &range));
     expect_invalid(
         rng,
         pool::UnspentBind,
@@ -2634,18 +2669,18 @@ fn unspent_bind_rejects_a_duplicating_complement() {
     let unspent = build_unspent_pcd_between_blocks(
         rng,
         &pool,
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
         BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
     );
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
+    let range = user.derivation_pcd(rng, note, EpochIndex::new(0), EpochIndex::new(0));
     let (elapsed_seq, nf_seq, _complement_seq) = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&note, &range),
-        &[user.nf_at(&note, EpochIndex(0))],
+        &[user.nf_at(&note, EpochIndex::new(0))],
     );
     // The honest complement is empty; duplicating the tested member squares
     // its encoding, and the squarefree derivation rejects it.
-    let duplicating = NfSeqPoly::new(EpochIndex(0), &[user.nf_at(&note, EpochIndex(0))]);
+    let duplicating = NfSeqPoly::new(EpochIndex::new(0), &[user.nf_at(&note, EpochIndex::new(0))]);
     expect_invalid(
         rng,
         pool::UnspentBind,
@@ -2683,7 +2718,7 @@ fn multi_window_span_binds_once() {
     }
 
     let nfs: Vec<Nullifier> = (0..=last_epoch)
-        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .map(|epoch| user.nf_at(&note, EpochIndex::new(epoch)))
         .collect();
     let arbitrary = build_unspent_pcd_between_anchors(
         rng,
@@ -2696,8 +2731,8 @@ fn multi_window_span_binds_once() {
     assert_eq!(
         unspent.data().3,
         (
-            EpochIndex(last_epoch),
-            user.nf_at(&note, EpochIndex(last_epoch))
+            EpochIndex::new(last_epoch),
+            user.nf_at(&note, EpochIndex::new(last_epoch))
         ),
         "one bind carries the whole multi-window span"
     );
@@ -2715,7 +2750,7 @@ fn one_window_serves_init_bind_and_spend() {
     let init_height = mine_cm_block(rng, &mut pool, note.commitment());
     let epoch = init_height.epoch();
 
-    let window = user.derivation_pcd(rng, note, epoch, EpochIndex(epoch.0 + 1));
+    let window = user.derivation_pcd(rng, note, epoch, EpochIndex::new(u32::from(epoch) + 1));
     let spendable = user.spendable_init(rng, &note, &pool, init_height);
     let again = user.derivation_pcd(rng, note, epoch, epoch);
     assert_eq!(
@@ -2762,9 +2797,9 @@ fn summary_spendable_syncs_to_a_spend() {
     while pool.height().0 < EPOCH_SIZE {
         pool.mine(random_block(rng, 1, 2));
     }
-    let lifted = user.lift_to_epoch(rng, &pool, &note, spendable, EpochIndex(1));
-    let bind_pcd = honest_spend_bind(rng, &user, &note, lifted, EpochIndex(1));
+    let lifted = user.lift_to_epoch(rng, &pool, &note, spendable, EpochIndex::new(1));
+    let bind_pcd = honest_spend_bind(rng, &user, &note, lifted, EpochIndex::new(1));
 
-    assert_eq!(bind_pcd.data().1, user.nf_at(&note, EpochIndex(1)));
-    assert_eq!(bind_pcd.data().2, user.nf_at(&note, EpochIndex(2)));
+    assert_eq!(bind_pcd.data().1, user.nf_at(&note, EpochIndex::new(1)));
+    assert_eq!(bind_pcd.data().2, user.nf_at(&note, EpochIndex::new(2)));
 }

--- a/crates/tachyon/tests/integration/proof.rs
+++ b/crates/tachyon/tests/integration/proof.rs
@@ -57,7 +57,7 @@ fn honest_spend_bind(
     spendable: Pcd<spendable::SpendableHeader>,
     spend_epoch: EpochIndex,
 ) -> Pcd<spend::SpendHeader> {
-    let derived = user.derivation_pcd(rng, *note, spend_epoch, EpochIndex(spend_epoch.0 + 2));
+    let derived = user.derivation_pcd(rng, *note, spend_epoch, EpochIndex(spend_epoch.0 + 1));
     let witness = witness::spend_bind(
         (*spendable.data(), *derived.data()),
         &user.covering_window(note, &derived),
@@ -148,7 +148,7 @@ fn spendable_init_rejects_tg_absent() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
     let absent_tg = Tachygram::from(Fp::random(&mut *rng));
 
     let err = PROOF_SYSTEM
@@ -1394,7 +1394,7 @@ fn unspent_bind_rejects_tip_mismatch() {
     // final member, so the poly bind passes; the divisibility read then
     // finds no such member in the genuine sequence and rejects it.
     let (_, _, _, (unspent_last, _), _) = *unspent.data();
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), unspent_last.next().unwrap());
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), unspent_last);
     let witness = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&note, &range),
@@ -1464,7 +1464,7 @@ fn unspent_bind_rejects_elapsed_mismatch() {
         &[user.nf_at(&note, EpochIndex(0))],
         BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
     );
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
     let (_honest_elapsed_seq, nf_seq, complement_seq) = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&note, &range),
@@ -1510,7 +1510,7 @@ fn unspent_bind_rejects_uncovered_start() {
     // later window) cannot cover it.
     // The builder would segment out of range, so the witness is assembled
     // by hand: the genuine covering sequence, an empty complement.
-    let range = user.derivation_pcd(rng, note, EpochIndex(64), EpochIndex(65));
+    let range = user.derivation_pcd(rng, note, EpochIndex(64), EpochIndex(64));
     let window = user.covering_window(&note, &range);
     let witness = (
         NfSeqPoly::new(EpochIndex(0), &[user.nf_at(&note, EpochIndex(0))]),
@@ -1556,7 +1556,7 @@ fn unspent_bind_rejects_uncovered_end() {
         )
         .expect("EndEpochUnspentSeed");
 
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
     let window = user.covering_window(&note, &range);
     // The builder would segment out of range, so the witness is assembled
     // by hand: the genuine elapsed and covering sequence, an empty
@@ -1761,6 +1761,43 @@ fn nf_derive_rejects_a_misaligned_epoch_start() {
     );
 }
 
+/// A window has to land inside the epoch range: an index past `EPOCH_MAX`
+/// maps to no block height, so it labels no reachable epoch.
+///
+/// The witness is assembled here rather than through [`witness::nf_derive`],
+/// which derives the window prover-side and so trips the same bound before the
+/// step runs. The sequence is empty for the same reason: the range check
+/// precedes every use of it.
+#[test]
+fn nf_derive_rejects_a_window_past_the_final_epoch() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    // Group-aligned for any EPOCH_MAX of the form `2^k - 1`, and short of a
+    // whole window by three epochs.
+    let epoch_start = EpochIndex(EPOCH_MAX - 3);
+    let master = honest_master(rng, &user, note);
+
+    let err = PROOF_SYSTEM
+        .fuse(
+            rng,
+            delegation::NfDerive,
+            (epoch_start, NfSeqPoly::new(epoch_start, &[])),
+            master,
+            Proof::trivial().carry::<()>(()),
+        )
+        .err()
+        .unwrap();
+    let ragu_core::Error::InvalidWitness(inner) = err else {
+        panic!("expected InvalidWitness, got {err:?}");
+    };
+    assert_eq!(
+        inner.to_string(),
+        "NfDerive: window exceeds the epoch range"
+    );
+}
+
 /// A leaf exports its whole window, labelled with the window's bounds, and
 /// every window of the same note carries the same `cm`.
 #[test]
@@ -1770,12 +1807,12 @@ fn derivation_exports_the_whole_window() {
     let note = user.random_note(500);
 
     let epoch_start = EpochIndex(12);
-    let epoch_end = EpochIndex(epoch_start.0 + NF_DERIVATION_WIDTH as u32);
-    let range = user.derivation_pcd(rng, note, epoch_start, epoch_end);
-    let (cm, start, commit, range_end) = *range.data();
+    let epoch_last = EpochIndex(epoch_start.0 + NF_DERIVATION_WIDTH as u32 - 1);
+    let range = user.derivation_pcd(rng, note, epoch_start, epoch_last);
+    let (cm, start, commit, range_last) = *range.data();
 
     assert_eq!(start, epoch_start, "starts at the witnessed epoch");
-    assert_eq!(range_end, epoch_end, "spans the whole window");
+    assert_eq!(range_last, epoch_last, "spans the whole window");
     let members = user.covering_window(&note, &range);
     let seq = NfSeqPoly::new(epoch_start, &members);
     assert_eq!(commit, seq.commit(), "header commits the window sequence");
@@ -1784,7 +1821,7 @@ fn derivation_exports_the_whole_window() {
         rng,
         note,
         EpochIndex(100_000),
-        EpochIndex(100_000 + NF_DERIVATION_WIDTH as u32),
+        EpochIndex(100_000 + NF_DERIVATION_WIDTH as u32 - 1),
     );
     assert_eq!(cm, far.data().0, "same note cm");
 }
@@ -1799,21 +1836,21 @@ fn derivation_covers_with_whole_windows() {
 
     // Spans two windows: the fixture fuses whole-window leaves internally.
     let start = EpochIndex(NF_DERIVATION_WIDTH as u32 - 2);
-    let end = EpochIndex(NF_DERIVATION_WIDTH as u32 + 2);
-    let range = user.derivation_pcd(rng, note, start, end);
-    let (cm, cover_start, commit, cover_end) = *range.data();
+    let last = EpochIndex(NF_DERIVATION_WIDTH as u32 + 2);
+    let range = user.derivation_pcd(rng, note, start, last);
+    let (cm, cover_start, commit, cover_last) = *range.data();
 
     assert_eq!(Tachygram::from(cm), note.commitment().into());
     assert!(
-        cover_start.0 <= start.0 && end.0 <= cover_end.0,
+        cover_start.0 <= start.0 && last.0 <= cover_last.0,
         "covers the requested range"
     );
     assert_eq!(
-        (cover_end.0 - cover_start.0) % NF_DERIVATION_WIDTH as u32,
+        (cover_last.0 - cover_start.0 + 1) % NF_DERIVATION_WIDTH as u32,
         0,
         "whole windows"
     );
-    let members: Vec<Nullifier> = (cover_start.0..cover_end.0)
+    let members: Vec<Nullifier> = (cover_start.0..=cover_last.0)
         .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
         .collect();
     let seq = NfSeqPoly::new(cover_start, &members);
@@ -1829,8 +1866,8 @@ fn nullifier_fuse_rejects_non_contiguous() {
     // Windows separated by a gap: the left window covers `[0, 16)`, the right
     // starts at 32, so the halves are not adjacent.
     let (left_start, right_start) = (EpochIndex(0), EpochIndex(32));
-    let range_a = user.derivation_pcd(rng, note, left_start, EpochIndex(16));
-    let range_b = user.derivation_pcd(rng, note, right_start, EpochIndex(48));
+    let range_a = user.derivation_pcd(rng, note, left_start, EpochIndex(15));
+    let range_b = user.derivation_pcd(rng, note, right_start, EpochIndex(47));
     let witness = witness::nullifier_fuse(
         (*range_a.data(), *range_b.data()),
         &user.covering_window(&note, &range_a),
@@ -1855,8 +1892,8 @@ fn nullifier_fuse_rejects_wrong_cm() {
     let note_b = user.random_note(700);
 
     let (left_start, right_start) = (EpochIndex(0), EpochIndex(16));
-    let range_a = user.derivation_pcd(rng, note_a, left_start, EpochIndex(16));
-    let range_b = user.derivation_pcd(rng, note_b, right_start, EpochIndex(32));
+    let range_a = user.derivation_pcd(rng, note_a, left_start, EpochIndex(15));
+    let range_b = user.derivation_pcd(rng, note_b, right_start, EpochIndex(31));
     let witness = witness::nullifier_fuse(
         (*range_a.data(), *range_b.data()),
         &user.covering_window(&note_a, &range_a),
@@ -1888,7 +1925,7 @@ fn spend_bind_parts(
     let init_height = mine_cm_block(rng, &mut pool, note.commitment());
     let epoch = init_height.epoch();
     let spendable = user.spendable_init(rng, note, &pool, init_height);
-    let derived = user.derivation_pcd(rng, *note, epoch, EpochIndex(epoch.0 + 2));
+    let derived = user.derivation_pcd(rng, *note, epoch, EpochIndex(epoch.0 + 1));
     (spendable, derived, epoch)
 }
 
@@ -1925,7 +1962,7 @@ fn spend_bind_rejects_uncovering_range() {
 
     let (spendable, _derived, epoch) = spend_bind_parts(rng, &user, &note);
     let ahead = EpochIndex(epoch.0 + NF_DERIVATION_WIDTH as u32);
-    let derived_ahead = user.derivation_pcd(rng, note, ahead, EpochIndex(ahead.0 + 2));
+    let derived_ahead = user.derivation_pcd(rng, note, ahead, EpochIndex(ahead.0 + 1));
     // The builder would segment out of range, so the witness is assembled
     // by hand: the genuine covering sequence, an empty complement.
     let window = user.covering_window(&note, &derived_ahead);
@@ -1953,7 +1990,7 @@ fn spend_bind_rejects_a_foreign_range() {
     let other = user.random_note(700);
 
     let (spendable, _derived, epoch) = spend_bind_parts(rng, &user, &note);
-    let foreign = user.derivation_pcd(rng, other, epoch, EpochIndex(epoch.0 + 2));
+    let foreign = user.derivation_pcd(rng, other, epoch, EpochIndex(epoch.0 + 1));
     let witness = witness::spend_bind(
         (*spendable.data(), *foreign.data()),
         &user.covering_window(&other, &foreign),
@@ -2000,7 +2037,7 @@ fn spendable_init_rejects_a_forged_nullifier() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
     let dummy_tg = Tachygram::from(Fp::random(&mut *rng));
     let (_, _, _, _, nf_seq, complement_seq) = witness::spendable_init(
         (*nf_header.data(), ()),
@@ -2035,7 +2072,7 @@ fn spendable_init_rejects_an_uncovering_range() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let nf_header = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
     let past = EpochIndex(NF_DERIVATION_WIDTH as u32);
     let dummy_tg = Tachygram::from(Fp::random(&mut *rng));
     // The builder would segment out of range, so the witness is assembled
@@ -2078,7 +2115,7 @@ fn unspent_bind_rejects_a_foreign_sequence() {
         &[user.nf_at(&note, EpochIndex(0))],
         BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
     );
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
     let witness = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&other, &range),
@@ -2230,8 +2267,8 @@ fn nullifier_fuse_composes() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let left = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(16));
-    let right = user.derivation_pcd(rng, note, EpochIndex(16), EpochIndex(32));
+    let left = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(15));
+    let right = user.derivation_pcd(rng, note, EpochIndex(16), EpochIndex(31));
     let left_nfs: Vec<Nullifier> = (0..16)
         .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
         .collect();
@@ -2244,9 +2281,9 @@ fn nullifier_fuse_composes() {
         .fuse(rng, delegation::NullifierFuse, fuse_witness, left, right)
         .expect("NullifierFuse");
 
-    let (cm, start, commit, end) = *merged.data();
+    let (cm, start, commit, last) = *merged.data();
     assert_eq!(cm, note.commitment());
-    assert_eq!((start, end), (EpochIndex(0), EpochIndex(32)));
+    assert_eq!((start, last), (EpochIndex(0), EpochIndex(31)));
     let members: Vec<Nullifier> = (0..32)
         .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
         .collect();
@@ -2266,8 +2303,8 @@ fn nullifier_fuse_rejects_a_wrong_merged() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(500);
 
-    let left = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(16));
-    let right = user.derivation_pcd(rng, note, EpochIndex(16), EpochIndex(32));
+    let left = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(15));
+    let right = user.derivation_pcd(rng, note, EpochIndex(16), EpochIndex(31));
     let left_nfs: Vec<Nullifier> = (0..16)
         .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
         .collect();
@@ -2314,7 +2351,7 @@ fn spend_bind_rejects_a_forged_next_over_a_garbage_complement() {
     let init_height = mine_cm_block(rng, &mut pool, note.commitment());
     let epoch = init_height.epoch();
     let spendable = user.spendable_init(rng, &note, &pool, init_height);
-    let derived = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(epoch.0 + 2));
+    let derived = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(epoch.0 + 1));
 
     let (nf_seq, _complement_seq, _nf_next) = witness::spend_bind(
         (*spendable.data(), *derived.data()),
@@ -2322,12 +2359,12 @@ fn spend_bind_rejects_a_forged_next_over_a_garbage_complement() {
     );
 
     // Garbage complement: another note's members in place of this note's.
-    let (_, deriv_start, _, deriv_end) = *derived.data();
+    let (_, deriv_start, _, deriv_last) = *derived.data();
     let stranger_mk = user.mk(&stranger);
     let older_members: Vec<Nullifier> = (deriv_start.0..epoch.0)
         .map(|epoch_idx| stranger_mk.derive_nullifier(EpochIndex(epoch_idx)))
         .collect();
-    let newer_members: Vec<Nullifier> = (epoch.0 + 2..deriv_end.0)
+    let newer_members: Vec<Nullifier> = (epoch.0 + 2..=deriv_last.0)
         .map(|epoch_idx| stranger_mk.derive_nullifier(EpochIndex(epoch_idx)))
         .collect();
     assert!(!older_members.is_empty(), "lower run must carry members");
@@ -2529,7 +2566,7 @@ fn unspent_bind_rejects_a_forged_complement() {
     );
     // A two-epoch derivation, so the honest complement is nonempty and the
     // forgery cannot hide behind the constant 1.
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(2));
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
     let (elapsed_seq, nf_seq, _complement_seq) = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&note, &range),
@@ -2568,7 +2605,7 @@ fn unspent_bind_rejects_a_wrong_epoch_member() {
         &[user.nf_at(&note, EpochIndex(0))],
         epoch1_height..=epoch1_height,
     );
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(2));
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
     let elapsed_seq = NfSeqPoly::new(EpochIndex(1), &[user.nf_at(&note, EpochIndex(0))]);
     let complement_seq = NfSeqPoly::new(EpochIndex(0), &[user.nf_at(&note, EpochIndex(0))]);
     let nf_seq = NfSeqPoly::new(EpochIndex(0), &user.covering_window(&note, &range));
@@ -2600,7 +2637,7 @@ fn unspent_bind_rejects_a_duplicating_complement() {
         &[user.nf_at(&note, EpochIndex(0))],
         BlockHeight(init_height.0 + 1)..=BlockHeight(init_height.0 + 1),
     );
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(1));
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), EpochIndex(0));
     let (elapsed_seq, nf_seq, _complement_seq) = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&note, &range),
@@ -2678,9 +2715,9 @@ fn one_window_serves_init_bind_and_spend() {
     let init_height = mine_cm_block(rng, &mut pool, note.commitment());
     let epoch = init_height.epoch();
 
-    let window = user.derivation_pcd(rng, note, epoch, EpochIndex(epoch.0 + 2));
+    let window = user.derivation_pcd(rng, note, epoch, EpochIndex(epoch.0 + 1));
     let spendable = user.spendable_init(rng, &note, &pool, init_height);
-    let again = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
+    let again = user.derivation_pcd(rng, note, epoch, epoch);
     assert_eq!(
         again.data(),
         window.data(),
@@ -2704,7 +2741,7 @@ fn summary_spendable_syncs_to_a_spend() {
     pool.mine(random_block(rng, 1, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, _, anchor_last, _) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch);
 
     let (spendable, ()) = PROOF_SYSTEM
         .fuse(

--- a/crates/tachyon/tests/integration/proof.rs
+++ b/crates/tachyon/tests/integration/proof.rs
@@ -14,7 +14,7 @@ use rand::{SeedableRng as _, rngs::StdRng};
 use rand_core::CryptoRng;
 use zcash_tachyon::{
     ActionSetPoly, Anchor, BlockHeight, EpochIndex, NfSeqPoly, Note, Tachygram, TachygramSetPoly,
-    constants::EPOCH_SIZE,
+    constants::{EPOCH_MAX, EPOCH_SIZE},
     digest::poseidon,
     effect,
     entropy::ActionEntropy,
@@ -102,7 +102,7 @@ fn same_epoch_honest_spend_accepted() {
 
     let expected = TachygramSetPoly::from_iter([
         user.nf_at(&note, epoch).into(),
-        user.nf_at(&note, epoch.next()).into(),
+        user.nf_at(&note, epoch.next().unwrap()).into(),
     ])
     .commit();
     assert_eq!(stamp.data().1, expected, "publishes {{N_E, N_E+1}}");
@@ -365,7 +365,7 @@ fn spend_bind_honest() {
     let bind_pcd = honest_spend_bind(rng, &user, &note, spendable_pcd, spend_epoch);
     let (_cm, present_nf, nf_next, _anchor) = *bind_pcd.data();
     assert_eq!(present_nf, user.nf_at(&note, spend_epoch));
-    assert_eq!(nf_next, user.nf_at(&note, spend_epoch.next()));
+    assert_eq!(nf_next, user.nf_at(&note, spend_epoch.next().unwrap()));
 }
 
 #[test]
@@ -561,7 +561,7 @@ fn spend_stamp_assembles_tachygrams() {
     let (_actions, tg_commit, _anchor) = *stamp_pcd.data();
     let expected = TachygramSetPoly::from_iter([
         Tachygram::from(user.nf_at(&note, spend_epoch)),
-        Tachygram::from(user.nf_at(&note, spend_epoch.next())),
+        Tachygram::from(user.nf_at(&note, spend_epoch.next().unwrap())),
     ])
     .commit();
     assert_eq!(tg_commit, expected);
@@ -1394,7 +1394,7 @@ fn unspent_bind_rejects_tip_mismatch() {
     // final member, so the poly bind passes; the divisibility read then
     // finds no such member in the genuine sequence and rejects it.
     let (_, _, _, (unspent_last, _), _) = *unspent.data();
-    let range = user.derivation_pcd(rng, note, EpochIndex(0), unspent_last.next());
+    let range = user.derivation_pcd(rng, note, EpochIndex(0), unspent_last.next().unwrap());
     let witness = witness::unspent_bind(
         (*unspent.data(), *range.data()),
         &user.covering_window(&note, &range),
@@ -1412,6 +1412,41 @@ fn unspent_bind_rejects_tip_mismatch() {
         inner.to_string(),
         "UnspentBind: sequence does not match the derivation"
     );
+}
+
+#[test]
+fn unspent_bind_window_may_end_at_the_final_epoch() {
+    let rng = &mut StdRng::seed_from_u64(0);
+    let user = WalletSim::new(shared_sk());
+    let note = user.random_note(500);
+
+    // The epoch space's last derivation window: the unspent span covers all
+    // of it, ending at the final epoch, which has no successor.
+    let epoch_start = EpochIndex(EPOCH_MAX + 1 - NF_DERIVATION_WIDTH as u32);
+    let epoch_last = EpochIndex(EPOCH_MAX);
+    let range = user.derivation_pcd(rng, note, epoch_start, epoch_last);
+
+    let elapsed: Vec<Nullifier> = (epoch_start.0..=epoch_last.0)
+        .map(|epoch| user.nf_at(&note, EpochIndex(epoch)))
+        .collect();
+    let synthetic_unspent = (
+        Anchor::from(Fp::ZERO),
+        (epoch_start, elapsed[0]),
+        NfSeqPoly::new(epoch_start, &elapsed).commit(),
+        (epoch_last, elapsed[elapsed.len() - 1]),
+        Anchor::from(Fp::ZERO),
+    );
+
+    let (elapsed_seq, nf_seq, complement_seq) = witness::unspent_bind(
+        (synthetic_unspent, *range.data()),
+        &user.covering_window(&note, &range),
+        &elapsed,
+    );
+
+    // The span covers the whole window, so the complement is empty on both
+    // sides: the multiplicative identity.
+    assert_eq!(complement_seq.commit(), NfSeqPoly::default().commit());
+    assert_eq!(elapsed_seq.commit(), nf_seq.commit());
 }
 
 #[test]
@@ -1516,7 +1551,7 @@ fn unspent_bind_rejects_uncovered_end() {
                 anchor,
                 last,
                 user.nf_at(&note, last),
-                user.nf_at(&note, last.next()),
+                user.nf_at(&note, last.next().unwrap()),
             ),
         )
         .expect("EndEpochUnspentSeed");
@@ -1529,7 +1564,10 @@ fn unspent_bind_rejects_uncovered_end() {
     let witness = (
         NfSeqPoly::new(
             last,
-            &[user.nf_at(&note, last), user.nf_at(&note, last.next())],
+            &[
+                user.nf_at(&note, last),
+                user.nf_at(&note, last.next().unwrap()),
+            ],
         ),
         NfSeqPoly::new(EpochIndex(0), &window),
         NfSeqPoly::new(EpochIndex(0), &[]),
@@ -1894,7 +1932,7 @@ fn spend_bind_rejects_uncovering_range() {
     let witness = (
         NfSeqPoly::new(ahead, &window),
         NfSeqPoly::new(ahead, &[]),
-        user.nf_at(&note, epoch.next()),
+        user.nf_at(&note, epoch.next().unwrap()),
     );
     expect_invalid(
         rng,
@@ -2642,7 +2680,7 @@ fn one_window_serves_init_bind_and_spend() {
 
     let window = user.derivation_pcd(rng, note, epoch, EpochIndex(epoch.0 + 2));
     let spendable = user.spendable_init(rng, &note, &pool, init_height);
-    let again = user.derivation_pcd(rng, note, epoch, epoch.next());
+    let again = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
     assert_eq!(
         again.data(),
         window.data(),
@@ -2651,7 +2689,7 @@ fn one_window_serves_init_bind_and_spend() {
 
     let bind_pcd = honest_spend_bind(rng, &user, &note, spendable, epoch);
     assert_eq!(bind_pcd.data().1, user.nf_at(&note, epoch));
-    assert_eq!(bind_pcd.data().2, user.nf_at(&note, epoch.next()));
+    assert_eq!(bind_pcd.data().2, user.nf_at(&note, epoch.next().unwrap()));
 }
 
 /// A summary-started spendable lifts across the epoch boundary and binds to a
@@ -2666,7 +2704,7 @@ fn summary_spendable_syncs_to_a_spend() {
     pool.mine(random_block(rng, 1, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, _, anchor_last, _) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
 
     let (spendable, ()) = PROOF_SYSTEM
         .fuse(

--- a/crates/tachyon/tests/integration/qr.rs
+++ b/crates/tachyon/tests/integration/qr.rs
@@ -1507,7 +1507,7 @@ fn qr_unspent_init_accepts_an_absent_nullifier_against_its_bucket() {
 fn qr_unspent_segments_of_consecutive_epochs_fuse_over_a_boundary_link() {
     let rng = &mut StdRng::seed_from_u64(0);
     let epoch0 = EpochIndex(0);
-    let epoch1 = epoch0.next();
+    let epoch1 = epoch0.next().unwrap();
     let mut pool = PoolSim::genesis_with(random_block(rng, 1, 1));
     // Fill epoch zero and open epoch one, one stamp per block.
     pool.advance(epoch1.first_block().0 + 1, |_| random_block(rng, 1, 1));
@@ -1600,8 +1600,8 @@ fn qr_spendable_init_starts_a_spendable_that_reaches_spend_bind() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
     let epoch0 = EpochIndex(0);
-    let epoch1 = epoch0.next();
-    let epoch2 = epoch1.next();
+    let epoch1 = epoch0.next().unwrap();
+    let epoch2 = epoch1.next().unwrap();
     let mut pool = PoolSim::genesis_with(vec![vec![Tachygram::from(note.commitment())]]);
     // Fill epochs zero and one and open epoch two, one stamp per block.
     pool.advance(epoch2.first_block().0, |_| random_block(rng, 1, 1));
@@ -1713,7 +1713,7 @@ fn qr_short_bucket_reaches_spend_bind_through_a_same_epoch_suffix() {
     assert_eq!(bucket.pcd.data().2, short_anchor);
     assert_eq!(
         bucket.pcd.data().3,
-        QrDiscriminant::from(short_anchor.next_epoch(epoch.next()).unwrap()),
+        QrDiscriminant::from(short_anchor.next_epoch(epoch.next().unwrap()).unwrap()),
         "the seal uses the short span's hypothetical closing tick"
     );
     assert_ne!(bucket.pcd.data().3, qr_discriminant_of(&pool, tip_anchor));
@@ -1745,7 +1745,7 @@ fn qr_short_bucket_reaches_spend_bind_through_a_same_epoch_suffix() {
         "the suffix covers only the same epoch, without a boundary crossing"
     );
     let lifted = user.lift(rng, spendable, suffix, &note);
-    let derived = user.derivation_pcd(rng, note, epoch, epoch.next().next());
+    let derived = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap().next().unwrap());
     let (bind, ()) = PROOF_SYSTEM
         .fuse(
             rng,
@@ -1763,7 +1763,7 @@ fn qr_short_bucket_reaches_spend_bind_through_a_same_epoch_suffix() {
         (
             note.commitment(),
             nf,
-            user.nf_at(&note, epoch.next()),
+            user.nf_at(&note, epoch.next().unwrap()),
             tip_anchor
         ),
         "the spend reaches the pool tip without crossing at the bucket's endpoint"
@@ -1869,7 +1869,7 @@ fn qr_spendable_init_rejects_a_bucket_of_another_epoch() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
     let epoch0 = EpochIndex(0);
-    let epoch1 = epoch0.next();
+    let epoch1 = epoch0.next().unwrap();
     let mut pool = PoolSim::genesis_with(vec![vec![Tachygram::from(note.commitment())]]);
     pool.advance(epoch1.last_block().0, |_| random_block(rng, 1, 1));
     let terminal0 = pool.block(epoch0.last_block()).anchor();
@@ -1922,7 +1922,7 @@ fn qr_spendable_init_rejects_a_bucket_opening_elsewhere() {
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
     let epoch0 = EpochIndex(0);
-    let epoch1 = epoch0.next();
+    let epoch1 = epoch0.next().unwrap();
     let mut pool = PoolSim::genesis_with(random_block(rng, 1, 1));
     pool.advance(epoch1.last_block().0, |_| random_block(rng, 1, 1));
     let terminal0 = pool.block(epoch0.last_block()).anchor();
@@ -1957,7 +1957,7 @@ fn qr_spendable_init_rejects_a_bucket_opening_elsewhere() {
     let fake_last = fake_prev.next_stamp(epoch1, &commit).expect("one member");
     let discriminant = QrDiscriminant::from(
         fake_last
-            .next_epoch(epoch1.next())
+            .next_epoch(epoch1.next().unwrap())
             .expect("epoch two is nonzero"),
     );
     let (intake, ()) = PROOF_SYSTEM
@@ -2496,7 +2496,7 @@ fn qr_intake_merge_rejects_different_epochs() {
         .seed(
             rng,
             summary::SummarySeed,
-            witness::summary_seed(((), ()), junction, epoch.next(), &right_members),
+            witness::summary_seed(((), ()), junction, epoch.next().unwrap(), &right_members),
         )
         .expect("SummarySeed");
 

--- a/crates/tachyon/tests/integration/qr.rs
+++ b/crates/tachyon/tests/integration/qr.rs
@@ -123,7 +123,7 @@ fn qr_epoch_unspent(
 #[test]
 fn qr_summary_intake_init_starts_a_root_from_a_summary() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let members: [Tachygram; 6] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -174,7 +174,7 @@ fn qr_stamp_intake_seed_roots_an_intake_on_one_stamp() {
     assert_eq!(
         *stamp_root.pcd.data(),
         (
-            EpochIndex(0),
+            EpochIndex::new(0),
             anchor_prev,
             anchor_last,
             discriminant,
@@ -210,7 +210,13 @@ fn qr_stamp_intake_seed_rejects_an_empty_stamp() {
         .seed(
             rng,
             qr::QrStampIntakeSeed,
-            witness::qr_stamp_intake_seed(((), ()), anchor_prev, EpochIndex(3), discriminant, &[]),
+            witness::qr_stamp_intake_seed(
+                ((), ()),
+                anchor_prev,
+                EpochIndex::new(3),
+                discriminant,
+                &[],
+            ),
         )
         .err()
         .unwrap();
@@ -223,7 +229,7 @@ fn qr_stamp_intake_seed_rejects_an_empty_stamp() {
 #[test]
 fn qr_intake_split_partitions_the_contents_by_class() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let members: [Tachygram; 12] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -299,7 +305,7 @@ fn qr_intake_split_partitions_the_contents_by_class() {
 #[test]
 fn qr_intake_split_rejects_a_forged_partition() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let members: [Tachygram; 8] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -344,7 +350,7 @@ fn qr_intake_split_rejects_a_forged_partition() {
 #[test]
 fn qr_intake_split_rejects_the_exceptional_value_on_the_non_residue_side() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let exceptional = Tachygram::from(-Fp::from(discriminant));
@@ -405,7 +411,7 @@ fn qr_intake_split_rejects_the_exceptional_value_on_the_non_residue_side() {
 fn qr_intake_split_checks_the_exceptional_value_at_its_depth() {
     let rng = &mut StdRng::seed_from_u64(0);
     for depth in [1, 31] {
-        let epoch = EpochIndex(3);
+        let epoch = EpochIndex::new(3);
         let start = Anchor::from(Fp::random(&mut *rng));
         let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
         // Choose x from R_1 and the selected split depth.
@@ -492,7 +498,7 @@ fn qr_intake_split_checks_the_exceptional_value_at_its_depth() {
 #[test]
 fn qr_side_descend_carries_each_side_one_level_down() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let members: [Tachygram; 12] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -561,7 +567,7 @@ fn qr_side_descend_carries_each_side_one_level_down() {
 #[test]
 fn qr_side_descend_rejects_a_foreign_sibling() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let members: [Tachygram; 12] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -619,7 +625,7 @@ fn qr_side_descend_rejects_a_foreign_sibling() {
 #[test]
 fn qr_side_descend_rejects_a_foreign_interpolant() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let members: [Tachygram; 12] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -677,7 +683,7 @@ fn qr_side_descend_rejects_a_foreign_interpolant() {
 #[test]
 fn qr_side_descend_rejects_a_foreign_quotient() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let members: [Tachygram; 12] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -733,7 +739,7 @@ fn qr_side_descend_rejects_a_foreign_quotient() {
 #[test]
 fn qr_side_descend_rejects_a_child_short_of_a_member() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let members: [Tachygram; 12] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -837,7 +843,7 @@ fn qr_side_descend_rejects_a_child_short_of_a_member() {
 #[test]
 fn qr_side_descend_refuses_a_full_register() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let members: [Tachygram; 2] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -910,7 +916,7 @@ fn qr_side_descend_refuses_a_full_register() {
 #[test]
 fn qr_intake_merge_joins_two_spans() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let start = Anchor::from(Fp::random(&mut *rng));
     let left_members: [Tachygram; 5] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -980,7 +986,7 @@ fn qr_intake_merge_joins_two_spans() {
 #[test]
 fn qr_intake_merge_rejects_a_gap() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let left_start = Anchor::from(Fp::random(&mut *rng));
     let right_start = Anchor::from(Fp::random(&mut *rng));
@@ -1039,7 +1045,7 @@ fn qr_intake_merge_rejects_a_gap() {
 #[test]
 fn qr_intake_merge_rejects_different_profiles() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let start = Anchor::from(Fp::random(&mut *rng));
     let left_members: [Tachygram; 12] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -1433,7 +1439,7 @@ fn qr_bucket_seal_accepts_a_short_span_at_its_own_tick() {
     let (_, _, anchor_last, discriminant, ..) = *intake.pcd.data();
     assert_eq!(
         discriminant,
-        QrDiscriminant::from(anchor_last.next_epoch(EpochIndex(1)).unwrap())
+        QrDiscriminant::from(anchor_last.next_epoch(EpochIndex::new(1)).unwrap())
     );
 
     let bucket = seal_qr_intake(rng, intake, Anchor::from(Fp::ZERO));
@@ -1506,7 +1512,7 @@ fn qr_unspent_init_accepts_an_absent_nullifier_against_its_bucket() {
 #[test]
 fn qr_unspent_segments_of_consecutive_epochs_fuse_over_a_boundary_link() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch0 = EpochIndex(0);
+    let epoch0 = EpochIndex::new(0);
     let epoch1 = epoch0.next().unwrap();
     let mut pool = PoolSim::genesis_with(random_block(rng, 1, 1));
     // Fill epoch zero and open epoch one, one stamp per block.
@@ -1599,7 +1605,7 @@ fn qr_spendable_init_starts_a_spendable_that_reaches_spend_bind() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
-    let epoch0 = EpochIndex(0);
+    let epoch0 = EpochIndex::new(0);
     let epoch1 = epoch0.next().unwrap();
     let epoch2 = epoch1.next().unwrap();
     let mut pool = PoolSim::genesis_with(vec![vec![Tachygram::from(note.commitment())]]);
@@ -1656,7 +1662,7 @@ fn qr_spendable_init_starts_a_spendable_that_reaches_spend_bind() {
     );
 
     let lifted = user.lift_to_epoch(rng, &pool, &note, spendable, epoch2);
-    let derived = user.derivation_pcd(rng, note, epoch2, EpochIndex(epoch2.0 + 1));
+    let derived = user.derivation_pcd(rng, note, epoch2, EpochIndex::new(u32::from(epoch2) + 1));
     let (bind, ()) = PROOF_SYSTEM
         .fuse(
             rng,
@@ -1675,7 +1681,7 @@ fn qr_spendable_init_starts_a_spendable_that_reaches_spend_bind() {
         (present_nf, nf_next),
         (
             user.nf_at(&note, epoch2),
-            user.nf_at(&note, EpochIndex(epoch2.0 + 1))
+            user.nf_at(&note, EpochIndex::new(u32::from(epoch2) + 1))
         )
     );
 }
@@ -1688,7 +1694,7 @@ fn qr_short_bucket_reaches_spend_bind_through_a_same_epoch_suffix() {
     let rng = &mut StdRng::seed_from_u64(196);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
-    let epoch = EpochIndex(0);
+    let epoch = EpochIndex::new(0);
     let nf = user.nf_at(&note, epoch);
     let mut pool = PoolSim::genesis_with(vec![vec![Tachygram::from(note.commitment())]]);
     let short_anchor = pool.anchor();
@@ -1775,7 +1781,7 @@ fn qr_spendable_init_rejects_an_absent_commitment() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
-    let epoch0 = EpochIndex(0);
+    let epoch0 = EpochIndex::new(0);
     // The note's cm is published nowhere in this pool.
     let mut pool = PoolSim::genesis_with(random_block(rng, 1, 1));
     pool.advance(epoch0.last_block().0, |_| random_block(rng, 1, 1));
@@ -1817,7 +1823,7 @@ fn qr_spendable_init_rejects_a_bucket_whose_span_differs_from_the_segment() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
-    let epoch0 = EpochIndex(0);
+    let epoch0 = EpochIndex::new(0);
     let mut pool = PoolSim::genesis_with(vec![vec![Tachygram::from(note.commitment())]]);
     pool.advance(epoch0.last_block().0, |_| random_block(rng, 1, 1));
 
@@ -1868,7 +1874,7 @@ fn qr_spendable_init_rejects_a_bucket_of_another_epoch() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
-    let epoch0 = EpochIndex(0);
+    let epoch0 = EpochIndex::new(0);
     let epoch1 = epoch0.next().unwrap();
     let mut pool = PoolSim::genesis_with(vec![vec![Tachygram::from(note.commitment())]]);
     pool.advance(epoch1.last_block().0, |_| random_block(rng, 1, 1));
@@ -1921,7 +1927,7 @@ fn qr_spendable_init_rejects_a_bucket_opening_elsewhere() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
-    let epoch0 = EpochIndex(0);
+    let epoch0 = EpochIndex::new(0);
     let epoch1 = epoch0.next().unwrap();
     let mut pool = PoolSim::genesis_with(random_block(rng, 1, 1));
     pool.advance(epoch1.last_block().0, |_| random_block(rng, 1, 1));
@@ -2427,7 +2433,7 @@ fn qr_unspent_init_accepts_buckets_at_every_depth() {
 #[test]
 fn qr_intake_merge_rejects_different_discriminants() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let left_members: [Tachygram; 4] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
     let right_members: [Tachygram; 4] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -2478,7 +2484,7 @@ fn qr_intake_merge_rejects_different_discriminants() {
 #[test]
 fn qr_intake_merge_rejects_different_epochs() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let start = Anchor::from(Fp::random(&mut *rng));
     let left_members: [Tachygram; 4] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -2532,7 +2538,7 @@ fn qr_intake_merge_rejects_different_epochs() {
 #[test]
 fn qr_partition_routes_consecutive_values_by_profile() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let anchor_prev = Anchor::from(Fp::random(&mut *rng));
     let discriminant = QrDiscriminant::from(Fp::random(&mut *rng));
     let base = Fp::random(&mut *rng);

--- a/crates/tachyon/tests/integration/qr.rs
+++ b/crates/tachyon/tests/integration/qr.rs
@@ -1656,7 +1656,7 @@ fn qr_spendable_init_starts_a_spendable_that_reaches_spend_bind() {
     );
 
     let lifted = user.lift_to_epoch(rng, &pool, &note, spendable, epoch2);
-    let derived = user.derivation_pcd(rng, note, epoch2, EpochIndex(epoch2.0 + 2));
+    let derived = user.derivation_pcd(rng, note, epoch2, EpochIndex(epoch2.0 + 1));
     let (bind, ()) = PROOF_SYSTEM
         .fuse(
             rng,
@@ -1745,7 +1745,7 @@ fn qr_short_bucket_reaches_spend_bind_through_a_same_epoch_suffix() {
         "the suffix covers only the same epoch, without a boundary crossing"
     );
     let lifted = user.lift(rng, spendable, suffix, &note);
-    let derived = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap().next().unwrap());
+    let derived = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
     let (bind, ()) = PROOF_SYSTEM
         .fuse(
             rng,

--- a/crates/tachyon/tests/integration/stamp.rs
+++ b/crates/tachyon/tests/integration/stamp.rs
@@ -303,13 +303,25 @@ fn double_spend_cannot_aggregate() {
 
     // Two spendable lineages for the SAME note produce identical nullifiers.
     let init_a = wallet.spendable_init(rng, &spend, &pool, cm_height);
-    let sp_a = wallet.lift_to_epoch(rng, &pool, &spend, init_a, cm_height.epoch().next());
+    let sp_a = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &spend,
+        init_a,
+        cm_height.epoch().next().unwrap(),
+    );
     let init_b = wallet.spendable_init(rng, &spend, &pool, cm_height);
-    let sp_b = wallet.lift_to_epoch(rng, &pool, &spend, init_b, cm_height.epoch().next());
+    let sp_b = wallet.lift_to_epoch(
+        rng,
+        &pool,
+        &spend,
+        init_b,
+        cm_height.epoch().next().unwrap(),
+    );
     let anchor = sp_a.data().2;
     assert_eq!(anchor, sp_b.data().2, "same-note lifts share an anchor");
 
-    let spend_epoch = cm_height.epoch().next();
+    let spend_epoch = cm_height.epoch().next().unwrap();
     let autonome_a = wallet.autonome(
         rng,
         anchor,
@@ -739,7 +751,7 @@ fn lift_advances_a_stamp_anchor() {
 
     pool.advance(2, |_| random_block(rng, 1, 4));
     let lifted_to = pool.height();
-    let chain = build_anchor_chain_pcd(rng, &pool, stamped_at.next()..=lifted_to);
+    let chain = build_anchor_chain_pcd(rng, &pool, stamped_at.next().unwrap()..=lifted_to);
 
     let before = stamp.clone();
     let lifted = stamp
@@ -767,7 +779,7 @@ fn lift_then_verify() {
     let digest = plan.digest().expect("valid plan");
 
     pool.advance(2, |_| random_block(rng, 1, 4));
-    let chain = build_anchor_chain_pcd(rng, &pool, stamped_at.next()..=pool.height());
+    let chain = build_anchor_chain_pcd(rng, &pool, stamped_at.next().unwrap()..=pool.height());
 
     let lifted = stamp.prove_lift(rng, [digest], chain).expect("lift");
 
@@ -853,7 +865,7 @@ fn lift_rejects_wrong_digests() {
     let foreign_digest = random_action(rng).digest().expect("valid action");
 
     pool.advance(2, |_| random_block(rng, 1, 4));
-    let chain = build_anchor_chain_pcd(rng, &pool, stamped_at.next()..=pool.height());
+    let chain = build_anchor_chain_pcd(rng, &pool, stamped_at.next().unwrap()..=pool.height());
 
     let lifted = stamp
         .prove_lift(rng, [foreign_digest], chain)
@@ -896,7 +908,7 @@ fn merge_after_lift() {
     )
     .expect_err("mismatched anchors must not merge");
 
-    let chain = build_anchor_chain_pcd(rng, &pool, height_a.next()..=height_b);
+    let chain = build_anchor_chain_pcd(rng, &pool, height_a.next().unwrap()..=height_b);
     let lifted_a = stamp_a
         .prove_lift(rng, [plan_a.digest().expect("valid plan")], chain)
         .expect("lift onto the later anchor");

--- a/crates/tachyon/tests/integration/stamp.rs
+++ b/crates/tachyon/tests/integration/stamp.rs
@@ -77,9 +77,9 @@ fn plan_prove_rejects_invalid_inputs() {
 
     let sp_a = user.fresh_spend(rng, &pool, height, &note_a);
     let sp_b = user.fresh_spend(rng, &pool, height, &note_b);
-    let spend_end = EpochIndex(spend_epoch.0 + 2);
-    let range_a = user.derivation_pcd(rng, note_a, spend_epoch, spend_end);
-    let range_b = user.derivation_pcd(rng, note_b, spend_epoch, spend_end);
+    let spend_last = EpochIndex(spend_epoch.0 + 1);
+    let range_a = user.derivation_pcd(rng, note_a, spend_epoch, spend_last);
+    let range_b = user.derivation_pcd(rng, note_b, spend_epoch, spend_last);
 
     let (rcv_a, theta_a, alpha_a) = spend_witness(rng, &note_a);
     let plan_a = action::Plan::spend(note_a, theta_a, rcv_a, |alpha| {

--- a/crates/tachyon/tests/integration/stamp.rs
+++ b/crates/tachyon/tests/integration/stamp.rs
@@ -77,7 +77,7 @@ fn plan_prove_rejects_invalid_inputs() {
 
     let sp_a = user.fresh_spend(rng, &pool, height, &note_a);
     let sp_b = user.fresh_spend(rng, &pool, height, &note_b);
-    let spend_last = EpochIndex(spend_epoch.0 + 1);
+    let spend_last = EpochIndex::new(u32::from(spend_epoch) + 1);
     let range_a = user.derivation_pcd(rng, note_a, spend_epoch, spend_last);
     let range_b = user.derivation_pcd(rng, note_b, spend_epoch, spend_last);
 

--- a/crates/tachyon/tests/integration/summary.rs
+++ b/crates/tachyon/tests/integration/summary.rs
@@ -24,7 +24,7 @@ use crate::fixtures::{
 #[test]
 fn summary_advance_folds_stamp_into_accumulator_and_anchor() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let stamp_a: [Tachygram; 3] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
     let stamp_b: [Tachygram; 2] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
@@ -95,7 +95,7 @@ fn summary_over_an_anchor_span_matches_the_pool() {
     let (pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, anchor_prev, anchor_last, acc_commit) = *pcd.data();
 
-    assert_eq!(epoch, EpochIndex(0));
+    assert_eq!(epoch, EpochIndex::new(0));
     assert_eq!(
         anchor_prev,
         Anchor::default(),
@@ -128,7 +128,7 @@ fn summary_seed_rejects_empty_stamp() {
         .seed(
             rng,
             summary::SummarySeed,
-            witness::summary_seed(((), ()), start, EpochIndex(3), &[]),
+            witness::summary_seed(((), ()), start, EpochIndex::new(3), &[]),
         )
         .err()
         .unwrap();
@@ -141,7 +141,7 @@ fn summary_seed_rejects_empty_stamp() {
 #[test]
 fn summary_advance_rejects_wrong_accumulator() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let stamp_a = [Tachygram::from(Fp::random(&mut *rng))];
     let stamp_b = [Tachygram::from(Fp::random(&mut *rng))];
@@ -177,7 +177,7 @@ fn summary_advance_rejects_wrong_accumulator() {
 #[test]
 fn summary_advance_rejects_forged_extension() {
     let rng = &mut StdRng::seed_from_u64(0);
-    let epoch = EpochIndex(3);
+    let epoch = EpochIndex::new(3);
     let start = Anchor::from(Fp::random(&mut *rng));
     let stamp_a = [Tachygram::from(Fp::random(&mut *rng))];
     let stamp_b = [Tachygram::from(Fp::random(&mut *rng))];
@@ -228,7 +228,7 @@ fn summary_seed_on_a_foreign_epoch_leaves_the_chain() {
         .seed(
             rng,
             summary::SummarySeed,
-            witness::summary_seed(((), ()), first.prev, EpochIndex(1), &first.stamps[0].1),
+            witness::summary_seed(((), ()), first.prev, EpochIndex::new(1), &first.stamps[0].1),
         )
         .expect("SummarySeed");
     let (_, _, anchor_last, _) = *seeded.data();
@@ -510,7 +510,7 @@ fn summary_spendable_init_rejects_an_epoch_mismatch() {
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
     let claimed = epoch.next().unwrap();
-    let deriv = user.derivation_pcd(rng, note, epoch, EpochIndex(epoch.0 + 1));
+    let deriv = user.derivation_pcd(rng, note, epoch, EpochIndex::new(u32::from(epoch) + 1));
 
     let err = PROOF_SYSTEM
         .fuse(
@@ -614,7 +614,7 @@ fn summary_spendable_init_rejects_a_published_nullifier() {
     let rng = &mut StdRng::seed_from_u64(0);
     let user = WalletSim::new(shared_sk());
     let note = user.random_note(300);
-    let spent = Tachygram::from(user.nf_at(&note, EpochIndex(0)));
+    let spent = Tachygram::from(user.nf_at(&note, EpochIndex::new(0)));
     let mut pool = PoolSim::genesis_with(vec![vec![Tachygram::from(note.commitment())]]);
     pool.mine(vec![vec![spent]]);
     pool.mine(random_block(rng, 2, 2));

--- a/crates/tachyon/tests/integration/summary.rs
+++ b/crates/tachyon/tests/integration/summary.rs
@@ -339,7 +339,7 @@ fn summary_unspent_init_fuses_with_a_per_stamp_segment() {
     let mut pool = PoolSim::genesis_with(random_block(rng, 2, 2));
     pool.mine(random_block(rng, 2, 2));
     pool.mine(random_block(rng, 2, 2));
-    let end = pool.block(pool.height().prev()).anchor();
+    let end = pool.block(pool.height().prev().unwrap()).anchor();
     let (pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), end));
     let (epoch, anchor_prev, anchor_last, _) = *pcd.data();
     let nf = Nullifier::from(Fp::random(&mut *rng));
@@ -393,7 +393,7 @@ fn summary_spendable_init_starts_a_spendable_from_a_summary() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, _, anchor_last, _) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
 
     let (spendable, ()) = PROOF_SYSTEM
         .fuse(
@@ -436,8 +436,8 @@ fn summary_spendable_init_rejects_a_foreign_covering_sequence() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next());
-    let foreign_deriv = user.derivation_pcd(rng, other, epoch, epoch.next());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
+    let foreign_deriv = user.derivation_pcd(rng, other, epoch, epoch.next().unwrap());
     let witness = witness::summary_spendable_init(
         (*deriv.data(), *summary_pcd.data()),
         &members,
@@ -473,7 +473,7 @@ fn summary_spendable_init_rejects_a_foreign_accumulator() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, _members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
     let foreign: [Tachygram; 4] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
 
     let err = PROOF_SYSTEM
@@ -509,7 +509,7 @@ fn summary_spendable_init_rejects_an_epoch_mismatch() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let claimed = epoch.next();
+    let claimed = epoch.next().unwrap();
     let deriv = user.derivation_pcd(rng, note, epoch, EpochIndex(epoch.0 + 2));
 
     let err = PROOF_SYSTEM
@@ -545,7 +545,7 @@ fn summary_spendable_init_rejects_a_forged_nullifier() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
     let (creation_epoch, _genuine, nf_seq, complement_seq, summary_set) =
         witness::summary_spendable_init(
             (*deriv.data(), *summary_pcd.data()),
@@ -583,7 +583,7 @@ fn summary_spendable_init_rejects_an_absent_commitment() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
 
     let err = PROOF_SYSTEM
         .fuse(
@@ -620,7 +620,7 @@ fn summary_spendable_init_rejects_a_published_nullifier() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
 
     let err = PROOF_SYSTEM
         .fuse(

--- a/crates/tachyon/tests/integration/summary.rs
+++ b/crates/tachyon/tests/integration/summary.rs
@@ -393,7 +393,7 @@ fn summary_spendable_init_starts_a_spendable_from_a_summary() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, _, anchor_last, _) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch);
 
     let (spendable, ()) = PROOF_SYSTEM
         .fuse(
@@ -436,8 +436,8 @@ fn summary_spendable_init_rejects_a_foreign_covering_sequence() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
-    let foreign_deriv = user.derivation_pcd(rng, other, epoch, epoch.next().unwrap());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch);
+    let foreign_deriv = user.derivation_pcd(rng, other, epoch, epoch);
     let witness = witness::summary_spendable_init(
         (*deriv.data(), *summary_pcd.data()),
         &members,
@@ -473,7 +473,7 @@ fn summary_spendable_init_rejects_a_foreign_accumulator() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, _members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch);
     let foreign: [Tachygram; 4] = array::from_fn(|_| Tachygram::from(Fp::random(&mut *rng)));
 
     let err = PROOF_SYSTEM
@@ -510,7 +510,7 @@ fn summary_spendable_init_rejects_an_epoch_mismatch() {
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
     let claimed = epoch.next().unwrap();
-    let deriv = user.derivation_pcd(rng, note, epoch, EpochIndex(epoch.0 + 2));
+    let deriv = user.derivation_pcd(rng, note, epoch, EpochIndex(epoch.0 + 1));
 
     let err = PROOF_SYSTEM
         .fuse(
@@ -545,7 +545,7 @@ fn summary_spendable_init_rejects_a_forged_nullifier() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch);
     let (creation_epoch, _genuine, nf_seq, complement_seq, summary_set) =
         witness::summary_spendable_init(
             (*deriv.data(), *summary_pcd.data()),
@@ -583,7 +583,7 @@ fn summary_spendable_init_rejects_an_absent_commitment() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch);
 
     let err = PROOF_SYSTEM
         .fuse(
@@ -620,7 +620,7 @@ fn summary_spendable_init_rejects_a_published_nullifier() {
     pool.mine(random_block(rng, 2, 2));
     let (summary_pcd, members) = build_summary_pcd(rng, &pool, (Anchor::default(), pool.anchor()));
     let (epoch, ..) = *summary_pcd.data();
-    let deriv = user.derivation_pcd(rng, note, epoch, epoch.next().unwrap());
+    let deriv = user.derivation_pcd(rng, note, epoch, epoch);
 
     let err = PROOF_SYSTEM
         .fuse(


### PR DESCRIPTION
pulled out of #200 and refactored

`EpochIndex::next` and `BlockHeight::next` now return `Option` so callers must handle edge cases.

`NullifierDerivation` now carries `epoch_last` which is range inclusive.
